### PR TITLE
Add tracking to post publish share buttons

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-tracking-to-post-publish-share-buttons
+++ b/projects/js-packages/publicize-components/changelog/add-tracking-to-post-publish-share-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added tracking events for post publish share buttons

--- a/projects/js-packages/publicize-components/changelog/fix-versions
+++ b/projects/js-packages/publicize-components/changelog/fix-versions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+fixed versions

--- a/projects/js-packages/publicize-components/src/components/share-buttons/share-buttons.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-buttons/share-buttons.tsx
@@ -1,10 +1,11 @@
 import { SocialServiceIcon } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
-import React, { useCallback } from 'react';
+import { useCallback } from '@wordpress/element';
 import { availableNetworks } from './available-networks';
 import styles from './styles.module.scss';
 import { usePrepareUrl } from './usePrepareUrl';
+import type React from 'react';
 
 export type ShareButtonsProps = {
 	buttonStyle?: 'icon' | 'text' | 'icon-text';

--- a/projects/js-packages/publicize-components/src/components/share-buttons/share-buttons.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-buttons/share-buttons.tsx
@@ -1,33 +1,10 @@
 import { SocialServiceIcon } from '@automattic/jetpack-components';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { availableNetworks } from './available-networks';
 import styles from './styles.module.scss';
 import { usePrepareUrl } from './usePrepareUrl';
-
-/**
- * Click handler for the share buttons.
- *
- * @param {string} url - The URL.
- * @param {object} data - The tracking data.
- *
- * @returns {Function} The click handler.
- */
-function getOnClick( url: string, data?: unknown ) {
-	return function onClick( event: React.MouseEvent< HTMLAnchorElement > ) {
-		event.preventDefault();
-
-		// TODO Add tracking here
-		// eslint-disable-next-line no-console
-		console.log( 'onClick', { data } );
-
-		window.open(
-			url,
-			'',
-			'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600'
-		);
-	};
-}
 
 export type ShareButtonsProps = {
 	buttonStyle?: 'icon' | 'text' | 'icon-text';
@@ -39,6 +16,25 @@ export const ShareButtons: React.FC< ShareButtonsProps > = ( {
 	buttonVariant,
 } ) => {
 	const prepareUrl = usePrepareUrl();
+
+	const { recordEvent } = useAnalytics();
+
+	const getOnClick = useCallback(
+		function ( url: string, data?: unknown ) {
+			return function onClick( event: React.MouseEvent< HTMLAnchorElement > ) {
+				event.preventDefault();
+
+				recordEvent( 'jetpack_social_share_button_clicked', data );
+
+				window.open(
+					url,
+					'',
+					'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600'
+				);
+			};
+		},
+		[ recordEvent ]
+	);
 
 	return (
 		<div className={ styles[ 'share-buttons' ] }>
@@ -57,7 +53,7 @@ export const ShareButtons: React.FC< ShareButtonsProps > = ( {
 						href={ href }
 						target="_blank"
 						rel="noopener noreferrer"
-						onClick={ getOnClick( href ) }
+						onClick={ getOnClick( href, { network: networkName } ) }
 						data-network={ networkName }
 						className={ styles[ networkName ] }
 					>

--- a/projects/js-packages/publicize-components/src/components/share-buttons/usePrepareUrl.ts
+++ b/projects/js-packages/publicize-components/src/components/share-buttons/usePrepareUrl.ts
@@ -1,5 +1,5 @@
 import { useSelect } from '@wordpress/data';
-import { useCallback } from 'react';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Prepares the URL to share.

--- a/projects/plugins/social/changelog/add-tracking-to-post-publish-share-buttons
+++ b/projects/plugins/social/changelog/add-tracking-to-post-publish-share-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added traking for social sharing buttons


### PR DESCRIPTION
Related #33074

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add tracking to post publish sharing buttons

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pdrWKz-1b4-p2

## Does this pull request change what data or activity we track or use?


## Testing instructions:


* Boot up the PR and run `jetpack build plugins/jetpack`
* Create a new post and hit publish or for an existing post, run this in browser console
    - `wp.data.dispatch('core/edit-post').togglePublishSidebar();`
* On the post publish panel, confirm that you see the sharing buttons for Twitter and WhatsApp
* Open browser console 
* Run `localStorage.setItem('debug', 'dops:analytics');`
* Click on the sharing button
* Confirm that you see something like this in the console
```
dops:analytics - Super Props: {blog_id: 123456789}
dops:analytics Record event "jetpack_social_share_button_clicked" called with props {"network":"twitter","blog_id":123456789}
```
* Goto MC Live tracking
* Confirm that you see the event named `jetpack_social_share_button_clicked`