### PR TITLE
Blocks: improve escaping of block attributes.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-output-escaping
+++ b/projects/plugins/jetpack/changelog/update-output-escaping
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Blocks: improve escaping of block attributes.
+Security: Blocks: avoid saving invalid block attributes that may appear to other editors on the site.

--- a/projects/plugins/jetpack/changelog/update-output-escaping
+++ b/projects/plugins/jetpack/changelog/update-output-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Blocks: improve escaping of block attributes.

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -54,7 +54,7 @@ function render_block( $attributes, $content ) {
 	}
 
 	$element   = get_attribute( $attributes, 'element' );
-	$text      = get_attribute( $attributes, 'text' );
+	$text      = wp_kses_post( get_attribute( $attributes, 'text' ) );
 	$unique_id = get_attribute( $attributes, 'uniqueId' );
 	$url       = get_attribute( $attributes, 'url' );
 	$classes   = Blocks::classes( FEATURE_NAME, $attributes, array( 'wp-block-button' ) );
@@ -72,12 +72,16 @@ function render_block( $attributes, $content ) {
 		$button_attributes .= sprintf( ' data-id-attr="%1$s" id="%1$s"', esc_attr( $unique_id ) );
 	}
 
+	if ( ! in_array( $element, array( 'a', 'button', 'input' ), true ) ) {
+		$element = 'a';
+	}
+
 	if ( 'a' === $element ) {
 		$button_attributes .= sprintf( ' href="%s" target="_blank" role="button" rel="noopener noreferrer"', esc_url( $url ) );
 	} elseif ( 'button' === $element ) {
 		$button_attributes .= ' type="submit"';
 	} elseif ( 'input' === $element ) {
-		$button_attributes .= sprintf( ' type="submit" value="%s"', wp_strip_all_tags( $text, true ) );
+		$button_attributes .= sprintf( ' type="submit" value="%s"', esc_attr( wp_strip_all_tags( $text, true ) ) );
 	}
 
 	$button = 'input' === $element

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -297,12 +297,12 @@ function render_video( $media ) {
 			title="%1$s"
 			type="%2$s"
 			class="wp-story-video intrinsic-ignore wp-video-%3$s"
-			data-id="%3$s"
+			data-id="%3$d"
 			src="%4$s">
 		</video>',
 		esc_attr( get_the_title( $media['id'] ) ),
 		esc_attr( $media['mime'] ),
-		$media['id'],
+		absint( $media['id'] ),
 		esc_attr( $media['url'] )
 	);
 }

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -407,7 +407,7 @@ class Jetpack_Memberships {
 		$button_styles = implode( ';', $button_styles );
 
 		return sprintf(
-			'<div class="%1$s"><a role="button" %6$s href="%2$s" class="%3$s" style="%4$s">%5$s</a></div>',
+			'<div class="%1$s"><a role="button" href="%2$s" class="%3$s" style="%4$s">%5$s</a></div>',
 			esc_attr(
 				Blocks::classes(
 					self::$button_block_name,
@@ -418,8 +418,7 @@ class Jetpack_Memberships {
 			esc_url( $this->get_subscription_url( $plan_id ) ),
 			isset( $attrs['submitButtonClasses'] ) ? esc_attr( $attrs['submitButtonClasses'] ) : 'wp-block-button__link',
 			esc_attr( $button_styles ),
-			wp_kses( $button_label, self::$tags_allowed_in_the_button ),
-			isset( $attrs['submitButtonAttributes'] ) ? sanitize_text_field( $attrs['submitButtonAttributes'] ) : '' // Needed for arbitrary target=_blank on WPCOM VIP.
+			wp_kses( $button_label, self::$tags_allowed_in_the_button )
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Better escape some of our block attributes.

## Proposed changes for output security hardening:
* the story block;
* the button block (in use in multiple blocks like the Form block, the AI assistant, Calendly, Eventbrite, Mailchimp, Paid Content (aka Premium Content), Recipe block (in Beta), Payments button.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
* p3btAN-2sq-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* For each block, try using them normally to see if they're still working properly, and then try to edit the attributes.