### PR TITLE
Fix blocks missing translations in simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-block-missing-translation
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-block-missing-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix version mismatch

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "4.10.x-dev"
+			"dev-trunk": "4.11.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.10.0",
+	"version": "4.11.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.10.0';
+	const PACKAGE_VERSION = '4.11.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/sync/changelog/fix-block-missing-translation
+++ b/projects/packages/sync/changelog/fix-block-missing-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix version mismatch

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.57.0';
+	const PACKAGE_VERSION = '1.57.1-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/changelog/fix-blocks-localization
+++ b/projects/plugins/jetpack/changelog/fix-blocks-localization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix blocks title and description not localized

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/editor.js
@@ -7,8 +7,6 @@ import './editor.scss';
 import './components/feedback/style.scss';
 
 registerJetpackBlockFromMetadata( metadata, {
-	// The API version needs to be explicitly specified in this instance for styles to be loaded.
-	apiVersion: metadata.apiVersion,
 	edit,
 	save,
 } );

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
@@ -1,10 +1,10 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 3,
+	"apiVersion": 1,
 	"name": "jetpack/business-hours",
 	"title": "Business Hours",
 	"description": "Display opening hours for your business.",
-	"keywords": ["opening hours", "closing time", "schedule", "working day"],
+	"keywords": [ "opening hours", "closing time", "schedule", "working day" ],
 	"version": "12.5.0",
 	"textdomain": "jetpack",
 	"category": "grow",
@@ -22,7 +22,7 @@
 			"fontSize": true,
 			"lineHeight": true
 		},
-		"align": ["wide", "full"]
+		"align": [ "wide", "full" ]
 	},
 	"attributes": {
 		"days": {

--- a/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
+++ b/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
@@ -6,8 +6,11 @@ import {
 } from '@automattic/jetpack-shared-extension-utils';
 import { registerBlockType } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
+import { _x } from '@wordpress/i18n';
 
 const JETPACK_PREFIX = 'jetpack/';
+const LOCALIZED_BLOCK_PROPERTIES = [ 'title', 'description', 'keywords' ];
+const DEFAULT_TEXTDOMAIN = 'jetpack';
 
 /**
  * Registers a gutenberg block if the availability requirements are met.
@@ -59,6 +62,24 @@ export default function registerJetpackBlock( name, settings, childBlocks = [], 
 	return result;
 }
 
+// Localize properties passed as parameter when applicable.
+// Note: the documentation states that `registerBlockType` wraps localized properties in `_x`
+// when it is passed the metadata object as the first param. I haven't found this to be true
+// with the latest version of `@wordpress/blocks` (12.18.0) at the time of writing this.
+// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#javascript
+const localizeBlockProperties = ( metadata, props ) => {
+	const result = { ...props };
+
+	for ( const prop in props ) {
+		if ( LOCALIZED_BLOCK_PROPERTIES.includes( prop ) ) {
+			// eslint-disable-next-line
+			result[ prop ] = _x( props[ prop ], null, metadata.textdomain || DEFAULT_TEXTDOMAIN );
+		}
+	}
+
+	return result;
+};
+
 /**
  * Wrapper around registerJetpackBlock to register a block by specifying its metadata.
  *
@@ -69,20 +90,25 @@ export default function registerJetpackBlock( name, settings, childBlocks = [], 
  * @returns {object|boolean} Either false if the block is not available, or the results of `registerBlockType`
  */
 export function registerJetpackBlockFromMetadata( metadata, settings, childBlocks, prefix ) {
-	const clientSettings = {
+	const mergedSettings = {
+		...metadata,
 		...settings,
+	};
+	const processedSettings = {
+		...localizeBlockProperties( metadata, mergedSettings ),
 		icon: getBlockIconProp( metadata ),
 	};
+
 	const { variations } = metadata;
 
 	if ( Array.isArray( variations ) && variations.length > 0 ) {
-		clientSettings.variations = variations.map( variation => {
+		processedSettings.variations = variations.map( variation => {
 			return {
-				...variation,
+				...localizeBlockProperties( metadata, variation ),
 				icon: getBlockIconProp( variation ),
 			};
 		} );
 	}
 
-	return registerJetpackBlock( metadata.name, clientSettings, childBlocks, prefix );
+	return registerJetpackBlock( metadata.name, processedSettings, childBlocks, prefix );
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-block-missing-translation
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-block-missing-translation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_20"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_21_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "a97bf2e2d9e8d00007b082bce5ee69c3249504c6"
+                "reference": "42f702a13ab337ae035fcd24b9e915e779ac8647"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.10.x-dev"
+                    "dev-trunk": "4.11.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.20
+ * Version: 1.6.21-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.20",
+	"version": "1.6.21-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1694788078746839-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
https://github.com/Automattic/jetpack/pull/32698, https://github.com/Automattic/jetpack/pull/32815, and https://github.com/Automattic/jetpack/pull/33073 introduced localization issues for simple sites: block titles and descriptions were displayed in English no matter the user's selected language. This PR fixes it.

The blocks involved are: Business Hours, AI Chat, Amazon, Blogroll, Google Docs Embed, Recipe, Create with Voice.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Review the code
- Regression testing:
  - Spin up a test site with this PR. This could be a self-hosted site or a simple site.
  - Create a new post.
  - Notice that the aforementioned blocks are not broken.
- Localization testing:
  - Download this branch.
  - Build the plugin: `jetpack build plugins/jetpack`.
  - Remote sync the plugin with your sandbox (see PCYsg-eg0-p2).
  - Change the language of your WordPress.com account to something different than English.
  - In WordPress.com, select the site linked to your sandbox and create a new post.
  - In the block inserter, notice that the block titles and descriptions for the blocks above are translated.

_Blocks info translated to French_
<img width="300" alt="Screenshot 2023-09-19 at 9 47 38 AM" src="https://github.com/Automattic/jetpack/assets/1620183/b6cb23e4-b0de-4be5-ae59-ce82a9148aab">
<img width="300" alt="Screenshot 2023-09-19 at 9 47 49 AM" src="https://github.com/Automattic/jetpack/assets/1620183/0d71c2ba-d0c6-4d50-93da-55d5018763fe">
<img width="300" alt="Screenshot 2023-09-19 at 9 47 57 AM" src="https://github.com/Automattic/jetpack/assets/1620183/6788636c-ee1b-4a50-a2e6-e31305607da0">
<img width="300" alt="Screenshot 2023-09-19 at 9 48 04 AM" src="https://github.com/Automattic/jetpack/assets/1620183/cbd3d4d2-22de-476e-90e5-8f672d93b6a6">
<img width="300" alt="Screenshot 2023-09-19 at 9 48 15 AM" src="https://github.com/Automattic/jetpack/assets/1620183/d6d95720-2cbf-46a4-8a8d-ee140ec7b038">
<img width="300" alt="Screenshot 2023-09-19 at 9 48 23 AM" src="https://github.com/Automattic/jetpack/assets/1620183/31266c4f-a5eb-4887-8a6f-917d6d5519a4">
<img width="300" alt="Screenshot 2023-09-19 at 9 48 31 AM" src="https://github.com/Automattic/jetpack/assets/1620183/0b336b00-4d24-4f5e-b041-391ea003141e">
