### PR TITLE
CRM: Fix Automation bootstrap loading workflows from DB

### DIFF
--- a/projects/plugins/crm/changelog/crm-fix-automation-bootstrap-db-workflows
+++ b/projects/plugins/crm/changelog/crm-fix-automation-bootstrap-db-workflows
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixing the previous PR loading workflow from the database. Use find_by instead of find_all
+
+

--- a/projects/plugins/crm/src/automation/class-automation-bootstrap.php
+++ b/projects/plugins/crm/src/automation/class-automation-bootstrap.php
@@ -265,7 +265,6 @@ final class Automation_Bootstrap {
 		foreach ( $workflows as $workflow ) {
 			if ( $workflow instanceof Automation_Workflow ) {
 				try {
-					$workflow->set_engine( $this->engine );
 					$this->engine->add_workflow( $workflow, true );
 				} catch ( \Exception $e ) {
 					$this->engine->get_logger()->log( $e->getMessage() );

--- a/projects/plugins/crm/src/automation/class-automation-bootstrap.php
+++ b/projects/plugins/crm/src/automation/class-automation-bootstrap.php
@@ -245,7 +245,7 @@ final class Automation_Bootstrap {
 	 */
 	protected function register_workflows(): void {
 		$workflow_repository = new Workflow\Workflow_Repository();
-		$workflows           = $workflow_repository->find_all(
+		$workflows           = $workflow_repository->find_by(
 			array(
 				'active' => true,
 			)


### PR DESCRIPTION
## Proposed changes:

This PR is a quick fix in the bootstrap code. It should use `find_by` method instead of `find_all`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Check the code
- Tests should pass
- Manual test. Add this workflow to the database running this code in your WP installation:

```php
	$workflow = new \Automattic\Jetpack\CRM\Automation\Automation_Workflow(
		[
			'name'         => 'New contact: Set status to "Customer"',
			'description'  => 'This automation will change the status of a contact to "Customer" when they are created.',
			'category'     => 'contact',
			'active'       => true,
			'triggers'     => [
				\Automattic\Jetpack\CRM\Automation\Triggers\Contact_Created::get_slug(),
			],
			'initial_step' => 1,
			'steps' => [
				1 => [
					'slug'           => \Automattic\Jetpack\CRM\Automation\Actions\Update_Contact_Status::get_slug(),
					'attributes'     => [
						'new_status' => 'Customer',
					],
					'next_step'      => null,
				],
			],
		]
	);
	
	$repo = new \Automattic\Jetpack\CRM\Automation\Workflow\Workflow_Repository();
	$workflow = $repo->persist( $workflow );
```

Create a new Contact, with the status `Lead`. It will be changed to `Customer` status automatically.

