### PR TITLE
Fix/menu focus no my jetpack

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -67,6 +67,7 @@ import {
 	getPartnerCoupon,
 	isAtomicSite,
 	isWoASite,
+	showMyJetpack,
 	isWooCommerceActive,
 	userIsSubscriber,
 } from 'state/initial-state';
@@ -630,6 +631,8 @@ class Main extends React.Component {
 
 		if ( this.props.isWoaSite ) {
 			window.wpNavMenuClassChange( { dashboard: 1, settings: 1 } );
+		} else if ( ! this.props.showMyJetpack ) {
+			window.wpNavMenuClassChange( { dashboard: 1, settings: 2 } );
 		} else {
 			window.wpNavMenuClassChange();
 		}
@@ -897,6 +900,7 @@ export default connect(
 			connectingUserFrom: getConnectingUserFrom( state ),
 			isAtomicSite: isAtomicSite( state ),
 			isWoaSite: isWoASite( state ),
+			showMyJetpack: showMyJetpack( state ),
 			isWooCommerceActive: isWooCommerceActive( state ),
 			hasSeenWCConnectionModal: getHasSeenWCConnectionModal( state ),
 			partnerCoupon: getPartnerCoupon( state ),

--- a/projects/plugins/jetpack/changelog/fix-menu-focus-no-my-jetpack
+++ b/projects/plugins/jetpack/changelog/fix-menu-focus-no-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix menu focus state without My Jetpack


### PR DESCRIPTION
Fixes #33243 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds an additional check for menu focus handling so it works properly when My Jetpack is not initialized

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See the issue description in #33243 
* Apply this patch to your local Jetpack environment or use the Jetpack Beta plugin
* You will need to either use a multisite to test or modify the `should_initialize` function in `packages/my-jetpack/src/class-initializer.php` to always return false. This will ensure that My Jetpack is not initialized and does not show in the WP Admin menu.
* Note that if you temporarily modify the code to test, you will need to rebuild `plugins/jetpack`
* Now, navigate to the Jetpack dashboard.
* Confirm that clicking on "Dashboard" and "Settings" puts focus on the selected nav item. The item has focus when the text is bolded.

