### PR TITLE
My Jetpack: use Stats purchase page within wp-admin

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-use-odyssey-stats-purchase
+++ b/projects/packages/my-jetpack/changelog/update-use-odyssey-stats-purchase
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats: link to purchase page within wp-admin

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -197,9 +197,13 @@ class Stats extends Module_Product {
 	 * @return ?string
 	 */
 	public static function get_purchase_url() {
-		$blog_id = Jetpack_Options::get_option( 'id' );
 		// The returning URL could be customized by changing the `redirect_uri` param with relative path.
-		return sprintf( 'https://wordpress.com/stats/purchase/%d?from=jetpack-my-jetpack&redirect_uri=%s', $blog_id, rawurldecode( 'admin.php?page=stats' ) );
+		return sprintf(
+			'%s#!/stats/purchase/%d?from=jetpack-my-jetpack&redirect_uri=%s',
+			admin_url( 'admin.php?page=stats' ),
+			Jetpack_Options::get_option( 'id' ),
+			rawurlencode( 'admin.php?page=stats' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

The PR proposes to change the Stats card 'upgrade' button in My Jetpack to link to Stats purchase page in Odyssey Stats to avoid user confusion being redirected to Wordpress.com. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Build my-jetpack and jetpack `jetpack build packages/my-jetpack && jetpack build plugins/jetpack`
* Build Odyssey Stats with Calypso trunk:`cd apps/odyssey-stats && STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`

* Open `/wp-admin/admin.php?page=my-jetpack` for a site without any Stats subscriptions
* Ensure you see `Upgrade` button for the Stats card
* Ensure the `Upgrade` button takes you to the stats purchase page within Wp-Admin

<img width="368" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/453535df-5146-44f8-8ab9-a81ac6612407">


