### PR TITLE
Launchpad: Add earn checklist

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-earn-newsletter-launchpad-checklist
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-earn-newsletter-launchpad-checklist
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: Add earn-newsletter checklist.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -486,6 +486,32 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/page/' . $data['site_slug_encoded'];
 			},
 		),
+
+		// Earn tasks
+		'stripe_connected'                => array(
+			'get_title'           => function () {
+				return __( 'Connect a Stripe account', 'jetpack-mu-wpcom' );
+			},
+			'is_visible_callback' => '__return_true',
+			'get_calypso_path'    => function ( $task, $default, $data ) {
+				if ( function_exists( 'get_memberships_connected_account_redirect' ) ) {
+					return get_memberships_connected_account_redirect(
+						get_current_user_id(),
+						get_current_blog_id()
+					);
+				}
+				return '/earn/payments/' . $data['site_slug_encoded'];
+			},
+		),
+		'paid_offer_created'              => array(
+			'get_title'           => function () {
+				return __( 'Set up an offer', 'jetpack-mu-wpcom' );
+			},
+			'is_visible_callback' => '__return_true',
+			'get_calypso_path'    => function ( $task, $default, $data ) {
+				return '/earn/payments-plans/' . $data['site_slug_encoded'];
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -886,25 +886,47 @@ function wpcom_launchpad_get_newsletter_subscriber_count() {
 /**
  * Determines if Stripe has been connected.
  *
- * @return bool Whether or not Stripe account is connected.
+ * @return bool Whether Stripe account is connected.
  */
-function wpcom_is_stripe_connected() {
-	require_lib( 'memberships' );
-	$blog_id  = get_current_blog_id();
-	$settings = (array) get_memberships_settings_for_site( $blog_id );
-	return boolval( $settings['connected_account_id'] );
+function wpcom_launchpad_is_stripe_connected() {
+	$membership_settings = wpcom_launchpad_get_membership_settings();
+	if ( ! $membership_settings ) {
+		return false;
+	}
+	return isset( $membership_settings['connected_account_id'] ) && $membership_settings['connected_account_id'] !== '';
 }
 
 /**
- * Determines if paid membership plans exists
+ * Determines if any paid membership plan exists.
  *
- * @return bool Whether or not paid membership plans exist.
+ * @return bool Whether paid plan exists.
  */
-function wpcom_has_paid_membership_plans() {
+function wpcom_launchpad_has_paid_membership_plans() {
+	$membership_settings = wpcom_launchpad_get_membership_settings();
+	if ( ! $membership_settings ) {
+		return false;
+	}
+	return isset( $membership_settings['products'] ) && is_array( $membership_settings['products'] ) && ( count( $membership_settings['products'] ) > 0 );
+}
+
+/**
+ * Get membership settings.
+ *
+ * @return array|null Membership settings or null.
+ */
+function wpcom_launchpad_get_membership_settings() {
+	$is_atomic = defined( 'IS_ATOMIC' ) && IS_ATOMIC;
+
+	// Memberships lib is only available on Simple sites.
+	// A follow up will fetch membership settings for Atomic.
+	if ( $is_atomic ) {
+		return null;
+	}
+
 	require_lib( 'memberships' );
 	$blog_id  = get_current_blog_id();
 	$settings = (array) get_memberships_settings_for_site( $blog_id );
-	return count( $settings['products'] ) > 0;
+	return $settings;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -891,7 +891,7 @@ function wpcom_launchpad_get_newsletter_subscriber_count() {
 function wpcom_is_stripe_connected() {
 	require_lib( 'memberships' );
 	$blog_id  = get_current_blog_id();
-	$settings = get_memberships_settings_for_site( $blog_id );
+	$settings = (array) get_memberships_settings_for_site( $blog_id );
 	return boolval( $settings['connected_account_id'] );
 }
 
@@ -903,7 +903,7 @@ function wpcom_is_stripe_connected() {
 function wpcom_has_paid_membership_plans() {
 	require_lib( 'memberships' );
 	$blog_id  = get_current_blog_id();
-	$settings = get_memberships_settings_for_site( $blog_id );
+	$settings = (array) get_memberships_settings_for_site( $blog_id );
 	return count( $settings['products'] ) > 0;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -490,7 +490,7 @@ function wpcom_launchpad_get_task_definitions() {
 		// Earn tasks
 		'stripe_connected'                => array(
 			'get_title'           => function () {
-				return __( 'Connect a Stripe account', 'jetpack-mu-wpcom' );
+				return __( 'Connect a Stripe account to collect payments', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback' => '__return_true',
 			'get_calypso_path'    => function ( $task, $default, $data ) {
@@ -505,7 +505,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 		'paid_offer_created'              => array(
 			'get_title'           => function () {
-				return __( 'Set up an offer', 'jetpack-mu-wpcom' );
+				return __( 'Set up an offer for your supporters', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback' => '__return_true',
 			'get_calypso_path'    => function ( $task, $default, $data ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -493,7 +493,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Connect a Stripe account to collect payments', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback'  => '__return_true',
-			'is_complete_callback' => 'wpcom_is_stripe_connected',
+			'is_complete_callback' => 'wpcom_launchpad_is_stripe_connected',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				if ( function_exists( 'get_memberships_connected_account_redirect' ) ) {
 					return get_memberships_connected_account_redirect(
@@ -508,7 +508,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Set up an offer for your supporters', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_has_paid_membership_plans',
+			'is_complete_callback' => 'wpcom_launchpad_has_paid_membership_plans',
 			'is_visible_callback'  => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/earn/payments-plans/' . $data['site_slug_encoded'];

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -489,11 +489,12 @@ function wpcom_launchpad_get_task_definitions() {
 
 		// Earn tasks
 		'stripe_connected'                => array(
-			'get_title'           => function () {
+			'get_title'            => function () {
 				return __( 'Connect a Stripe account to collect payments', 'jetpack-mu-wpcom' );
 			},
-			'is_visible_callback' => '__return_true',
-			'get_calypso_path'    => function ( $task, $default, $data ) {
+			'is_visible_callback'  => '__return_true',
+			'is_complete_callback' => 'wpcom_is_stripe_connected',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
 				if ( function_exists( 'get_memberships_connected_account_redirect' ) ) {
 					return get_memberships_connected_account_redirect(
 						get_current_user_id(),
@@ -504,11 +505,12 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 		'paid_offer_created'              => array(
-			'get_title'           => function () {
+			'get_title'            => function () {
 				return __( 'Set up an offer for your supporters', 'jetpack-mu-wpcom' );
 			},
-			'is_visible_callback' => '__return_true',
-			'get_calypso_path'    => function ( $task, $default, $data ) {
+			'is_complete_callback' => 'wpcom_has_paid_membership_plans',
+			'is_visible_callback'  => '__return_true',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/earn/payments-plans/' . $data['site_slug_encoded'];
 			},
 		),
@@ -879,6 +881,30 @@ function wpcom_launchpad_get_newsletter_subscriber_count() {
 	}
 
 	return (int) $total_subscribers;
+}
+
+/**
+ * Determines if Stripe has been connected.
+ *
+ * @return bool Whether or not Stripe account is connected.
+ */
+function wpcom_is_stripe_connected() {
+	require_lib( 'memberships' );
+	$blog_id  = get_current_blog_id();
+	$settings = get_memberships_settings_for_site( $blog_id );
+	return boolval( $settings['connected_account_id'] );
+}
+
+/**
+ * Determines if paid membership plans exists
+ *
+ * @return bool Whether or not paid membership plans exist.
+ */
+function wpcom_has_paid_membership_plans() {
+	require_lib( 'memberships' );
+	$blog_id  = get_current_blog_id();
+	$settings = get_memberships_settings_for_site( $blog_id );
+	return count( $settings['products'] ) > 0;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -191,6 +191,14 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_paid_newsletter_enabled',
 		),
+		'earn-newsletter'        => array(
+			'title'               => 'Newsletter',
+			'task_ids'            => array(
+				'set_up_payments',
+				'newsletter_plan_created',
+			),
+			'is_enabled_callback' => 'wpcom_launchpad_is_newsletter_or_write_intent',
+		),
 	);
 
 	$extended_task_list_definitions = apply_filters( 'wpcom_launchpad_extended_task_list_definitions', array() );
@@ -913,6 +921,20 @@ function wpcom_launchpad_is_paid_newsletter_enabled() {
 	}
 
 	return wpcom_launchpad_has_goal_paid_subscribers() && apply_filters( 'wpcom_launchpad_intent_paid_newsletter_enabled', false );
+}
+
+/**
+ * Checks if site has newsletter or write as site intent.
+ *
+ * @return bool True if the task list is enabled, false otherwise.
+ */
+function wpcom_launchpad_is_newsletter_or_write_intent() {
+	$intent = get_option( 'site_intent', false );
+	if ( 'newsletter' !== $intent || 'write' !== $intent ) {
+		return true;
+	}
+
+	return false;
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -192,7 +192,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_is_paid_newsletter_enabled',
 		),
 		'earn'                   => array(
-			'title'               => 'Newsletter',
+			'title'               => 'Earn',
 			'task_ids'            => array(
 				'stripe_connected',
 				'paid_offer_created',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -194,8 +194,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 		'earn-newsletter'        => array(
 			'title'               => 'Newsletter',
 			'task_ids'            => array(
-				'set_up_payments',
-				'newsletter_plan_created',
+				'stripe_connected',
+				'paid_offer_created',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_newsletter_or_write_intent',
 		),

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -191,7 +191,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_paid_newsletter_enabled',
 		),
-		'earn-newsletter'        => array(
+		'earn'                   => array(
 			'title'               => 'Newsletter',
 			'task_ids'            => array(
 				'stripe_connected',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -197,7 +197,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'stripe_connected',
 				'paid_offer_created',
 			),
-			'is_enabled_callback' => 'wpcom_launchpad_is_newsletter_or_write_intent',
+			'is_enabled_callback' => '__return_true',
 		),
 	);
 
@@ -921,20 +921,6 @@ function wpcom_launchpad_is_paid_newsletter_enabled() {
 	}
 
 	return wpcom_launchpad_has_goal_paid_subscribers() && apply_filters( 'wpcom_launchpad_intent_paid_newsletter_enabled', false );
-}
-
-/**
- * Checks if site has newsletter or write as site intent.
- *
- * @return bool True if the task list is enabled, false otherwise.
- */
-function wpcom_launchpad_is_newsletter_or_write_intent() {
-	$intent = get_option( 'site_intent', false );
-	if ( 'newsletter' === $intent || 'write' === $intent ) {
-		return true;
-	}
-
-	return false;
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -930,7 +930,7 @@ function wpcom_launchpad_is_paid_newsletter_enabled() {
  */
 function wpcom_launchpad_is_newsletter_or_write_intent() {
 	$intent = get_option( 'site_intent', false );
-	if ( 'newsletter' !== $intent || 'write' !== $intent ) {
+	if ( 'newsletter' === $intent || 'write' === $intent ) {
 		return true;
 	}
 


### PR DESCRIPTION
**UPDATE: I am changing this PR to add a generic Earn checklist, and may add an earn-newsletter checklist later**

## Proposed changes:
* Adds 'earn' checklist to Launchpad. We'll use this to show a Launchpad checklist on Earn pages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) This can be tested via the testing instructions in its companion frontend PR here: 
https://github.com/Automattic/wp-calypso/pull/81930

2) To test in isolation: 
   - Run  to load this branch in your sandbox. 
   - Sandbox public-api and the domain of your test site. 
   - Go to `https://developer.wordpress.com/docs/api/console/`, select `WP REST API` and `wpcom/v2`, and enter the endpoint: `/sites/YOURDOMAIN/launchpad?checklist_slug=earn`
   - Confirm you receive back a valid checklist with the stripe_connected and paid_offer_created tasks. 

