### PR TITLE
AI Excerpt: Add `Beta` label to sidebar panel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-add-beta-label
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-add-beta-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: Add `Beta` label to sidebar panel

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -104,7 +104,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/editor.js
+++ b/projects/plugins/jetpack/extensions/editor.js
@@ -53,7 +53,12 @@ apiFetch.use( ( options, next ) => {
 /**
  * Detect whether the extension is a beta extension.
  *
- * @param {string} name - Block name
+ * @example
+ * ```js
+ * import { isBetaExtension } from './';
+ * isBetaExtension( 'ai-content-lens' ); // true
+ * ```
+ * @param {string} name - Extension name
  * @returns {boolean}     Whether the extension is a beta extension
  */
 export function isBetaExtension( name ) {

--- a/projects/plugins/jetpack/extensions/index.scss
+++ b/projects/plugins/jetpack/extensions/index.scss
@@ -5,6 +5,10 @@
 	box-shadow: 0 0 3px var( --jp-green-30 );
 	transition: 0.5s box-shadow linear;
 
+	&.inset-shadow {
+		box-shadow: inset 0 0 3px var( --jp-green-30 );
+	}
+
 	&::before {
 		content: 'BETA';
 		position: absolute;

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -17,6 +17,7 @@ import React from 'react';
  * Internal dependencies
  */
 import UpgradePrompt from '../../../../blocks/ai-assistant/components/upgrade-prompt';
+import { isBetaExtension } from '../../../../editor';
 import useAutosaveAndRedirect from '../../../../shared/use-autosave-and-redirect';
 import { AiExcerptControl } from '../../components/ai-excerpt-control';
 /**
@@ -247,7 +248,11 @@ ${ postContent }
 }
 
 export const PluginDocumentSettingPanelAiExcerpt = () => (
-	<PluginDocumentSettingPanel name="ai-content-lens-plugin" title={ __( 'Excerpt', 'jetpack' ) }>
+	<PluginDocumentSettingPanel
+		className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
+		name="ai-content-lens-plugin"
+		title={ __( 'Excerpt', 'jetpack' ) }
+	>
 		<AiPostExcerpt />
 	</PluginDocumentSettingPanel>
 );

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.7-a.1
+ * Version: 12.7-a.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.7-a.1' );
+define( 'JETPACK__VERSION', '12.7-a.2' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.7.0-a.1",
+	"version": "12.7.0-a.2",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This applies styles to the AI Excerpt panel when the extension is defined as `beta`.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: Add `Beta` label to sidebar panel

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure the extension is defined as `beta`.
* Ensure [`beta` extensions](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/README.md#beta-extensions) are enabled.
* Go to the block editor
* Open the post sidebar
* Identify the AI Excerpt panel
* Confirm you see the `Beta` label and also the green box-shadow

<img width="320" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/ff41e6f6-6113-4d7d-8de0-24b38718d92f">

* Confirm the label and box shadow aren't shown when hovering the panel
* Confirm it's possible to use the feature as usual  

Additionally, you could confirm the `Beta` label and the box shadow don't show when the feature is moved to production. 
* [Move this line](https://github.com/Automattic/jetpack/blob/88042daa22d00ddbc4f4abce8d709274010af8ca/projects/plugins/jetpack/extensions/index.json#L68) of the index.json file to the `production` section
* Confirm the `Beta` label and the box shadow aren't there
<img width="333" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/d92a7f09-c09d-4990-84a9-4b4351885bf8">

