### PR TITLE
SSO: add force 2fa functionality

### DIFF
--- a/projects/plugins/jetpack/changelog/add-force-2fa
+++ b/projects/plugins/jetpack/changelog/add-force-2fa
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+SSO: offer ability to force a site to use Jetpack SSO with Two-Factor Authentication for certain roles.

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -58,6 +58,28 @@ class Jetpack_SSO {
 		add_action( 'login_form_jetpack-sso', '__return_true' );
 
 		add_filter( 'wp_login_errors', array( $this, 'sso_reminder_logout_wpcom' ) );
+
+		/**
+		 * Filter to include Force 2FA feature.
+		 *
+		 * By default, `manage_options` users are forced when enable. The capability can be modified
+		 * with the `jetpack_force_2fa_cap` filter.
+		 *
+		 * To enable the feature, add the following code:
+		 * add_filter( 'jetpack_force_2fa', '__return_true' );
+		 *
+		 * @param bool $force_2fa Whether to force 2FA or not.
+		 *
+		 * @todo Provide a UI to enable/disable the feature.
+		 *
+		 * @since $$next-version$$
+		 * @module SSO
+		 * @return bool
+		 */
+		if ( apply_filters( 'jetpack_force_2fa', false ) ) {
+			require_once JETPACK__PLUGIN_DIR . 'modules/sso/class-jetpack-force-2fa.php';
+			new Jetpack_Force_2FA();
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -76,7 +76,8 @@ class Jetpack_SSO {
 		 * @module SSO
 		 * @return bool
 		 */
-		if ( apply_filters( 'jetpack_force_2fa', false ) ) {
+		if ( ! class_exists( 'Jetpack_Force_2FA' ) && apply_filters( 'jetpack_force_2fa', false ) ) {
+			// Checking for the class to avoid collisions with existing standalone Jetpack Force 2FA plugin and break out if so.
 			require_once JETPACK__PLUGIN_DIR . 'modules/sso/class-jetpack-force-2fa.php';
 			new Jetpack_Force_2FA();
 		}

--- a/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
+++ b/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Plugin Name: Force Jetpack 2FA
+ * Plugin URI: http://automattic.com
+ * Description: Force admins to use two factor authentication.
+ * Author: Brandon Kraft, Josh Betz, Automattic
+ * Version: 0.1
+ * Author URI: http://automattic.com
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Force users to use two factor authentication.
+ */
+class Jetpack_Force_2FA {
+
+	/**
+	 * The role to force 2FA for.
+	 *
+	 * Defaults to manage_options via the plugins_loaded function.
+	 * Can be modified with the jetpack_force_2fa_cap filter.
+	 *
+	 * @var string
+	 */
+	private $role;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'after_setup_theme', array( $this, 'plugins_loaded' ) );
+	}
+
+	/**
+	 * Load the plugin via the plugins_loaded hook.
+	 */
+	public function plugins_loaded() {
+		/**
+		 * Filter the role to force 2FA for.
+		 * Defaults to manage_options.
+		 *
+		 * @param string $role The role to force 2FA for.
+		 * @return string
+		 * @since $$next-version$$
+		 * @module SSO
+		 */
+		$this->role = apply_filters( 'jetpack_force_2fa_cap', 'manage_options' );
+
+		// Bail if Jetpack SSO is not active
+		if ( ! class_exists( 'Jetpack' ) || ! Jetpack::is_active() || ! Jetpack::is_module_active( 'sso' ) ) {
+			add_action( 'admin_notices', array( $this, 'admin_notice' ) );
+			return;
+		}
+
+		$this->force_2fa();
+	}
+
+	/**
+	 * Display an admin notice if Jetpack SSO is not active.
+	 */
+	public function admin_notice() {
+		/**
+		 * Filter if an admin notice is deplayed when Force 2FA is required, but SSO is not enabled.
+		 * Defaults to true.
+		 *
+		 * @param bool $display_notice Whether to display the notice.
+		 * @return bool
+		 * @since $$next-version$$
+		 * @module SSO
+		 */
+		if ( apply_filters( 'jetpack_force_2fa_dependency_notice', true ) && current_user_can( $this->role ) ) {
+			printf( '<div class="%1$s"><p>%2$s</p></div>', 'notice notice-warning', 'Jetpack Force 2FA requires Jetpack and the Jetpack SSO module.' );
+		}
+	}
+
+	/**
+	 * Force 2FA when using Jetpack SSO and force Jetpack SSO.
+	 *
+	 * @return void
+	 */
+	private function force_2fa() {
+		// Allows WP.com login to a local account if it matches the local account.
+		add_filter( 'jetpack_sso_match_by_email', '__return_true', 9999 );
+
+		// multisite
+		if ( is_multisite() ) {
+
+			// Hide the login form
+			add_filter( 'jetpack_remove_login_form', '__return_true', 9999 );
+			add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true', 9999 );
+			add_filter( 'jetpack_sso_display_disclaimer', '__return_false', 9999 );
+
+			add_filter(
+				'wp_authenticate_user',
+				function () {
+					return new WP_Error( 'wpcom-required', $this->get_login_error_message() ); },
+				9999
+			);
+
+			add_filter( 'jetpack_sso_require_two_step', '__return_true' );
+
+			add_filter( 'allow_password_reset', '__return_false' );
+		} else {
+			// Not multisite.
+
+			// Completely disable the standard login form for admins.
+			add_filter(
+				'wp_authenticate_user',
+				function ( $user ) {
+					if ( is_wp_error( $user ) ) {
+						return $user;
+					}
+					if ( $user->has_cap( $this->role ) ) {
+						return new WP_Error( 'wpcom-required', $this->get_login_error_message(), $user->user_login );
+					}
+					return $user;
+				},
+				9999
+			);
+
+			add_filter(
+				'allow_password_reset',
+				function ( $allow, $user_id ) {
+					if ( user_can( $user_id, $this->role ) ) {
+						return false;
+					}
+					return $allow; },
+				9999,
+				2
+			);
+
+			add_action( 'jetpack_sso_pre_handle_login', array( $this, 'jetpack_set_two_step' ) );
+		}
+	}
+
+	/**
+	 * Specifically set the two step filter for Jetpack SSO.
+	 *
+	 * @param Object $user_data The user data from WordPress.com.
+	 *
+	 * @return void
+	 */
+	public function jetpack_set_two_step( $user_data ) {
+		$user = Jetpack_SSO::get_user_by_wpcom_id( $user_data->ID );
+
+		// Borrowed from Jetpack. Ignores the match_by_email setting.
+		if ( empty( $user ) ) {
+			$user = get_user_by( 'email', $user_data->email );
+		}
+
+		if ( $user && $user->has_cap( $this->role ) ) {
+			add_filter( 'jetpack_sso_require_two_step', '__return_true' );
+		}
+	}
+
+	/**
+	 * Get the login error message.
+	 *
+	 * @return string
+	 */
+	private function get_login_error_message() {
+		/**
+		 * Filter the login error message.
+		 * Defaults to a message that explains the user must use a WordPress.com account with 2FA enabled.
+		 *
+		 * @param string $message The login error message.
+		 * @return string
+		 * @since $$next-version$$
+		 * @module SSO
+		 */
+		return apply_filters(
+			'jetpack_force_2fa_login_error_message',
+			sprintf( 'For added security, please log in using your WordPress.com account.<br /><br />Note: Your account must have <a href="%1$s" target="_blank">Two Step Authentication</a> enabled, which can be configured from <a href="%2$s" target="_blank">Security Settings</a>.', 'https://support.wordpress.com/security/two-step-authentication/', 'https://wordpress.com/me/security/two-step' )
+		);
+	}
+}
+
+new Jetpack_Force_2FA();

--- a/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
+++ b/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
@@ -1,12 +1,8 @@
 <?php
 /**
- * Plugin Name: Force Jetpack 2FA
- * Plugin URI: http://automattic.com
- * Description: Force admins to use two factor authentication.
- * Author: Brandon Kraft, Josh Betz, Automattic
- * Version: 0.1
- * Author URI: http://automattic.com
- * Text Domain: jetpack
+ * Force Jetpack 2FA Functionality
+ *
+ * Ported from original repo at https://github.com/automattic/jetpack-force-2fa
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
+++ b/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
@@ -176,5 +176,3 @@ class Jetpack_Force_2FA {
 		);
 	}
 }
-
-new Jetpack_Force_2FA();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Brings https://github.com/automattic/jetpack-force-2fa into Jetpack itself behind a `jetpack_force_2fa` flag. Defaulted to off.

Defaults to forcing SSO + 2fa for admins when SSO is enabled and the filter is returned true. The capability (manage_options) can be modified with the `jetpack_force_2fa_cap` filter.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds functionality for forcing SSO+2fa for indicated user capabilities.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a - Came up when talking about possibilities with VIP for a client.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No change.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Jetpack connnected + SSO
* Connect an account that does not have 2fa enabled to the Jetpack site (either cycle the connection or make a new admin user connected to a non-2fa WP.com account.
* Create a new user with subscriber or contributor role.
* Log out and log back into admin account with regular WP creds (not SSO) This should work.
* Enable flag via `add_filter( 'jetpack_force_2fa', '__return_true' );`
* Log out and log back in with regular WP creds. It should fail.
* Log in with WP.com SSO with an account that has 2fa enabled. It should work.
* Log out and login with the non-2fa WP.com account via SSO. It should fail.
* Add a filter to modify the cap, e.g. `add_filter( 'jetpack_force_2fa_cap, function() { return 'read' } );`
* Verify that the contributor forces SSO.
