### PR TITLE
Jetpack Beta: Use WP core `Plugin_Upgrader` to install plugins

### DIFF
--- a/projects/plugins/beta/changelog/fix-jetpack-beta-plugin-installation
+++ b/projects/plugins/beta/changelog/fix-jetpack-beta-plugin-installation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use WordPress core's `Plugin_Upgrader` to install plugins, as it handles edge cases better.

--- a/projects/plugins/beta/src/class-plugin.php
+++ b/projects/plugins/beta/src/class-plugin.php
@@ -9,6 +9,8 @@ namespace Automattic\JetpackBeta;
 
 use Composer\Semver\Comparator as Semver;
 use InvalidArgumentException;
+use Plugin_Upgrader;
+use WP_Ajax_Upgrader_Skin;
 use WP_Error;
 
 /**
@@ -838,35 +840,33 @@ class Plugin {
 	 * @return null|WP_Error
 	 */
 	private function install( $which, $info ) {
-		// Download the required version of the plugin.
-		$temp_path = download_url( $info->download_url );
-		if ( is_wp_error( $temp_path ) ) {
-			return new WP_Error(
-				'download_error',
-				// translators: %1$s: download url, %2$s: error message.
-				sprintf( __( 'Error Downloading: <a href="%1$s">%1$s</a> - Error: %2$s', 'jetpack-beta' ), $info->download_url, $temp_path->get_error_message() )
-			);
-		}
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
-		// Init the WP_Filesystem API.
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		$creds = request_filesystem_credentials( site_url() . '/wp-admin/', '', false, false, array() );
-		if ( ! WP_Filesystem( $creds ) ) {
-			return new WP_Error( 'fs_api_error', __( 'Jetpack Beta: No File System access', 'jetpack-beta' ) );
-		}
+		$skin     = new WP_Ajax_Upgrader_Skin();
+		$upgrader = new Plugin_Upgrader( $skin );
+		$upgrader->init();
+		$result = $upgrader->install(
+			$info->download_url,
+			array(
+				'overwrite_package' => true,
+			)
+		);
 
-		// Unzip the downloaded plugin.
-		global $wp_filesystem;
-		$plugin_path = str_replace( ABSPATH, $wp_filesystem->abspath(), WP_PLUGIN_DIR );
-		$result      = unzip_file( $temp_path, $plugin_path );
 		if ( is_wp_error( $result ) ) {
-			// translators: %1$s: error message.
-			return new WP_Error( 'unzip_error', sprintf( __( 'Error Unziping file: Error: %1$s', 'jetpack-beta' ), $result->get_error_message() ) );
+			return $result;
+		}
+		$errors = $upgrader->skin->get_errors();
+		if ( is_wp_error( $errors ) && $errors->get_error_code() ) {
+			return $errors;
+		}
+		if ( $result === false ) {
+			return new WP_Error( 'install_error', __( 'There was an error installing your plugin.', 'jetpack-beta' ) );
 		}
 
 		// Record the source info, if it's a dev version.
 		if ( 'dev' === $which ) {
-			$wp_filesystem->put_contents( "$plugin_path/{$this->dev_plugin_slug()}/.jpbeta.json", wp_json_encode( $info, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+			global $wp_filesystem; // Should have been set up by the upgrader already.
+			$wp_filesystem->put_contents( WP_PLUGIN_DIR . '/' . $this->dev_plugin_slug() . '/.jpbeta.json', wp_json_encode( $info, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
 		}
 
 		return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
WordPress core's `Plugin_Upgrader` class can be passed a URL to download and install, and the zips we're installing are structured properly. Let's use that instead of rolling our own logic that doesn't handle as many edge cases.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1695225622639149/1695224363.670039-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Switch between different versions of plugins, both development and release, using the web UI, wp-cli, and where applicable upgrade buttons in the plugins page or in admin notices. Everything should work as expected.
  * In particular, try using Jetpack Beta to install Jetpack 12.6, connect it, then downgrade it to 12.5.
  * One way to trigger admin notices and such for jetpack-dev versions is to install the "rc" version then edit `wp-content/plugins/jetpack-dev/.jpbeta.json` to change "source" to "trunk".
* Arrange for errors to happen during the installation process, for example by `chmod -R u-w` your WordPress install. Ensure these are handled appropriately by all the same methods.