### PR TITLE
AI Excerpt: disable `Generate` button when no post content

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-disable-when-no-content
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-disable-when-no-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: disable `Generate` button when no post content

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -6,7 +6,7 @@ import {
 	ERROR_QUOTA_EXCEEDED,
 	useAiSuggestions,
 } from '@automattic/jetpack-ai-client';
-import { TextareaControl, ExternalLink, Button, Notice } from '@wordpress/components';
+import { TextareaControl, ExternalLink, Button, Notice, BaseControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { useState, useEffect } from '@wordpress/element';
@@ -215,33 +215,37 @@ ${ postContent }
 					disabled={ isBusy || isQuotaExceeded }
 				/>
 
-				<div className="jetpack-generated-excerpt__generate-buttons-container">
-					<Button
-						onClick={ discardExpert }
-						variant="secondary"
-						isDestructive
-						disabled={ requestingState !== 'done' || isQuotaExceeded }
-					>
-						{ __( 'Discard', 'jetpack' ) }
-					</Button>
-
-					<Button
-						onClick={ setExpert }
-						variant="secondary"
-						disabled={ requestingState !== 'done' || isQuotaExceeded }
-					>
-						{ __( 'Accept', 'jetpack' ) }
-					</Button>
-
-					<Button
-						onClick={ requestExcerpt }
-						variant="secondary"
-						isBusy={ isBusy }
-						disabled={ isGenerateButtonDisabled || isQuotaExceeded || ! postContent }
-					>
-						{ __( 'Generate', 'jetpack' ) }
-					</Button>
-				</div>
+				<BaseControl
+					help={
+						! postContent?.length ? __( 'Add content to generate an excerpt.', 'jetpack' ) : null
+					}
+				>
+					<div className="jetpack-generated-excerpt__generate-buttons-container">
+						<Button
+							onClick={ discardExpert }
+							variant="secondary"
+							isDestructive
+							disabled={ requestingState !== 'done' || isQuotaExceeded }
+						>
+							{ __( 'Discard', 'jetpack' ) }
+						</Button>
+						<Button
+							onClick={ setExpert }
+							variant="secondary"
+							disabled={ requestingState !== 'done' || isQuotaExceeded }
+						>
+							{ __( 'Accept', 'jetpack' ) }
+						</Button>
+						<Button
+							onClick={ requestExcerpt }
+							variant="secondary"
+							isBusy={ isBusy }
+							disabled={ isGenerateButtonDisabled || isQuotaExceeded || ! postContent }
+						>
+							{ __( 'Generate', 'jetpack' ) }
+						</Button>
+					</div>
+				</BaseControl>
 			</div>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -237,7 +237,7 @@ ${ postContent }
 						onClick={ requestExcerpt }
 						variant="secondary"
 						isBusy={ isBusy }
-						disabled={ isGenerateButtonDisabled || isQuotaExceeded }
+						disabled={ isGenerateButtonDisabled || isQuotaExceeded || ! postContent }
 					>
 						{ __( 'Generate', 'jetpack' ) }
 					</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The changes in this PR disable the "Generate" button if the post has no content and display a help legend below it.

Fixes https://github.com/Automattic/jetpack/issues/33303

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: disable `Generate` button when no post content

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Ensure the post doesn't have content
* Open the post sidebar
* Identify the AI Excerpt panel
* Confirm the `Generate` button is disabled
* Confirm it shows the `Add content to generate an excerpt.` help
* Confirm once there is content in the block, the button will enable and the help will disappear.

No content | With content
-------|----------
<img width="343" alt="Screenshot 2023-09-26 at 09 41 46" src="https://github.com/Automattic/jetpack/assets/77539/9361b805-5432-407c-89fd-d75a2bd603d6"> | <img width="298" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/d880eee3-4057-4360-b3ea-9ca1a9ed0e6a">