### PR TITLE
AI Chat: Avoid extra HTTP request and only load initial state in editor

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-chat-dont-load-extra-scripts-on-frontend
+++ b/projects/plugins/jetpack/changelog/update-ai-chat-dont-load-extra-scripts-on-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Chat: Remove extra request in $search->is_active() and only load initial state in editor

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
@@ -83,11 +83,14 @@ function load_assets( $attr ) {
  * Add the initial state for the AI Chat block.
  */
 function add_ai_chat_block_data() {
+	// TODO
+	if ( ! is_admin() ) {
+		return;
+	}
 	$search        = new Search_Module_Control();
 	$plan          = new Search_Plan();
 	$initial_state = array(
 		'jetpackSettings' => array(
-			'search_module_active'   => $search->is_active(),
 			'instant_search_enabled' => $search->is_instant_search_enabled(),
 			'plan_supports_search'   => $plan->supports_instant_search(),
 		),

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
@@ -83,7 +83,7 @@ function load_assets( $attr ) {
  * Add the initial state for the AI Chat block.
  */
 function add_ai_chat_block_data() {
-	// TODO
+	// Only relevant to the editor right now.
 	if ( ! is_admin() ) {
 		return;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Apparently $search->is_active() results in an extra request. It wasn't in use anyway, so removing that call. 

Also updates the block to only load the initial state data in the editor. It's not used in front end views. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1695157280687139/1695153900.948679-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Make sure the block still looks good on front end and the editor. 
- Check for extra requests to front end like p1695157594059919/1695153900.948679-slack-C01U2KGS2PQ