### PR TITLE
First Posts stream: Update/add first posts stream helpers

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add-first-posts-stream-helpers
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add-first-posts-stream-helpers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds a feature to include helpers for the First Posts stream. In particular, an option is being added to the sync list.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -39,6 +39,8 @@ class Jetpack_Mu_Wpcom {
 
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_marketplace_products_updater' ) );
 
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_first_posts_stream_helpers' ) );
+
 		// Unified navigation fix for changes in WordPress 6.2.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'unbind_focusout_on_wp_admin_bar_menu_toggle' ) );
 
@@ -171,5 +173,14 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 
 		\Marketplace_Products_Updater::init();
+	}
+
+	/**
+	 * Load First Posts stream helpers.
+	 *
+	 * @return void
+	 */
+	public static function load_first_posts_stream_helpers() {
+		require_once __DIR__ . '/features/first-posts-stream/first-posts-stream-helpers.php';
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/first-posts-stream/first-posts-stream-helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/first-posts-stream/first-posts-stream-helpers.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * First posts stream helpers
+ *
+ * @package automattic/jetpack-mu-wpcom
+ * @since 4.11.0
+ */
+
+/**
+ * Adds the required options to the sync list for the First Posts Stream feature.
+ *
+ * @param array $allowed_options The allowed options.
+ */
+function register_first_posts_stream_options_sync( $allowed_options ) {
+	if ( ! is_array( $allowed_options ) ) {
+		return $allowed_options;
+	}
+
+	$launchpad_options = array(
+		'wpcom_has_first_post',
+	);
+
+	return array_merge( $allowed_options, $launchpad_options );
+}
+
+add_filter( 'jetpack_sync_options_whitelist', 'register_first_posts_stream_options_sync', 10, 1 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Adds a helper feature for the First Posts stream. In particular, this diff adds the `wpcom_has_first_post` option to the sync list.
In order for this to work this should be merged: D121677-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* apply this PR on your AT site following instruction on https://github.com/Automattic/jetpack/pull/33253#issuecomment-1730172823 and follow instructions in D121677-code ignoring the `JETPACK__SANDBOX_DOMAIN` setting.
