### PR TITLE
My Jetpack: redirect Stats upgrade to a proper page for free license owners

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-stats-upgrade-url-free-license
+++ b/projects/packages/my-jetpack/changelog/update-stats-upgrade-url-free-license
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Redirect to a proper upgrade page for free license owners

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.6.0",
+	"version": "3.6.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.6.0';
+	const PACKAGE_VERSION = '3.6.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -182,6 +182,29 @@ class Stats extends Module_Product {
 	}
 
 	/**
+	 * Returns a redirect parameter for an upgrade URL if current purchase license is a free license
+	 * or an empty string otherwise.
+	 *
+	 * @return string
+	 */
+	public static function get_url_redirect_string() {
+		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
+			return '';
+		}
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				if (
+					0 === strpos( $purchase->product_slug, static::get_wpcom_free_product_slug() )
+				) {
+					return '&productType=personal';
+				}
+			}
+		}
+		return '';
+	}
+
+	/**
 	 * Checks whether the product supports trial or not.
 	 * Since Jetpack Stats has been widely available as a free product in the past, it "supports" a trial.
 	 *
@@ -199,9 +222,10 @@ class Stats extends Module_Product {
 	public static function get_purchase_url() {
 		// The returning URL could be customized by changing the `redirect_uri` param with relative path.
 		return sprintf(
-			'%s#!/stats/purchase/%d?from=jetpack-my-jetpack&redirect_uri=%s',
+			'%s#!/stats/purchase/%d?from=jetpack-my-jetpack%s&redirect_uri=%s',
 			admin_url( 'admin.php?page=stats' ),
 			Jetpack_Options::get_option( 'id' ),
+			static::get_url_redirect_string(),
 			rawurlencode( 'admin.php?page=stats' )
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/81745

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* For free license owners redirect upgrade button directly to the purchase page instead of a summary page

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build my-jetpack and jetpack `jetpack build packages/my-jetpack && jetpack build plugins/jetpack`
* Build Odyssey Stats with Calypso trunk: `cd apps/odyssey-stats && STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Open `/wp-admin/admin.php?page=my-jetpack` for a site without any Stats subscriptions
* Ensure you see `Upgrade` button for the Stats card and clicking it redirects you to a purchase page
* Purchase a free license by changing the slider to 0
* Open `/wp-admin/admin.php?page=my-jetpack` for the same site
* Ensure you see `Upgrade` button for the Stats card and clicking it redirects you to a purchase page again (not a summary page stating that you already own a free license)