### PR TITLE
AI Excerpt: add a fallback for ToggleGroupControl components 

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-experpt-add-model-selector-fallback
+++ b/projects/plugins/jetpack/changelog/update-ai-experpt-add-model-selector-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: add a fallback for ToggleGroupControl components

--- a/projects/plugins/jetpack/extensions/shared/components/ai-model-selector-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/shared/components/ai-model-selector-control/index.tsx
@@ -3,6 +3,7 @@
  */
 import { AI_MODEL_GPT_3_5_Turbo_16K, AI_MODEL_GPT_4 } from '@automattic/jetpack-ai-client';
 import {
+	RadioControl,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line wpcalypso/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line wpcalypso/no-unsafe-wp-apis
 } from '@wordpress/components';
@@ -32,6 +33,26 @@ export default function AiModelSelectorControl( {
 			  )
 			: __( 'The fastest model, great for most everyday tasks.', 'jetpack' );
 
+	/*
+	 * Add a fallback for the ToggleGroupControlOption component,
+	 * since it is experimental and might not be available in all versions of Gutenberg.
+	 */
+	if ( ! ToggleGroupControlOption ) {
+		return (
+			<RadioControl
+				label={ __( 'Model', 'jetpack' ) }
+				className="ai-model-selector-control__radio-control"
+				selected={ model }
+				options={ [
+					{ label: __( 'GPT-3.5 Turbo', 'jetpack' ), value: AI_MODEL_GPT_3_5_Turbo_16K },
+					{ label: __( 'GPT-4', 'jetpack' ), value: AI_MODEL_GPT_4 },
+				] }
+				onChange={ onModelChange }
+				help={ help }
+			/>
+		);
+	}
+
 	return (
 		<ToggleGroupControl
 			isBlock
@@ -42,7 +63,6 @@ export default function AiModelSelectorControl( {
 			help={ help }
 		>
 			<ToggleGroupControlOption
-				title={ __( 'GPT-3.5 Turbo', 'jetpack' ) }
 				label={ __( 'GTP-3.5 Turbo', 'jetpack' ) }
 				value={ AI_MODEL_GPT_3_5_Turbo_16K }
 			/>

--- a/projects/plugins/jetpack/extensions/shared/components/ai-model-selector-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/shared/components/ai-model-selector-control/index.tsx
@@ -37,7 +37,7 @@ export default function AiModelSelectorControl( {
 	 * Add a fallback for the ToggleGroupControlOption component,
 	 * since it is experimental and might not be available in all versions of Gutenberg.
 	 */
-	if ( ! ToggleGroupControlOption ) {
+	if ( ! ToggleGroupControlOption || ! ToggleGroupControl ) {
 		return (
 			<RadioControl
 				label={ __( 'Model', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/shared/components/ai-model-selector-control/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/ai-model-selector-control/style.scss
@@ -13,3 +13,7 @@
 		margin-bottom: 12px;
 	}
 }
+
+.ai-model-selector-control__radio-control .components-flex {
+	gap: 8px;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up of https://github.com/Automattic/jetpack/pull/33111

Since `<ToggleGroupControl />` and `<ToggleGroupControlOption />` are experimental components, it would be good to add a fallback implementation since they might not be available in all versions of Gutenberg.
This PR uses the regular `<RadioControl />` when the components are not available.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: add a fallback for ToggleGroupControl components

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This is tricky. You can downgrade the WordPress cover version to generate the issue. Another way could be just setting an unavailable component when it's imported, [here](https://github.com/Automattic/jetpack/blob/00c9ad57dbc38d331db122b57b4856d330d6f16b/projects/plugins/jetpack/extensions/shared/components/ai-model-selector-control/index.tsx#L7-L8). For instance:

```jsx
import {
	RadioControl,
	__NoExist as ToggleGroupControl, // eslint-disable-line wpcalypso/no-unsafe-wp-apis
	__NoExist as ToggleGroupControlOption, // eslint-disable-line wpcalypso/no-unsafe-wp-apis
} from '@wordpress/components';
```

* Compile
* Go to the block editor
* Open the post sidebar
* Look at the AI Excerpt panel
* Now, the panel should show the Radio control implementation

<img width="369" alt="Screenshot 2023-09-15 at 17 35 23" src="https://github.com/Automattic/jetpack/assets/77539/6c4e3fe9-43eb-48d1-b32e-6bb9a1f2c037">

* Confirm the help legend changes when you select the model
* Confirm the `model` is adequately propagated to the request payload

<img width="1045" alt="Screenshot 2023-09-15 at 17 36 42" src="https://github.com/Automattic/jetpack/assets/77539/2fcb3953-2f87-47ef-93b7-f05972be4371">
