### PR TITLE
Backports changes for mu-wpcom-plugin 1.6.21 and jetpack 12.7-a.1

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2023-09-25
+### Added
+- Export GuidelineMessage for use in other blocks. [#33180]
+
 ## [0.1.8] - 2023-09-19
 ### Added
 - AI Client: Add support for the jetpack-ai role on the prompt messages. [#33052]
@@ -128,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.1.9]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.5...v0.1.6

--- a/projects/js-packages/ai-client/changelog/update-ai-chat-show-guideline
+++ b/projects/js-packages/ai-client/changelog/update-ai-chat-show-guideline
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Export GuidelineMessage for use in other blocks. 

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.1.9-alpha",
+	"version": "0.1.9",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.42.5] - 2023-09-25
+### Added
+- Added WhatsApp social icon. [#33074]
+- Aded CopyToClipboard component. [#33265]
+
 ## [0.42.4] - 2023-09-19
+
 - Minor internal updates.
 
 ## [0.42.3] - 2023-09-13
@@ -820,6 +826,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.42.5]: https://github.com/Automattic/jetpack-components/compare/0.42.4...0.42.5
 [0.42.4]: https://github.com/Automattic/jetpack-components/compare/0.42.3...0.42.4
 [0.42.3]: https://github.com/Automattic/jetpack-components/compare/0.42.2...0.42.3
 [0.42.2]: https://github.com/Automattic/jetpack-components/compare/0.42.1...0.42.2

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [0.42.5] - 2023-09-25
 ### Added
 - Added WhatsApp social icon. [#33074]
-- Aded CopyToClipboard component. [#33265]
+- Added CopyToClipboard component. [#33265]
 
 ## [0.42.4] - 2023-09-19
 

--- a/projects/js-packages/components/changelog/add-copy-to-clipboard-component
+++ b/projects/js-packages/components/changelog/add-copy-to-clipboard-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Aded CopyToClipboard component

--- a/projects/js-packages/components/changelog/update-add-post-publish-sharing-buttons
+++ b/projects/js-packages/components/changelog/update-add-post-publish-sharing-buttons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added WhatsApp social icon

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.42.5-alpha",
+	"version": "0.42.5",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.30.0] - 2023-09-25
+### Added
+- Handle connection error codes and display proper error messages. Enabled for the "private network" error only at the moment. [#32898]
+
 ## [0.29.10] - 2023-09-13
 ### Changed
 - Updated package dependencies. [#33001]
@@ -628,6 +632,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.30.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.29.10...v0.30.0
 [0.29.10]: https://github.com/Automattic/jetpack-connection-js/compare/v0.29.9...v0.29.10
 [0.29.9]: https://github.com/Automattic/jetpack-connection-js/compare/v0.29.8...v0.29.9
 [0.29.8]: https://github.com/Automattic/jetpack-connection-js/compare/v0.29.7...v0.29.8

--- a/projects/js-packages/connection/changelog/add-private-network-connection
+++ b/projects/js-packages/connection/changelog/add-private-network-connection
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Handle connection error codes and display proper error messages. Enabled for the "private network" error only at the moment.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.30.0-alpha",
+	"version": "0.30.0",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.0] - 2023-09-25
+### Added
+- Added a new post-publish panel for quick sharing. [#33231]
+- Added sharing buttons to be used in post-publish panel. [#33074]
+- Added tracking events for post publish share buttons. [#33231]
+
+### Fixed
+- Fixed versions. [#33231]
+- Publicize: Reinstate the connect an account link. [#33182]
+
 ## [0.38.0] - 2023-09-19
 ### Changed
 - Move auto-conversion notice near the Instagram one [#33106]
@@ -429,6 +439,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.39.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.35.0...v0.36.0

--- a/projects/js-packages/publicize-components/changelog/add-post-publish-one-click-sharing-panel
+++ b/projects/js-packages/publicize-components/changelog/add-post-publish-one-click-sharing-panel
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added a new post-publish panel for quick sharing

--- a/projects/js-packages/publicize-components/changelog/add-tracking-to-post-publish-share-buttons
+++ b/projects/js-packages/publicize-components/changelog/add-tracking-to-post-publish-share-buttons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added tracking events for post publish share buttons

--- a/projects/js-packages/publicize-components/changelog/fix-social-add-connection-link
+++ b/projects/js-packages/publicize-components/changelog/fix-social-add-connection-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Publicize: Reinstate the connect an account link

--- a/projects/js-packages/publicize-components/changelog/fix-versions
+++ b/projects/js-packages/publicize-components/changelog/fix-versions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-fixed versions

--- a/projects/js-packages/publicize-components/changelog/update-add-post-publish-sharing-buttons
+++ b/projects/js-packages/publicize-components/changelog/update-add-post-publish-sharing-buttons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added sharing buttons to be used in post-publish panel

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.39.0-alpha",
+	"version": "0.39.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.10] - 2023-09-25
+
 ## [3.3.9] - 2023-09-19
+
 - Minor internal updates.
 
 ## [3.3.8] - 2023-08-23
@@ -170,6 +173,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[3.3.10]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.9...3.3.10
 [3.3.9]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.8...3.3.9
 [3.3.8]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.7...3.3.8
 [3.3.7]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.6...3.3.7

--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.3.10] - 2023-09-25
+- Minor internal updates.
 
 ## [3.3.9] - 2023-09-19
 

--- a/projects/packages/changelogger/changelog/update-replace-phpunit-assertObjectHasAttribute
+++ b/projects/packages/changelogger/changelog/update-replace-phpunit-assertObjectHasAttribute
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Replace PHPUnit deprecated `assertObject(Not)HasAttribute` with `assertObject(Not)HasAttribute` (via yoast polyfills for older versions). No change to the package itself.
-
-

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '3.3.10-alpha';
+	const VERSION = '3.3.10';
 
 	/**
 	 * Constructor.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.0] - 2023-09-25
+### Added
+- Disallow private IP addresses for site connection. [#32898]
+
 ## [1.57.5] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.57.4] - 2023-09-13
@@ -883,6 +888,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[1.58.0]: https://github.com/Automattic/jetpack-connection/compare/v1.57.5...v1.58.0
 [1.57.5]: https://github.com/Automattic/jetpack-connection/compare/v1.57.4...v1.57.5
 [1.57.4]: https://github.com/Automattic/jetpack-connection/compare/v1.57.3...v1.57.4
 [1.57.3]: https://github.com/Automattic/jetpack-connection/compare/v1.57.2...v1.57.3

--- a/projects/packages/connection/changelog/add-private-network-connection
+++ b/projects/packages/connection/changelog/add-private-network-connection
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Disallow private IP addresses for site connection.

--- a/projects/packages/connection/changelog/update-replace-phpunit-assertObjectHasAttribute
+++ b/projects/packages/connection/changelog/update-replace-phpunit-assertObjectHasAttribute
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Replace PHPUnit deprecated `assertObject(Not)HasAttribute` with `assertObject(Not)HasAttribute` (via yoast polyfills for older versions). No change to the package itself.
-
-

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.58.0-alpha';
+	const PACKAGE_VERSION = '1.58.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.11.0] - 2023-09-25
+### Added
+- Adds 100 Year Plan features, including the ability to set a legacy contact and enable locked mode. [#33081]
+- Adds a feature to include helpers for the First Posts stream. In particular, an option is being added to the sync list. [#33253]
+- Add the Calypso path for the setup_link_in_bio task. [#32905]
+- Support Videopress tasks on the Customer Home Launchpad. [#33153]
+
+### Fixed
+- Locked Mode: Now applies cap filter in REST API requests as well. [#33246]
+
 ## [4.10.0] - 2023-09-19
 ### Added
 - Add removal capability for navigator available checklists [#33019]
@@ -359,6 +369,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[4.11.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.10.0...v4.11.0
 [4.10.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.9.0...v4.10.0
 [4.9.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.8.0...v4.9.0
 [4.8.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.7.0...v4.8.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/100-year-plan-enhanced-ownership
+++ b/projects/packages/jetpack-mu-wpcom/changelog/100-year-plan-enhanced-ownership
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Adds 100 Year Plan features, including the ability to set a legacy contact and enable locked mode.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-calypso-path-for-link-in-bio
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-calypso-path-for-link-in-bio
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the Calypso path for the setup_link_in_bio task

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-support-launchpad-videopress-tasks.x
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-support-launchpad-videopress-tasks.x
@@ -1,6 +1,0 @@
-Significance: minor
-Type: added
-
-Support Videopress tasks on the Customer Home Launchpad
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-locked-mode-rest-api
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-locked-mode-rest-api
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Locked Mode: Now applies cap filter in REST API requests as well

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-trunk-versions
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-trunk-versions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Edited versions of packages to reflect their status correctly.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add-first-posts-stream-helpers
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add-first-posts-stream-helpers
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Adds a feature to include helpers for the First Posts stream. In particular, an option is being added to the sync list.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "4.11.x-dev"
+			"dev-trunk": "4.12.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.11.0-alpha",
+	"version": "4.11.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.11.0",
+	"version": "4.12.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.11.0-alpha';
+	const PACKAGE_VERSION = '4.11.0';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.11.0';
+	const PACKAGE_VERSION = '4.12.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2023-09-25
+### Added
+- Add barebones infrastructure for querying jetpack product data. [#33095]
+
+### Changed
+- Stats: link to purchase page within WP Admin. [#33227]
+
 ## [3.5.0] - 2023-09-19
 ### Changed
 - Added support for upgradable products. Updated the Stats card  to handle upgradeable products. [#33058]
@@ -1026,6 +1033,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[3.6.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.5.0...3.6.0
 [3.5.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.4.5...3.5.0
 [3.4.5]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.4.4...3.4.5
 [3.4.4]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.4.3...3.4.4

--- a/projects/packages/my-jetpack/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add barebones infrastructure for querying jetpack product data

--- a/projects/packages/my-jetpack/changelog/update-use-odyssey-stats-purchase
+++ b/projects/packages/my-jetpack/changelog/update-use-odyssey-stats-purchase
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Stats: link to purchase page within wp-admin

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.6.0-alpha",
+	"version": "3.6.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.6.0-alpha';
+	const PACKAGE_VERSION = '3.6.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.5] - 2023-09-25
+### Changed
+- Add 127.0.0.1 into the list of known local domains. [#32898]
+- WP.com Compatibility: Abort out early checking if Protect is active. WP.com's protection is not site option based. [#33196]
+
 ## [1.18.4] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.18.3] - 2023-09-11
@@ -279,6 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[1.18.5]: https://github.com/Automattic/jetpack-status/compare/v1.18.4...v1.18.5
 [1.18.4]: https://github.com/Automattic/jetpack-status/compare/v1.18.3...v1.18.4
 [1.18.3]: https://github.com/Automattic/jetpack-status/compare/v1.18.2...v1.18.3
 [1.18.2]: https://github.com/Automattic/jetpack-status/compare/v1.18.1...v1.18.2

--- a/projects/packages/status/changelog/add-private-network-connection
+++ b/projects/packages/status/changelog/add-private-network-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Add 127.0.0.1 into the list of known local domains.

--- a/projects/packages/status/changelog/update-no-wpcom-module-check
+++ b/projects/packages/status/changelog/update-no-wpcom-module-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-WP.com Compatibility: abort out early checking if Protect is active. WP.com's protection is not site option based.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.57.2] - 2023-09-25
+### Added
+- Site Settings Endpoint: Allow for updating and retrieving of the wpcom_newsletter_categories site option. [#33234]
+
 ## [1.57.1] - 2023-09-20
 ### Added
 - Adds legacy contact and locked mode options for 100-year plan [#33081]
@@ -926,6 +930,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.57.2]: https://github.com/Automattic/jetpack-sync/compare/v1.57.1...v1.57.2
 [1.57.1]: https://github.com/Automattic/jetpack-sync/compare/v1.57.0...v1.57.1
 [1.57.0]: https://github.com/Automattic/jetpack-sync/compare/v1.56.0...v1.57.0
 [1.56.0]: https://github.com/Automattic/jetpack-sync/compare/v1.55.2...v1.56.0

--- a/projects/packages/sync/changelog/fix-subscriptions-block-no-category-excl-when-none-selected
+++ b/projects/packages/sync/changelog/fix-subscriptions-block-no-category-excl-when-none-selected
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Site Settings Endpoint: Allow for updating and retrieving of the wpcom_newsletter_categories site option

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.57.2-alpha';
+	const PACKAGE_VERSION = '1.57.2';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2023-09-25
+### Fixed
+- Add bi-yearly constants for complete and videopress in config. [#33095]
+
 ## [0.17.0] - 2023-09-19
 ### Changed
 - Add VideoPress assets enqueuing logic after the revert c9fa94de7886af75b65b8c75e642fb529144eb31 (reverted d5ca47d8de53df832e67ac8b9d6bda3663c3e8df). This time P2s should not be affected. [#33042]
@@ -1115,6 +1119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.17.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.15.3...v0.16.0
 [0.15.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.15.2...v0.15.3

--- a/projects/packages/videopress/changelog/add-bi-yearly-constants-to-videopress-plugin
+++ b/projects/packages/videopress/changelog/add-bi-yearly-constants-to-videopress-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Add bi-yearly constants for complete and videopress in config

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.17.1-alpha",
+	"version": "0.17.1",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.17.1-alpha';
+	const PACKAGE_VERSION = '0.17.1';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.7-a.1 - 2023-09-25
+### Enhancements
+- Added a new post publish panel for quick sharing. [#33231]
+- AI Assistant: Modify language reminder for toolbar options. [#33211]
+- AI Assistant: Start using backend to generate the prompts. [#33018]
+- AI Assistant: Update block description. [#33218]
+- AI Chat: Fix feedback section styles and include svg for icons. [#33187]
+- AI Chat: Show guideline message. [#33180]
+- AI Extension: Show AI Form extension with connection nudge for disconnected users. [#33186]
+- Blogroll: Add blog appender site searching. [#33060]
+- Blogroll: Fix blogroll block typography editor styling. [#33209]
+- Blogroll: Update blogroll appender height, max lines of text, and container scrolling. [#33245]
+- Blogroll: Update CSS styling to allow blogroll block color styling customizations. [#33214]
+- Blogroll Block: Add the ability to subscribe to recommended blogs. [#33199]
+- Paywall Block: Update description. [#33274]
+- Sidebar: Rename the "Inbox" menu to "My Mailboxes" for domain-only sites. [#33239]
+- Update Blogroll appender accessibility. [#33269]
+
+### Improved compatibility
+- Improve color handling for the newsletter categories. [#33206]
+
+### Bug fixes
+- AI Chat: Remove extra request in $search->is_active() and only load initial state in editor. [#33195]
+- AI Extension: Revert PR causing stream rendering issue on Firefox. [#33223]
+- Dashboard: Avoid errors when dashboard is accessed by WordPress users with a custom non-admin role. [#33263]
+- Fix menu focus state without My Jetpack. [#33251]
+- Fix subscribe block button not showing on newline. [#33260]
+- Hide launchpad modal on first post for bloggers. [#33098]
+- Skip video file addition to upload queue if it fails the space/allowance check. [#33212]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Adds legacy contact and locked mode options for 100-year plan. [#33081]
+- Adjust styling in AI chat button. [#33213]
+- Site Settings Endpoint: Allow for updating and retrieving of the wpcom_newsletter_categories site option via the endpoint. [#33234]
+- Subscriptions Block: Do not append newsletter category exclusions to subscribe url when none categories were checked. [#33181]
+
 ## 12.6.1 - 2023-09-21
 ### Bug Fixes
 - WooCommerce Analytics: fix a fatal error that can occur with WooCommerce enabled.

--- a/projects/plugins/jetpack/changelog/Improve accessibility
+++ b/projects/plugins/jetpack/changelog/Improve accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Update blogroll appender accessibility

--- a/projects/plugins/jetpack/changelog/add-append-wpcom-site-to-blog-roll
+++ b/projects/plugins/jetpack/changelog/add-append-wpcom-site-to-blog-roll
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Blogroll: Add blog appender site searching

--- a/projects/plugins/jetpack/changelog/add-enhanced-ownership
+++ b/projects/plugins/jetpack/changelog/add-enhanced-ownership
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Adds legacy contact and locked mode options for 100-year plan

--- a/projects/plugins/jetpack/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/jetpack/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-

--- a/projects/plugins/jetpack/changelog/add-post-publish-one-click-sharing-panel
+++ b/projects/plugins/jetpack/changelog/add-post-publish-one-click-sharing-panel
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Added a new post publish panel for quick sharing

--- a/projects/plugins/jetpack/changelog/add-private-network-connection
+++ b/projects/plugins/jetpack/changelog/add-private-network-connection
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/blogroll-add-subscribe-button
+++ b/projects/plugins/jetpack/changelog/blogroll-add-subscribe-button
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Blogroll Block: add the ability to subscribe to recommended blogs

--- a/projects/plugins/jetpack/changelog/change-inbox-menu-to-my-mailboxes-for-domain-only-sites
+++ b/projects/plugins/jetpack/changelog/change-inbox-menu-to-my-mailboxes-for-domain-only-sites
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Sidebar: Rename the "Inbox" menu to "My Mailboxes" for domain-only sites.

--- a/projects/plugins/jetpack/changelog/feat-add_image_fallback
+++ b/projects/plugins/jetpack/changelog/feat-add_image_fallback
@@ -1,5 +1,0 @@
-Significance: patch
-Type: compat
-Comment: Blogroll add fallback images
-
-

--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-language-switch
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-language-switch
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Modify language reminder for toolbar options

--- a/projects/plugins/jetpack/changelog/fix-blank-dashboard-custom-roles
+++ b/projects/plugins/jetpack/changelog/fix-blank-dashboard-custom-roles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Dashboard: avoid errors when dashboard is accessed by WordPress users with a custom non-admin role.

--- a/projects/plugins/jetpack/changelog/fix-blogroll-editor-color-styling
+++ b/projects/plugins/jetpack/changelog/fix-blogroll-editor-color-styling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Blogroll: Update CSS styling to allow blogroll block color styling customizations

--- a/projects/plugins/jetpack/changelog/fix-launchpad-hide-modal-on-first-post
+++ b/projects/plugins/jetpack/changelog/fix-launchpad-hide-modal-on-first-post
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-hide launchpad modal on first post for bloggers

--- a/projects/plugins/jetpack/changelog/fix-menu-focus-no-my-jetpack
+++ b/projects/plugins/jetpack/changelog/fix-menu-focus-no-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix menu focus state without My Jetpack

--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-fallback-color
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-fallback-color
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-Improve color handling for the newsletter categories

--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-newline-fix
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-newline-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix subscribe block button not showing on newline.

--- a/projects/plugins/jetpack/changelog/fix-subscriptions-block-no-category-excl-when-none-selected
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-block-no-category-excl-when-none-selected
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions Block: Do not append newsletter category exclusions to subscribe url, when none categories were checked

--- a/projects/plugins/jetpack/changelog/fix-video-upload-bugfix
+++ b/projects/plugins/jetpack/changelog/fix-video-upload-bugfix
@@ -1,4 +1,0 @@
-Significance: minor
-Type: bugfix
-
-Skip video file addition to upload queue if it fails the space/allowance check

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 12.7-a.0
-
-

--- a/projects/plugins/jetpack/changelog/revert-33026-update-jetpack-form-extend-with-ai-data
+++ b/projects/plugins/jetpack/changelog/revert-33026-update-jetpack-form-extend-with-ai-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Extension: Revert PR causing stream rendering issue on Firefox

--- a/projects/plugins/jetpack/changelog/sitebot-button-styling
+++ b/projects/plugins/jetpack/changelog/sitebot-button-styling
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-adjust styling in ai chat button

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-block-description
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-block-description
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Update block description

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-use-backend-prompt-for-assistant-actions
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-use-backend-prompt-for-assistant-actions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: start using backend to generate the prompts.

--- a/projects/plugins/jetpack/changelog/update-ai-chat-dont-load-extra-scripts-on-frontend
+++ b/projects/plugins/jetpack/changelog/update-ai-chat-dont-load-extra-scripts-on-frontend
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Chat: Remove extra request in $search->is_active() and only load initial state in editor

--- a/projects/plugins/jetpack/changelog/update-ai-chat-fix-feedback-style-and-icons
+++ b/projects/plugins/jetpack/changelog/update-ai-chat-fix-feedback-style-and-icons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Chat: Fix feedback section styles and include svg for icons.

--- a/projects/plugins/jetpack/changelog/update-ai-chat-show-guideline
+++ b/projects/plugins/jetpack/changelog/update-ai-chat-show-guideline
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Chat: Show guideline message

--- a/projects/plugins/jetpack/changelog/update-ai-form-disconnected
+++ b/projects/plugins/jetpack/changelog/update-ai-form-disconnected
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: Show AI Form extension with connection nudge for disconnected users

--- a/projects/plugins/jetpack/changelog/update-blog-roll-settings-persistance
+++ b/projects/plugins/jetpack/changelog/update-blog-roll-settings-persistance
@@ -1,5 +1,0 @@
-Significance: patch
-Type: enhancement
-Comment: Beta block under development
-
-

--- a/projects/plugins/jetpack/changelog/update-blogroll-appender-improvements-v1
+++ b/projects/plugins/jetpack/changelog/update-blogroll-appender-improvements-v1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Blogroll: Update blogroll appender height, max lines of text, and container scrolling

--- a/projects/plugins/jetpack/changelog/update-blogroll-typography
+++ b/projects/plugins/jetpack/changelog/update-blogroll-typography
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Blogroll: Fix blogroll block typography editor styling

--- a/projects/plugins/jetpack/changelog/update-changelog-stable-tag
+++ b/projects/plugins/jetpack/changelog/update-changelog-stable-tag
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Stable tag bump.
-
-

--- a/projects/plugins/jetpack/changelog/update-paywall-block-description
+++ b/projects/plugins/jetpack/changelog/update-paywall-block-description
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Paywall block: update description

--- a/projects/plugins/jetpack/changelog/update-replace-phpunit-assertObjectHasAttribute
+++ b/projects/plugins/jetpack/changelog/update-replace-phpunit-assertObjectHasAttribute
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Replace PHPUnit deprecated `assertObject(Not)HasAttribute` with `assertObject(Not)HasAttribute` (via yoast polyfills for older versions). No change to the plugin itself.
-
-

--- a/projects/plugins/jetpack/changelog/update-site-settings-incl-wpcom-newsletter-categories
+++ b/projects/plugins/jetpack/changelog/update-site-settings-incl-wpcom-newsletter-categories
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Site Settings Endpoint: Allow for updating and retrieving of the wpcom_newsletter_categories site option via the endpoint

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -104,7 +104,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_a_0",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_a_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
@@ -69,7 +69,7 @@ HTML;
 /**
  * Register site_recommendations settings
  *
- * @since $$next-version$$
+ * @since 12.7
  */
 function site_recommendations_settings() {
 	register_setting(

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.7-a.0
+ * Version: 12.7-a.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.7-a.0' );
+define( 'JETPACK__VERSION', '12.7-a.1' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.7.0-a.0",
+	"version": "12.7.0-a.1",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.21 - 2023-09-25
+
 ## 1.6.20 - 2023-09-19
 
 ## 1.6.19 - 2023-09-11

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-trunk-versions
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-trunk-versions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-ai-chat-fix-feedback-style-and-icons
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-ai-chat-fix-feedback-style-and-icons
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_21"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_22_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_21_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_21"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "42f702a13ab337ae035fcd24b9e915e779ac8647"
+                "reference": "0f4b2235912eb430459c7c80ebaab5991d3ad322"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.11.x-dev"
+                    "dev-trunk": "4.12.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.21-alpha
+ * Version: 1.6.21
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.21
+ * Version: 1.6.22-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.21-alpha",
+	"version": "1.6.21",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.21",
+	"version": "1.6.22-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Backports changes for mu-wpcom-plugin 1.6.21 and jetpack 12.7-a.1.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread the changelogs.

