### PR TITLE
Label automation: update Premium Content name to Paid content.

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-premium-content
+++ b/projects/github-actions/repo-gardening/changelog/update-premium-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Labels: update "Premium Content" to "Paid Content".

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -64,6 +64,11 @@ function cleanName( name ) {
 		name = 'Payments';
 	}
 
+	// Premium Content was renamed into Paid content.
+	if ( name === 'premium-content' ) {
+		name = 'Paid content';
+	}
+
 	// Rating Star was renamed into Star Rating.
 	if ( name === 'rating-star' ) {
 		name = 'Star Rating';


### PR DESCRIPTION
## Proposed changes:

In #30775, we renamed the block. Let's rename the label that's added when making changes to that block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1694795310790049-slack-CQD1HH4MA

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* You cannot test this here before this PR is merged.
* You can, however, test this in a fork, by merging this PR in your fork and then opening a PR that makes changes to the ~~Premium~~ Paid Content block. Here is an example:
    * https://github.com/jeherve/jetpack/pull/99

