### PR TITLE
Site Settings Endpoint: Include wpcom_newsletter_categories site option

### DIFF
--- a/projects/packages/sync/changelog/fix-subscriptions-block-no-category-excl-when-none-selected
+++ b/projects/packages/sync/changelog/fix-subscriptions-block-no-category-excl-when-none-selected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Site Settings Endpoint: Allow for updating and retrieving of the wpcom_newsletter_categories site option

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -183,6 +183,7 @@ class Defaults {
 		'wpcom_is_fse_activated',
 		'wpcom_legacy_contact',
 		'wpcom_locked_mode',
+		'wpcom_newsletter_categories',
 		'wpcom_newsletter_categories_enabled',
 		'wpcom_publish_comments_with_markdown',
 		'wpcom_publish_posts_with_markdown',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.57.1';
+	const PACKAGE_VERSION = '1.57.2-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/changelog/update-site-settings-incl-wpcom-newsletter-categories
+++ b/projects/plugins/jetpack/changelog/update-site-settings-incl-wpcom-newsletter-categories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Site Settings Endpoint: Allow for updating and retrieving of the wpcom_newsletter_categories site option via the endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -356,9 +356,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						)
 					);
 
-					require_lib( 'newsletter-categories' );
-					$newsletter_category_ids = get_newsletter_category_ids( $blog_id );
-
 					$api_cache = $site->is_jetpack() ? (bool) get_option( 'jetpack_api_cache_enabled' ) : true;
 
 					$response[ $key ] = array(
@@ -445,7 +442,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'rss_use_excerpt'                  => (bool) get_option( 'rss_use_excerpt' ),
 						'launchpad_screen'                 => (string) get_option( 'launchpad_screen' ),
 						'wpcom_featured_image_in_email'    => (bool) get_option( 'wpcom_featured_image_in_email' ),
-						'wpcom_newsletter_categories'      => is_array( $newsletter_category_ids ) ? $newsletter_category_ids : array(),
+						'wpcom_newsletter_categories'      => get_option( 'wpcom_newsletter_categories', array() ),
 						'wpcom_newsletter_categories_enabled' => (bool) get_option( 'wpcom_newsletter_categories_enabled' ),
 						'sm_enabled'                       => (bool) get_option( 'sm_enabled' ),
 						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -356,6 +356,9 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						)
 					);
 
+					require_lib( 'newsletter-categories' );
+					$newsletter_category_ids = get_newsletter_category_ids( $blog_id );
+
 					$api_cache = $site->is_jetpack() ? (bool) get_option( 'jetpack_api_cache_enabled' ) : true;
 
 					$response[ $key ] = array(
@@ -442,6 +445,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'rss_use_excerpt'                  => (bool) get_option( 'rss_use_excerpt' ),
 						'launchpad_screen'                 => (string) get_option( 'launchpad_screen' ),
 						'wpcom_featured_image_in_email'    => (bool) get_option( 'wpcom_featured_image_in_email' ),
+						'wpcom_newsletter_categories'      => is_array( $newsletter_category_ids ) ? $newsletter_category_ids : array(),
 						'wpcom_newsletter_categories_enabled' => (bool) get_option( 'wpcom_newsletter_categories_enabled' ),
 						'sm_enabled'                       => (bool) get_option( 'sm_enabled' ),
 						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),
@@ -1021,6 +1025,21 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'wpcom_featured_image_in_email':
 					update_option( 'wpcom_featured_image_in_email', (int) (bool) $value );
 					$updated[ $key ] = (int) (bool) $value;
+					break;
+
+				case 'wpcom_newsletter_categories':
+					$sanitized_value = (array) $value;
+					array_walk_recursive(
+						$sanitized_value,
+						function ( &$value ) {
+							if ( ! is_int( $value ) ) {
+								$value = (int) $value;
+							}
+						}
+					);
+					if ( update_option( $key, $sanitized_value ) ) {
+						$updated[ $key ] = $sanitized_value;
+					}
 					break;
 
 				case 'wpcom_newsletter_categories_enabled':

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -358,10 +358,10 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 					$newsletter_categories   = maybe_unserialize( get_option( 'wpcom_newsletter_categories', array() ) );
 					$newsletter_category_ids = array_map(
-						$newsletter_categories,
 						function ( $newsletter_category ) {
 							return $newsletter_category['term_id'];
-						}
+						},
+						$newsletter_categories
 					);
 
 					$api_cache = $site->is_jetpack() ? (bool) get_option( 'jetpack_api_cache_enabled' ) : true;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -118,6 +118,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'wpcom_publish_comments_with_markdown'    => '(bool) Whether markdown is enabled for comments',
 			'launchpad_screen'                        => '(string) Whether or not launchpad is presented and what size it will be',
 			'wpcom_featured_image_in_email'           => '(bool) Whether the Featured image is displayed in the New Post email template or not',
+			'wpcom_newsletter_categories'             => '(array) Array of post category ids that are marked as newsletter categories',
 			'wpcom_newsletter_categories_enabled'     => '(bool) Whether the newsletter categories are enabled or not',
 			'sm_enabled'                              => '(bool) Whether the newsletter Subscribe Modal is enabled or not',
 			'wpcom_gifting_subscription'              => '(bool) Whether gifting is enabled for non auto-renew sites',

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -231,6 +231,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_is_fse_activated'                       => '1',
 			'videopress_private_enabled_for_site'          => false,
 			'wpcom_featured_image_in_email'                => false,
+			'wpcom_newsletter_categories'                  => array(),
 			'wpcom_newsletter_categories_enabled'          => false,
 			'wpcom_gifting_subscription'                   => true,
 			'launch-status'                                => 'unlaunched',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/81958

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  Include the `wpcom_newsletter_categories` site option value to the site settings endpoint's response
* Allow for updating the `wpcom_newsletter_categories` via the site settings endpoint
* Sync the `wpcom_newsletter_categories` site option value for atomic and jetpack connected sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- p1695207441794379-slack-C02TCEHP3HA
- p1695277511631029-slack-C02TCEHP3HA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the PR to your sandbox
* Go to developer console 
* Confirm that the response from `WP.COM API GET v1.4 /sites/$site-slug/settings` now includes the newsletter categories 
* Confirm that it is now possible to update the newsletter categories with a call to `WP.COM API POST v1.4 /sites/$site-slug/settings` when passing some valid category ids in the body of the request. E.g.:
```
{ "wpcom_newsletter_categories": [ 1 ] }
```