### PR TITLE
Subscriptions modal: enable for Jetpack sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-enable-for-jetpack
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-enable-for-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe modal: enable for Jetpack sites

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6064,6 +6064,10 @@ endif;
 				'replacement' => null,
 				'version'     => 'jetpack-11.8.0',
 			),
+			'jetpack_subscriptions_modal_enabled'          => array(
+				'replacement' => null,
+				'version'     => 'jetpack-12.7.0',
+			),
 		);
 
 		foreach ( $filter_deprecated_list as $tag => $args ) {

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -159,18 +159,6 @@ HTML;
 	}
 
 	/**
-	 * Returns true if we should load Newsletter content.
-	 *
-	 * @return bool
-	 */
-	public static function should_load_subscriber_modal() {
-		// Adding extra check/flag to load only on WP.com
-		// When ready for Jetpack release, remove this.
-		$is_wpcom = ( new Host() )->is_wpcom_platform();
-		return $is_wpcom;
-	}
-
-	/**
 	 * Returns true if a site visitor should see
 	 * the Subscribe Modal.
 	 *
@@ -228,14 +216,6 @@ HTML;
 	}
 }
 
-add_filter(
-	'jetpack_subscriptions_modal_enabled',
-	array(
-		'Jetpack_Subscribe_Modal',
-		'should_load_subscriber_modal',
-	)
-);
-
 /**
  * Filter for enabling or disabling the Jetpack Subscribe Modal
  * feature. We use this filter here and in several other places
@@ -244,9 +224,9 @@ add_filter(
  *
  * @since 12.4
  *
- * @param bool Defaults to false.
+ * @param bool Defaults to true.
  */
-if ( apply_filters( 'jetpack_subscriptions_modal_enabled', false ) ) {
+if ( apply_filters( 'jetpack_subscriptions_modal_enabled', true ) ) {
 	Jetpack_Subscribe_Modal::init();
 }
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -7,7 +7,6 @@
  */
 
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
-use Automattic\Jetpack\Status\Host;
 use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
 
 /**
@@ -216,35 +215,11 @@ HTML;
 	}
 }
 
-/**
- * Filter for enabling or disabling the Jetpack Subscribe Modal
- * feature. We use this filter here and in several other places
- * to conditionally load options and functionality related to
- * this feature.
- *
- * @since 12.4
- *
- * @param bool Defaults to true.
- */
-if ( apply_filters( 'jetpack_subscriptions_modal_enabled', true ) ) {
-	Jetpack_Subscribe_Modal::init();
-}
+Jetpack_Subscribe_Modal::init();
 
 add_action(
 	'rest_api_switched_to_blog',
 	function () {
-		/**
-		 * Filter for enabling or disabling the Jetpack Subscribe Modal
-		 * feature. We use this filter here and in several other places
-		 * to conditionally load options and functionality related to
-		 * this feature.
-		 *
-		 * @since 12.4
-		 *
-		 * @param bool Defaults to false.
-		 */
-		if ( apply_filters( 'jetpack_subscriptions_modal_enabled', false ) ) {
-			Jetpack_Subscribe_Modal::init();
-		}
+		Jetpack_Subscribe_Modal::init();
 	}
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enables Subscribe modal for Jetpack sites. Previously this was enabled just for .com sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings -> Newsletter
* Enable modal
* Open a blog post as non logged in, non-subscribed user (i.e. incognito window would do)

