### PR TITLE
CRM: Automations - workflows database query fix for updated_at row

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-automations-workflow-table-timestamp
+++ b/projects/plugins/crm/changelog/fix-crm-automations-workflow-table-timestamp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Automations: Fixed a development issueaffecting workflow database creation.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -894,7 +894,7 @@ function zeroBSCRM_createTables(){
 	`steps` LONGTEXT NOT NULL,
 	`active` TINYINT(1) NOT NULL DEFAULT 0,
 	`version` INT(14) NOT NULL DEFAULT 1,
-	`created_at` TIMESTAMP NOT NULL DEFAULT NOW(),
+	`created_at` INT(14) DEFAULT NULL,
 	`updated_at` INT(14) DEFAULT NULL,
 	PRIMARY KEY (`id`),
 	INDEX `name` (`name` ASC),

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -895,7 +895,7 @@ function zeroBSCRM_createTables(){
 	`active` TINYINT(1) NOT NULL DEFAULT 0,
 	`version` INT(14) NOT NULL DEFAULT 1,
 	`created_at` TIMESTAMP NOT NULL DEFAULT NOW(),
-	`updated_at` TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
+	`updated_at` INT(14) DEFAULT NULL,
 	PRIMARY KEY (`id`),
 	INDEX `name` (`name` ASC),
 	INDEX `active` (`active` ASC),


### PR DESCRIPTION
## Proposed changes:

* In https://github.com/Automattic/jetpack/pull/33129 a new query was added, which appears to cause issues when testing PRs on trunk using Jurassic Ninja. While spinning up a fresh site results in an API error, using the Beta tester plugin and activating the branch for a recent CRM PR results in `WordPress database error: [Invalid default value for 'updated_at']`
* After discussion in Slack - p1695366780951289-slack-CTXBP902X - a fix was made for the `updated_at` row -  https://github.com/Automattic/jetpack/pull/33262.
* This turned out to also cause issues in some MYSQL versions - `WordPress database error:</strong> [Incorrect table definition; there can be only one TIMESTAMP column with CURRENT_TIMESTAMP in DEFAULT or ON UPDATE clause]`
* This new fix removes the timestamp from `updated_at` to fix that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1695630755165109/1695630186.873189-slack-CTXBP902X
https://github.com/Automattic/zero-bs-crm/issues/3344

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test, you should be able to spin up a new Jurassic Ninja site using the Live Branches link (if using the internal Live Branches Tampermonkey script). Alternatively you should be able to switch to this branch using the beta tester plugin on a Jurassic Ninja site, and no errors should display. This should also work on any local installation you are running.
* Then, check that the `*_zbs_workflows` table exists in the database. 
* You can also test running the query directly, after removing that table (both locally, on a JN site, or any other test site):
```
	CREATE TABLE IF NOT EXISTS wp_zbs_workflows(
	`id` INT NOT NULL AUTO_INCREMENT,
	`zbs_site` INT NOT NULL,
	`zbs_owner` INT NOT NULL,
	`name` VARCHAR(255) NOT NULL,
	`description` VARCHAR(255) NULL DEFAULT NULL,
	`category` VARCHAR(255) NOT NULL,
	`triggers` LONGTEXT NOT NULL,
	`initial_step` LONGTEXT NOT NULL,
	`active` TINYINT(1) NOT NULL DEFAULT 0,
	`version` INT(14) NOT NULL DEFAULT 1,
	`created_at` INT(14) DEFAULT NULL,
	`updated_at` INT(14) DEFAULT NULL,
	PRIMARY KEY (`id`),
	INDEX `name` (`name` ASC),
	INDEX `category` (`category` ASC),
	INDEX `created_at` (`created_at` ASC)
	) ENGINE = InnoDB
	DEFAULT CHARACTER SET = utf8
	COLLATE = utf8_general_ci 
```