### PR TITLE
Locked Mode: Apply cap filter in API requests

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-locked-mode-rest-api
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-locked-mode-rest-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Locked Mode: Now applies cap filter in REST API requests as well

--- a/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
@@ -10,11 +10,17 @@
  * and the option enabled.
  */
 function wpcom_lm_maybe_add_map_meta_cap_filter() {
+	// On REST API requests, wait until we switch to the correct blog to add the filter.
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST && 'plugins_loaded' === current_filter() ) {
+		return;
+	}
+
 	if ( wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) && get_option( 'wpcom_locked_mode' ) ) {
 		add_filter( 'map_meta_cap', 'wpcom_lm_remove_post_capabilities', 10, 2 );
 	}
 }
 add_action( 'plugins_loaded', 'wpcom_lm_maybe_add_map_meta_cap_filter', 11 );
+add_action( 'rest_api_switched_to_blog', 'wpcom_lm_maybe_add_map_meta_cap_filter' );
 
 /**
  * Registers Locked Mode settings.


### PR DESCRIPTION
On API requests we've not switched to the correct site yet, when we look for feature and option on plugins_loaded.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds an action to run the cap filter determination once we switched to the correct site on API requests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox public-api.
* Add a 100-year plan to a test site.
* Navigate to /settings/general and activate Locked Mode.
* Make sure the navigation bar updates and content menu items are removed.

