### PR TITLE
CRM: Resolves #3327 - respect notify param in `create_event` API endpoint

### DIFF
--- a/projects/plugins/crm/api/create_event.php
+++ b/projects/plugins/crm/api/create_event.php
@@ -48,8 +48,8 @@ if ( is_array( $potential_task ) ) {
 	}
 
 	$task_fields['notify'] = -1;
-	if ( isset( $potential_task['notify'] ) && (int) $potential_task['notify'] === 24 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$task_fields['notify'] = 24; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	if ( isset( $potential_task['notify'] ) && (int) $potential_task['notify'] === 24 ) {
+		$task_fields['notify'] = 24;
 		// the current setup uses a separate array for task reminders
 		$task_reminders[] = array(
 			'remind_at' => -86400,

--- a/projects/plugins/crm/changelog/fix-crm-3327-respect_notify_param_in_event_api
+++ b/projects/plugins/crm/changelog/fix-crm-3327-respect_notify_param_in_event_api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+API: task reminder param is no longer ignored

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -6134,6 +6134,8 @@ function jpcrm_deleted_invoice_counts( $all_invoices = null ) {
 			if (isset($eventFields['customer']) && $eventFields['customer'] > 0) $args['data']['contacts'] = array($eventFields['customer']);
 			if (isset($eventFields['company']) && $eventFields['company'] > 0) $args['data']['companies'] = array($eventFields['company']);
 
+			$args['data']['reminders'] = array();
+
 		// reminders into new DAL2 eventreminder format:
 		if (is_array($reminders) && count($reminders) > 0) foreach ($reminders as $reminder){
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -6138,7 +6138,7 @@ function jpcrm_deleted_invoice_counts( $all_invoices = null ) {
 		if (is_array($reminders) && count($reminders) > 0) foreach ($reminders as $reminder){
 
 			// this just adds with correct fields
-			$args['reminders'][] = array(
+			$args['data']['reminders'][] = array(
 
 				'event' => (int)$eventID,
 				'remind_at' => (int)$reminder['remind_at'], // just assume is int - garbage in, garbage out ($reminder['remind_at']) ? $reminder['remind_at'] : false; // if int, this

--- a/projects/plugins/crm/includes/ZeroBSCRM.IntegrationFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.IntegrationFuncs.php
@@ -873,7 +873,8 @@ function zeroBS_integrations_addOrUpdateTransaction(
 
 }
 
-function zeroBS_integrations_addOrUpdateEvent(
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+function zeroBS_integrations_addOrUpdateTask(
 	$eventID = -1,  /* Req - the event ID */
 	$dataArray =array(),  /* Req: title,to, from */
 	$eventReminders = array()  /* Req: remind_at,sent (v3+) */

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -517,7 +517,7 @@ function zeroBSCRM_task_ui_assignment($taskObject = array(), $taskID = -1){
     if (array_key_exists('owner', $taskObject)) $currentEventUserID = $taskObject['owner'];
     
     $html = "";
-    if ($currentEventUserID == "" || $currentEventUserID == -1){
+	if ( $currentEventUserID === '' || $currentEventUserID <= 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
         $html .= "<div class='no-owner'><i class='ui icon user circle zbs-unassigned'></i>";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: Resolves Automattic/zero-bs-crm#3327 - respect notify param in `create_event` API call

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The `create_event` API endpoint expects a `notify` param per the docs:
https://automattic.github.io/jetpack-crm-api-docs/#create-event

It should have created a 24-hr notification if one passes `24` as the value. However, there were a few things preventing this. The PR does the following:

* In `zeroBS_addUpdateEvent()` we were adding the `reminder` key one level too shallow (`$args['reminders']` → `$args['data']['reminders']`).
* Deletion of the reminder requires the key to exist with an empty value. As such, I initialise the key with an empty array.
* There was groundwork laid in the backend to allow for multiple notifications, but we only allow one notification via the editor, and while the endpoint had some code that was partially built out, the vars it was using were never actually set or used. I just chopped this for now and stuck with one notification.
* Updates `event` to `task` (see Automattic/zero-bs-crm#3330)

Note: while I could've done a lot more cleanup here, I tried to stay to an extremely limited scope, as the current API system isn't a priority. For example, if an owner of value `-1` is passed to DAL, it sets it to the current WP user. However, when using the API there is no current WP user, so it sets the owner to `0`. This affects all objects, but isn't a big deal...usually. I fixed a PHP notice it was causing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

```
Pass the following to the `create_event` API endpoint:

{"title":"some task title","customer":-1,"notes":"this is the description","to":"2018-02-01 03:30","from":"2018-02-01 03:30","notify":24,"complete":0,"owner":-1,"event_id":""}

In `trunk`, the task will be created, but:
* You'll get a PHP notice when visiting the task in the CRM.
* The reminder is not added to the database or ticked in the CRM.
* The response gives a notify value of `-1`.

In the `fix/crm/3327-respect_notify_param_in_event_api` branch, the above is handled correctly:
* The PHP notice is no more.
* The reminder is created in the database and ticked in the CRM.
* The response gives a notify value of `24`.

As a bonus, pass the same payload with a `notify` value of `-1` and the new `event_id` value. The reminder will be removed from the database.