### PR TITLE
Launchpad: Logic to disable the blog_launched task on the Customer Home

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-support-start-writing-on-customer-home
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-support-start-writing-on-customer-home
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support Start Writing tasks on the Customer Home Launchpad

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1125,6 +1125,15 @@ function wpcom_launchpad_is_blog_launched_task_disabled() {
 		}
 		return true;
 	}
+	if ( 'start-writing' === get_option( 'site_intent' ) ) {
+		if ( wpcom_is_checklist_task_complete( 'plan_completed' )
+			&& wpcom_is_checklist_task_complete( 'domain_upsell' )
+			&& wpcom_is_checklist_task_complete( 'setup_blog' )
+			&& wpcom_is_checklist_task_complete( 'first_post_published' ) ) {
+			return false;
+		}
+		return true;
+	}
 	return false;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/pull/33272
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR makes task blog_launched disabled for the `Start Writing` flow when the required tasks are not complete yet. This is used to allow us to display the pre-launch Launchpad on the Customer Home page.
* Please, review https://github.com/Automattic/jetpack/pull/33272 first.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
* On an incognito tab, navigate to `/setup/start-writing`
* Create a new account
* After creating the account, you'll be redirected to the editor, where you need to make a post.
* Open the developer console in the same window you have your recently created site open
* Make a `GET` request to `WP REST API -> wpcom/v2 -> /sites/{siteSlug}/launchpad?checklist_slug=start-writing`
* You should see the `blog_launched` task with the `disabled` key equal to `true`.
* Now, make a `PUT` request to `WP REST API -> wpcom/v2 -> /sites/{siteSlug}/launchpad` with the following payload:
```
checklist_statuses = {"plan_completed":true,"domain_upsell":true,"setup_blog":true, "first_post_published":true}
```

* Make a `GET` request to `WP REST API -> wpcom/v2 -> /sites/{siteSlug}/launchpad?checklist_slug=start-writing` again, and now the `blog_launched` task should have prop `disabled` equal to false.