### PR TITLE
AI Chat: UX fixes

### DIFF
--- a/projects/plugins/jetpack/changelog/sitebot-ux
+++ b/projects/plugins/jetpack/changelog/sitebot-ux
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adjust styling and UX of changing the block label. Stop triggering the search from gutenberg

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/controls.js
@@ -3,7 +3,7 @@ import { BaseControl, PanelBody, TextControl, TextareaControl } from '@wordpress
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
-export function AiChatControls( { setAttributes, askButtonLabel, placeholder } ) {
+export function AiChatControls( { setAttributes, placeholder } ) {
 	const [ promptOverride, setPromptOverride ] = useEntityProp(
 		'root',
 		'site',
@@ -13,19 +13,6 @@ export function AiChatControls( { setAttributes, askButtonLabel, placeholder } )
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack' ) } initialOpen={ false }>
-					<BaseControl
-						label={ __( 'Ask button', 'jetpack' ) }
-						help={ __( 'What do you want the button to say?', 'jetpack' ) }
-						className="jetpack-ai-chat__ask-button-text"
-					>
-						<TextControl
-							placeholder={ __( 'Ask', 'jetpack' ) }
-							onChange={ newAskButtonLabel =>
-								setAttributes( { askButtonLabel: newAskButtonLabel } )
-							}
-							value={ askButtonLabel }
-						/>
-					</BaseControl>
 					<BaseControl
 						label={ __( 'Input placeholder', 'jetpack' ) }
 						help={ __( 'Customize the placeholder text.', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/edit.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps, RichText } from '@wordpress/block-editor';
+import { TextControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
@@ -9,7 +10,6 @@ import './editor.scss';
 import ConnectPrompt from './components/nudge-connect';
 import EnableJetpackSearchPrompt from './components/nudge-enable-search';
 import { AiChatControls } from './controls';
-import QuestionAnswer from './question-answer';
 
 export default function Edit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
@@ -17,10 +17,21 @@ export default function Edit( { attributes, setAttributes } ) {
 		<div { ...blockProps }>
 			<ConnectPrompt />
 			<EnableJetpackSearchPrompt />
-			<QuestionAnswer
-				askButtonLabel={ attributes.askButtonLabel }
-				placeholder={ attributes.placeholder }
-			/>
+			<div className="jetpack-ai-chat-question-wrapper">
+				<TextControl
+					className="jetpack-ai-chat-question-input"
+					placeholder={ attributes.placeholder }
+					size={ 50 }
+					disabled={ true }
+				/>
+				<RichText
+					className="wp-block-button__link jetpack-ai-chat-question-button"
+					onChange={ value => setAttributes( { askButtonLabel: value } ) }
+					value={ attributes.askButtonLabel }
+					withoutInteractiveFormatting
+					allowedFormats={ [ 'core/bold', 'core/italic', 'core/strikethrough' ] }
+				/>
+			</div>
 			<InspectorControls>
 				<AiChatControls
 					askButtonLabel={ attributes.askButtonLabel }

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/edit.js
@@ -21,7 +21,6 @@ export default function Edit( { attributes, setAttributes } ) {
 				<TextControl
 					className="jetpack-ai-chat-question-input"
 					placeholder={ attributes.placeholder }
-					size={ 50 }
 					disabled={ true }
 				/>
 				<RichText

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
@@ -120,7 +120,12 @@ export default function QuestionAnswer( { askButtonLabel, blogId, blogType, plac
 						onChange={ newQuestion => setQuestion( newQuestion ) }
 					/>
 
-					<Button variant="primary" disabled={ isLoading } onClick={ handleSubmitQuestion }>
+					<Button
+						variant="primary"
+						className="wp-block-button__link jetpack-ai-chat-question-button"
+						disabled={ isLoading }
+						onClick={ handleSubmitQuestion }
+					>
 						{ askButtonLabel }
 					</Button>
 				</div>

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
@@ -5,17 +5,25 @@
 .wp-block-jetpack-ai-chat {
 	.jetpack-ai-chat-question-wrapper {
 		display: flex;
-		flex-wrap: wrap;
+		flex-direction: row;
+		flex-wrap: nowrap;
 		margin: 1rem 0;
 
-		input {
-			flex: 1;
-			font-size: 16px;
-			padding: 15px 23px;
-			line-height: 1.3;
+		.jetpack-ai-chat-question-input {
+			flex: auto;
+			flex-grow: 4;
+			input {
+				width: 100%;
+				font-size: 16px;
+				padding: 15px 23px;
+				line-height: 1.3;
+			}
 		}
+
 		.jetpack-ai-chat-question-button {
-			flex: 1;
+			flex: auto;
+			flex-grow: 1;
+			text-wrap: nowrap;
 			margin-left: 10px;
 			height: 53px;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
@@ -10,28 +10,14 @@
 
 		input {
 			flex: 1;
-			padding: 0.5rem;
 			font-size: 16px;
+			padding: 15px 23px;
+			line-height: 1.3;
 		}
-
-		button {
-			margin-inline-start: 1rem;
-			border: none;
-			transition: 0.3s;
-			cursor: pointer;
-			position: relative;
-			display: block;
-			color: var(--wp-components-color-accent-inverted, #fff);
-			background-color: var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, #006ba1));;
-			font-size: 16px;
-			padding: 0.5rem 1rem;
-			height: 38px;
-			border-radius: 2px;
-
-			&:disabled {
-				opacity: 0.5;
-				cursor: not-allowed;
-			}
+		.jetpack-ai-chat-question-button {
+			flex: 1;
+			margin-left: 10px;
+			height: 53px;
 		}
 
 	}


### PR DESCRIPTION
This introduces small UX fixes to how AI Chat looks both on frontend and the backend

<img width="1078" alt="Zrzut ekranu 2023-09-19 o 17 09 41" src="https://github.com/Automattic/jetpack/assets/3775068/01268898-5040-4306-9a87-33d2d760ee5a">


## Proposed changes:
* Stop triggering search from Gutenberg, UX is now purely for editing
* Editable button to change the label right in a WYSIWYG manner
* Styling more consistent with other blocks (search, subscriptions)
* Inherit site styles




## Does this pull request change what data or activity we track or use?
NO

## Testing instructions:

* Insert the AI Chat block on any environment
* Edit button label
* Edit placeholder
* Click around and have a feel.


