### PR TITLE
Newsletter categories: Improve the handling of theme colors on both frontend & editor.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-fallback-color
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-fallback-color
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Improve color handling for the newsletter categories

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -187,6 +187,9 @@ export function SubscriptionEdit( props ) {
 		'--subscribe-block-border-radius': borderRadius
 			? borderRadius + 'px'
 			: DEFAULT_BORDER_RADIUS_VALUE + 'px',
+		'--subscribe-block-text-color': 'var(--wp--preset--color--foreground)',
+		'--subscribe-block-background-color': 'var(--wp--preset--color--background)',
+		'--subscribe-block-accent-color': 'var(--wp--preset--color--foreground)',
 	};
 
 	const emailFieldStyles = {
@@ -293,43 +296,44 @@ export function SubscriptionEdit( props ) {
 			) }
 
 			<div className={ getBlockClassName() } style={ cssVars }>
-				{ newsletterCategoriesEnabled ? (
-					<div className="wp-block-jetpack-subscriptions__newsletter-categories">
-						{ newsletterCategories.map( category => {
-							return (
-								<div
-									key={ `newsletter-category-${ category.id }` }
-									className="wp-block-jetpack-subscriptions__newsletter-category"
-								>
-									<div>{ category.name }</div>
-								</div>
-							);
-						} ) }
-					</div>
-				) : null }
-
 				<div className="wp-block-jetpack-subscriptions__form" role="form">
-					<TextControl
-						placeholder={ subscribePlaceholder }
-						disabled={ true }
-						className={ classnames(
-							emailFieldClasses,
-							'wp-block-jetpack-subscriptions__textfield'
-						) }
-						style={ emailFieldStyles }
-					/>
-					<RichText
-						className={ classnames(
-							buttonClasses,
-							'wp-block-jetpack-subscriptions__button',
-							'wp-block-button__link'
-						) }
-						onChange={ value => setAttributes( { submitButtonText: value } ) }
-						style={ buttonStyles }
-						value={ submitButtonText }
-						withoutInteractiveFormatting
-						allowedFormats={ [ 'core/bold', 'core/italic', 'core/strikethrough' ] }
-					/>
+					{ newsletterCategoriesEnabled ? (
+						<div className="wp-block-jetpack-subscriptions__newsletter-categories">
+							{ newsletterCategories.map( category => {
+								return (
+									<div
+										key={ `newsletter-category-${ category.id }` }
+										className="wp-block-jetpack-subscriptions__newsletter-category"
+									>
+										<div>{ category.name }</div>
+									</div>
+								);
+							} ) }
+						</div>
+					) : null }
+					<div className="wp-block-jetpack-subscriptions__form-elements">
+						<TextControl
+							placeholder={ subscribePlaceholder }
+							disabled={ true }
+							className={ classnames(
+								emailFieldClasses,
+								'wp-block-jetpack-subscriptions__textfield'
+							) }
+							style={ emailFieldStyles }
+						/>
+						<RichText
+							className={ classnames(
+								buttonClasses,
+								'wp-block-jetpack-subscriptions__button',
+								'wp-block-button__link'
+							) }
+							onChange={ value => setAttributes( { submitButtonText: value } ) }
+							style={ buttonStyles }
+							value={ submitButtonText }
+							withoutInteractiveFormatting
+							allowedFormats={ [ 'core/bold', 'core/italic', 'core/strikethrough' ] }
+						/>
+					</div>
 				</div>
 				{ showSubscribersTotal && (
 					<div className="wp-block-jetpack-subscriptions__subscount">{ subscriberCountString }</div>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -187,9 +187,9 @@ export function SubscriptionEdit( props ) {
 		'--subscribe-block-border-radius': borderRadius
 			? borderRadius + 'px'
 			: DEFAULT_BORDER_RADIUS_VALUE + 'px',
-		'--subscribe-block-text-color': 'var(--wp--preset--color--foreground)',
-		'--subscribe-block-background-color': 'var(--wp--preset--color--background)',
-		'--subscribe-block-accent-color': 'var(--wp--preset--color--foreground)',
+		'--subscribe-block-text-color': 'var(--wp--preset--color--foreground, #3c434a)',
+		'--subscribe-block-background-color': 'var(--wp--preset--color--background, white)',
+		'--subscribe-block-accent-color': 'var(--wp--preset--color--foreground, #3c434a)',
 	};
 
 	const emailFieldStyles = {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -27,6 +27,9 @@ const DEFAULT_BORDER_WEIGHT_VALUE = 1;
 const DEFAULT_FONTSIZE_VALUE      = '16px';
 const DEFAULT_PADDING_VALUE       = 15;
 const DEFAULT_SPACING_VALUE       = 10;
+const DEFAULT_ACCENT_COLOR        = '#3c434a';
+const DEFAULT_BACKGROUND_COLOR    = 'white';
+const DEFAULT_TEXT_COLOR          = '#3c434a';
 
 /**
  * Registers the block for use in Gutenberg
@@ -445,6 +448,35 @@ function get_element_styles_from_attributes( $attributes ) {
 
 	$categories_styles = sprintf( '--subscribe-block-border-radius: %dpx;', get_attribute( $attributes, 'borderRadius', DEFAULT_BORDER_RADIUS_VALUE ) );
 
+	$subscribe_block_accent_color     = DEFAULT_ACCENT_COLOR;
+	$subscribe_block_background_color = DEFAULT_BACKGROUND_COLOR;
+	$subscribe_block_text_color       = DEFAULT_TEXT_COLOR;
+
+	$global_styles = wp_get_global_styles(
+		array( 'color' )
+	);
+
+	if ( isset( $global_styles['background'] ) ) {
+		$subscribe_block_background_color = $global_styles['background'];
+	}
+
+	if ( isset( $global_styles['text'] ) ) {
+		$subscribe_block_text_color = $global_styles['text'];
+	}
+
+	if ( function_exists( 'wpcom_get_site_accent_color' ) ) {
+		$site_accent_color = wpcom_get_site_accent_color();
+		if ( $site_accent_color ) {
+			$subscribe_block_accent_color = $site_accent_color;
+		}
+	} else {
+		$subscribe_block_accent_color = $subscribe_block_text_color;
+
+	}
+	$categories_styles .= sprintf( ' --subscribe-block-accent-color: %s; ', $subscribe_block_accent_color );
+	$categories_styles .= sprintf( ' --subscribe-block-background-color: %s; ', $subscribe_block_background_color );
+	$categories_styles .= sprintf( ' --subscribe-block-text-color: %s; ', $subscribe_block_text_color );
+
 	if ( has_attribute( $attributes, 'customBorderColor' ) ) {
 		$style = sprintf( 'border-color: %s; border-style: solid;', get_attribute( $attributes, 'customBorderColor' ) );
 
@@ -686,8 +718,7 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 		)
 	);
 
-	$post_access_level = get_post_access_level_for_current_post();
-
+	$post_access_level     = get_post_access_level_for_current_post();
 	$newsletter_categories = $data['newsletter_categories'];
 
 	?>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -1,5 +1,9 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
+@function x($var-name, $fallback) {
+	@return unquote("var(#{$var-name}, #{$fallback})");
+}
+
 .is-style-compact {
 	.wp-block-jetpack-subscriptions__button,
 	.wp-block-button__link {
@@ -127,10 +131,10 @@
 			font-size: $default-font-size;
 			font-weight: 500;
 			line-height: 20px;
-			color: #3c434a; // $studio-gray-70
-			border: 1px solid $gray-200;
+			color: var(--subscribe-block-text-color);
+			border: 1px solid var(--subscribe-block-accent-color);
 			border-radius: var(--subscribe-block-border-radius);
-			background: $white;
+			background: var(--subscribe-block-background-color);
 			transition: background 0.1s;
 			user-select: none;
 
@@ -140,14 +144,15 @@
 		}
 
 		input[type="checkbox"]:checked + div {
-			background: color-mix(in srgb, var(--wp--preset--color--primary) 5%, white);
-			border-color: var(--wp--preset--color--primary);
+			background: color-mix(in srgb, var(--subscribe-block-accent-color) 5%, white);
+			border-color: var(--subscribe-block-accent-color);
 
 			svg {
 				display: block;
 
 				path {
-					fill: var( --wp--preset--color--primary );
+					fill: var(--subscribe-block-accent-color);
+
 				}
 			}
 		}


### PR DESCRIPTION

## Proposed changes:
- Improves the handling of theme colors on both frontend & editor.
- Fixes the wrapping in the editor

This defines 3 CSS variables:

- `--subscribe-block-accent-color`
- `--subscribe-block-text-color`
- `--subscribe-block-background-color`

Depending on the environment, these get filled in with values from the theme used.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Apply this PR
- Add a subscribe block to a site with newsletter categories enabled 
- Test with different themes

