### PR TITLE
CRM: Resolves #3337 - add invoice status and mapping settings migration

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3337-invoice_status_migration
+++ b/projects/plugins/crm/changelog/fix-crm-3337-invoice_status_migration
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Adds migration for invoice statuses and mapping settings
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -4743,7 +4743,8 @@ function zeroBSCRM_get_invoice_defaults( $obj_id = -1 ) {
 	}
 
 	$defaults = array(
-		'status'                    => 'draft',
+		'status'                    => 'Draft',
+		'status_label'              => __( 'Draft', 'zero-bs-crm' ),
 		'new_invoice'               => true,
 		'id'                        => $obj_id,
 		'invoice_items'             => array(),

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -1197,6 +1197,11 @@ function zeroBSCRM_migration_invoice_language_fixes() {
 
 	foreach ( $invoice_statuses as $invoice_status => $translated_status ) {
 
+		// if the "translation" is the same as English, continue
+		if ( $translated_status === $invoice_status ) {
+			continue;
+		}
+
 		// if there are settings, we may need to update mappings too
 		if ( $woosync_settings ) {
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -216,7 +216,7 @@ function zbscrm_JS_draw_invoice_actions_html( res ) {
 	html += '<div id="zbs_invoice_actions">';
 
 	html += '<div class="zbs-invoice-status">';
-	html += '<span class="' + jpcrm.esc_attr(res.invoiceObj.status) + ' statty">' + jpcrm.esc_html(res.invoiceObj.status_label) + '</span>';
+	html += '<span class="' + jpcrm.esc_attr(res.invoiceObj.status.toLowerCase()) + ' statty">' + jpcrm.esc_html(res.invoiceObj.status_label) + '</span>';
 	html += '</div>';
 
 	//now the preview, download pdf, and send buttons controlled by the data output (not via complex PHP ifs on page)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: Resolves Automattic/zero-bs-crm#3337 - add invoice status and mapping settings migration

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #32909 I made invoice statuses store in English, which fixed several inconsistencies. At the time, I opted out of doing a migration, as it was possible to do a full Woo resync as needed. However, @cleacos pointed out that the mapping settings could be lost as well, so this PR introduces a migration.

It makes changes if:
* the current locale is not `en_US`
* the translated text is not the same as English
* it finds a translated match in invoice mapping statuses and/or invoice statuses

As I was leery of changing WooSync settings, I also store a backup before making the change.

I also spotted a few other translation glitches:

* A new invoice would start with a status of `draft` (lowercase), so it didn't match in the dropdown. I changed this to `Draft`.
* In the left corner, there's some CSS based on invoice status that expects a class matching the lowercase name of the status. I added the conversion when outputting the class.
* As of the new PR, new invoices didn't have the new `status_label` in the default object, so would show undefined in the left corner. I corrected this.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Switch WP to Spanish: `/wp-admin/options-general.php`
2. Add a few invoices: `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=invoice`
3. Change and save mapping settings: `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=woosync`
4. In the database, update the invoice statuses to `Pagado` or some other valid Spanish status.
5. In the database, update the mapping in the `zbscrm_dmz_ext_woosync` settings key to some valid Spanish status.

Note that steps 4 and 5 represent how WooSync would store things in JPCRM 6.1.

In `trunk`:
* Editing the invoice will show correctly, but only because of a fallback to handle unknown statuses. The status dropdown will show two of the same Spanish status, with the last one (fallback) selected.
* The invoice mappings saved in Spanish will not be selected.

In the `fix/crm/3337-invoice_status_migration` branch (you may need to manually run the `zeroBSCRM_migration_invoice_language_fixes` migration if you made the changes after the migration initially ran, as migrations only run automatically once):
* The invoice status is switched to English in the database, and the status select is working as expected.
* The invoice mappings are updated to English in the database, and the mapping selects are matched as expected.