### PR TITLE
AI Extension: Show AI Form extension with connection nudge for disconnected users

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-form-disconnected
+++ b/projects/plugins/jetpack/changelog/update-ai-form-disconnected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: Show AI Form extension with connection nudge for disconnected users

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -20,8 +20,10 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import classNames from 'classnames';
+import ConnectPrompt from '../../../../components/connect-prompt';
 import UpgradePrompt from '../../../../components/upgrade-prompt';
 import useAIFeature from '../../../../hooks/use-ai-feature';
+import { isUserConnected } from '../../../../lib/connection';
 import { PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, getPrompt } from '../../../../lib/prompt';
 import { AiAssistantUiContext } from '../../ui-handler/context';
 import { AI_ASSISTANT_JETPACK_FORM_NOTICE_ID } from '../../ui-handler/with-ui-handler-data-provider';
@@ -75,6 +77,8 @@ export default function AiAssistantBar( {
 } ) {
 	const wrapperRef = useRef< HTMLDivElement >( null );
 	const inputRef = useRef< HTMLInputElement >( null );
+
+	const connected = isUserConnected();
 
 	const { inputValue, setInputValue, isVisible, assistantAnchor } =
 		useContext( AiAssistantUiContext );
@@ -209,16 +213,17 @@ export default function AiAssistantBar( {
 			} ) }
 		>
 			{ siteRequireUpgrade && <UpgradePrompt /> }
+			{ ! connected && <ConnectPrompt /> }
 			<AIControl
 				ref={ inputRef }
-				disabled={ siteRequireUpgrade }
+				disabled={ siteRequireUpgrade || ! connected }
 				value={ isLoading ? undefined : inputValue }
 				placeholder={ isLoading ? loadingPlaceholder : placeholder }
 				onChange={ setInputValue }
 				onSend={ onSend }
 				onStop={ stopSuggestion }
 				state={ requestingState }
-				isTransparent={ siteRequireUpgrade }
+				isTransparent={ siteRequireUpgrade || ! connected }
 				showButtonLabels={ ! isMobileMode }
 				showGuideLine={ showGuideLine }
 			/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -11,8 +11,6 @@ import { addFilter } from '@wordpress/hooks';
 /*
  * Internal dependencies
  */
-import { AI_Assistant_Initial_State } from '../../hooks/use-ai-feature';
-import { isUserConnected } from '../../lib/connection';
 import AiAssistantBar from './components/ai-assistant-bar';
 import AiAssistantToolbarButton from './components/ai-assistant-toolbar-button';
 import { isJetpackFromBlockAiCompositionAvailable } from './constants';
@@ -68,17 +66,6 @@ export function isPossibleToExtendJetpackFormBlock(
 		}
 	} else if ( blockName !== 'jetpack/contact-form' ) {
 		// If it is not a child block, check if it is the Jetpack Form block.
-		return false;
-	}
-
-	// Do not extend the block if the site is not connected.
-	const connected = isUserConnected();
-	if ( ! connected ) {
-		return false;
-	}
-
-	// Do not extend if there is an error getting the feature.
-	if ( AI_Assistant_Initial_State.errorCode ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32557

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes two checks disabling the extension, both for connection (one for an error that happens when the user is not connected)
* Moves the connection check to the extension by showing a nudge, exactly as the AI Assistant

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect your test site to Jetpack as admin
* Create a non-admin user, like an Author
* Log in as the non-admin user
* Go to the block editor without connecting the user to Jetpack
* Add a form
* Check that the extension is visible
* Check that there is a nudge with the message "Your account is not connected to Jetpack at the moment."
* Click on the connection button and connect the user
* Go back to the block editor
* Check that the form is working as normal

| Before | After
|-|-
|![2023-09-19_16-27-01](https://github.com/Automattic/jetpack/assets/8486249/63aeb96c-722b-45e4-aa79-4a9782289faf) | ![2023-09-19_15-59-11](https://github.com/Automattic/jetpack/assets/8486249/b01c0ccf-9d4e-4691-8f5f-86fa91bada5d)
