### PR TITLE
Add copy to clipboard component

### DIFF
--- a/projects/js-packages/components/changelog/add-copy-to-clipboard-component
+++ b/projects/js-packages/components/changelog/add-copy-to-clipboard-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Aded CopyToClipboard component

--- a/projects/js-packages/components/components/button/types.ts
+++ b/projects/js-packages/components/components/button/types.ts
@@ -13,7 +13,7 @@ type JetpackButtonBaseProps = {
 	variant?: 'primary' | 'secondary' | 'link' | 'tertiary';
 	weight?: 'bold' | 'regular';
 	fullWidth?: boolean;
-	ref: React.ForwardedRef< unknown >;
+	ref?: React.ForwardedRef< unknown >;
 };
 
 type WPButtonProps = Omit< React.ComponentProps< typeof Button >, 'size' | 'variant' >;

--- a/projects/js-packages/components/components/copy-to-clipboard/index.tsx
+++ b/projects/js-packages/components/components/copy-to-clipboard/index.tsx
@@ -1,0 +1,67 @@
+import { useCopyToClipboard } from '@wordpress/compose';
+import { useState, useRef, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import Button from '../button';
+import { ClipboardIcon, CheckmarkIcon } from '../icons';
+import { CopyToClipboardProps } from './types';
+import type React from 'react';
+
+export const CopyToClipboard: React.FC< CopyToClipboardProps > = ( {
+	buttonStyle = 'icon',
+	textToCopy,
+	onCopy,
+	...buttonProps
+} ) => {
+	const [ hasCopied, setHasCopied ] = useState( false );
+
+	const copyTimer = useRef< ReturnType< typeof setTimeout > | undefined >();
+
+	const copyRef = useCopyToClipboard( textToCopy, () => {
+		if ( copyTimer.current ) {
+			clearTimeout( copyTimer.current );
+		}
+
+		setHasCopied( true );
+
+		onCopy?.();
+
+		copyTimer.current = setTimeout( () => {
+			setHasCopied( false );
+			copyTimer.current = undefined;
+		}, 3000 );
+	} );
+
+	useEffect( () => {
+		// Clear copyTimer on component unmount.
+		return () => {
+			if ( copyTimer.current ) {
+				clearTimeout( copyTimer.current );
+			}
+		};
+	}, [] );
+
+	let icon: React.ReactNode = null;
+	let label: React.ReactNode = null;
+
+	if ( 'text' !== buttonStyle ) {
+		icon = hasCopied ? <CheckmarkIcon /> : <ClipboardIcon />;
+	}
+
+	const defaultLabel = __( 'Copy to clipboard', 'jetpack' );
+
+	if ( 'icon' !== buttonStyle ) {
+		label = hasCopied ? __( 'Copied!', 'jetpack' ) : defaultLabel;
+	}
+
+	return (
+		<Button
+			aria-label={ defaultLabel }
+			icon={ icon }
+			children={ label }
+			ref={ copyRef }
+			{ ...buttonProps }
+		/>
+	);
+};
+
+export default CopyToClipboard;

--- a/projects/js-packages/components/components/copy-to-clipboard/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/copy-to-clipboard/stories/index.stories.tsx
@@ -1,0 +1,25 @@
+import CopyToClipboard from '../index';
+import type { StoryFn, Meta } from '@storybook/react';
+
+export default {
+	title: 'JS Packages/Components/CopyToClipboard',
+	component: CopyToClipboard,
+} as Meta< typeof CopyToClipboard >;
+
+const Template: StoryFn< typeof CopyToClipboard > = args => <CopyToClipboard { ...args } />;
+export const _default = Template.bind( {} );
+_default.args = {
+	textToCopy: 'Some text to copy',
+};
+
+export const IconText = Template.bind( {} );
+IconText.args = {
+	buttonStyle: 'icon-text',
+	textToCopy: 'Some text to copy',
+};
+
+export const OnlyText = Template.bind( {} );
+OnlyText.args = {
+	buttonStyle: 'text',
+	textToCopy: 'Some text to copy',
+};

--- a/projects/js-packages/components/components/copy-to-clipboard/types.ts
+++ b/projects/js-packages/components/components/copy-to-clipboard/types.ts
@@ -1,0 +1,7 @@
+import { ButtonProps } from '../button/types';
+
+export type CopyToClipboardProps = ButtonProps & {
+	buttonStyle?: 'icon' | 'text' | 'icon-text';
+	textToCopy: string | ( () => string );
+	onCopy?: VoidFunction;
+};

--- a/projects/js-packages/components/components/icons/index.tsx
+++ b/projects/js-packages/components/components/icons/index.tsx
@@ -171,6 +171,16 @@ export const CheckmarkIcon: React.FC< BaseIconProps > = ( {
 	</IconWrapper>
 );
 
+export const ClipboardIcon: React.FC< BaseIconProps > = ( {
+	size,
+	className = styles[ 'clipboard-icon' ],
+	color,
+} ) => (
+	<IconWrapper className={ className } size={ size } color={ color }>
+		<Path d="M5.625 5.5H15.375C15.444 5.5 15.5 5.55596 15.5 5.625V15.375C15.5 15.444 15.444 15.5 15.375 15.5H5.625C5.55596 15.5 5.5 15.444 5.5 15.375V5.625C5.5 5.55596 5.55596 5.5 5.625 5.5ZM4 5.625C4 4.72754 4.72754 4 5.625 4H15.375C16.2725 4 17 4.72754 17 5.625V10V15.375C17 16.2725 16.2725 17 15.375 17C15.375 17 6.52246 17 5.625 17C4.72754 17 4 16.2725 4 15.375V5.625ZM18.5 17.2812V8.28125H20V17.2812C20 18.7995 18.7704 20 17.2511 20H6.25V18.5H17.2511C17.9409 18.5 18.5 17.9721 18.5 17.2812Z" />
+	</IconWrapper>
+);
+
 export const JetpackIcon: React.FC< BaseIconProps > = ( {
 	size,
 	className = styles.jetpack,

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -37,6 +37,7 @@ export { default as Col } from './components/layout/col';
 export { default as Testimonials } from './components/testimonials';
 export { default as Container } from './components/layout/container';
 export { default as useBreakpointMatch } from './components/layout/use-breakpoint-match';
+export { default as CopyToClipboard } from './components/copy-to-clipboard';
 export * from './components/icons';
 export { default as SplitButton } from './components/split-button';
 export { default as ThemeProvider } from './components/theme-provider';


### PR DESCRIPTION
This PR extracts some code from #33261 to add the `CopyToClipboard` component in a separate PR along with its stories

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `ClipboardIcon`
* Add `CopyToClipboard` component and its stories.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1695375861373249/1695363141.448729-slack-C02JJ910CNL

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* `cd projects/js-packages/storybook`
* Run `pnpm run storybook:dev`
* Confirm that you see `CopyToClipoard` under Component
* Confirm that it works as expected

<img width="1571" alt="Screenshot 2023-09-22 at 3 39 10 PM" src="https://github.com/Automattic/jetpack/assets/18226415/a5c24b3f-823e-443b-ac77-583805284839">