### PR TITLE
Launchpad: Support design first tasks on Customer Home

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-support-design-first-on-customer-home
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-support-design-first-on-customer-home
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support Design First tasks on the Customer Home Launchpad

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -266,6 +266,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Launch your blog', 'jetpack-mu-wpcom' );
 			},
 			'isLaunchTask'          => true,
+			'is_disabled_callback'  => 'wpcom_launchpad_is_blog_launch_disabled',
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
 		'setup_blog'                      => array(
@@ -1107,6 +1108,20 @@ function wpcom_launchpad_is_link_in_bio_launch_disabled() {
  */
 function wpcom_launchpad_is_videopress_launch_disabled() {
 	return ! wpcom_is_checklist_task_complete( 'videopress_upload' );
+}
+
+/**
+ * Determines whether or not the blog launch task is enabled
+ *
+ * @return boolean True if blog launch task is enabled
+ */
+function wpcom_launchpad_is_blog_launch_disabled() {
+	if ( 'design-first' === get_option( 'site_intent' ) ) {
+		return ! wpcom_is_checklist_task_complete( 'plan_completed' )
+			|| ! wpcom_is_checklist_task_complete( 'domain_upsell' )
+			|| ! wpcom_is_checklist_task_complete( 'setup_blog' );
+	}
+	return false;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -275,7 +275,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$flow = get_option( 'site_intent' );
-				return '/setup' . $flow . '/setup-blog?siteSlug' . $data['site_slug_encoded'];
+				return '/setup/' . $flow . '/setup-blog?siteSlug' . $data['site_slug_encoded'];
 			},
 		),
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -88,9 +88,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'get_calypso_path'     => function () {
+			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$flow = get_option( 'site_intent' );
-				return '/setup/' . $flow . '/plans/';
+				return '/setup/' . $flow . '/plans/?siteSlug=' . $data['site_slug_encoded'];
 			},
 		),
 		'plan_selected'                   => array(
@@ -266,7 +266,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Launch your blog', 'jetpack-mu-wpcom' );
 			},
 			'isLaunchTask'          => true,
-			'is_disabled_callback'  => 'wpcom_launchpad_is_blog_launch_disabled',
+			'is_disabled_callback'  => 'wpcom_launchpad_is_blog_launched_disabled',
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
 		'setup_blog'                      => array(
@@ -1115,7 +1115,7 @@ function wpcom_launchpad_is_videopress_launch_disabled() {
  *
  * @return boolean True if blog launch task is enabled
  */
-function wpcom_launchpad_is_blog_launch_disabled() {
+function wpcom_launchpad_is_blog_launched_disabled() {
 	if ( 'design-first' === get_option( 'site_intent' ) ) {
 		return ! wpcom_is_checklist_task_complete( 'plan_completed' )
 			|| ! wpcom_is_checklist_task_complete( 'domain_upsell' )

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -275,7 +275,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$flow = get_option( 'site_intent' );
-				return '/setup/' . $flow . '/setup-blog?siteSlug' . $data['site_slug_encoded'];
+				return '/setup/' . $flow . '/setup-blog?siteSlug=' . $data['site_slug_encoded'];
 			},
 		),
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -31,6 +31,10 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				$flow = get_option( 'site_intent' );
+				return '/setup/update-design/designSetup?siteSlug=' . $data['site_slug_encoded'] . '&flow=' . $flow;
+			},
 		),
 		'design_selected'                 => array(
 			'get_title'            => function () {
@@ -84,6 +88,10 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'get_calypso_path'     => function () {
+				$flow = get_option( 'site_intent' );
+				return '/setup/' . $flow . '/plans/';
+			},
 		),
 		'plan_selected'                   => array(
 			'get_title'            => function () {
@@ -265,6 +273,10 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Name your blog', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				$flow = get_option( 'site_intent' );
+				return '/setup' . $flow . '/setup-blog?siteSlug' . $data['site_slug_encoded'];
+			},
 		),
 
 		// Free plan tasks.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -266,7 +266,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Launch your blog', 'jetpack-mu-wpcom' );
 			},
 			'isLaunchTask'          => true,
-			'is_disabled_callback'  => 'wpcom_launchpad_is_blog_launched_disabled',
+			'is_disabled_callback'  => 'wpcom_launchpad_is_blog_launched_task_disabled',
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
 		'setup_blog'                      => array(
@@ -1115,11 +1115,15 @@ function wpcom_launchpad_is_videopress_launch_disabled() {
  *
  * @return boolean True if blog launch task is enabled
  */
-function wpcom_launchpad_is_blog_launched_disabled() {
+function wpcom_launchpad_is_blog_launched_task_disabled() {
 	if ( 'design-first' === get_option( 'site_intent' ) ) {
-		return ! wpcom_is_checklist_task_complete( 'plan_completed' )
-			|| ! wpcom_is_checklist_task_complete( 'domain_upsell' )
-			|| ! wpcom_is_checklist_task_complete( 'setup_blog' );
+		// We only want the blog_launched task enabled after other key tasks are all complete.
+		if ( wpcom_is_checklist_task_complete( 'plan_completed' )
+			&& wpcom_is_checklist_task_complete( 'domain_upsell' )
+			&& wpcom_is_checklist_task_complete( 'setup_blog' ) ) {
+			return false;
+		}
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR will help us to support the Design First pre-launch Launchpad on the Customer Home. I added the path property to the tasks that were missing it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/support-design-first-on-customer-home
```
* Make sure you are sandboxed
* Open an incognito tab
* Navigate to `/setup/design-first`
* Create a new account 
* After creating your account, you should be able to get the site slug.
* Open the developer console in the same window you have your recently created site open
* Make a `GET` request to `WP REST API -> wpcom/v2 -> /sites/{siteSlug}/launchpad?checklist_slug=design-first`
* You should see the `blog_launched` task with the `disabled` key equal to `true`.

<img width="1052" alt="Screen Shot 2023-09-26 at 18 35 38" src="https://github.com/Automattic/jetpack/assets/1234758/c51fa2d6-5c0a-4389-aaf6-c48d5f570a9d">

* Now, make a `PUT` request to `WP REST API -> wpcom/v2 -> /sites/{siteSlug}/launchpad` with the following payload:
```
checklist_statuses = {"plan_completed":true,"domain_upsell":true,"setup_blog":true}
```

* Make a `GET` request to `WP REST API -> wpcom/v2 -> /sites/{siteSlug}/launchpad?checklist_slug=design-first` again, and now the `blog_launched` task should have prop `disabled` equal to false.

