### PR TITLE
CRM: Automations backend action Transaction Set Status

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-3197-automations-backend-action-transaction-set-status
+++ b/projects/plugins/crm/changelog/add-crm-3197-automations-backend-action-transaction-set-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Automation: Added transaction set status action

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Transactions.php
@@ -17,7 +17,7 @@
   / Breaking Checks
    ====================================================== */
 
-
+use Automattic\Jetpack\CRM\Event_Manager\Events_Manager;
 
 /**
 * ZBS DAL >> Transactions
@@ -229,6 +229,14 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
 
         );
 
+		/**
+		 * Events_Manager instance. Manages CRM events.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @var Events_Manager
+		 */
+		private $events_manager;
 
     function __construct($args=array()) {
 
@@ -241,7 +249,7 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
         ); foreach ($defaultArgs as $argK => $argV){ $this->$argK = $argV; if (is_array($args) && isset($args[$argK])) {  if (is_array($args[$argK])){ $newData = $this->$argK; if (!is_array($newData)) $newData = array(); foreach ($args[$argK] as $subK => $subV){ $newData[$subK] = $subV; }$this->$argK = $newData;} else { $this->$argK = $args[$argK]; } } }
         #} =========== / LOAD ARGS =============
 
-
+			$this->events_manager = new Events_Manager();
     }
 
     // ===============================================================================
@@ -1794,6 +1802,8 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
                                         'extraMeta'             => $confirmedExtraMeta #} This is the "extraMeta" passed (as saved)
                                     ));
 
+											$data['id'] = $id; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+											$this->events_manager->transaction()->updated( $data ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
                                 
 
                             }
@@ -1965,7 +1975,8 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
                             'automatorpassthrough'=>$automatorPassthrough, #} This passes through any custom log titles or whatever into the Internal automator recipe.
                             'extraMeta'=>$confirmedExtraMeta #} This is the "extraMeta" passed (as saved)
                         ));
-
+												$data['id'] = $newID; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+												$this->events_manager->transaction()->created( $data ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
                     }
                     
                     return $newID;
@@ -2120,6 +2131,8 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
                 'id'=>$id,
                 'saveOrphans'=>$saveOrphans
             ));
+
+					$this->events_manager->transaction()->deleted( $id );
 
             return $del;
 

--- a/projects/plugins/crm/src/automation/commons/actions/transactions/class-set-transaction-status.php
+++ b/projects/plugins/crm/src/automation/commons/actions/transactions/class-set-transaction-status.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Jetpack CRM Automation Set_Transaction_Status action.
+ *
+ * @package automattic/jetpack-crm
+ * @since $$next-version$$
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Actions;
+
+use Automattic\Jetpack\CRM\Automation\Base_Action;
+use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Transaction;
+
+/**
+ * Adds the Set_Transaction_Status class.
+ *
+ * @since $$next-version$$
+ */
+class Set_Transaction_Status extends Base_Action {
+
+	/**
+	 * Get the slug name of the step.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The slug name of the step.
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/set_transaction_status';
+	}
+
+	/**
+	 * Get the title of the step.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string|null The title of the step.
+	 */
+	public static function get_title(): ?string {
+		return __( 'Set Transaction Status Action', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the step.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string|null The description of the step.
+	 */
+	public static function get_description(): ?string {
+		return __( 'Action to set the transaction status', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the data type.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The type of the step.
+	 */
+	public static function get_data_type(): string {
+		return Data_Type_Transaction::get_slug();
+	}
+
+	/**
+	 * Get the category of the step.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string|null The category of the step.
+	 */
+	public static function get_category(): ?string {
+		return __( 'Transaction', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the allowed triggers.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string[]|null The allowed triggers.
+	 */
+	public static function get_allowed_triggers(): ?array {
+		return array();
+	}
+
+	/**
+	 * Update the DAL with the transaction status.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param mixed  $data Data passed from the trigger.
+	 * @param ?mixed $previous_data (Optional) The data before being changed.
+	 */
+	public function execute( $data, $previous_data = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		global $zbs;
+		$zbs->DAL->transactions->setTransactionStatus( $data['id'], $this->attributes['new_status'] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	}
+}

--- a/projects/plugins/crm/src/event-manager/class-events-manager.php
+++ b/projects/plugins/crm/src/event-manager/class-events-manager.php
@@ -58,4 +58,15 @@ class Events_Manager {
 	public function invoice(): Invoice_Event {
 		return new Invoice_Event();
 	}
+
+	/**
+	 * Return the Transaction_Event instance.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return Transaction_Event A Transaction_Event instance.
+	 */
+	public function transaction(): Transaction_Event {
+		return new Transaction_Event();
+	}
 }

--- a/projects/plugins/crm/src/event-manager/managers/class-transaction-event.php
+++ b/projects/plugins/crm/src/event-manager/managers/class-transaction-event.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Transaction Event.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Event_Manager;
+
+/**
+ * Transaction Event class.
+ *
+ * @since $$next-version$$
+ */
+class Transaction_Event implements Event {
+
+	/**
+	 * The Transaction_Event instance.
+	 *
+	 * @since $$next-version$$
+	 * @var Transaction_Event
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get the singleton instance of this class.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return Transaction_Event The Transaction_Event instance.
+	 */
+	public static function get_instance(): Transaction_Event {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * A new transaction was created.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $transaction_data The created transaction data.
+	 * @return void
+	 */
+	public function created( array $transaction_data ): void {
+		do_action( 'jpcrm_transaction_created', $transaction_data );
+	}
+
+	/**
+	 * The transaction was updated.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $transaction_data The updated transaction data.
+	 * @return void
+	 */
+	public function updated( array $transaction_data ): void {
+		do_action( 'jpcrm_transaction_updated', $transaction_data );
+	}
+
+	/**
+	 * The transaction was deleted.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $transaction_id The deleted transaction id.
+	 * @return void
+	 */
+	public function deleted( int $transaction_id ): void {
+		do_action( 'jpcrm_transaction_deleted', $transaction_id );
+	}
+}

--- a/projects/plugins/crm/tests/php/automation/transactions/actions/class-set-transaction-status-test.php
+++ b/projects/plugins/crm/tests/php/automation/transactions/actions/class-set-transaction-status-test.php
@@ -1,0 +1,79 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\CRM\Automation\Tests;
+
+use Automattic\Jetpack\CRM\Automation\Actions\Set_Transaction_Status;
+use Automattic\Jetpack\CRM\Automation\Automation_Engine;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Transaction;
+use Automattic\Jetpack\CRM\Automation\Triggers\Transaction_Created;
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
+
+/**
+ * Test Automation Workflow functionalities
+ *
+ * @covers Automattic\Jetpack\CRM\Automation\Actions\Set_Transaction_Status_Test
+ */
+class Set_Transaction_Status_Test extends JPCRM_Base_Integration_Test_Case {
+
+	/**
+	 * A helper class to generate data for the automation tests.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var Automation_Faker
+	 */
+	private $automation_faker;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->automation_faker = Automation_Faker::instance();
+		$this->automation_faker->reset_all();
+	}
+
+	/**
+	 * @testdox Test the set transaction status action executes the action, within a workflow.
+	 */
+	public function test_set_transaction_status_action_with_workflow() {
+		global $zbs;
+
+		$automation = new Automation_Engine();
+		$automation->register_trigger( Transaction_Created::class );
+		$automation->register_step( Set_Transaction_Status::class );
+		$automation->register_data_type( Data_Type_Transaction::class );
+
+		$workflow_data = array(
+			'name'         => 'Set Transaction Action Workflow Test',
+			'description'  => 'This is a test',
+			'category'     => 'Test',
+			'is_active'    => true,
+			'triggers'     => array(
+				Transaction_Created::get_slug(),
+			),
+			'initial_step' => 0,
+			'steps'        => array(
+				0 => array(
+					'slug'       => Set_Transaction_Status::get_slug(),
+					'attributes' => array(
+						'new_status' => 'Paid',
+					),
+					'next_step'  => null,
+				),
+			),
+		);
+
+		$workflow = new Automation_Workflow( $workflow_data );
+		$workflow->set_engine( $automation );
+
+		$automation->add_workflow( $workflow );
+		$automation->init_workflows();
+
+		$transaction_id = $this->add_transaction( array( 'status' => 'Draft' ) );
+
+		$transaction = $zbs->DAL->transactions->getTransaction( $transaction_id );
+		$this->assertSame( 'Paid', $transaction['status'] );
+	}
+}

--- a/projects/plugins/crm/tests/php/class-jpcrm-base-integration-test-case.php
+++ b/projects/plugins/crm/tests/php/class-jpcrm-base-integration-test-case.php
@@ -49,6 +49,19 @@ class JPCRM_Base_Integration_Test_Case extends JPCRM_Base_Test_Case {
 	}
 
 	/**
+	 * Add a transaction.
+	 *
+	 * @param array $args (Optional) A list of arguments we should use for the transaction.
+	 *
+	 * @return int The transaction ID.
+	 */
+	public function add_transaction( array $args = array() ) {
+		global $zbs;
+
+		return $zbs->DAL->transactions->addUpdateTransaction( array( 'data' => $this->generate_transaction_data( $args ) ) );
+	}
+
+	/**
 	 * Get a contact.
 	 *
 	 * @param int|string $id The ID of the contact we want to get.

--- a/projects/plugins/crm/tests/php/class-jpcrm-base-test-case.php
+++ b/projects/plugins/crm/tests/php/class-jpcrm-base-test-case.php
@@ -109,4 +109,33 @@ class JPCRM_Base_Test_Case extends WP_UnitTestCase {
 			)
 		);
 	}
+
+	/**
+	 * Generate default transaction data.
+	 *
+	 * @param array $args (Optional) A list of arguments we should use for the transaction.
+	 *
+	 * @return array An array of basic transaction data.
+	 */
+	public function generate_transaction_data( $args = array() ): array {
+		return wp_parse_args(
+			$args,
+			array(
+				'title'          => 'Some transaction title',
+				'desc'           => 'Some desc',
+				'ref'            => 'TransactionReference_1',
+				'hash'           => 'mASOpAnf334Pncl1px4',
+				'status'         => 'Completed',
+				'type'           => 'Sale',
+				'currency'       => 'USD',
+				'total'          => '150.00',
+				'tax'            => '10.00',
+				'lineitems'      => false,
+				'date'           => 1676000000,
+				'date_completed' => 1676923766,
+				'created'        => 1675000000,
+				'lastupdated'    => 1675000000,
+			)
+		);
+	}
 }

--- a/projects/plugins/crm/tests/php/event-manager/class-event-manager-faker.php
+++ b/projects/plugins/crm/tests/php/event-manager/class-event-manager-faker.php
@@ -55,4 +55,33 @@ class Event_Manager_Faker {
 
 		return $data;
 	}
+
+	/**
+	 * Return data for a dummy transaction.
+	 *
+	 * @return array
+	 */
+	public function transaction_data() {
+		$data = array(
+			'id'   => 1,
+			'data' => array(
+				'title'          => 'Some transaction title',
+				'ref'            => 'transaction_reference_1',
+				'desc'           => 'Some desc',
+				'hash'           => 'mASOpAnf334Pncl1px4',
+				'status'         => 'Completed',
+				'type'           => 'Sale',
+				'currency'       => 'USD',
+				'total'          => '150.00',
+				'tax'            => '10.00',
+				'lineitems'      => array(),
+				'date'           => 1676000000,
+				'date_completed' => 1676923766,
+				'created'        => 1675000000,
+				'lastupdated'    => 1675000000,
+			),
+		);
+
+		return $data;
+	}
 }

--- a/projects/plugins/crm/tests/php/event-manager/class-event-manager-test.php
+++ b/projects/plugins/crm/tests/php/event-manager/class-event-manager-test.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack\CRM\Event_Manager\Tests;
 
 use Automattic\Jetpack\CRM\Event_Manager\Contact_Event;
 use Automattic\Jetpack\CRM\Event_Manager\Invoice_Event;
+use Automattic\Jetpack\CRM\Event_Manager\Transaction_Event;
 use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Test_Case;
 
 require_once __DIR__ . '/class-event-manager-faker.php';
@@ -201,5 +202,65 @@ class Event_Manager_Test extends JPCRM_Base_Test_Case {
 
 		$invoice_event = new Invoice_Event();
 		$invoice_event->updated( $invoice_data );
+	}
+
+	/**
+	 * @testdox Test that transaction created event is fired
+	 */
+	public function test_notify_on_transaction_created() {
+
+		$transaction_data = Event_Manager_Faker::instance()->transaction_data();
+
+		add_action(
+			'jpcrm_transaction_created',
+			function ( $transaction ) use ( $transaction_data ) {
+				$this->assertEquals( $transaction, $transaction_data );
+			},
+			10,
+			1
+		);
+
+		$transaction_event = new Transaction_Event();
+		$transaction_event->created( $transaction_data );
+	}
+
+	/**
+	 * @testdox Test that transaction created event is fired
+	 */
+	public function test_notify_on_transaction_updated() {
+
+		$transaction_data = Event_Manager_Faker::instance()->transaction_data();
+
+		add_action(
+			'jpcrm_transaction_updated',
+			function ( $transaction ) use ( $transaction_data ) {
+				$this->assertEquals( $transaction, $transaction_data );
+			},
+			10,
+			1
+		);
+
+		$transaction_event = new Transaction_Event();
+		$transaction_event->updated( $transaction_data );
+	}
+
+	/**
+	 * @testdox Test that transaction deleted event is fired
+	 */
+	public function test_notify_on_transaction_deleted() {
+
+		$transaction_deleted_id = 12345;
+
+		add_action(
+			'jpcrm_transaction_deleted',
+			function ( $invoice_id ) use ( $transaction_deleted_id ) {
+				$this->assertEquals( $invoice_id, $transaction_deleted_id );
+			},
+			10,
+			1
+		);
+
+		$transaction_event = new Transaction_Event();
+		$transaction_event->deleted( $transaction_deleted_id );
 	}
 }


### PR DESCRIPTION
This PR adds the action Transaction Set Status, and the needed event manager for transactions.

## Proposed changes:
* Add Transaction Set Status Action
* Add Transaction Event Manager

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3333
https://github.com/Automattic/zero-bs-crm/issues/3197

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the code
* Check the coverage of our new tests
* Run the tests and make sure they are passing

