### PR TITLE
CRM: Add SQL transaction/rollback style to integration tests

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-3345-add-sql-transaction-to-integration-tests
+++ b/projects/plugins/crm/changelog/update-crm-3345-add-sql-transaction-to-integration-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Changed the method to ensure the DB transactions inside tests and to have a clean DB on each test instead of using the JPCRM reset database function.
+
+

--- a/projects/plugins/crm/tests/php/class-jpcrm-base-integration-test-case.php
+++ b/projects/plugins/crm/tests/php/class-jpcrm-base-integration-test-case.php
@@ -19,7 +19,26 @@ class JPCRM_Base_Integration_Test_Case extends JPCRM_Base_Test_Case {
 	public function tear_down(): void {
 		parent::tear_down();
 
-		zeroBSCRM_database_reset( false );
+		global $wpdb;
+
+		// Rollback the transaction
+		$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	}
+
+	/**
+	 * Set up the database before each test.
+	 *
+	 * @since $$next-version$$
+	 *
+	 *  @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wpdb;
+
+		// Start the SQL transaction
+		$wpdb->query( 'START TRANSACTION' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3345

## Proposed changes:

This PR changes the way we reset the DB for each test. The right way to do it is with SQL transactions and then rollback it. 

Now we were resetting only the JPCRM database using the function zeroBSCRM_database_reset(); but in our test, we could add WP users and other DB items that are not part of JPCRM. We have to keep the testing DB clean and in the same state on each test, so we have to use the transaction way to roll back any change.

- START TRANSACTION
- Run test
- ROLLBACK

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Check the code.
- Tests should pass as before.

