### PR TITLE
Delete K6 all blocks post test

### DIFF
--- a/.github/files/jetpack-staging-sites/k6-frontend.js
+++ b/.github/files/jetpack-staging-sites/k6-frontend.js
@@ -36,16 +36,6 @@ export default function () {
 			check( res, {
 				'random post status was 200': r => r.status == 200,
 			} );
-
-			// Jetpack Blocks test post.
-			if ( site.url !== 'https://jetpackedgeprivate.wpcomstaging.com' ) {
-				res = http.get( `${ site.url }/2023/06/09/jetpack-blocks/` );
-				check( res, {
-					'blocks test post status was 200': r => r.status == 200,
-					'verify blocks post end contents': r =>
-						r.body.includes( 'End of Jetpack Blocks post content' ),
-				} );
-			}
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #

## Proposed changes:
This removes the K6 test that loads and checks the "all-blocks" post on the staging sites.

We've implemented a new test data strategy that involves purging blog data on a recurring basis, which means there won't be this static post to load.

We've replaced that test coverage with e2e block smoke testing that actually goes a level deeper and makes sure all the blocks are rendering correctly. 👍 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1692798943977029-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
Nope 👍 

## Testing instructions:

- [ ] Run the staging workflow and make sure the K6 tests still pass.


