### PR TITLE
Fix static function call in WooCommerce Analytics

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-static-call-in-analytics
+++ b/projects/plugins/jetpack/changelog/fix-static-call-in-analytics
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Small typo fix
+
+

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -144,7 +144,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	 *
 	 * @return array
 	 */
-	public static function get_cart_checkout_info() {
+	public function get_cart_checkout_info() {
 		$transient_name = 'jetpack_woocommerce_analytics_cart_checkout_info_cache';
 
 		$info = get_transient( $transient_name );
@@ -162,19 +162,19 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 			$checkout_page_id = wc_get_page_id( 'checkout' );
 
 			$info = array(
-				'cart_page_contains_cart_block'         => self::post_contains_text(
+				'cart_page_contains_cart_block'         => $this->post_contains_text(
 					$cart_page_id,
 					'<!-- wp:woocommerce/cart'
 				),
-				'cart_page_contains_cart_shortcode'     => self::post_contains_text(
+				'cart_page_contains_cart_shortcode'     => $this->post_contains_text(
 					$cart_page_id,
 					'[woocommerce_cart]'
 				),
-				'checkout_page_contains_checkout_block' => self::post_contains_text(
+				'checkout_page_contains_checkout_block' => $this->post_contains_text(
 					$checkout_page_id,
 					'<!-- wp:woocommerce/checkout'
 				),
-				'checkout_page_contains_checkout_shortcode' => self::post_contains_text(
+				'checkout_page_contains_checkout_shortcode' => $this->post_contains_text(
 					$checkout_page_id,
 					'[woocommerce_checkout]'
 				),


### PR DESCRIPTION
This fixes the static call that get introduced by #33145 for a function that's no longer static.

## Testing instructions:

No testing needed, this should fix a warning about `Uncaught Error: Non-static method Jetpack_WooCommerce_Analytics_Universal::post_contains_text() cannot be called statically`

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

- On a connected, tracked website, run the following command on cli: `wp transient delete jetpack_woocommerce_analytics_cart_checkout_info_cache`
- Load the website on a live domain (jurassic or something connected) and add a product to cart.
- Make sure to error is thrown in the logs.