### PR TITLE
ci: Add job summaries to workflow_run workflows

### DIFF
--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -40,6 +40,10 @@ jobs:
     outputs:
       upgrade_check: ${{ steps.upgrade_check.outputs.id }}
     steps:
+      - name: Log info
+        run: |
+          echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+
       - uses: actions/checkout@v3
 
       - name: Get token

--- a/.github/workflows/slack-workflow-failed.yml
+++ b/.github/workflows/slack-workflow-failed.yml
@@ -33,114 +33,114 @@ jobs:
             TITLE=$(jq -r '.workflow_run.display_title' "$GITHUB_EVENT_PATH")
             BRANCH=${TITLE##* on }
             echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-
-            gh_set_output message "$(
-              jq -nc --slurpfile event "$GITHUB_EVENT_PATH" --arg branch "$BRANCH" '$event[0] as $e | $e.workflow_run as $run | {
-                icon_emoji: ":github-rejected:",
-                text: "*\( $e.workflow.name ) failed on \( $branch )*\n<\( $run.html_url )|Run #\( $run.id )>",
-                blocks: [
-                  {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: "*\( $e.workflow.name ) failed on \( $branch )*"
-                    }
-                  },
-                  {
-                    type: "context",
-                    elements: [
-                      {
-                        type: "plain_text",
-                        text: "Duration: \( ( $run.updated_at | fromdateiso8601 ) - ( $run.run_started_at | fromdateiso8601 ) | strftime( "%H:%M:%S" ) )"
-                      }
-                    ]
-                  },
-                  {
-                    type: "actions",
-                    elements: [
-                      {
-                        type: "button",
-                        text: {
-                          type: "plain_text",
-                          text: "Run #\( $run.id )"
-                        },
-                        url: $run.html_url
-                      }
-                    ]
-                  }
-                ]
-              }'
-            )"
+            DATA=$( jq -nc --slurpfile event "$GITHUB_EVENT_PATH" --arg branch "$BRANCH" '$event[0] as $e | $e.workflow_run as $run |
+              {
+                workflow_name: $e.workflow.name,
+                branch: $branch,
+                run_id: $run.id,
+                run_url: $run.html_url,
+                duration: ( ( $run.updated_at | fromdateiso8601 ) - ( $run.run_started_at | fromdateiso8601 ) | strftime( "%H:%M:%S" ) ),
+              }
+            ' )
           else
             BRANCH=$(jq -r '.workflow_run.head_branch' "$GITHUB_EVENT_PATH")
             echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-
-            gh_set_output message "$(
-              jq -nc --slurpfile event "$GITHUB_EVENT_PATH" '$event[0] as $e | $e.workflow_run as $run | {
-                icon_emoji: ":github-rejected:",
-                text: "*\( $e.workflow.name ) failed on \( $run.head_branch )*\n<\( $run.html_url )|Run #\( $run.id )>",
-                blocks: [
-                  {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: "*\( $e.workflow.name ) failed on \( $run.head_branch )*"
-                    }
-                  },
-                  {
-                    type: "context",
-                    elements: [
-                      {
-                        type: "plain_text",
-                        text: "Commit: \( $run.head_commit.id[0:8] ) \( $run.head_commit.message | sub( "\n.*"; ""; "m" ) )",
-                        emoji: false
-                      },
-                      {
-                        type: "plain_text",
-                        text: "Author: \( $run.head_commit.author.name )",
-                        emoji: false
-                      },
-                      {
-                        type: "plain_text",
-                        text: "Duration: \( ( $run.updated_at | fromdateiso8601 ) - ( $run.run_started_at | fromdateiso8601 ) | strftime( "%H:%M:%S" ) )"
-                      }
-                    ]
-                  },
-                  {
-                    type: "actions",
-                    elements: [
-                      {
-                        type: "button",
-                        text: {
-                          type: "plain_text",
-                          text: "Run #\( $run.id )"
-                        },
-                        url: $run.html_url
-                      },
-                      {
-                        type: "button",
-                        text: {
-                          type: "plain_text",
-                          text: "Commit"
-                        },
-                        url: "\( $run.head_repository.html_url )/commit/\( $run.head_commit.id )"
-                      },
-                      (
-                        $run.head_commit.message | sub( "\n.*"; ""; "m" ) | match( " \\(#([0-9]+)\\)$" ).captures[0].string | {
-                          type: "button",
-                          text: {
-                            type: "plain_text",
-                            text: "PR #\(.)"
-                          },
-                          url: "\( $run.head_repository.html_url )/pull/\(.)"
-                        }
-                      )
-                    ]
-                  }
-                ]
-              }'
-            )"
+            DATA=$( jq -nc --slurpfile event "$GITHUB_EVENT_PATH" '$event[0] as $e | $e.workflow_run as $run |
+              ( $run.head_commit.message | sub( "\n.*"; ""; "m" ) | match( " \\(#([0-9]+)\\)$" ).captures[0].string // null ) as $pr |
+              {
+                workflow_name: $e.workflow.name,
+                branch: $run.head_branch,
+                run_id: $run.id,
+                run_url: $run.html_url,
+                duration: ( ( $run.updated_at | fromdateiso8601 ) - ( $run.run_started_at | fromdateiso8601 ) | strftime( "%H:%M:%S" ) ),
+                commit: "\( $run.head_commit.id[0:8] ) \( $run.head_commit.message | sub( "\n.*"; ""; "m" ) )",
+                author: ( $run.head_commit.author.name ),
+                commit_url: "\( $run.head_repository.html_url )/commit/\( $run.head_commit.id )",
+                pr: $pr,
+                pr_url: ( if $pr then "\( $run.head_repository.html_url )/pull/\( $pr )" else null end )
+              }
+            ' )
           fi
+
+          jq -r '[
+            "### \( .workflow_name ) failed on \( .branch )",
+            "",
+            if .commit then "Commit: \( .commit )" else empty end,
+            if .author then "Author: \( .author )" else empty end,
+            "Duration: \( .duration )",
+            "",
+            (
+              [
+                "[Run #\( .run_id )](\( .run_url ))",
+                if .commit_url then "[Commit](\( .commit_url ))" else empty end,
+                if .pr then "[PR #\( .pr )](\( .pr_url ))" else empty end
+              ] | join( " | " )
+            )
+          ] | join( "\n" )' <<<"$DATA" >> $GITHUB_STEP_SUMMARY
+
+          gh_set_output message "$( jq -c '
+            {
+              icon_emoji: ":github-rejected:",
+              text: "*\( .workflow_name ) failed on \( .branch )*\n<\( .run_url )|Run #\( .run_id )>",
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: "*\( .workflow_name ) failed on \( .branch )*"
+                  }
+                },
+                {
+                  type: "context",
+                  elements: [
+                    if .commit then {
+                      type: "plain_text",
+                      text: "Commit: \( .commit )",
+                      emoji: false
+                    } else empty end,
+                    if .author then {
+                      type: "plain_text",
+                      text: "Author: \( .author )",
+                      emoji: false
+                    } else empty end,
+                    {
+                      type: "plain_text",
+                      text: "Duration: \( .duration )"
+                    }
+                  ]
+                },
+                {
+                  type: "actions",
+                  elements: [
+                    {
+                      type: "button",
+                      text: {
+                        type: "plain_text",
+                        text: "Run #\( .run_id )"
+                      },
+                      url: .run_url
+                    },
+                    if .commit_url then {
+                      type: "button",
+                      text: {
+                        type: "plain_text",
+                        text: "Commit"
+                      },
+                      url: .commit_url
+                    } else empty end,
+                    if .pr then {
+                      type: "button",
+                      text: {
+                        type: "plain_text",
+                        text: "PR #\( .pr )"
+                      },
+                      url: .pr_url,
+                    } else empty end
+                  ]
+                }
+              ]
+            }
+          ' <<<"$DATA" )"
 
       - name: Send message to alerts channel
         uses: slackapi/slack-github-action@v1.24.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When looking at a run of one of the workflow_run workflows, it can be difficult to determine what the triggering workflow was. We can address this by using GitHub's [job summaries][1] feature.

[1]: https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/

I wound up doing kind of a big refactor on `slack-workflow-failed.yml` to DRY things. It was already repeating itself and this would have made it even worse.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Fork the repo, merge this in the fork, and trigger the workflows.
  * For `slack-workflow-failed.yml` you might look at where I already did that with https://github.com/anomiex/testing/actions/runs/6250220528 and https://github.com/anomiex/testing/actions/runs/6250222975 and p1695220883557889-slack-C02SV8APDTM.