### PR TITLE
Boost: Remove global state from History component

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/History.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/History.svelte
@@ -4,11 +4,13 @@
 	import ErrorNotice from '../../../elements/ErrorNotice.svelte';
 	import ReactComponent from '../../../elements/ReactComponent.svelte';
 	import { PerformanceHistory } from '../../../react-components/PerformanceHistory';
-	import { performanceHistoryPanelDS } from '../../../stores/data-sync-client';
-	import { modulesState } from '../../../stores/modules';
 	import { recordBoostEvent } from '../../../utils/analytics';
 	import { castToString } from '../../../utils/cast-to-string';
 	import routerHistory from '../../../utils/router-history';
+
+	export let isOpen: boolean;
+	export let needsUpgrade: boolean;
+	export let onToggle;
 
 	const siteIsOnline = Jetpack_Boost.site.online;
 
@@ -53,13 +55,6 @@
 			isLoading = false;
 		}
 	}
-
-	const panelStore = performanceHistoryPanelDS.store;
-	const onToggleHistory = status => {
-		panelStore.set( status );
-	};
-
-	$: needsUpgrade = $modulesState.performance_history.available === false;
 </script>
 
 <div class="jb-performance-history" class:loading={isLoading}>
@@ -73,8 +68,8 @@
 	{/if}
 	<ReactComponent
 		this={PerformanceHistory}
-		onToggle={onToggleHistory}
-		isOpen={$panelStore}
+		{onToggle}
+		{isOpen}
 		{needsUpgrade}
 		handleUpgrade={() => routerHistory.navigate( '/upgrade' )}
 		{periods}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -9,6 +9,8 @@
 	import { scoreChangeModal, ScoreChangeMessage } from '../../../api/speed-scores';
 	import ErrorNotice from '../../../elements/ErrorNotice.svelte';
 	import ReactComponent from '../../../elements/ReactComponent.svelte';
+	import { performanceHistoryPanelDS } from '../../../stores/data-sync-client';
+	import { modulesState } from '../../../stores/modules';
 	import RefreshIcon from '../../../svg/refresh.svg';
 	import { recordBoostEvent } from '../../../utils/analytics';
 	import { castToString } from '../../../utils/cast-to-string';
@@ -102,6 +104,14 @@
 	function dismissModal() {
 		modalData = null;
 	}
+
+	const panelStore = performanceHistoryPanelDS.store;
+	const onTogglePerformanceHistory = status => {
+		panelStore.set( status );
+	};
+
+	$: performanceHistoryNeedsUpgrade = $modulesState.performance_history.available === false;
+	$: performanceHistoryIsOpen = $panelStore;
 </script>
 
 <div class="jb-container">
@@ -177,7 +187,11 @@
 		/>
 	</div>
 	{#if siteIsOnline}
-		<History />
+		<History
+			isOpen={performanceHistoryIsOpen}
+			needsUpgrade={performanceHistoryNeedsUpgrade}
+			onToggle={onTogglePerformanceHistory}
+		/>
 	{/if}
 </div>
 

--- a/projects/plugins/boost/changelog/refactor-history-component
+++ b/projects/plugins/boost/changelog/refactor-history-component
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove global state from History component.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves global state to parent component (Score).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-286-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the History component is togglable and works as expected.
![CleanShot 2023-09-25 at 14 27 15](https://github.com/Automattic/jetpack/assets/11799079/cafd7a05-d478-4108-a610-e3df169e6d9e)
