### PR TITLE
AI Extension: Avoid empty form state after AI request

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-form-extension-empty-form
+++ b/projects/plugins/jetpack/changelog/update-ai-form-extension-empty-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: Avoid empty form state after AI request

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -213,8 +213,12 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 					lastBlockUpdated = ! compareBlocks( lastBlock, lastBlockFromCurrentList );
 				}
 
-				// Only update the blocks when the valid list changed, meaning a new block arrived or the last block was updated.
-				if ( validBlocks.length !== currentListOfValidBlocks.current.length || lastBlockUpdated ) {
+				if (
+					// Only update the blocks when there are valid blocks, to avoid having no children and triggering the empty state.
+					validBlocks.length > 0 &&
+					// Only update the blocks when the valid list changed, meaning a new block arrived or the last block was updated.
+					( validBlocks.length !== currentListOfValidBlocks.current.length || lastBlockUpdated )
+				) {
 					// Only update the valid blocks
 					replaceInnerBlocks( clientId, validBlocks );
 
@@ -263,6 +267,9 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 							} ),
 						] );
 					}
+
+					// Reset the list of valid blocks after the request is done.
+					currentListOfValidBlocks.current = [];
 				}
 			},
 			[ clientId, replaceInnerBlocks ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32299

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a check for the number of valid blocks to avoid setting the inner blocks to an empty array. Has the side effect of not destroying the form if the response is invalid and does not generate any blocks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a new form and ask for some content
* Ask for some form update
* Check that the empty form placeholder is not displayed anymore, in contrast to the behavior seen in https://github.com/Automattic/jetpack/issues/32299#issuecomment-1673257398

https://github.com/Automattic/jetpack/assets/8486249/ca3fdc5e-daef-478f-a033-88204423b2b7
