### PR TITLE
BlogRoll: Add image fallback

### DIFF
--- a/projects/plugins/jetpack/changelog/feat-add_image_fallback
+++ b/projects/plugins/jetpack/changelog/feat-add_image_fallback
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Blogroll add fallback images
+
+

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/edit.js
@@ -17,7 +17,14 @@ function BlogrollItemEdit( { className, attributes, setAttributes } ) {
 				render={ ( { open } ) => (
 					<Button variant="link" onClick={ open } style={ { padding: 0 } }>
 						<figure>
-							<img src={ icon } alt={ name } />
+							<img
+								onError={ event => {
+									event.target.src = 'https://s0.wp.com/i/webclip.png';
+									event.onerror = null;
+								} }
+								src={ icon }
+								alt={ name }
+							/>
 						</figure>
 					</Button>
 				) }

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/edit.js
@@ -19,8 +19,9 @@ function BlogrollItemEdit( { className, attributes, setAttributes } ) {
 						<figure>
 							<img
 								onError={ event => {
-									event.target.src = 'https://s0.wp.com/i/webclip.png';
-									event.onerror = null;
+									if ( event.target.src !== 'https://s0.wp.com/i/webclip.png' ) {
+										event.target.src = 'https://s0.wp.com/i/webclip.png';
+									}
 								} }
 								src={ icon }
 								alt={ name }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/81952

## Proposed changes:
Add a fallback image when for any reason the blogroll item image fails to load.

## Does this pull request change what data or activity we track or use?

This PR loads an image on blogroll-item in case of failure

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the editor in your jetpack site
* Make sure you have the blogroll block
* To simulate a broken image, I did:
	- Open the code editor
	- Found a blogroll item and changed the image URL to break it. ( like in this video https://github.com/Automattic/wp-calypso/issues/81952 )

* After that you should see the "wordpress" fallback image