### PR TITLE
VideoPress: Fix settings toggle on AT

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-atomic-toggle
+++ b/projects/plugins/jetpack/changelog/fix-videopress-atomic-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix the override condition on VideoPress toggle for AT sites


### PR DESCRIPTION
Fix AT sites VideoPress toggle

Fixes #32348

## Proposed changes:
This PR adds a conditional treatment for the override property on VideoPress module. The `override` property inevitably disables the toggle, but using the `overrideCondition` allows us to selectively enable/disable the toggle based on different conditions/scenarios.

NOTE: it's important not to mix the concept of enabling/disabling the toggle (input control) with enabling/disabling the module itself (VideoPress)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
On simple, Jetpack and P2 sites things should not change, visiting Jetpack settings on the performance tab should show the toggle as it was. For testing this you'll need to:
- `jetpack build plugins/jetpack`
- emulate the case by adding `override: inactive` to the VideoPress module. Use this code, paste it on `projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php` on line 298 (before `Connection_Initial_State::render_script( 'react-plugin' );`)

```php
wp_add_inline_script(
	'react-plugin',
	'
		if ( window.Initial_State && window.Initial_State.getModules ) {

			if ( ! ( "videopress" in window.Initial_State.getModules ) ) {
				window.Initial_State.getModules.videopress = {};
			}
			window.Initial_State.getModules.videopress.override = "inactive";
		}
	',
	'before'
);
```
- a similar approach to above should be doable on simple sites

On Atomic sites:

- create an atomic site: p9o2xV-1r2-p2
- use the cli to disable `videopress` module
- visit the Jetpack settings page, tab performance (/wp-admin/admin.php?page=jetpack#/performance) to see the "Media" card show the module inactive and the toggle disabled:
<img width="522" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/bc804bce-c484-4878-a780-28e4c82931e2">

- install Jetpack Beta plugin https://github.com/Automattic/jetpack-beta/releases and activate it
- Go to Jetpack Beta settings, manage Jetpack and look for the branch for this PR, enable it
- [ ] visit Jetpack settings again and see the toggle for "Media" should now be enabled (the control, not the module)
- [ ] enable the module. See that once enabled (the module) the toggle becomes disabled (this is by design)
