### PR TITLE
Launchpad: Hide title task if completed

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/hide-title-task-if-completed
+++ b/projects/packages/jetpack-mu-wpcom/changelog/hide-title-task-if-completed
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Changing Launchpad task visibility
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -293,6 +293,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Give your site a name', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_site_title_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},
@@ -1375,6 +1376,18 @@ function wpcom_launchpad_is_add_about_page_visible() {
 	return ! wpcom_launchpad_is_update_about_page_task_visible() && registered_meta_key_exists( 'post', '_wpcom_template_layout_category', 'page' );
 }
 
+/**
+ * Determine `site_title` task visibility. The task is not visible if the name was already set.
+ *
+ * @return bool True if we should show the task, false otherwise.
+ */
+function wpcom_launchpad_is_site_title_task_visible() {
+	// Hide the task if it's already completed on write intent
+	if ( get_option( 'site_intent' ) === 'write' && wpcom_launchpad_is_task_option_completed( array( 'id' => 'site_title' ) ) ) {
+		return false;
+	}
+	return true;
+}
 /**
  * Completion hook for the `add_about_page` task.
  *


### PR DESCRIPTION


More context/fixes: https://github.com/Automattic/wp-calypso/issues/82148

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds a visibility callback to the `site_title` task, so it's not visible for sites with `write` intent and that the user already completed the task.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Create a new site with `write` intent
- During onboarding, choose a site name.
- Launch the site
- On Customer home, check that the `site_title` task is displayed as completed.
- Apply this PR to your sandbox
- Refresh the page
- Check that the task is not shown anymore
![image](https://github.com/Automattic/jetpack/assets/3801502/68a692a9-7692-48eb-98c2-e7d897c19560)


