### PR TITLE
CRM: Update the workflow schema to use pointer steps

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-3312-update-workflow-schema-to-use-pointer-steps
+++ b/projects/plugins/crm/changelog/update-crm-3312-update-workflow-schema-to-use-pointer-steps
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Internal workflow schema update. Adding pointers to the steps inside of a workflow.

--- a/projects/plugins/crm/src/automation/class-automation-engine.php
+++ b/projects/plugins/crm/src/automation/class-automation-engine.php
@@ -414,10 +414,6 @@ class Automation_Engine {
 
 				$step_slug = $step->get_slug();
 
-				if ( isset( $step_data['attributes'] ) && is_array( $step_data['attributes'] ) ) {
-					$step->set_attributes( $step_data['attributes'] );
-				}
-
 				$this->get_logger()->log( '[' . $step->get_slug() . '] Executing step. Type: ' . $step->get_data_type() );
 
 				$data_type = $this->maybe_transform_data_type( $trigger_data_type, $step::get_data_type() );

--- a/projects/plugins/crm/src/automation/class-automation-engine.php
+++ b/projects/plugins/crm/src/automation/class-automation-engine.php
@@ -293,8 +293,8 @@ class Automation_Engine {
 			);
 		}
 
-		$step_name                     = $class_name::get_slug();
-		$this->steps_map[ $step_name ] = $class_name;
+		$step_slug                     = $class_name::get_slug();
+		$this->steps_map[ $step_slug ] = $class_name;
 	}
 
 	/**
@@ -420,7 +420,10 @@ class Automation_Engine {
 
 				$data_type = $this->maybe_transform_data_type( $trigger_data_type, $step::get_data_type() );
 				$step->execute( $data_type->get_entity() );
-				$step_data = $step->get_next_step();
+
+				//todo: return Step instance instead of array
+				$step_id   = $step->get_next_step_id();
+				$step_data = $workflow->get_step( $step_id );
 
 				$this->get_logger()->log( '[' . $step->get_slug() . '] Step executed!' );
 

--- a/projects/plugins/crm/src/automation/class-automation-engine.php
+++ b/projects/plugins/crm/src/automation/class-automation-engine.php
@@ -329,6 +329,8 @@ class Automation_Engine {
 	 * @throws Workflow_Exception Throws an exception if the workflow is not valid.
 	 */
 	public function add_workflow( Automation_Workflow $workflow, bool $init_workflow = false ) {
+		$workflow->set_engine( $this );
+
 		$this->workflows[] = $workflow;
 
 		if ( $init_workflow ) {
@@ -385,8 +387,6 @@ class Automation_Engine {
 		$this->get_logger()->log( sprintf( 'Trigger activated: %s', $trigger->get_slug() ) );
 		$this->get_logger()->log( sprintf( 'Executing workflow: %s', $workflow->name ) );
 
-		$step_data = $workflow->get_initial_step();
-
 		// Convert the trigger data into a data type instance.
 		try {
 			$trigger_data_type = $this->get_data_type_instance( $trigger::get_data_type(), $trigger_data );
@@ -396,6 +396,8 @@ class Automation_Engine {
 				Automation_Exception::GENERAL_ERROR
 			);
 		}
+
+		$step_data = $workflow->get_initial_step();
 
 		while ( $step_data ) {
 			try {

--- a/projects/plugins/crm/src/automation/class-automation-logger.php
+++ b/projects/plugins/crm/src/automation/class-automation-logger.php
@@ -103,6 +103,31 @@ class Automation_Logger {
 	}
 
 	/**
+	 * Get formatted log.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $output Whether or not the log is set to output.
+	 * @return string[]|null The formatted log as array.
+	 */
+	public function formatted_log( $output = false ): ?array {
+		if ( $output ) {
+			echo "***** LOGS *****\n";
+			foreach ( $this->log as $log ) {
+				echo $log[0] . ' - ' . $log[1] . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+			echo "***** END LOGS *****\n";
+		} else {
+			$output = array();
+			foreach ( $this->log as $log ) {
+				$output[] = $log[0] . ' - ' . $log[1]; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+			return $output;
+		}
+		return null;
+	}
+
+	/**
 	 * Add a log entry.
 	 *
 	 * @since $$next-version$$

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -56,12 +56,20 @@ class Automation_Workflow {
 	public $triggers;
 
 	/**
-	 * The workflow initial step.
+	 * The workflow initial step id.
+	 *
+	 * @since $$next-version$$
+	 * @var int|string|null
+	 */
+	public $initial_step_id;
+
+	/**
+	 * The workflow steps list
 	 *
 	 * @since $$next-version$$
 	 * @var array
 	 */
-	public $initial_step;
+	public $steps;
 
 	/**
 	 * The workflow active status.
@@ -103,13 +111,14 @@ class Automation_Workflow {
 	 * @param array $workflow_data The workflow data to be constructed.
 	 */
 	public function __construct( array $workflow_data ) {
-		$this->id           = $workflow_data['id'] ?? null;
-		$this->triggers     = $workflow_data['triggers'] ?? array();
-		$this->initial_step = $workflow_data['initial_step'] ?? array();
-		$this->name         = $workflow_data['name'];
-		$this->description  = $workflow_data['description'] ?? '';
-		$this->category     = $workflow_data['category'] ?? '';
-		$this->active       = $workflow_data['is_active'] ?? true;
+		$this->id              = $workflow_data['id'] ?? null;
+		$this->triggers        = $workflow_data['triggers'] ?? array();
+		$this->steps           = $workflow_data['steps'] ?? array();
+		$this->initial_step_id = $workflow_data['initial_step'] ?? null;
+		$this->name            = $workflow_data['name'];
+		$this->description     = $workflow_data['description'] ?? '';
+		$this->category        = $workflow_data['category'] ?? '';
+		$this->active          = $workflow_data['is_active'] ?? true;
 	}
 
 	/**
@@ -184,10 +193,21 @@ class Automation_Workflow {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $step_data The data for the step to be set as the initial step.
+	 * @param int|string|null $step_id The initial step id.
 	 */
-	public function set_initial_step( array $step_data ) {
-		$this->initial_step = $step_data;
+	public function set_initial_step_id( $step_id ) {
+		$this->initial_step_id = $step_id;
+	}
+
+	/**
+	 * Set the step list of this workflow.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $steps The steps of the workflow.
+	 */
+	public function set_steps( array $steps ) {
+		$this->steps = $steps;
 	}
 
 	/**
@@ -204,8 +224,19 @@ class Automation_Workflow {
 			'category'     => $this->category,
 			'is_active'    => $this->active,
 			'triggers'     => $this->triggers,
-			'initial_step' => $this->initial_step,
+			'initial_step' => $this->initial_step_id,
 		);
+	}
+
+	/**
+	 * Get the initial step data of this workflow.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array|null The initial step data of the workflow.
+	 */
+	public function get_initial_step(): ?array {
+		return $this->steps[ $this->initial_step_id ] ?? null;
 	}
 
 	/**
@@ -213,10 +244,15 @@ class Automation_Workflow {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return array
+	 * @param int|string $id The step id.
+	 * @return array|null The step data instance.
 	 */
-	public function get_initial_step(): array {
-		return $this->initial_step;
+	public function get_step( $id ): ?array {
+		if ( $id === null ) {
+			return null;
+		}
+
+		return $this->steps[ $id ] ?? null;
 	}
 
 	/**
@@ -281,6 +317,7 @@ class Automation_Workflow {
 	 *
 	 * @param Automation_Engine $engine An instance of the Automation_Engine class.
 	 * @return void
+	 * @throws Workflow_Exception|Automation_Exception Exception if there is an issue with the Engine.
 	 */
 	public function set_engine( Automation_Engine $engine ): void {
 		$this->automation_engine = $engine;

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -326,6 +326,9 @@ class Automation_Workflow {
 	 */
 	public function set_engine( Automation_Engine $engine ): void {
 		$this->automation_engine = $engine;
+
+		// Process and check the steps when the engine is set.
+		$this->process_steps();
 	}
 
 	/**
@@ -370,5 +373,19 @@ class Automation_Workflow {
 	 */
 	public function get_logger(): Automation_Logger {
 		return $this->logger ?? Automation_Logger::instance();
+	}
+
+	/**
+	 * Process the steps of the workflow.
+	 *
+	 * @throws Workflow_Exception|Automation_Exception Exception if there is an issue processing the steps.
+	 * @since $$next-version$$
+	 */
+	private function process_steps() {
+		foreach ( $this->steps as $step_data ) {
+			if ( ! isset( $step_data['class_name'] ) ) {
+				$step_data['class_name'] = $this->get_engine()->get_step_class( $step_data['slug'] );
+			}
+		}
 	}
 }

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -166,7 +166,10 @@ class Automation_Workflow {
 	 */
 	public function init_triggers() {
 
+		$this->get_logger()->log( 'Initializing Workflow triggers...' );
+
 		if ( ! $this->is_active() ) {
+			$this->get_logger()->log( 'The workflow is not active. No triggers loaded.' );
 			return;
 		}
 
@@ -177,6 +180,8 @@ class Automation_Workflow {
 				/** @var Base_Trigger $trigger */
 				$trigger = new $trigger_class();
 				$trigger->init( $this );
+
+				$this->get_logger()->log( 'Trigger initialized: ' . $trigger_slug );
 
 			} catch ( Automation_Exception $e ) {
 				throw new Workflow_Exception(

--- a/projects/plugins/crm/src/automation/class-base-condition.php
+++ b/projects/plugins/crm/src/automation/class-base-condition.php
@@ -76,9 +76,9 @@ abstract class Base_Condition extends Base_Step implements Condition {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return array|null The next step data.
+	 * @return int|null The next step data.
 	 */
-	public function get_next_step(): ?array {
+	public function get_next_step_id(): ?int {
 		return ( $this->condition_met ? $this->next_step_true : $this->next_step_false );
 	}
 

--- a/projects/plugins/crm/src/automation/class-base-step.php
+++ b/projects/plugins/crm/src/automation/class-base-step.php
@@ -36,9 +36,9 @@ abstract class Base_Step implements Step {
 	 * Next linked step.
 	 *
 	 * @since $$next-version$$
-	 * @var array|null
+	 * @var int|string|null
 	 */
-	protected $next_step;
+	protected $next_step_id = null;
 
 	/**
 	 * Base_Step constructor.
@@ -100,10 +100,10 @@ abstract class Base_Step implements Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $step_data The next linked step.
+	 * @param int|string|null $step_id The next linked step id.
 	 */
-	public function set_next_step( array $step_data ) {
-		$this->next_step = $step_data;
+	public function set_next_step( $step_id ) {
+		$this->next_step = $step_id;
 	}
 
 	/**
@@ -111,10 +111,10 @@ abstract class Base_Step implements Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return array|null The next linked step.
+	 * @return int|string|null The next linked step id.
 	 */
-	public function get_next_step(): ?array {
-		return $this->next_step;
+	public function get_next_step_id() {
+		return $this->next_step_id;
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/interface-step.php
+++ b/projects/plugins/crm/src/automation/interface-step.php
@@ -30,18 +30,18 @@ interface Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return array|null The next linked step.
+	 * @return int|string|null The next linked step.
 	 */
-	public function get_next_step(): ?array;
+	public function get_next_step_id();
 
 	/**
 	 * Set the next step.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $step_data The next linked step.
+	 * @param int|string|null $step_id The next linked step.
 	 */
-	public function set_next_step( array $step_data );
+	public function set_next_step( $step_id );
 
 	/**
 	 * Get the step attribute definitions.

--- a/projects/plugins/crm/tests/php/automation/class-automation-workflow-test.php
+++ b/projects/plugins/crm/tests/php/automation/class-automation-workflow-test.php
@@ -67,12 +67,15 @@ class Automation_Workflow_Test extends JPCRM_Base_Test_Case {
 		$workflow = new Automation_Workflow( $workflow_data );
 		$workflow->set_engine( $engine );
 
-		$workflow->set_initial_step(
+		$workflow->set_steps(
 			array(
-				'slug'       => 'dummy_step_123',
-				'class_name' => Dummy_Step::class,
+				0 => array(
+					'slug'       => 'dummy_step_123',
+					'class_name' => Dummy_Step::class,
+				),
 			)
 		);
+		$workflow->set_initial_step_id( 0 );
 
 		$contact_data      = $this->automation_faker->contact_data();
 		$automation_result = $workflow->execute( new Contact_Updated(), $contact_data );
@@ -217,11 +220,14 @@ class Automation_Workflow_Test extends JPCRM_Base_Test_Case {
 		$workflow = new Automation_Workflow( $workflow_data );
 		$workflow->set_logger( $logger );
 		$workflow->set_engine( $automation );
-		$workflow->set_initial_step(
+		$workflow->set_steps(
 			array(
-				'slug' => 'dummy_step',
+				0 => array(
+					'slug' => 'dummy_step',
+				),
 			)
 		);
+		$workflow->set_initial_step_id( 0 );
 
 		// Add and init the workflows
 		$automation->add_workflow( $workflow );
@@ -273,7 +279,6 @@ class Automation_Workflow_Test extends JPCRM_Base_Test_Case {
 		$workflow_data = $this->automation_faker->workflow_with_condition_action();
 
 		$workflow = new Automation_Workflow( $workflow_data );
-		$workflow->set_engine( $automation );
 
 		$automation->add_workflow( $workflow );
 		$automation->init_workflows();

--- a/projects/plugins/crm/tests/php/automation/contacts/actions/class-add-remove-contact-tag-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/actions/class-add-remove-contact-tag-test.php
@@ -109,6 +109,7 @@ class Add_Remove_Contact_Tag_Test extends JPCRM_Base_Integration_Test_Case {
 						$tag_id,
 					),
 				),
+				'next_step'  => null,
 			)
 		);
 

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -65,13 +65,17 @@ class Automation_Faker {
 			'triggers'     => array(
 				'jpcrm/contact_created',
 			),
-			'initial_step' => array(
-				'slug'       => 'send_email_action',
-				'attributes' => array(
-					'to'       => 'admin@example.com',
-					'template' => 'send_welcome_email',
+			'initial_step' => 0,
+			'steps'        => array(
+				// Step 0
+				0 => array(
+					'slug'       => 'send_email_action',
+					'attributes' => array(
+						'to'       => 'admin@example.com',
+						'template' => 'send_welcome_email',
+					),
+					'next_step'  => null,
 				),
-				'next_step'  => null,
 			),
 		);
 	}
@@ -186,18 +190,24 @@ class Automation_Faker {
 			'triggers'     => array(
 				'jpcrm/contact_created',
 			),
-			'initial_step' => array(
-				'slug'            => 'contact_status_condition',
-				'class_name'      => Contact_Condition::class,
-				'attributes'      => array(
-					'field'    => 'status',
-					'operator' => 'is',
-					'value'    => 'lead',
+			'initial_step' => 0,
+			'steps'        => array(
+				// Step 0
+				0 => array(
+					'slug'            => 'contact_status_condition',
+					'class_name'      => Contact_Condition::class,
+					'attributes'      => array(
+						'field'    => 'status',
+						'operator' => 'is',
+						'value'    => 'lead',
+					),
+					'next_step_true'  => 1,
+					'next_step_false' => null,
 				),
-				'next_step_true'  => array(
+				// Step 1
+				1 => array(
 					'slug' => 'dummy_step',
 				),
-				'next_step_false' => null,
 			),
 		);
 	}
@@ -215,15 +225,21 @@ class Automation_Faker {
 			'triggers'     => array(
 				$trigger_slug,
 			),
-			'initial_step' => array(
-				'slug'            => Contact_Field_Changed::get_slug(),
-				'attributes'      => array(
-					'field'    => 'status',
-					'operator' => 'is',
-					'value'    => 'Lead',
+			'initial_step' => 0,
+			'steps'        => array(
+				// Step 0
+				0 => array(
+					'slug'            => Contact_Field_Changed::get_slug(),
+					'attributes'      => array(
+						'field'    => 'status',
+						'operator' => 'is',
+						'value'    => 'Lead',
+					),
+					'next_step_true'  => 1,
+					'next_step_false' => null,
 				),
-				'next_step_true'  => $action_data,
-				'next_step_false' => null,
+				// Step 1
+				1 => $action_data,
 			),
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/zero-bs-crm/issues/3312

## Proposed changes:

This PR updates the Workflow schema and the steps inside of it. Now, steps are linked through pointers, with the step id.

Example of Workflow:

```
array(
    'id'           => 'testing',
    'name'         => 'New Contact',
    'active'       => true,
    'version'      => 1,
    'description'  => 'This automation will change the status of a contact to "Customer" when they are created.',
    'category'     => 'Contact',
    'triggers'     => array(
        'jpcrm/invoice_created',
    ),
    'initial_step' => 'step_1',
    'steps'        => array(
        'step_1' => array(
            'slug'       => 'jpcrm/update_contact_status',
            'attributes' => array(
                'new_status' => 'Customer',
            ),
            'next_step'  => 'step_2',
        ),
        'step_2' => array(
            'slug'       => 'jpcrm/send_email',
            'attributes' => array(
                'to'      => 'admin@example.com',
                'subject' => 'New Customer',
                'body'    => 'A new customer has been created.',
            ),
            'next_step'  => null,
        ),
    ),
);
```
Now, instead of having the `initial_step` with all the step info linked (folder scheme), we have the new `steps` array with an index (step ID), and the `initial_step` has the step id (index). Also, `next_step` `next_step_true` `next_step_false` is the ID of the next step.

**Note**: We should work in our model with the Step instance rather than retrieving IDs. This will be handled in a following PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pbhBOz-3Wf-p2

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Check the code.
- Check that the tests continue passing.

