### PR TITLE
Add tracking to WooCommerce my account page

### DIFF
--- a/projects/plugins/jetpack/changelog/add-woocommerce-my-account-tracking
+++ b/projects/plugins/jetpack/changelog/add-woocommerce-my-account-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add tracking to my account page in WooCommerce

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
@@ -29,14 +29,14 @@ class Jetpack_WooCommerce_Analytics {
 	/**
 	 * Instance of the Universal functions
 	 *
-	 * @var Static property to hold concrete analytics impl that does the work (universal or legacy)
+	 * @var Static property to hold concrete analytics implementation that does the work (universal or legacy)
 	 */
 	private static $analytics = false;
 
 	/**
 	 * Instance of the My account functions
 	 *
-	 * @var Static property to hold concrete analytics impl that does the work.
+	 * @var Static property to hold concrete analytics implementation that does the work.
 	 */
 	private static $myaccount = false;
 

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
@@ -9,7 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require __DIR__ . '/classes/class-jetpack-woocommerce-analytics-trait.php';
 require_once __DIR__ . '/classes/class-jetpack-woocommerce-analytics-universal.php';
+require_once __DIR__ . '/classes/class-jetpack-woocommerce-analytics-my-account.php';
 
 /**
  * Class Jetpack_WooCommerce_Analytics
@@ -30,6 +32,13 @@ class Jetpack_WooCommerce_Analytics {
 	 * @var Static property to hold concrete analytics impl that does the work (universal or legacy)
 	 */
 	private static $analytics = false;
+
+	/**
+	 * Instance of the My account functions
+	 *
+	 * @var Static property to hold concrete analytics impl that does the work.
+	 */
+	private static $myaccount = false;
 
 	/**
 	 * WooCommerce Analytics is only available to Jetpack connected WooCommerce stores with both plugins set to active
@@ -69,6 +78,7 @@ class Jetpack_WooCommerce_Analytics {
 	 */
 	private function __construct() {
 		self::$analytics = new Jetpack_WooCommerce_Analytics_Universal();
+		self::$myaccount = new Jetpack_WooCommerce_Analytics_My_Account();
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
@@ -55,7 +55,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 		if ( ! empty( $wp->query_vars ) ) {
 
 			foreach ( $wp->query_vars as $key => $value ) {
-				// we skip pagename
+				// we skip pagename.
 				if ( 'pagename' === $key ) {
 					continue;
 				}
@@ -104,7 +104,8 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 				}
 
 				/**
-				 * We don't want to register the custom endpoint name but the core name for.
+				 * $core_endpoints is an array of core_permalink => custom_permalink,
+				 * query_vars gives us the custom_permalink, but we want to track it as core_permalink.
 				 */
 				if ( array_search( $key, $core_endpoints, true ) ) {
 					$key = array_search( $key, $core_endpoints, true );
@@ -193,7 +194,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 				jQuery('.woocommerce-MyAccount-navigation-link--customer-logout').on('click', function() {
 					_wca.push({
 							'_en': 'woocommerceanalytics_my_account_tab_click',
-							'pi': 'logout'," .
+							'tab': 'logout'," .
 							$common_props . '
 					});
 				});

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Jetpack_WooCommerce_Analytics_My_Account {
 
 	use Jetpack_WooCommerce_Analytics_Trait;
+
 	/**
 	 * Jetpack_WooCommerce_Analytics_My_Account constructor.
 	 */

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
@@ -78,6 +78,12 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 				}
 
 				if ( $core_endpoints['edit-address'] === $key && in_array( $value, array( 'billing', 'shipping' ), true ) ) {
+					$refer = wp_get_referer();
+					if ( $refer === wc_get_endpoint_url( 'edit-address', $value ) ) {
+						// It means we're likely coming from the same page after a failed save and don't want to retrigger the address click event.
+						continue;
+					}
+
 					$this->record_event( 'woocommerceanalytics_my_account_address_click', array( 'address' => $value ) );
 					continue;
 				}
@@ -87,6 +93,13 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 					continue;
 				}
 
+				if ( $core_endpoints['edit-address'] ) {
+					$refer = wp_get_referer();
+					if ( $refer === wc_get_endpoint_url( 'edit-address', 'billing' ) || $refer === wc_get_endpoint_url( 'edit-address', 'shipping' ) ) {
+						// It means we're likely coming from the edit page save and don't want to retrigger the page view event.
+						continue;
+					}
+				}
 				/**
 				 * The main dashboard view has page as key, so we rename it.
 				 */

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Jetpack_WooCommerce_Analytics_My_Account
+ *
+ * @package automattic/jetpack
+ * @author  Automattic
+ */
+
+/**
+ * Bail if accessed directly
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Jetpack_WooCommerce_Analytics_My_Account
+ * Filters and Actions added to My Account pages to perform analytics
+ */
+class Jetpack_WooCommerce_Analytics_My_Account {
+
+	use Jetpack_WooCommerce_Analytics_Trait;
+	/**
+	 * Jetpack_WooCommerce_Analytics_My_Account constructor.
+	 */
+	public function __construct() {
+
+		add_action( 'woocommerce_account_content', array( $this, 'track_tabs' ) );
+		add_action( 'woocommerce_customer_save_address', array( $this, 'track_save_address' ), 10, 2 );
+		add_action( 'wp', array( $this, 'track_add_payment_method' ) );
+		add_action( 'wp', array( $this, 'track_delete_payment_method' ) );
+		add_action( 'woocommerce_save_account_details', array( $this, 'track_save_account_details' ) );
+		add_action( 'wp_logout', array( $this, 'track_logouts' ) );
+		add_filter( 'woocommerce_my_account_my_orders_actions', array( $this, 'add_initiator_prop_to_my_account_action_links' ) );
+		add_action( 'woocommerce_cancelled_order', array( $this, 'track_order_cancel_event' ), 10, 0 );
+		add_action( 'before_woocommerce_pay', array( $this, 'track_order_pay_event' ) );
+		add_action( 'woocommerce_account_content', array( $this, 'add_initiator_prop_to_order_urls' ) );
+		add_filter( 'query_vars', array( $this, 'add_initiator_param_to_query_vars' ) );
+	}
+
+	/**
+	 * Track my account tabs, we only trigger an event if a tab is viewed.
+	 *
+	 * We also track other events here, like order number clicks, order action clicks,
+	 * address clicks, payment method add and delete.
+	 */
+	public function track_tabs() {
+		global $wp;
+
+		// WooCommerce keeps a map of my-account endpoints keys and their custom permalinks.
+		$core_endpoints = WC()->query->get_query_vars();
+
+		if ( ! empty( $wp->query_vars ) ) {
+
+			foreach ( $wp->query_vars as $key => $value ) {
+				// we skip pagename
+				if ( 'pagename' === $key ) {
+					continue;
+				}
+
+				// We don't want to track our own analytics params.
+				if ( '_wca_initiator' === $key ) {
+					continue;
+				}
+
+				if ( $core_endpoints['view-order'] === $key && is_numeric( $value ) ) {
+					$initiator = get_query_var( '_wca_initiator' );
+					if ( 'number' === $initiator ) {
+						$this->record_event( 'woocommerceanalytics_my_account_order_number_click' );
+						continue;
+					}
+					if ( 'action' === $initiator ) {
+						$this->record_event( 'woocommerceanalytics_my_account_order_action_click', array( 'action' => 'view' ) );
+						continue;
+					}
+				}
+
+				if ( $core_endpoints['edit-address'] === $key && in_array( $value, array( 'billing', 'shipping' ), true ) ) {
+					$this->record_event( 'woocommerceanalytics_my_account_address_click', array( 'address' => $value ) );
+					continue;
+				}
+
+				if ( $core_endpoints['add-payment-method'] === $key ) {
+					$this->record_event( 'woocommerceanalytics_my_account_payment_add' );
+					continue;
+				}
+
+				/**
+				 * The main dashboard view has page as key, so we rename it.
+				 */
+				if ( 'page' === $key ) {
+					$key = 'dashboard';
+				}
+
+				/**
+				 * If a custom permalink is used for one of the pages, query_vars will have 2 keys, the custom permalink and the core endpoint key.
+				 * To avoid triggering the event twice, we skip the core one and only track the custom one.
+				 * Tracking the custom endpoint is safer than hoping the duplicated, redundant core endpoint is always present.
+				 */
+				if ( $core_endpoints[ $key ] && $core_endpoints[ $key ] !== $key ) {
+					continue;
+				}
+
+				/**
+				 * We don't want to register the custom endpoint name but the core name for.
+				 */
+				if ( array_search( $key, $core_endpoints, true ) ) {
+					$key = array_search( $key, $core_endpoints, true );
+				}
+
+				$this->record_event( 'woocommerceanalytics_my_account_page_view', array( 'tab' => $key ) );
+			}
+		}
+	}
+
+	/**
+	 * Track address save events, this can only come from the my account page.
+	 *
+	 * @param int    $customer_id The customer id.
+	 * @param string $load_address The address type (billing, shipping).
+	 */
+	public function track_save_address( $customer_id, $load_address ) {
+		$this->record_event( 'woocommerceanalytics_my_account_address_save', array( 'address' => $load_address ) );
+	}
+
+	/**
+	 * Track payment method add events, this can only come from the my account page.
+	 */
+	public function track_add_payment_method() {
+		if ( isset( $_POST['woocommerce_add_payment_method'] ) && isset( $_POST['payment_method'] ) ) {
+
+			$nonce_value = wc_get_var( $_REQUEST['woocommerce-add-payment-method-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+
+			if ( ! wp_verify_nonce( $nonce_value, 'woocommerce-add-payment-method' ) ) {
+				return;
+			}
+
+			$this->record_event( 'woocommerceanalytics_my_account_details_save' );
+			return;
+		}
+	}
+
+	/**
+	 * Track payment method delete events.
+	 */
+	public function track_delete_payment_method() {
+		global $wp;
+		if ( isset( $wp->query_vars['delete-payment-method'] ) ) {
+			$this->record_event( 'woocommerceanalytics_my_account_payment_delete' );
+			return;
+		}
+	}
+
+	/**
+	 * Track order cancel events.
+	 */
+	public function track_order_cancel_event() {
+		if ( isset( $_GET['_wca_initiator'] ) && ( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'woocommerce-cancel_order' ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$this->record_event( 'woocommerceanalytics_my_account_order_action_click', array( 'action' => 'cancel' ) );
+		}
+	}
+
+	/**
+	 * Track order pay events.
+	 */
+	public function track_order_pay_event() {
+		if ( isset( $_GET['_wca_initiator'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$this->record_event( 'woocommerceanalytics_my_account_order_action_click', array( 'action' => 'pay' ) );
+		}
+	}
+
+	/**
+	 * Track account details save events, this can only come from the my account page.
+	 */
+	public function track_save_account_details() {
+		$this->record_event( 'woocommerceanalytics_my_account_details_save' );
+	}
+
+	/**
+	 * Track logout events.
+	 */
+	public function track_logouts() {
+		$referrer = wp_get_referer();
+
+		if ( ! $referrer ) {
+			return;
+		}
+		// check if the dashboard url is contained whithin the referrer url
+		if ( false === strpos( $referrer, wc_get_account_endpoint_url( 'dashboard' ) ) ) {
+			return;
+		}
+
+		$this->record_event( 'woocommerceanalytics_my_account_tab_click', array( 'tab' => 'logout' ) );
+	}
+
+	/**
+	 * Add referrer prop to my account action links
+	 *
+	 * @param array $actions My account action links.
+	 * @return array
+	 */
+	public function add_initiator_prop_to_my_account_action_links( $actions ) {
+		foreach ( $actions as $key => $action ) {
+			if ( ! isset( $action['url'] ) ) {
+				continue;
+			}
+			$url                    = add_query_arg( array( '_wca_initiator' => 'action' ), $action['url'] );
+			$actions[ $key ]['url'] = $url;
+		}
+
+		return $actions;
+	}
+
+	/**
+	 * Add an initiator prop to the order url.
+	 *
+	 * The get_view_order_url is used in a lot of places,
+	 * so we want to limit it just to my account page.
+	 */
+	public function add_initiator_prop_to_order_urls() {
+		add_filter(
+			'woocommerce_get_view_order_url',
+			function ( $url ) {
+				return add_query_arg( array( '_wca_initiator' => 'number' ), $url );
+			},
+			10,
+			1
+		);
+
+		add_filter(
+			'woocommerce_get_endpoint_url',
+			function ( $url, $endpoint ) {
+				if ( 'edit-address' === $endpoint ) {
+					return add_query_arg( array( '_wca_initiator' => 'action' ), $url );
+				}
+				return $url;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Add initiator to query vars
+	 *
+	 * @param array $query_vars Query vars.
+	 * @return array
+	 */
+	public function add_initiator_param_to_query_vars( $query_vars ) {
+		$query_vars[] = '_wca_initiator';
+		return $query_vars;
+	}
+}

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
@@ -60,6 +60,11 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 					continue;
 				}
 
+				// When no permalink is set, the first page is page_id, so we skip it.
+				if ( 'page_id' === $key ) {
+					continue;
+				}
+
 				// We don't want to track our own analytics params.
 				if ( '_wca_initiator' === $key ) {
 					continue;

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -68,16 +68,16 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		wc_enqueue_js( "_wca.push({$js});" );
 	}
 
-			/**
-			 * Compose event properties.
-			 *
-			 * @param string  $event_name The name of the event to record.
-			 * @param array   $properties Optional array of (key => value) event properties.
-			 * @param integer $product_id Optional id of the product relating to the event.
-			 *
-			 * @return string|void
-			 */
-	public function process_event_properties( $event_name, $properties = array(), $product_id = null, ) {
+	/**
+	 * Compose event properties.
+	 *
+	 * @param string  $event_name The name of the event to record.
+	 * @param array   $properties Optional array of (key => value) event properties.
+	 * @param integer $product_id Optional id of the product relating to the event.
+	 *
+	 * @return string|void
+	 */
+	public function process_event_properties( $event_name, $properties = array(), $product_id = null ) {
 
 		// Only set product details if we have a product id.
 		if ( $product_id ) {

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -225,27 +225,35 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		return $info;
 	}
 
-	/**
-	 * Search a specific post for text content.
-	 *
-	 * @param integer $post_id The id of the post to search.
-	 * @param string  $text    The text to search for.
-	 * @return integer 1 if post contains $text (otherwise 0).
-	 */
+		/**
+		 * Search a specific post for text content.
+		 *
+		 * Note: similar code is in a WooCommerce core PR:
+		 * https://github.com/woocommerce/woocommerce/pull/25932
+		 *
+		 * @param integer $post_id The id of the post to search.
+		 * @param string  $text    The text to search for.
+		 * @return integer 1 if post contains $text (otherwise 0).
+		 */
 	public function post_contains_text( $post_id, $text ) {
-		// Get the post object by post ID.
-		$post = get_post( $post_id );
+		global $wpdb;
 
-		// If the post doesn't exist or doesn't have content, return 0.
-		if ( ! $post || ! isset( $post->post_content ) ) {
-			return 0;
-		}
+		// Search for the text anywhere in the post.
+		$wildcarded = "%{$text}%";
 
-		// Use PHP's native string search functions to look for the text.
-		if ( strpos( $post->post_content, $text ) !== false ) {
-			return 1;
-		}
+		// No better way to search post content without having filters expanding blocks.
+		// This is already cached up in the parent function.
+		$result = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"
+				SELECT COUNT( * ) FROM {$wpdb->prefix}posts
+				WHERE ID=%d
+				AND {$wpdb->prefix}posts.post_content LIKE %s
+				",
+				array( $post_id, $wildcarded )
+			)
+		);
 
-		return 0;
+		return ( '0' !== $result ) ? 1 : 0;
 	}
 }

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Jetpack_WooCommerce_Analytics_Trait
+ *
+ * @package automattic/jetpack
+ * @author  Automattic
+ */
+
+/**
+ * Bail if accessed directly
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Jetpack_WooCommerce_Analytics_Trait
+ * Common functionality for WooCommerce Analytics classes.
+ */
+trait Jetpack_WooCommerce_Analytics_Trait {
+
+	/**
+	 * Default event properties which should be included with all events.
+	 *
+	 * @return array Array of standard event props.
+	 */
+	public function get_common_properties() {
+		$site_info          = array(
+			'blog_id'     => Jetpack::get_option( 'id' ),
+			'ui'          => $this->get_user_id(),
+			'url'         => home_url(),
+			'woo_version' => WC()->version,
+			'store_admin' => in_array( 'administrator', wp_get_current_user()->roles, true ) ? 1 : 0,
+		);
+		$cart_checkout_info = $this->get_cart_checkout_info();
+		return array_merge( $site_info, $cart_checkout_info );
+	}
+
+	/**
+	 * Render tracks event properties as string of JavaScript object props.
+	 *
+	 * @param  array $properties Array of key/value pairs.
+	 * @return string String of the form "key1: value1, key2: value2, " (etc).
+	 */
+	private function render_properties_as_js( $properties ) {
+		$js_args_string = '';
+		foreach ( $properties as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$js_args_string = $js_args_string . "'$key': " . wp_json_encode( $value ) . ',';
+			} else {
+				$js_args_string = $js_args_string . "'$key': '" . esc_js( $value ) . "', ";
+			}
+		}
+		return $js_args_string;
+	}
+
+		/**
+		 * Record an event with optional product and custom properties.
+		 *
+		 * @param string  $event_name The name of the event to record.
+		 * @param array   $properties Optional array of (key => value) event properties.
+		 * @param integer $product_id The id of the product relating to the event.
+		 *
+		 * @return string|void
+		 */
+	public function record_event( $event_name, $properties = array(), $product_id = null ) {
+		$js = $this->process_event_properties( $event_name, $properties, $product_id );
+		wc_enqueue_js( "_wca.push({$js});" );
+	}
+
+			/**
+			 * Compose event properties.
+			 *
+			 * @param string  $event_name The name of the event to record.
+			 * @param array   $properties Optional array of (key => value) event properties.
+			 * @param integer $product_id Optional id of the product relating to the event.
+			 *
+			 * @return string|void
+			 */
+	public function process_event_properties( $event_name, $properties = array(), $product_id = null, ) {
+
+		// Only set product details if we have a product id.
+		if ( $product_id ) {
+			$product = wc_get_product( $product_id );
+			if ( ! $product instanceof WC_Product ) {
+				return;
+			}
+			$product_details = $this->get_product_details( $product );
+		}
+
+		/**
+		 * Allow defining custom event properties in WooCommerce Analytics.
+		 *
+		 * @module woocommerce-analytics
+		 *
+		 * @since 12.5
+		 *
+		 * @param array $all_props Array of event props to be filtered.
+		 */
+		$all_props = apply_filters(
+			'jetpack_woocommerce_analytics_event_props',
+			array_merge(
+				$properties,
+				$this->get_common_properties()
+			)
+		);
+
+		$js = "{'_en': '" . esc_js( $event_name ) . "'";
+
+		if ( isset( $product_details ) ) {
+				$js .= ",'pi': '" . esc_js( $product_id ) . "'";
+				$js .= ",'pn': '" . esc_js( $product_details['name'] ) . "'";
+				$js .= ",'pc': '" . esc_js( $product_details['category'] ) . "'";
+				$js .= ",'pp': '" . esc_js( $product_details['price'] ) . "'";
+				$js .= ",'pt': '" . esc_js( $product_details['type'] ) . "'";
+		}
+
+		$js .= ',' . $this->render_properties_as_js( $all_props ) . '}';
+
+		return $js;
+	}
+
+	/**
+	 * Get the current user id
+	 *
+	 * @return int
+	 */
+	public function get_user_id() {
+		if ( is_user_logged_in() ) {
+			$blogid = Jetpack::get_option( 'id' );
+			$userid = get_current_user_id();
+			return $blogid . ':' . $userid;
+		}
+		return 'null';
+	}
+
+	/**
+	 * Get info about the cart & checkout pages, in particular
+	 * whether the store is using shortcodes or Gutenberg blocks.
+	 * This info is cached in a transient.
+	 *
+	 * Note: similar code is in a WooCommerce core PR:
+	 * https://github.com/woocommerce/woocommerce/pull/25932
+	 *
+	 * @return array
+	 */
+	public static function get_cart_checkout_info() {
+		$transient_name = 'jetpack_woocommerce_analytics_cart_checkout_info_cache';
+
+		$info = get_transient( $transient_name );
+
+		// Return cached data early to prevent additional processing, the transient lasts for 1 day.
+		if ( false !== $info ) {
+			return $info;
+		}
+
+		// If WC Blocks is version 10.6.0 or above, it's using the Cart/Checkout templates.
+		$cart_checkout_templates_in_use = class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && version_compare( Automattic\WooCommerce\Blocks\Package::get_version(), '10.6.0', '>=' );
+
+		if ( ! $cart_checkout_templates_in_use ) {
+			$cart_page_id     = wc_get_page_id( 'cart' );
+			$checkout_page_id = wc_get_page_id( 'checkout' );
+
+			$info = array(
+				'cart_page_contains_cart_block'         => self::post_contains_text(
+					$cart_page_id,
+					'<!-- wp:woocommerce/cart'
+				),
+				'cart_page_contains_cart_shortcode'     => self::post_contains_text(
+					$cart_page_id,
+					'[woocommerce_cart]'
+				),
+				'checkout_page_contains_checkout_block' => self::post_contains_text(
+					$checkout_page_id,
+					'<!-- wp:woocommerce/checkout'
+				),
+				'checkout_page_contains_checkout_shortcode' => self::post_contains_text(
+					$checkout_page_id,
+					'[woocommerce_checkout]'
+				),
+			);
+			set_transient( $transient_name, $info, DAY_IN_SECONDS );
+			return $info;
+		}
+
+		// We will only reach here if the Cart/Checkout templates are in use.
+
+		$cart_template        = null;
+		$checkout_template    = null;
+		$cart_template_id     = null;
+		$checkout_template_id = null;
+		$block_controller     = Automattic\WooCommerce\Blocks\Package::container()->get( Automattic\WooCommerce\Blocks\BlockTemplatesController::class );
+		$templates            = $block_controller->get_block_templates( array( 'cart', 'checkout' ) );
+
+		foreach ( $templates as $template ) {
+			if ( 'cart' === $template->slug ) {
+				$cart_template_id = ( $template->id );
+				continue;
+			}
+			if ( 'checkout' === $template->slug ) {
+				$checkout_template_id = ( $template->id );
+			}
+		}
+
+		// Get the template and its contents from the IDs we found above.
+		if ( function_exists( 'get_block_template' ) ) {
+			$cart_template     = get_block_template( $cart_template_id );
+			$checkout_template = get_block_template( $checkout_template_id );
+		}
+
+		if ( function_exists( 'gutenberg_get_block_template' ) ) {
+			$cart_template     = get_block_template( $cart_template_id );
+			$checkout_template = get_block_template( $checkout_template_id );
+		}
+
+		// Update the info transient with data we got from the templates, if the site isn't using WC Blocks we
+		// won't be doing this so no concern about overwriting.
+		$info = array(
+			'cart_page_contains_cart_block'             => str_contains( $cart_template->content, '<!-- wp:woocommerce/cart' ) ? 1 : 0,
+			'cart_page_contains_cart_shortcode'         => str_contains( $cart_template->content, '[woocommerce_cart]' ) ? 1 : 0,
+			'checkout_page_contains_checkout_block'     => str_contains( $checkout_template->content, '<!-- wp:woocommerce/checkout' ) ? 1 : 0,
+			'checkout_page_contains_checkout_shortcode' => str_contains( $checkout_template->content, '[woocommerce_checkout]' ) ? 1 : 0,
+		);
+		set_transient( $transient_name, $info, DAY_IN_SECONDS );
+		return $info;
+	}
+
+		/**
+		 * Search a specific post for text content.
+		 *
+		 * Note: similar code is in a WooCommerce core PR:
+		 * https://github.com/woocommerce/woocommerce/pull/25932
+		 *
+		 * @param integer $post_id The id of the post to search.
+		 * @param string  $text    The text to search for.
+		 * @return integer 1 if post contains $text (otherwise 0).
+		 */
+	public function post_contains_text( $post_id, $text ) {
+		global $wpdb;
+
+		// Search for the text anywhere in the post.
+		$wildcarded = "%{$text}%";
+
+		$result = $wpdb->get_var(
+			$wpdb->prepare(
+				"
+				SELECT COUNT( * ) FROM {$wpdb->prefix}posts
+				WHERE ID=%d
+				AND {$wpdb->prefix}posts.post_content LIKE %s
+				",
+				array( $post_id, $wildcarded )
+			)
+		);
+
+		return ( '0' !== $result ) ? 1 : 0;
+	}
+}

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -225,33 +225,27 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		return $info;
 	}
 
-		/**
-		 * Search a specific post for text content.
-		 *
-		 * Note: similar code is in a WooCommerce core PR:
-		 * https://github.com/woocommerce/woocommerce/pull/25932
-		 *
-		 * @param integer $post_id The id of the post to search.
-		 * @param string  $text    The text to search for.
-		 * @return integer 1 if post contains $text (otherwise 0).
-		 */
+	/**
+	 * Search a specific post for text content.
+	 *
+	 * @param integer $post_id The id of the post to search.
+	 * @param string  $text    The text to search for.
+	 * @return integer 1 if post contains $text (otherwise 0).
+	 */
 	public function post_contains_text( $post_id, $text ) {
-		global $wpdb;
+		// Get the post object by post ID.
+		$post = get_post( $post_id );
 
-		// Search for the text anywhere in the post.
-		$wildcarded = "%{$text}%";
+		// If the post doesn't exist or doesn't have content, return 0.
+		if ( ! $post || ! isset( $post->post_content ) ) {
+			return 0;
+		}
 
-		$result = $wpdb->get_var(
-			$wpdb->prepare(
-				"
-				SELECT COUNT( * ) FROM {$wpdb->prefix}posts
-				WHERE ID=%d
-				AND {$wpdb->prefix}posts.post_content LIKE %s
-				",
-				array( $post_id, $wildcarded )
-			)
-		);
+		// Use PHP's native string search functions to look for the text.
+		if ( strpos( $post->post_content, $text ) !== false ) {
+			return 1;
+		}
 
-		return ( '0' !== $result ) ? 1 : 0;
+		return 0;
 	}
 }

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -20,6 +20,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Filters and Actions added to Store pages to perform analytics
  */
 class Jetpack_WooCommerce_Analytics_Universal {
+
+	/**
+	 * Trait to handle common analytics functions.
+	 */
+	use Jetpack_WooCommerce_Analytics_Trait;
+
 	/**
 	 * Jetpack_WooCommerce_Analytics_Universal constructor.
 	 */
@@ -80,101 +86,6 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	}
 
 	/**
-	 * Default event properties which should be included with all events.
-	 *
-	 * @return array Array of standard event props.
-	 */
-	public function get_common_properties() {
-		$site_info          = array(
-			'blog_id'     => Jetpack::get_option( 'id' ),
-			'ui'          => $this->get_user_id(),
-			'url'         => home_url(),
-			'woo_version' => WC()->version,
-			'store_admin' => in_array( 'administrator', wp_get_current_user()->roles, true ) ? 1 : 0,
-		);
-		$cart_checkout_info = self::get_cart_checkout_info();
-		return array_merge( $site_info, $cart_checkout_info );
-	}
-
-	/**
-	 * Render tracks event properties as string of JavaScript object props.
-	 *
-	 * @param  array $properties Array of key/value pairs.
-	 * @return string String of the form "key1: value1, key2: value2, " (etc).
-	 */
-	private function render_properties_as_js( $properties ) {
-		$js_args_string = '';
-		foreach ( $properties as $key => $value ) {
-			if ( is_array( $value ) ) {
-				$js_args_string = $js_args_string . "'$key': " . wp_json_encode( $value ) . ',';
-			} else {
-				$js_args_string = $js_args_string . "'$key': '" . esc_js( $value ) . "', ";
-			}
-		}
-		return $js_args_string;
-	}
-
-	/**
-	 * Record an event with optional custom properties.
-	 *
-	 * @param string  $event_name The name of the event to record.
-	 * @param integer $product_id The id of the product relating to the event.
-	 * @param array   $properties Optional array of (key => value) event properties.
-	 *
-	 * @return string|void
-	 */
-	public function record_event( $event_name, $product_id, $properties = array() ) {
-		$js = $this->process_event_properties( $event_name, $product_id, $properties );
-		wc_enqueue_js( "_wca.push({$js});" );
-	}
-
-	/**
-	 * Compose event properties.
-	 *
-	 * @param string  $event_name The name of the event to record.
-	 * @param integer $product_id The id of the product relating to the event.
-	 * @param array   $properties Optional array of (key => value) event properties.
-	 *
-	 * @return string|void
-	 */
-	public function process_event_properties( $event_name, $product_id, $properties = array() ) {
-		$product = wc_get_product( $product_id );
-		if ( ! $product instanceof WC_Product ) {
-			return;
-		}
-		$product_details = $this->get_product_details( $product );
-
-		/**
-		 * Allow defining custom event properties in WooCommerce Analytics.
-		 *
-		 * @module woocommerce-analytics
-		 *
-		 * @since 12.5
-		 *
-		 * @param array $all_props Array of event props to be filtered.
-		 */
-		$all_props = apply_filters(
-			'jetpack_woocommerce_analytics_event_props',
-			array_merge(
-				$properties,
-				$this->get_common_properties()
-			)
-		);
-
-		$js = "{
-			'_en': '" . esc_js( $event_name ) . "',
-			'pi': '" . esc_js( $product_id ) . "',
-			'pn': '" . esc_js( $product_details['name'] ) . "',
-			'pc': '" . esc_js( $product_details['category'] ) . "',
-			'pp': '" . esc_js( $product_details['price'] ) . "',
-			'pt': '" . esc_js( $product_details['type'] ) . "'," .
-			$this->render_properties_as_js( $all_props ) . '
-		}';
-
-		return $js;
-	}
-
-	/**
 	 * On product lists or other non-product pages, add an event listener to "Add to Cart" button click
 	 */
 	public function loop_session_events() {
@@ -185,10 +96,10 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				foreach ( $data as $data_instance ) {
 					$this->record_event(
 						$data_instance['event'],
-						$data_instance['product_id'],
 						array(
 							'pq' => $data_instance['quantity'],
-						)
+						),
+						$data_instance['product_id']
 					);
 				}
 				// Clear data, now that these events have been recorded.
@@ -278,6 +189,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 
 		$this->record_event(
 			'woocommerceanalytics_product_view',
+			array(),
 			$product->get_id()
 		);
 	}
@@ -328,7 +240,6 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			if ( true === $include_express_payment ) {
 				$properties = $this->process_event_properties(
 					'woocommerceanalytics_product_checkout',
-					$product->get_id(),
 					array(
 						'pq'               => $cart_item['quantity'],
 						'payment_options'  => $enabled_payment_options,
@@ -336,7 +247,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 						'guest_checkout'   => 'Yes' === $guest_checkout ? 'Yes' : 'No',
 						'create_account'   => 'Yes' === $create_account ? 'Yes' : 'No',
 						'express_checkout' => 'null',
-					)
+					),
+					$product->get_id()
 				);
 				wc_enqueue_js(
 					"
@@ -357,7 +269,6 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			} else {
 				$this->record_event(
 					'woocommerceanalytics_product_checkout',
-					$product->get_id(),
 					array(
 						'pq'               => $cart_item['quantity'],
 						'payment_options'  => $enabled_payment_options,
@@ -365,7 +276,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 						'guest_checkout'   => 'Yes' === $guest_checkout ? 'Yes' : 'No',
 						'create_account'   => 'Yes' === $create_account ? 'Yes' : 'No',
 						'express_checkout' => 'null',
-					)
+					),
+					$product->get_id()
 				);
 			}
 		}
@@ -414,7 +326,6 @@ class Jetpack_WooCommerce_Analytics_Universal {
 
 			$this->record_event(
 				'woocommerceanalytics_product_purchase',
-				$product_id,
 				array(
 					'oi'               => $order->get_order_number(),
 					'pq'               => $order_item->get_quantity(),
@@ -423,7 +334,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 					'create_account'   => $create_account,
 					'guest_checkout'   => $guest_checkout,
 					'express_checkout' => $express_checkout,
-				)
+				),
+				$product_id
 			);
 		}
 	}
@@ -454,20 +366,6 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				} );
 			} );'
 		);
-	}
-
-	/**
-	 * Get the current user id
-	 *
-	 * @return int
-	 */
-	public function get_user_id() {
-		if ( is_user_logged_in() ) {
-			$blogid = Jetpack::get_option( 'id' );
-			$userid = get_current_user_id();
-			return $blogid . ':' . $userid;
-		}
-		return 'null';
 	}
 
 	/**
@@ -557,127 +455,6 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			$line = implode( '/', $out );
 		}
 		return $line;
-	}
-
-	/**
-	 * Search a specific post for text content.
-	 *
-	 * Note: similar code is in a WooCommerce core PR:
-	 * https://github.com/woocommerce/woocommerce/pull/25932
-	 *
-	 * @param integer $post_id The id of the post to search.
-	 * @param string  $text    The text to search for.
-	 * @return integer 1 if post contains $text (otherwise 0).
-	 */
-	public static function post_contains_text( $post_id, $text ) {
-		global $wpdb;
-
-		// Search for the text anywhere in the post.
-		$wildcarded = "%{$text}%";
-
-		$result = $wpdb->get_var(
-			$wpdb->prepare(
-				"
-				SELECT COUNT( * ) FROM {$wpdb->prefix}posts
-				WHERE ID=%d
-				AND {$wpdb->prefix}posts.post_content LIKE %s
-				",
-				array( $post_id, $wildcarded )
-			)
-		);
-
-		return ( '0' !== $result ) ? 1 : 0;
-	}
-
-	/**
-	 * Get info about the cart & checkout pages, in particular
-	 * whether the store is using shortcodes or Gutenberg blocks.
-	 * This info is cached in a transient.
-	 *
-	 * Note: similar code is in a WooCommerce core PR:
-	 * https://github.com/woocommerce/woocommerce/pull/25932
-	 *
-	 * @return array
-	 */
-	public static function get_cart_checkout_info() {
-		$transient_name = 'jetpack_woocommerce_analytics_cart_checkout_info_cache';
-
-		$info = get_transient( $transient_name );
-
-		// Return cached data early to prevent additional processing, the transient lasts for 1 day.
-		if ( false !== $info ) {
-			return $info;
-		}
-
-		// If WC Blocks is version 10.6.0 or above, it's using the Cart/Checkout templates.
-		$cart_checkout_templates_in_use = class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && version_compare( Automattic\WooCommerce\Blocks\Package::get_version(), '10.6.0', '>=' );
-
-		if ( ! $cart_checkout_templates_in_use ) {
-			$cart_page_id     = wc_get_page_id( 'cart' );
-			$checkout_page_id = wc_get_page_id( 'checkout' );
-
-			$info = array(
-				'cart_page_contains_cart_block'         => self::post_contains_text(
-					$cart_page_id,
-					'<!-- wp:woocommerce/cart'
-				),
-				'cart_page_contains_cart_shortcode'     => self::post_contains_text(
-					$cart_page_id,
-					'[woocommerce_cart]'
-				),
-				'checkout_page_contains_checkout_block' => self::post_contains_text(
-					$checkout_page_id,
-					'<!-- wp:woocommerce/checkout'
-				),
-				'checkout_page_contains_checkout_shortcode' => self::post_contains_text(
-					$checkout_page_id,
-					'[woocommerce_checkout]'
-				),
-			);
-			set_transient( $transient_name, $info, DAY_IN_SECONDS );
-			return $info;
-		}
-
-		// We will only reach here if the Cart/Checkout templates are in use.
-
-		$cart_template        = null;
-		$checkout_template    = null;
-		$cart_template_id     = null;
-		$checkout_template_id = null;
-		$block_controller     = Automattic\WooCommerce\Blocks\Package::container()->get( Automattic\WooCommerce\Blocks\BlockTemplatesController::class );
-		$templates            = $block_controller->get_block_templates( array( 'cart', 'checkout' ) );
-
-		foreach ( $templates as $template ) {
-			if ( 'cart' === $template->slug ) {
-				$cart_template_id = ( $template->id );
-				continue;
-			}
-			if ( 'checkout' === $template->slug ) {
-				$checkout_template_id = ( $template->id );
-			}
-		}
-
-		// Get the template and its contents from the IDs we found above.
-		if ( function_exists( 'get_block_template' ) ) {
-			$cart_template     = get_block_template( $cart_template_id );
-			$checkout_template = get_block_template( $checkout_template_id );
-		}
-
-		if ( function_exists( 'gutenberg_get_block_template' ) ) {
-			$cart_template     = get_block_template( $cart_template_id );
-			$checkout_template = get_block_template( $checkout_template_id );
-		}
-
-		// Update the info transient with data we got from the templates, if the site isn't using WC Blocks we
-		// won't be doing this so no concern about overwriting.
-		$info = array(
-			'cart_page_contains_cart_block'             => str_contains( $cart_template->content, '<!-- wp:woocommerce/cart' ) ? 1 : 0,
-			'cart_page_contains_cart_shortcode'         => str_contains( $cart_template->content, '[woocommerce_cart]' ) ? 1 : 0,
-			'checkout_page_contains_checkout_block'     => str_contains( $checkout_template->content, '<!-- wp:woocommerce/checkout' ) ? 1 : 0,
-			'checkout_page_contains_checkout_shortcode' => str_contains( $checkout_template->content, '[woocommerce_checkout]' ) ? 1 : 0,
-		);
-		set_transient( $transient_name, $info, DAY_IN_SECONDS );
-		return $info;
 	}
 
 	/**

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -43,6 +43,23 @@ Remove logic that prevents site admins being tracked and add store_admin propert
 - Repeat as a logged _out_ (e.g. guest) user, the event should be logged, and should have the `store_admin` property but it should be `0`
 - Repeat as a logged in, but _not_ admin user, (e.g. a customer), the event should be logged, and should have the `store_admin` property but it should be `0`
 
+Add Logic to track My account page
+- On a connected, live, WordPress account, check if existing tracks are being sent (either from the track page or using the Tracks - Vigilante extension).
+On the My Account page, test that:
+- `woocommerceanalytics_my_account_tab_click` with prop tab: logout is triggered when you click log out.
+- `woocommerceanalytics_my_account_page_view` with the prop tab: $tabName is being triggered on each top level tab you visit.
+- `woocommerceanalytics_my_account_order_number_click` Is being triggered if you clicked an order number in the orders view.
+woocommerceanalytics_my_account_order_action_click is being triggered with prop action: view if you click the view button, and action: pay if you click the pay button, and action: cancel if you click the cancel button.
+To see the pay and cancel buttons, change the order status to pending payment.
+- `woocommerceanalytics_my_account_address_click` with prop address: billing | shipping when you click on the button to edit an address.
+- `woocommerceanalytics_my_account_address_save` with prop address: billing | shipping when you save an address you edited.
+- `woocommerceanalytics_my_account_details_save` When you click save on the Accounts Details page.
+- For those you will need a payment method installed like Stripe or WCPay:
+Check that:
+- `woocommerceanalytics_my_account_payment_add` Is being triggered when you add a new payment method.
+- `woocommerceanalytics_my_account_payment_save` Is being triggered when you save a payment method you're adding.
+- `woocommerceanalytics_my_account_payment_delete` Is being triggered when you delete a payment method.
+
 ### Enabling beta blocks
 
 Testing most features on this list requires enabling Jetpack beta blocks. You can be the one of the first to test upcoming features by adding this constant as a snippet, or directly into your configuration file:

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -284,7 +284,6 @@
 	"projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php",
 	"projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php",
 	"projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php",
-	"projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php",
 	"projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php",
 	"projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php",
 	"projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full.php",


### PR DESCRIPTION
This PR does 2 things:

- It refactors universal class slightly and moves some of the shared logic to a trait.
- It adds tracking to my account page.

Closes https://github.com/woocommerce/woocommerce-blocks/issues/9730

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

This PR adds customer tracking to the my account page, it tracks what tabs they view and actions they do like adding payment methods, removing payment methods, updating addresses, and viewing orders. It doesn't track the actual content of address, payment method, or order, just the act of doing that.

## Testing instructions:

### Regression testing:

- On a connected, live, WordPress account, check if existing tracks are being sent (either from the track page or using the Tracks Vigilante extension).
- View a product, add it to cart, change its quantity from cart, and remove it from cart. Make sure all of those events trigger fine.

### Tracking testing:

- On a connected, live, WordPress account, check if existing tracks are being sent (either from the track page or using the Tracks Vigilante extension).
- On the My Account page, test that:
- `woocommerceanalytics_my_account_tab_click` with prop `tab: logout` is triggered when you click log out.
- `woocommerceanalytics_my_account_page_view` with the prop `tab: $tabName` is being triggered on each top level tab you visit.
- `woocommerceanalytics_my_account_order_number_click` Is being triggered if you clicked an order number in the orders view.
- `woocommerceanalytics_my_account_order_action_click` is being triggered with prop `action: view` if you click the view button, and `action: pay` if you click the pay button, and `action: cancel` if you click the cancel button.
    - To see the pay and cancel buttons, change the order status to pending payment. 
- `woocommerceanalytics_my_account_address_click` with prop `address: billing | shipping` when you click on the button to edit an address.
- `woocommerceanalytics_my_account_address_save`  with prop `address: billing | shipping` when you save an address you edited.
- `woocommerceanalytics_my_account_details_save` When you click save on the Accounts Details page.
For those you will need a payment method installed like Stripe or WCPay:
- Check that:
- `woocommerceanalytics_my_account_payment_add` Is being triggered when you add a new payment method.
- `woocommerceanalytics_my_account_payment_save` Is being triggered when you save a payment method you're adding.
- `woocommerceanalytics_my_account_payment_delete` Is being triggered when you delete a payment method.
