### PR TITLE
Rename Inbox menu for domain-only sites

### DIFF
--- a/projects/plugins/jetpack/changelog/change-inbox-menu-to-my-mailboxes-for-domain-only-sites
+++ b/projects/plugins/jetpack/changelog/change-inbox-menu-to-my-mailboxes-for-domain-only-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Sidebar: Rename the "Inbox" menu to "My Mailboxes" for domain-only sites.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -108,7 +108,7 @@ class Admin_Menu extends Base_Admin_Menu {
 	}
 
 	/**
-	 * Adds Inbox menu.
+	 * Adds My Mailboxes menu.
 	 */
 	public function add_my_mailboxes_menu() {
 		add_menu_page( __( 'My Mailboxes', 'jetpack' ), __( 'My Mailboxes', 'jetpack' ), 'manage_options', 'https://wordpress.com/mailboxes/' . $this->domain, null, 'dashicons-email', '4.64424' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php
@@ -63,6 +63,6 @@ class Domain_Only_Admin_Menu extends Base_Admin_Menu {
 		}
 
 		add_menu_page( esc_attr__( 'Manage Purchases', 'jetpack' ), __( 'Manage Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, 'dashicons-cart' );
-		add_menu_page( esc_attr__( 'Inbox', 'jetpack' ), __( 'Inbox', 'jetpack' ), 'manage_options', 'https://wordpress.com/inbox/' . $this->domain, null, 'dashicons-email' );
+		add_menu_page( esc_attr__( 'My Mailboxes', 'jetpack' ), __( 'My Mailboxes', 'jetpack' ), 'manage_options', 'https://wordpress.com/mailboxes/' . $this->domain, null, 'dashicons-email' );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-domain-only-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-domain-only-admin-menu.php
@@ -90,7 +90,7 @@ class Test_Domain_Only_Admin_Menu extends WP_UnitTestCase {
 
 		$this->assertEquals( 'https://wordpress.com/domains/manage/' . static::$domain . '/edit/' . static::$domain, $menu[0][2] );
 		$this->assertEquals( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, $menu[1][2] );
-		$this->assertEquals( 'https://wordpress.com/inbox/' . static::$domain, $menu[2][2] );
+		$this->assertEquals( 'https://wordpress.com/mailboxes/' . static::$domain, $menu[2][2] );
 	}
 
 	/**
@@ -112,6 +112,6 @@ class Test_Domain_Only_Admin_Menu extends WP_UnitTestCase {
 		$this->assertEquals( 'https://wordpress.com/domains/manage/' . static::$domain . '/edit/' . static::$domain, $menu[0][2] );
 		$this->assertEquals( 'https://wordpress.com/email/' . static::$domain . '/manage/' . static::$domain, $menu[1][2] );
 		$this->assertEquals( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, $menu[2][2] );
-		$this->assertEquals( 'https://wordpress.com/inbox/' . static::$domain, $menu[3][2] );
+		$this->assertEquals( 'https://wordpress.com/mailboxes/' . static::$domain, $menu[3][2] );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #32992

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Handles the case of renaming `Inbox` to `My Mailboxes` for domain-only sites which was missed in #32992

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* If you don't have one; create a domain-only site by navigating to `http://wordpress.com/domains` and choosing to `Just buy a domain`. Note the domain name.
* Point your WPCOM sandbox to `public-api.wordpress.com`
* Follow the directives specified [here](https://github.com/Automattic/jetpack/pull/33239#issuecomment-1729530599) to test in a Simple site.
* Go to Calypso and visit your domain-only dash: `https://wordpress.com/domains/manage/all/{$domain}/edit/{$domain}` where `{$domain}` is the name of the domain you just purchased for the domain-only site.
* Confirm that the previous `Inbox` menu is now named `My Mailboxes` and pointing to `/mailboxes`.

