### PR TITLE
AI Excerpt: add language and tone to AI setting

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-add-lang-tone-and-custom-to-settings-toggle
+++ b/projects/plugins/jetpack/changelog/update-ai-add-lang-tone-and-custom-to-settings-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: add language and tone to AI setting toggle control

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
@@ -93,7 +93,7 @@ export const LANGUAGE_MAP = {
 	},
 };
 
-const I18nMenuGroup = ( {
+export const I18nMenuGroup = ( {
 	value,
 	onChange,
 }: Pick< LanguageDropdownControlProps, 'value' | 'onChange' > ) => {
@@ -141,13 +141,18 @@ export default function I18nDropdownControl( {
 export function I18nMenuDropdown( {
 	value = defaultLanguage,
 	label = defaultLabel,
+	disabled = false,
 	onChange,
-}: Pick< LanguageDropdownControlProps, 'label' | 'onChange' | 'value' > ) {
+}: Pick< LanguageDropdownControlProps, 'label' | 'onChange' | 'value' > & {
+	disabled?: boolean;
+	toggleProps?: Record< string, unknown >;
+} ) {
 	return (
 		<DropdownMenu
 			className="ai-assistant__i18n-dropdown"
 			icon={ globe }
 			label={ label }
+			disabled={ disabled }
 			toggleProps={ {
 				children: (
 					<>
@@ -157,7 +162,15 @@ export function I18nMenuDropdown( {
 				),
 			} }
 		>
-			{ () => <I18nMenuGroup onChange={ onChange } value={ value } /> }
+			{ ( { onClose } ) => (
+				<I18nMenuGroup
+					onChange={ newLanguage => {
+						onChange( newLanguage );
+						onClose();
+					} }
+					value={ value }
+				/>
+			) }
 		</DropdownMenu>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -130,6 +130,7 @@ export type ToneProp = ( typeof PROMPT_TONES_LIST )[ number ];
 type ToneToolbarDropdownMenuProps = {
 	value?: ToneProp;
 	onChange: ( value: ToneProp ) => void;
+	label?: string;
 };
 
 const ToneMenuGroup = ( { value, onChange }: ToneToolbarDropdownMenuProps ) => (
@@ -149,13 +150,14 @@ const ToneMenuGroup = ( { value, onChange }: ToneToolbarDropdownMenuProps ) => (
 );
 
 export function ToneDropdownMenu( {
+	label = __( 'Change tone', 'jetpack' ),
 	value = DEFAULT_PROMPT_TONE,
 	onChange,
 }: ToneToolbarDropdownMenuProps ) {
 	return (
 		<DropdownMenu
 			icon={ speakToneIcon }
-			label={ __( 'Change tone', 'jetpack' ) }
+			label={ label }
 			className="ai-assistant__tone-dropdown"
 			popoverProps={ {
 				variant: 'toolbar',
@@ -163,15 +165,21 @@ export function ToneDropdownMenu( {
 			toggleProps={ {
 				children: (
 					<>
-						<div className="ai-assistant__tone-dropdown__toggle-label">
-							{ __( 'Change tone', 'jetpack' ) }
-						</div>
+						<div className="ai-assistant__tone-dropdown__toggle-label">{ label }</div>
 						<Icon icon={ chevronRight } />
 					</>
 				),
 			} }
 		>
-			{ () => <ToneMenuGroup value={ value } onChange={ onChange } /> }
+			{ ( { onClose } ) => (
+				<ToneMenuGroup
+					value={ value }
+					onChange={ newTone => {
+						onChange( newTone );
+						onClose();
+					} }
+				/>
+			) }
 		</DropdownMenu>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
@@ -8,14 +8,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import {
-	I18nMenuDropdown,
-	LANGUAGE_MAP,
-} from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
-import {
-	PROMPT_TONES_MAP,
-	ToneDropdownMenu,
-} from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
+import { I18nMenuDropdown } from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
+import { ToneDropdownMenu } from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
 import AiModelSelectorControl from '../../../../shared/components/ai-model-selector-control';
 /**
  * Types and constants
@@ -81,11 +75,6 @@ export function AiExcerptControl( {
 }: AiExcerptControlProps ) {
 	const [ isSettingActive, setIsSettingActive ] = React.useState( false );
 
-	const lang = language?.split( ' ' )[ 0 ];
-	const langLabel = LANGUAGE_MAP[ lang ]?.label || __( 'Language', 'jetpack' );
-
-	const toneLabel = PROMPT_TONES_MAP[ tone ]?.label;
-
 	function toggleSetting() {
 		setIsSettingActive( prev => ! prev );
 	}
@@ -111,10 +100,14 @@ export function AiExcerptControl( {
 						disabled={ disabled }
 						onChange={ onLanguageChange }
 						value={ language }
-						label={ langLabel }
+						label={ __( 'Language', 'jetpack' ) }
 					/>
 
-					<ToneDropdownMenu label={ toneLabel } value={ tone } onChange={ onToneChange } />
+					<ToneDropdownMenu
+						label={ __( 'Tone', 'jetpack' ) }
+						value={ tone }
+						onChange={ onToneChange }
+					/>
 					<AiModelSelectorControl
 						model={ model }
 						onModelChange={ onModelChange }

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
@@ -8,8 +8,14 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { I18nMenuDropdown } from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
-import { ToneDropdownMenu } from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
+import {
+	I18nMenuDropdown,
+	LANGUAGE_MAP,
+} from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
+import {
+	PROMPT_TONES_MAP,
+	ToneDropdownMenu,
+} from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
 import AiModelSelectorControl from '../../../../shared/components/ai-model-selector-control';
 /**
  * Types and constants
@@ -79,6 +85,13 @@ export function AiExcerptControl( {
 		setIsSettingActive( prev => ! prev );
 	}
 
+	// const langLabel = language || __( 'Language', 'jetpack' );
+	// const toneLabel = tone || __( 'Tone', 'jetpack' );
+
+	const lang = language?.split( ' ' )[ 0 ];
+	const langLabel = LANGUAGE_MAP[ lang ]?.label || __( 'Language', 'jetpack' );
+	const toneLabel = PROMPT_TONES_MAP[ tone ]?.label || __( 'Tone', 'jetpack' );
+
 	return (
 		<div className="jetpack-ai-generate-excerpt-control">
 			<BaseControl
@@ -100,14 +113,11 @@ export function AiExcerptControl( {
 						disabled={ disabled }
 						onChange={ onLanguageChange }
 						value={ language }
-						label={ __( 'Language', 'jetpack' ) }
+						label={ langLabel }
 					/>
 
-					<ToneDropdownMenu
-						label={ __( 'Tone', 'jetpack' ) }
-						value={ tone }
-						onChange={ onToneChange }
-					/>
+					<ToneDropdownMenu label={ toneLabel } value={ tone } onChange={ onToneChange } />
+
 					<AiModelSelectorControl
 						model={ model }
 						onModelChange={ onModelChange }

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
@@ -8,10 +8,20 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import {
+	I18nMenuDropdown,
+	LANGUAGE_MAP,
+} from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
+import {
+	PROMPT_TONES_MAP,
+	ToneDropdownMenu,
+} from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
 import AiModelSelectorControl from '../../../../shared/components/ai-model-selector-control';
 /**
  * Types and constants
  */
+import type { LanguageProp } from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
+import type { ToneProp } from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
 import type { AiModelTypeProp } from '@automattic/jetpack-ai-client';
 
 export type AiExcerptControlProps = {
@@ -40,6 +50,12 @@ export type AiExcerptControlProps = {
 	 */
 	onWordsNumberChange?: ( words: number ) => void;
 
+	language?: LanguageProp;
+	onLanguageChange?: ( language: LanguageProp ) => void;
+
+	tone?: ToneProp;
+	onToneChange?: ( tone: ToneProp ) => void;
+
 	model?: AiModelTypeProp;
 	onModelChange?: ( model: AiModelTypeProp ) => void;
 };
@@ -54,10 +70,21 @@ export function AiExcerptControl( {
 	words,
 	onWordsNumberChange,
 
+	language,
+	onLanguageChange,
+
+	tone,
+	onToneChange,
+
 	model,
 	onModelChange,
 }: AiExcerptControlProps ) {
 	const [ isSettingActive, setIsSettingActive ] = React.useState( false );
+
+	const lang = language?.split( ' ' )[ 0 ];
+	const langLabel = LANGUAGE_MAP[ lang ]?.label || __( 'Language', 'jetpack' );
+
+	const toneLabel = PROMPT_TONES_MAP[ tone ]?.label;
 
 	function toggleSetting() {
 		setIsSettingActive( prev => ! prev );
@@ -79,11 +106,21 @@ export function AiExcerptControl( {
 			</BaseControl>
 
 			{ isSettingActive && (
-				<AiModelSelectorControl
-					model={ model }
-					onModelChange={ onModelChange }
-					disabled={ disabled }
-				/>
+				<>
+					<I18nMenuDropdown
+						disabled={ disabled }
+						onChange={ onLanguageChange }
+						value={ language }
+						label={ langLabel }
+					/>
+
+					<ToneDropdownMenu label={ toneLabel } value={ tone } onChange={ onToneChange } />
+					<AiModelSelectorControl
+						model={ model }
+						onModelChange={ onModelChange }
+						disabled={ disabled }
+					/>
+				</>
 			) }
 
 			<RangeControl

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -56,8 +56,8 @@ function AiPostExcerpt() {
 	const [ excerptWordsNumber, setExcerptWordsNumber ] = useState( 50 );
 
 	const [ reenable, setReenable ] = useState( false );
-	const [ language, setLanguage ] = useState< LanguageProp >( 'en' );
-	const [ tone, setTone ] = useState< ToneProp >( 'formal' );
+	const [ language, setLanguage ] = useState< LanguageProp >();
+	const [ tone, setTone ] = useState< ToneProp >();
 	const [ model, setModel ] = useState< AiModelTypeProp >( AI_MODEL_GPT_4 );
 
 	const { request, stopSuggestion, suggestion, requestingState, error, reset } = useAiSuggestions(

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -22,7 +22,10 @@ import { AiExcerptControl } from '../../components/ai-excerpt-control';
 /**
  * Types and constants
  */
+import type { LanguageProp } from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
+import type { ToneProp } from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
 import type { AiModelTypeProp } from '@automattic/jetpack-ai-client';
+
 import './style.scss';
 
 type ContentLensMessageContextProps = {
@@ -32,6 +35,8 @@ type ContentLensMessageContextProps = {
 	words?: number;
 	request?: string;
 	content?: string;
+	language?: LanguageProp;
+	tone?: ToneProp;
 	model?: AiModelTypeProp;
 };
 
@@ -51,6 +56,8 @@ function AiPostExcerpt() {
 	const [ excerptWordsNumber, setExcerptWordsNumber ] = useState( 50 );
 
 	const [ reenable, setReenable ] = useState( false );
+	const [ language, setLanguage ] = useState< LanguageProp >( 'en' );
+	const [ tone, setTone ] = useState< ToneProp >( 'formal' );
 	const [ model, setModel ] = useState< AiModelTypeProp >( AI_MODEL_GPT_4 );
 
 	const { request, stopSuggestion, suggestion, requestingState, error, reset } = useAiSuggestions(
@@ -121,6 +128,8 @@ function AiPostExcerpt() {
 			contentType: 'post-excerpt',
 			postId,
 			words: excerptWordsNumber,
+			language,
+			tone,
 			content: `Post content:
 ${ postContent }
 `,
@@ -185,6 +194,16 @@ ${ postContent }
 					words={ excerptWordsNumber }
 					onWordsNumberChange={ wordsNumber => {
 						setExcerptWordsNumber( wordsNumber );
+						setReenable( true );
+					} }
+					language={ language }
+					onLanguageChange={ newLang => {
+						setLanguage( newLang );
+						setReenable( true );
+					} }
+					tone={ tone }
+					onToneChange={ newTone => {
+						setTone( newTone );
 						setReenable( true );
 					} }
 					model={ model }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


Follow-up of #32970

This PR adds the Language and Tone dropdowns to the AI Settings toggle control.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: add language and tone to AI setting

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the post sidebar
* Look at the AI Excerpt panel
* Play with the Settings toggle, as the video below shows

https://github.com/Automattic/jetpack/assets/77539/eaee3295-94cd-4663-8c61-bd1c2d115f65

* Confirm that the generated code follows the settings defined by the user
* You can confirm how the settings are passed to it by examining the request payload using your dev browser's network tab. Chrome:
  * Open the dev tools
  * Select the Network tab
  * Filter the request by ai-query
  * Take a look at the payload:

<img width="718" alt="Screenshot 2023-09-15 at 14 43 00" src="https://github.com/Automattic/jetpack/assets/77539/99e0800b-5186-453b-9001-d72244a29304">

### ALSO
Since this PR toches the Language and Tone dropdown, test them in the other AI implementations such as `AI Assistant Block`, `Ai Extension`, `Jetpack Form AI Assistant`.