### PR TITLE
[CRM] Register database workflows during automation bootstrap

### DIFF
--- a/projects/plugins/crm/changelog/crm-update-automation-bootstrap-db-workflows
+++ b/projects/plugins/crm/changelog/crm-update-automation-bootstrap-db-workflows
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Automations v2 is hidden behind a feature flag so this change is invisible to the user
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -56,7 +56,7 @@ global $wpdb, $ZBSCRM_t;
   $ZBSCRM_t['eventreminders']         = $wpdb->prefix . "zbs_event_reminders";
   $ZBSCRM_t['tax']                    = $wpdb->prefix . "zbs_tax_table";
   $ZBSCRM_t['security_log']           = $wpdb->prefix . "zbs_security_log";
-  $ZBSCRM_t['automation-workflows']   = $wpdb->prefix . 'zbs_workflows'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, Universal.WhiteSpace.PrecisionAlignment.Found
+  $ZBSCRM_t['automation-workflows']  = $wpdb->prefix . 'zbs_workflows'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, Universal.WhiteSpace.PrecisionAlignment.Found
 
 
 /**

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -56,7 +56,7 @@ global $wpdb, $ZBSCRM_t;
   $ZBSCRM_t['eventreminders']         = $wpdb->prefix . "zbs_event_reminders";
   $ZBSCRM_t['tax']                    = $wpdb->prefix . "zbs_tax_table";
   $ZBSCRM_t['security_log']           = $wpdb->prefix . "zbs_security_log";
-  $ZBSCRM_t['automation-workflows']  = $wpdb->prefix . 'zbs_workflows'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, Universal.WhiteSpace.PrecisionAlignment.Found
+  $ZBSCRM_t['automation-workflows']   = $wpdb->prefix . 'zbs_workflows'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, Universal.WhiteSpace.PrecisionAlignment.Found
 
 
 /**
@@ -885,6 +885,7 @@ function zeroBSCRM_createTables(){
 	$sql = 'CREATE TABLE IF NOT EXISTS ' . $ZBSCRM_t['automation-workflows'] . '(
 	`id` INT NOT NULL AUTO_INCREMENT,
 	`zbs_site` INT NOT NULL,
+	`zbs_team` INT NOT NULL,
 	`zbs_owner` INT NOT NULL,
 	`name` VARCHAR(255) NOT NULL,
 	`description` VARCHAR(600) NULL DEFAULT NULL,

--- a/projects/plugins/crm/src/automation/class-automation-bootstrap.php
+++ b/projects/plugins/crm/src/automation/class-automation-bootstrap.php
@@ -244,6 +244,13 @@ final class Automation_Bootstrap {
 	 * @return void
 	 */
 	protected function register_workflows(): void {
+		$workflow_repository = new Workflow\Workflow_Repository();
+		$workflows           = $workflow_repository->find_all(
+			array(
+				'active' => 1,
+			)
+		);
+
 		/**
 		 * Filter list of available workflows.
 		 *
@@ -253,7 +260,7 @@ final class Automation_Bootstrap {
 		 *
 		 * @param Automation_Workflow[] $workflows A collection of registered workflows.
 		 */
-		$workflows = apply_filters( 'jpcrm_automation_workflows', array() );
+		$workflows = apply_filters( 'jpcrm_automation_workflows', $workflows );
 
 		foreach ( $workflows as $workflow ) {
 			if ( $workflow instanceof Automation_Workflow ) {

--- a/projects/plugins/crm/src/automation/class-automation-bootstrap.php
+++ b/projects/plugins/crm/src/automation/class-automation-bootstrap.php
@@ -247,7 +247,7 @@ final class Automation_Bootstrap {
 		$workflow_repository = new Workflow\Workflow_Repository();
 		$workflows           = $workflow_repository->find_all(
 			array(
-				'active' => 1,
+				'active' => true,
 			)
 		);
 

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -91,7 +91,7 @@ class Automation_Workflow {
 	 * The workflow active status.
 	 *
 	 * @since $$next-version$$
-	 * @var int
+	 * @var bool
 	 */
 	public $active;
 
@@ -443,7 +443,7 @@ class Automation_Workflow {
 	 * @return void
 	 */
 	public function turn_on(): void {
-		$this->active = 1;
+		$this->active = true;
 	}
 
 	/**
@@ -454,7 +454,7 @@ class Automation_Workflow {
 	 * @return void
 	 */
 	public function turn_off(): void {
-		$this->active = 0;
+		$this->active = false;
 	}
 
 	/**
@@ -465,7 +465,7 @@ class Automation_Workflow {
 	 * @return bool Whether the workflow is active.
 	 */
 	public function is_active(): bool {
-		return (int) $this->active === 1;
+		return $this->active;
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -120,22 +120,6 @@ class Automation_Workflow {
 	protected $updated_at;
 
 	/**
-	 * A timestamp that reflects when the workflow was created.
-	 *
-	 * @since $$next-version$$
-	 * @var int
-	 */
-	protected $created_at;
-
-	/**
-	 * A timestamp that reflects when the workflow was last updated.
-	 *
-	 * @since $$next-version$$
-	 * @var int
-	 */
-	protected $updated_at;
-
-	/**
 	 * The automation engine.
 	 *
 	 * @since $$next-version$$

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -387,9 +387,9 @@ class Automation_Workflow {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int The index key for the next step of the workflow.
+	 * @return int|string|null The index key for the next step of the workflow.
 	 */
-	public function get_initial_step_index(): int {
+	public function get_initial_step_index() {
 		return $this->initial_step;
 	}
 

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -589,4 +589,14 @@ class Automation_Workflow {
 	public function set_id( $id ): void {
 		$this->id = $id;
 	}
+
+	/**
+	 * Set the workflow category.
+	 *
+	 * @param string $category The workflow category.
+	 * @return void
+	 */
+	public function set_category( string $category ): void {
+		$this->category = $category;
+	}
 }

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -481,7 +481,7 @@ class Automation_Workflow {
 	 * @return bool Whether the workflow is active.
 	 */
 	public function is_active(): bool {
-		return $this->active === 1;
+		return (int) $this->active === 1;
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -91,7 +91,7 @@ class Automation_Workflow {
 	 * The workflow active status.
 	 *
 	 * @since $$next-version$$
-	 * @var bool
+	 * @var int
 	 */
 	public $active;
 
@@ -342,8 +342,9 @@ class Automation_Workflow {
 	 * @since $$next-version$$
 	 *
 	 * @param int|string|null $step_id The initial step id.
+	 * @return void
 	 */
-	public function set_initial_step( $step_id ) {
+	public function set_initial_step( $step_id ): void {
 		$this->initial_step = $step_id;
 	}
 
@@ -458,7 +459,7 @@ class Automation_Workflow {
 	 * @return void
 	 */
 	public function turn_on(): void {
-		$this->active = true;
+		$this->active = 1;
 	}
 
 	/**
@@ -469,7 +470,7 @@ class Automation_Workflow {
 	 * @return void
 	 */
 	public function turn_off(): void {
-		$this->active = false;
+		$this->active = 0;
 	}
 
 	/**
@@ -480,7 +481,7 @@ class Automation_Workflow {
 	 * @return bool Whether the workflow is active.
 	 */
 	public function is_active(): bool {
-		return $this->active;
+		return $this->active === 1;
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -120,6 +120,22 @@ class Automation_Workflow {
 	protected $updated_at;
 
 	/**
+	 * A timestamp that reflects when the workflow was created.
+	 *
+	 * @since $$next-version$$
+	 * @var int
+	 */
+	protected $created_at;
+
+	/**
+	 * A timestamp that reflects when the workflow was last updated.
+	 *
+	 * @since $$next-version$$
+	 * @var int
+	 */
+	protected $updated_at;
+
+	/**
 	 * The automation engine.
 	 *
 	 * @since $$next-version$$

--- a/projects/plugins/crm/src/automation/workflow/class-workflow-repository.php
+++ b/projects/plugins/crm/src/automation/workflow/class-workflow-repository.php
@@ -72,17 +72,49 @@ class Workflow_Repository {
 	/**
 	 * Get all workflows.
 	 *
-	 * @param array $args (Optional) Arguments to filter the workflows result.
 	 * @since $$next-version$$
 	 *
 	 * @return Automation_Workflow[]
 	 */
-	public function find_all( array $args = array() ): array {
-		/** @todo Expand allowed arguments. */
-		if ( empty( $args ) && isset( $args['active'] ) ) {
-			$query = $this->wpdb->prepare( "SELECT * FROM {$this->table_name} WHERE active=%d", (int) $args['active'] ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		} else {
-			$query = "SELECT * FROM {$this->table_name}"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	public function find_all(): array {
+		return $this->find_by( array() );
+	}
+
+	/**
+	 * Find workflows with the given criteria.
+	 *
+	 * @param array $criteria Arguments to filter the workflows result.
+	 * @since $$next-version$$
+	 *
+	 * @return Automation_Workflow[]
+	 */
+	public function find_by( array $criteria ): array {
+
+		// todo: Add $order_by and pagination support with $limit and $offset
+
+		$query = "SELECT * FROM {$this->table_name}";
+
+		$allowed_criteria = array(
+			'active'     => '%d',
+			'name'       => '%s',
+			'category'   => '%s',
+			'created_at' => '%d',
+			'updated_at' => '%d',
+		);
+
+		$where = array();
+
+		// Prepare the WHERE criteria.
+		foreach ( $criteria as $key => $value ) {
+			if ( ! isset( $allowed_criteria[ $key ] ) ) {
+				continue;
+			}
+			$where[] = $this->wpdb->prepare( "{$key}={$allowed_criteria[ $key ]}", $value ); // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+
+		// Build the WHERE clause.
+		if ( ! empty( $where ) ) {
+			$query .= ' WHERE ' . implode( ' AND ', $where );
 		}
 
 		$rows = $this->wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared

--- a/projects/plugins/crm/src/automation/workflow/class-workflow-repository.php
+++ b/projects/plugins/crm/src/automation/workflow/class-workflow-repository.php
@@ -72,12 +72,20 @@ class Workflow_Repository {
 	/**
 	 * Get all workflows.
 	 *
+	 * @param array $args (Optional) Arguments to filter the workflows result.
 	 * @since $$next-version$$
 	 *
 	 * @return Automation_Workflow[]
 	 */
-	public function find_all(): array {
-		$rows = $this->wpdb->get_results( "SELECT * FROM {$this->table_name}", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	public function find_all( $args ): array {
+		/** @todo Expand allowed arguments. */
+		if ( isset( $args['active'] ) ) {
+			$query = $this->wpdb->prepare( "SELECT * FROM {$this->table_name} WHERE active=%d", (int) $args['active'] ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		} else {
+			$query = "SELECT * FROM {$this->table_name}"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+
+		$rows = $this->wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( empty( $rows ) ) {
 			return array();

--- a/projects/plugins/crm/src/automation/workflow/class-workflow-repository.php
+++ b/projects/plugins/crm/src/automation/workflow/class-workflow-repository.php
@@ -77,9 +77,9 @@ class Workflow_Repository {
 	 *
 	 * @return Automation_Workflow[]
 	 */
-	public function find_all( $args ): array {
+	public function find_all( array $args = array() ): array {
 		/** @todo Expand allowed arguments. */
-		if ( isset( $args['active'] ) ) {
+		if ( empty( $args ) && isset( $args['active'] ) ) {
 			$query = $this->wpdb->prepare( "SELECT * FROM {$this->table_name} WHERE active=%d", (int) $args['active'] ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		} else {
 			$query = "SELECT * FROM {$this->table_name}"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared


### PR DESCRIPTION
# This PR is based on https://github.com/Automattic/jetpack/pull/33130 which needs to be merged, first.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Bootstrap all active automation workflows that exist in the database.

Fix https://github.com/Automattic/zero-bs-crm/issues/3326

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add an argument to `Workflow_Repository::find_all()` so we only fetch active workflows.
* Fetch all active workflows from the database and initialise them during automation bootstrap.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

* pbhBOz-2ES-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Run the below snippet ones to add a workflow to the database.
2. Go to `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact`
3. Save the contact _(you don't have to add any data)_
4. Verify that the contact status was set to `Customer`
    * _This isn't default behaviour but rather the workflow in these instructions that forces the status to be "Customer"._

**Add workflow to database snippet**

```php
$workflow = new \Automattic\Jetpack\CRM\Automation\Automation_Workflow(
	[
		'name'         => 'New contact: Set status to "Customer"',
		'description'  => 'This automation will change the status of a contact to "Customer" when they are created.',
		'category'     => 'contact',
		'active'       => 1,
		'triggers'     => [
			\Automattic\Jetpack\CRM\Automation\Triggers\Contact_Created::get_slug(),
		],
		'initial_step' => [
			'slug'            => \Automattic\Jetpack\CRM\Automation\Actions\Update_Contact_Status::get_slug(),
			'attributes'      => [
				'new_status' => 'Customer',
			],
			'next_step_true'  => null,
			'next_step_false' => null,
		],
	]
);

$repo = new \Automattic\Jetpack\CRM\Automation\Workflow\Workflow_Repository();
$workflow = $repo->persist(  $workflow );
```