### PR TITLE
[CRM] Remove is_admin bootstrap condition for automations v2

### DIFF
--- a/projects/plugins/crm/changelog/crm-update-remove-is-admin-bootstrap-condition
+++ b/projects/plugins/crm/changelog/crm-update-remove-is-admin-bootstrap-condition
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Automations v2 is still in development, so this is an invisible change
+
+

--- a/projects/plugins/crm/modules/automations/jpcrm-automations-init.php
+++ b/projects/plugins/crm/modules/automations/jpcrm-automations-init.php
@@ -49,11 +49,8 @@ function load_module() {
 	require_once JPCRM_AUTOMATIONS_MODULE_PATH . '/admin/admin-page-init.php';
 	initialize_admin_page();
 
-	/* @todo Refactor this to be part of a separate initialisation process. */
-	if ( is_admin() ) {
-		$bootstrap = new Automation_Bootstrap();
-		$bootstrap->init();
-	}
+	$bootstrap = new Automation_Bootstrap();
+	$bootstrap->init();
 }
 
 add_action( 'jpcrm_load_modules', __NAMESPACE__ . '\load_module' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Remove the (at the time it was added) temporary `is_admin` condition while we figured out what to do to prevent logic leaking into the front-end.

This is bigger issue and will be looked into separately.

Fixes https://github.com/Automattic/zero-bs-crm/issues/3314

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove `is_admin` condition around Automations bootstrap logic.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pbhBOz-2P4-p2#comment-4943

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

If our automated integration tests still work, then everything should be good to go.