### PR TITLE
Fix video upload bug

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-video-upload-bugfix
+++ b/projects/plugins/jetpack/changelog/fix-video-upload-bugfix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Skip video file addition to upload queue if it fails the space/allowance check

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
@@ -102,10 +102,10 @@ class WPCOM_JSON_API_Upload_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 
 					if ( true !== $result ) {
 						$this->api->output_early( 400, array( 'errors' => $this->rewrite_generic_upload_error( array( $result ) ) ) );
+						continue;
 					}
 				}
 				$jetpack_media_files[] = $media_item;
-
 			} else {
 				$other_media_files[] = $media_item;
 			}


### PR DESCRIPTION
Fix a bug in the upload file queue iterator.

Fixes https://github.com/Automattic/jpop-issues/issues/8470

## Proposed changes:
This PR simply adds a `continue` statement on the file upload iteration when a video file fails the space/allowance check. The bug has been hidden since a filter takes place preventing the situation, but the filter is being fixed as it was wrongly messing with the returned value and then this bug became more evident and started to be triggered.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1695148738679889-slack-C9W0QF6KA
D122202-code

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The bug is not noticeable in regular use of the module, applying the PR should result in no changes uploading videos and free trial allowance.  This change is to land after and be tested against D122202-code

Checkout the diff on your sandbox. Sandbox public-api.wordpress.com. Follow instructions on the diff.