### PR TITLE
Social: Only allow selectable attached media types

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-only-allow-selectable-attached-media-types
+++ b/projects/js-packages/publicize-components/changelog/fix-social-only-allow-selectable-attached-media-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only allow selectable image types for Social attached media

--- a/projects/js-packages/publicize-components/src/components/media-picker/index.js
+++ b/projects/js-packages/publicize-components/src/components/media-picker/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, closeSmall } from '@wordpress/icons';
 import classNames from 'classnames';
 import { isVideo } from '../../hooks/use-media-restrictions';
+import { SELECTABLE_IMAGE_TYPES } from '../../hooks/use-media-restrictions/restrictions';
 import VideoPreview from '../video-preview';
 import styles from './styles.module.scss';
 
@@ -124,6 +125,7 @@ export default function MediaPicker( {
 		<ThemeProvider>
 			<MediaUploadCheck>
 				<MediaUpload
+					allowedTypes={ SELECTABLE_IMAGE_TYPES }
 					title={ buttonLabel }
 					onSelect={ onUpdateMedia }
 					render={ setMediaRender }

--- a/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
@@ -10,8 +10,9 @@ const VIDEOPRESS = 'video/videopress';
 const allowedImageTypes = [ 'image/jpeg', 'image/jpg', 'image/png' ];
 const facebookImageTypes = allowedImageTypes.concat( [
 	'image/gif',
-	'image/tiff',
-	'image/tif',
+	// We do not support tiff image, because Wordpress Core cannot display it.
+	// 'image/tiff',
+	// 'image/tif',
 	'image/bmp',
 ] );
 const facebookVideoTypes = [
@@ -155,9 +156,23 @@ export const PHOTON_CONVERTIBLE_TYPES = [
 	'image/png',
 	'image/jpeg',
 	'image/jpg',
-	'image/tiff',
-	'image/tif',
+	// We do not support tiff image, because Wordpress Core cannot display it.
+	// 'image/tiff',
+	// 'image/tif',
 	'image/heic',
 	'image/heif',
 	'image/webp',
+];
+
+/**
+ * These are the types that can be selected in the media picker.
+ * Contains all the allowed types, plus the Photon convertible types.
+ */
+export const SELECTABLE_IMAGE_TYPES = [
+	...new Set( [
+		...allowedImageTypes,
+		...facebookImageTypes,
+		...mastodonImageTypes,
+		...PHOTON_CONVERTIBLE_TYPES,
+	] ),
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue we had with `TIFF` files, and also only let's you select image types we either accept or be able to conveert.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Commented out `TIFF` as long as we cannot display the converted image in the picker
* Added the `allowedTypes` prop to the MediaUpload component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/orgs/Automattic/projects/733/views/2?pane=issue&itemId=38897474
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try to select a `TIFF` as attached media on trunk, it should be a spinner forever.
* Check out this PR, now you should not see the image in the media lib picker component to select

