### PR TITLE
CRM: Resolves #3316 - better slug generation

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3316-better_slug_generation
+++ b/projects/plugins/crm/changelog/fix-crm-3316-better_slug_generation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+Tags: better slug generation
+Tags: added tag slug migration

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -3199,7 +3199,7 @@ class zbsDAL {
             if (!isset($data['name']) || empty($data['name'])) return false;
 		if ( empty( $data['slug'] ) ) {
 
-			$potential_slug = $this->makeSlug( $data['name'] ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$potential_slug = sanitize_key( $data['name'] ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 			// catch empty slugs as per gh-462, chinese characters, for example
 			if ( empty( $potential_slug ) ) {

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -3203,12 +3203,12 @@ class zbsDAL {
 
 			// catch empty slugs as per gh-462, chinese characters, for example
 			if ( empty( $potential_slug ) ) {
-				$potential_slug = 'tag';
+				$this->get_new_tag_slug( $data['objtype'], 'tag', true ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			} else {
+				$data['slug'] = $this->get_new_tag_slug( $data['objtype'], $potential_slug ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 			}
 
-			$data['slug'] = $this->get_new_tag_slug( $data['objtype'], $potential_slug ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-
-			// if slug STILL empty, return false for now..
+			// if slug STILL empty (e.g. database error?), return false for now...
 			if ( empty( $data['slug'] ) ) {
 				return false;
 			}
@@ -3734,19 +3734,20 @@ class zbsDAL {
 	}
 
 	/**
-	 * Checks if a tag slug exists
+	 * Get a unique tag slug
 	 *
 	 * @param int    $obj_type_id Object type id.
 	 * @param string $slug Tag slug to check.
+	 * @param bool   $force_iteration Force iteration to occur (e.g. use `slug-N` instead of `slug`).
 	 *
-	 * @return string tag slug
+	 * @return string unique tag slug
 	 */
-	public function get_new_tag_slug( int $obj_type_id, string $slug ) {
+	public function get_new_tag_slug( int $obj_type_id, string $slug, bool $force_iteration = false ) {
 		global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		$slug_exists = $this->tag_slug_exists( $obj_type_id, $slug );
 
 		// slug as provided doesn't exist, so use that
-		if ( ! $slug_exists && $slug !== 'tag' ) {
+		if ( ! $slug_exists && ! $force_iteration ) {
 			return $slug;
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -37,6 +37,7 @@ global $zeroBSCRM_migrations; $zeroBSCRM_migrations = array(
 	'560', // 5.6.0 Moves old folder structure (zbscrm-store) to new (jpcrm-storage)
 	'task_offset_fix', // removes task timezone offsets from database
 	'refresh_user_roles', // Refresh user roles
+	'regenerate_tag_slugs', // Regenerate tag slugs
 	);
 
 global $zeroBSCRM_migrations_requirements; $zeroBSCRM_migrations_requirements = array(
@@ -1138,6 +1139,17 @@ function zeroBSCRM_migration_refresh_user_roles() {
 	zeroBSCRM_migrations_markComplete( 'refresh_user_roles', array( 'updated' => 1 ) );
 }
 
+/**
+ * Regenerate tag slugs
+ */
+function zeroBSCRM_migration_regenerate_tag_slugs() {
+	$obj_ids = array( ZBS_TYPE_CONTACT, ZBS_TYPE_COMPANY, ZBS_TYPE_QUOTE, ZBS_TYPE_INVOICE, ZBS_TYPE_TRANSACTION, ZBS_TYPE_EVENT, ZBS_TYPE_FORM );
+	foreach ( $obj_ids as $obj_id ) {
+		jpcrm_migration_regenerate_tag_slugs_for_obj_type( $obj_id );
+	}
+	zeroBSCRM_migrations_markComplete( 'regenerate_tag_slugs', array( 'updated' => 1 ) );
+}
+
 /* ======================================================
 	/ MIGRATIONS
    ====================================================== */
@@ -1239,6 +1251,69 @@ function zeroBSCRM_migration_refresh_user_roles() {
 function jpcrm_migration_load_wp_filesystem_direct() {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+}
+
+/**
+ * Regenerates tag slugs for a given object type.
+ *
+ * @param int $obj_type_id Object type ID.
+ */
+function jpcrm_migration_regenerate_tag_slugs_for_obj_type( int $obj_type_id ) {
+	global $zbs;
+
+	// get tags for object type
+	$tags = $zbs->DAL->getTagsForObjType( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		array(
+			'objtypeid'    => $obj_type_id,
+			'excludeEmpty' => false,
+		)
+	);
+
+	// store slugs we've used so we prevent duplicates
+	$used_slugs = array();
+
+	foreach ( $tags as $tag ) {
+
+		// generate a potential slug
+		$potential_slug = sanitize_key( $tag['name'] );
+
+		// this will be empty if Chinese or Cyrillic or symbols, so use `tag` fallback
+		if ( empty( $potential_slug ) ) {
+			if ( preg_match( '/^tag-\d+$/', $tag['slug'] ) && ! in_array( $tag['slug'], $used_slugs, true ) ) {
+				// if we had a fallback slug before and it hasn't been claimed by another tag, use it
+				$potential_slug = $tag['slug'];
+			} else {
+				// get a new fallback slug
+				$potential_slug = $zbs->DAL->get_new_tag_slug( $obj_type_id, 'tag', true ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			}
+		} elseif ( in_array( $potential_slug, $used_slugs, true ) ) {
+			// this needs an iteration
+			if ( preg_match( '/^' . $potential_slug . '-\d+$/', $tag['slug'] ) && ! in_array( $tag['slug'], $used_slugs, true ) ) {
+				// use old slug iteration
+				$potential_slug = $tag['slug'];
+			} else {
+				// generate a new slug iteration
+				$potential_slug = $zbs->DAL->get_new_tag_slug( $obj_type_id, $potential_slug ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			}
+		}
+
+		// if the new slug is different than the old one, update the database
+		if ( $potential_slug !== $tag['slug'] ) {
+			$zbs->DAL->addUpdateTag( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				array(
+					'id'   => $tag['id'],
+					'data' => array(
+						'objtype' => $obj_type_id,
+						'name'    => $tag['name'],
+						'slug'    => $potential_slug,
+					),
+				)
+			);
+		}
+
+		// store in index of used slugs
+		$used_slugs[] = $potential_slug;
+	}
 }
 
 /* ======================================================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3316 - better slug generation

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #33096 we solved issues with duplicates and fallback slugs. This PR switches tag slug generation from `$zbs->DAL->makeSlug()` to WP's native `sanitize_key()` (initially I looked at both `sanitize_title()` and `sanitize_title_with_dashes()`, but neither limits to alphanumeric chars + dashes + underscores despite what their docs say).

It also adds a new migration that regenerates tag slugs. I wanted to simplify the logic, but was struggling to do so while covering all scenarios. Feel free to suggest more condensed code! This is the current logic:

```
1. Generate slug:
    * If blank, use `tag` base:
        * If old slug looks like /^tag-\d+$/ and it's not been used, use it.
        * Otherwise, generate a new `tag-N` slug iteration. It'll be unique, as we check the database and increment by one.
    * If not blank:
        * If it hasn't been used, use it.
        * If it has been used, but the old slug was iterated and has the expected base and is available, use old slug.
        * If the new and old slug are unavailable, iterate.
2. Store slug in database if it doesn't match its old slug.
3. Cache slug in `$used_slugs`, preventing reuse by other tags.
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Start in `trunk`. Add tags like with a mix of ASCII and non-ASCII chars (e.g. `Product: (ПРОМО ПАКЕТ)`). Also, add some tags with duplicate slugs via the database.

In `trunk`, you'll see duplicate slugs, and the mixed-char labels will have a slug of `tag-N` on most systems.

Then switch to the `fix/crm/3316-better_slug_generation` branch. The migration should run, fixing duplicates and giving the mixed-char tags a slug derived from the ASCII chars (not always pretty, but more unique than `tag-N`).