### PR TITLE
Subscriptions Block: Do not optout from any newsletter categories when none selected

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-block-no-category-excl-when-none-selected
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-block-no-category-excl-when-none-selected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions Block: Do not append newsletter category exclusions to subscribe url, when none categories were checked

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -24,16 +24,21 @@ domReady( function () {
 			}
 			event.preventDefault();
 
-			// get all unchecked categories
-			const excluded_newsletter_categories = Array.from(
+			const newsletter_category_checkboxes = Array.from(
 				form.querySelectorAll(
 					'.wp-block-jetpack-subscriptions__newsletter-category input[type=checkbox]'
 				)
-			)
+			);
+
+			const unchecked_newsletter_categories = newsletter_category_checkboxes
 				.filter( checkbox => ! checkbox.checked )
 				.map( checkbox => checkbox.value );
 
-			const url =
+			const has_excluded_newsletter_categories =
+				unchecked_newsletter_categories.length > 0 &&
+				unchecked_newsletter_categories.length !== newsletter_category_checkboxes.length; // If all are unchecked, we treat it as if no exclusions were made.
+
+			let url =
 				'https://subscribe.wordpress.com/memberships/?' +
 				'blog=' +
 				form.dataset.blog +
@@ -43,9 +48,11 @@ domReady( function () {
 				form.dataset.post_access_level +
 				'&display=alternate' +
 				'&email=' +
-				encodeURIComponent( email ) +
-				'&excluded_newsletter_categories=' +
-				excluded_newsletter_categories.join( ',' );
+				encodeURIComponent( email );
+
+			if ( has_excluded_newsletter_categories ) {
+				url += '&excluded_newsletter_categories=' + unchecked_newsletter_categories.join( ',' );
+			}
 
 			window.scrollTo( 0, 0 );
 			tb_show( null, url + '&TB_iframe=true', null );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue where a user who did not select any newsletter categories, when subscribing to a site using the block, was in turn subscribing to the site with all the categories opted out from. Instead, the expectation is that the user should not be opted out from any newsletter categories in such case, in another words they should be subscribed to all categories.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When subscribing, verify if no newsletter category pills have been selected. If none are chosen, then omit including any newsletter category exclusions in the subscription request.

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1695132146012329-slack-C02TCEHP3HA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The PR branch can be tested on either a jetpack-connected site, simple or atomic
* The test site should have the "newsletter categories" blog RC sticker enabled
* Go to `/settings/newsletter/$site-slug`
* Enable newsletter categories on the site, and create some if there is none
  ![ZMX95s.png](https://github.com/Automattic/jetpack/assets/2019970/d83b3658-b717-400d-9f1b-7a5b003399dd)
* On the test site publish a page, or a post, with the Subscribe block
* Open an incognito window in your browser, have the network tab opened on the side, go to the page/post that you created in the previous step. 
* Enter some email address, leave all the newsletter category pills unselected and hit the **Subscribe**" button
* Verify that the network call to the subscribe endpoint did not have any `excluded_newsletter_categories` appended to its URL.


* Similarly verify that the exclusions are still being passed when some newsletter categories are selected