### PR TITLE
Status: Do not check WP.com for protect multisite option

### DIFF
--- a/projects/packages/status/changelog/update-no-wpcom-module-check
+++ b/projects/packages/status/changelog/update-no-wpcom-module-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WP.com Compatibility: abort out early checking if Protect is active. WP.com's protection is not site option based.

--- a/projects/packages/status/src/class-modules.php
+++ b/projects/packages/status/src/class-modules.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\IP\Utils as IP_Utils;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Class Automattic\Jetpack\Modules
@@ -193,8 +194,11 @@ class Modules {
 			$active = array_diff( $active, array( 'vaultpress' ) );
 		}
 
-		// If protect is active on the main site of a multisite, it should be active on all sites.
-		if ( ! in_array( 'protect', $active, true ) && is_multisite() && get_site_option( 'jetpack_protect_active' ) ) {
+		// If protect is active on the main site of a multisite, it should be active on all sites. Doesn't apply to WP.com.
+		if ( ! in_array( 'protect', $active, true )
+			&& ! ( new Host() )->is_wpcom_simple()
+			&& is_multisite()
+			&& get_site_option( 'jetpack_protect_active' ) ) {
 			$active[] = 'protect';
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The Protect check on multisite site not needed on WordPress.com due to the unique protection setup in place there. We can specifically abort out early to avoid an extra query.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates check to end early if on WP.com.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load `sun` on wp.com simple and see the extra query.
* Apply patch and see no query.

