### PR TITLE
Subscribe Block: Fix subscribe button not showing on newline.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-newline-fix
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-newline-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix subscribe block button not showing on newline.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -89,8 +89,7 @@
 	}
 
 	&.wp-block-jetpack-subscriptions__use-newline {
-		.wp-block-jetpack-subscriptions__form,
-		form {
+		.wp-block-jetpack-subscriptions__form-elements {
 			display: block;
 		}
 


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes subscribe button not showing on newline due to regression from https://github.com/Automattic/jetpack/pull/33144.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert Subscribe Block.
* Toggle newline option from the block settings.
* Ensure button shows on newline on editor view.
* Ensure button shows on newline on post view.


<img width="791" alt="image" src="https://github.com/Automattic/jetpack/assets/1287077/500577f5-5f82-4f89-a074-39d8497e3f28">

<img width="1293" alt="image" src="https://github.com/Automattic/jetpack/assets/1287077/71c1a525-3967-4b0b-a3f0-523e5b74f42c">

