### PR TITLE
Launchpad: Support Videopress tasks on the Customer Home

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-support-launchpad-videopress-tasks.x
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-support-launchpad-videopress-tasks.x
@@ -1,5 +1,6 @@
 Significance: minor
 Type: added
-Comment: Support Videopress tasks on the Customer Home Launchpad
+
+Support Videopress tasks on the Customer Home Launchpad
 
 

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-support-launchpad-videopress-tasks.x
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-support-launchpad-videopress-tasks.x
@@ -1,0 +1,5 @@
+Significance: minor
+Type: added
+Comment: Support Videopress tasks on the Customer Home Launchpad
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -240,6 +240,13 @@ function wpcom_launchpad_get_task_definitions() {
 			'add_listener_callback' => function () {
 				add_action( 'add_attachment', 'wpcom_launchpad_track_video_uploaded_task' );
 			},
+			'get_calypso_path'      => function ( $task, $default, $data ) {
+				$page_on_front = get_option( 'page_on_front', false );
+				if ( $page_on_front ) {
+					return '/page/' . $data['site_slug_encoded'] . '/' . $page_on_front;
+				}
+				return '/site-editor/' . $data['site_slug_encoded'] . '?canvas=edit';
+			},
 		),
 
 		// Blog tasks.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds support to Videopress tasks on the Customer Home page. This is part of the changes to support the Skip feature for the Videopress flow. The launchpad tasks on the Customer Home page uses the `get_calypso_path` property in the task definition to redirect the user when clicking on a task.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Please follow the steps described on https://github.com/Automattic/wp-calypso/pull/81854

