### PR TITLE
Jetpack: Fix undefined variable warnings in featured images fallback

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-undefined-variables-from-32824
+++ b/projects/plugins/jetpack/changelog/fix-undefined-variables-from-32824
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Featured images fallback: fix undefined variable warnings.

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images-fallback.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images-fallback.php
@@ -66,7 +66,7 @@ function jetpack_featured_images_fallback_get_image( $html, $post_id, $post_thum
 			$width  = isset( $image['width'] ) ? intval( $image['width'] ) : null;
 			$height = isset( $image['height'] ) ? intval( $image['height'] ) : null;
 
-			if ( $image['src_width'] && $image['src_height'] && $image['width'] && $image['height'] ) {
+			if ( ! empty( $image['src_width'] ) && ! empty( $image['src_height'] ) && ! empty( $image['width'] ) && ! empty( $image['height'] ) ) {
 				$src_width  = intval( $image['src_width'] );
 				$src_height = intval( $image['src_height'] );
 

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images-fallback.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images-fallback.php
@@ -63,9 +63,10 @@ function jetpack_featured_images_fallback_get_image( $html, $post_id, $post_thum
 
 			$image_sizes = '';
 
+			$width  = isset( $image['width'] ) ? intval( $image['width'] ) : null;
+			$height = isset( $image['height'] ) ? intval( $image['height'] ) : null;
+
 			if ( $image['src_width'] && $image['src_height'] && $image['width'] && $image['height'] ) {
-				$width      = intval( $image['width'] );
-				$height     = intval( $image['height'] );
 				$src_width  = intval( $image['src_width'] );
 				$src_height = intval( $image['src_height'] );
 
@@ -93,6 +94,9 @@ function jetpack_featured_images_fallback_get_image( $html, $post_id, $post_thum
 
 				// Use the theme's crop setting rather than forcing to true.
 				$image_src = add_query_arg( 'crop', $image['crop'], $image_src );
+
+				$image_srcset = null;
+				$image_sizes  = null;
 			}
 
 			$default_attr = array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #32824 introduced some new code, and unfortunately some code paths do not define variables that are needed later on. The later code handles the resulting `null`s properly, but we should still avoid the warnings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1695140087285159/1695132622.239659-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the tests from #32824, checking the log for warnings?