### PR TITLE
First posts stream: Update option only on Atomic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-first-posts-stream-check-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-first-posts-stream-check-atomic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Added check for jetpack sync option to only run on Atomic

--- a/projects/packages/jetpack-mu-wpcom/src/features/first-posts-stream/first-posts-stream-helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/first-posts-stream/first-posts-stream-helpers.php
@@ -12,6 +12,15 @@
  * @param array $allowed_options The allowed options.
  */
 function register_first_posts_stream_options_sync( $allowed_options ) {
+	// We are not either in Simple or Atomic.
+	if ( ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
+		return $allowed_options;
+	}
+
+	if ( ! ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
+		return $allowed_options;
+	}
+
 	if ( ! is_array( $allowed_options ) ) {
 		return $allowed_options;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Related to https://github.com/Automattic/jetpack/pull/33253, this PR adds a check to only sync the option if the code is running on WoA.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* apply this PR on your AT site following instruction on https://github.com/Automattic/jetpack/pull/33253#issuecomment-1730172823 and follow instructions in D121677-code ignoring the `JETPACK__SANDBOX_DOMAIN` setting.
