### PR TITLE
CRM: Automations - workflows database query fix

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-automations-workflow-table
+++ b/projects/plugins/crm/changelog/fix-crm-automations-workflow-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Automations: Fix an issue (only in development) with the automations workflow table creation

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -895,7 +895,7 @@ function zeroBSCRM_createTables(){
 	`active` TINYINT(1) NOT NULL DEFAULT 0,
 	`version` INT(14) NOT NULL DEFAULT 1,
 	`created_at` TIMESTAMP NOT NULL DEFAULT NOW(),
-	`updated_at` TIMESTAMP DEFAULT NULL,
+	`updated_at` TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
 	PRIMARY KEY (`id`),
 	INDEX `name` (`name` ASC),
 	INDEX `active` (`active` ASC),


### PR DESCRIPTION
## Proposed changes:

* In https://github.com/Automattic/jetpack/pull/33129 a new query was added, which appears to cause issues when testing PRs on trunk using Jurassic Ninja. While spinning up a fresh site results in an API error, using the Beta tester plugin and activating the branch for a recent CRM PR results in `WordPress database error: [Invalid default value for 'updated_at']`
* After discussion in Slack - p1695366780951289-slack-CTXBP902X - this PR changes the value for the `updated_at` row to now be: `updated_at` TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,`


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3338
p1695366780951289-slack-CTXBP902X

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test, you should be able to spin up a new Jurassic Ninja site using the Live Branches link (if using the internal Live Branches Tampermonkey script). Alternatively you should be able to switch to this branch using the beta tester plugin on a Jurassic Ninja site, and no errors should display.
* Then, check that the `*_zbs_workflows` table exists in the database. 
* You can also test running the query directly, after removing that table (both locally, on a JN site, or any other test site):
```
	CREATE TABLE IF NOT EXISTS wp_zbs_workflows(
	`id` INT NOT NULL AUTO_INCREMENT,
	`zbs_site` INT NOT NULL,
	`zbs_owner` INT NOT NULL,
	`name` VARCHAR(255) NOT NULL,
	`description` VARCHAR(255) NULL DEFAULT NULL,
	`category` VARCHAR(255) NOT NULL,
	`triggers` LONGTEXT NOT NULL,
	`initial_step` LONGTEXT NOT NULL,
	`active` TINYINT(1) NOT NULL DEFAULT 0,
	`version` INT(14) NOT NULL DEFAULT 1,
	`created_at` TIMESTAMP NOT NULL DEFAULT NOW(),
	`updated_at` TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
	PRIMARY KEY (`id`),
	INDEX `name` (`name` ASC),
	INDEX `category` (`category` ASC),
	INDEX `created_at` (`created_at` ASC)
	) ENGINE = InnoDB
	DEFAULT CHARACTER SET = utf8
	COLLATE = utf8_general_ci 
```