### PR TITLE
Dashboard: avoid blank dashboard when accessed via custom non-admin role.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -973,15 +973,15 @@ window.wpNavMenuClassChange = function ( pageOrder = { myJetpack: 1, dashboard: 
 	page = page.get( 'page' );
 
 	if ( myJetpackRoutes.includes( page ) ) {
-		getJetpackSubNavItem( pageOrder.myJetpack ).classList.add( 'current' );
+		getJetpackSubNavItem( pageOrder.myJetpack )?.classList.add( 'current' );
 	} else if (
 		dashboardRoutes.includes( hash ) ||
 		recommendationsRoutes.includes( hash ) ||
 		productDescriptionRoutes.includes( hash )
 	) {
-		getJetpackSubNavItem( pageOrder.dashboard ).classList.add( 'current' );
+		getJetpackSubNavItem( pageOrder.dashboard )?.classList.add( 'current' );
 	} else if ( settingsRoutes.includes( hash ) ) {
-		getJetpackSubNavItem( pageOrder.settings ).classList.add( 'current' );
+		getJetpackSubNavItem( pageOrder.settings )?.classList.add( 'current' );
 	}
 
 	const $body = jQuery( 'body' );

--- a/projects/plugins/jetpack/changelog/fix-blank-dashboard-custom-roles
+++ b/projects/plugins/jetpack/changelog/fix-blank-dashboard-custom-roles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: avoid errors when dashboard is accessed by WordPress users with a custom non-admin role.


### PR DESCRIPTION
Fixes #33191

## Proposed changes:

Let's be more defensive to avoid issues when the dashboard is accessed by non-admin custom roles, such as forum users when using bbPress.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> **Note**
> It's going to take you some time to set up your site, but once you have it set up, I would recommend that you also test #33264, so you will make the most of the work you've done.

On a brand new site:

* Install and activate the bbPress plugin
* Go to Users > Add New and create a new subscriber user with participant role.
* Go to Appearance > Themes
* Activate the Twenty Twenty One theme
* Go to Appearance > Customize > Widgets
* Add a bbPRess login widget
* In a new browser, access your site
* Log in using your custom user.
* Go to `yoursite.com/wp-admin/admin.php?page=jetpack#/dashboard`
* Ensure you can see the page.
