### PR TITLE
Boost: Remove global state from AdvancedCriticalCss component

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
@@ -4,6 +4,7 @@
 	import Header from '../../sections/Header.svelte';
 	import config from '../../stores/config';
 	import { connection } from '../../stores/connection';
+	import { criticalCssIssues } from '../../stores/critical-css-state-errors';
 	import { hasPrioritySupport } from '../../utils/paid-plan';
 	import { Router, Route } from '../../utils/router';
 	import AdvancedCriticalCss from './sections/AdvancedCriticalCss.svelte';
@@ -29,7 +30,11 @@
 
 		<Router>
 			<div class="jb-section jb-section--main">
-				<Route path="critical-css-advanced" component={AdvancedCriticalCss} />
+				<Route
+					path="critical-css-advanced"
+					component={AdvancedCriticalCss}
+					issues={$criticalCssIssues}
+				/>
 				<Route path="/" component={Modules} />
 			</div>
 		</Router>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
@@ -4,13 +4,13 @@
 	import BackButton from '../../../elements/BackButton.svelte';
 	import CloseButton from '../../../elements/CloseButton.svelte';
 	import { replaceCssState, updateProvider } from '../../../stores/critical-css-state';
-	import {
-		criticalCssIssues,
-		groupErrorsByFrequency,
-	} from '../../../stores/critical-css-state-errors';
+	import { groupErrorsByFrequency } from '../../../stores/critical-css-state-errors';
+	import { type Provider } from '../../../stores/critical-css-state-types';
 	import InfoIcon from '../../../svg/info.svg';
 	import routerHistory from '../../../utils/router-history';
 	import CriticalCssErrorDescription from '../elements/CriticalCssErrorDescription.svelte';
+
+	export let issues: Provider[];
 
 	const { navigate } = routerHistory;
 
@@ -28,16 +28,16 @@
 	 * Automatically navigate back to main Settings page if generator isn't done.
 	 */
 
-	$: if ( $criticalCssIssues.length === 0 ) {
+	$: if ( issues.length === 0 ) {
 		navigate( -1 );
 	}
 
-	$: dismissedIssues = $criticalCssIssues.filter( issue => issue.error_status === 'dismissed' );
-	$: activeIssues = $criticalCssIssues.filter( issue => issue.error_status !== 'dismissed' );
+	$: dismissedIssues = issues.filter( issue => issue.error_status === 'dismissed' );
+	$: activeIssues = issues.filter( issue => issue.error_status !== 'dismissed' );
 
 	function showDismissedIssues() {
 		replaceCssState( {
-			providers: $criticalCssIssues.map( issue => {
+			providers: issues.map( issue => {
 				issue.error_status = 'active';
 				return issue;
 			} ),

--- a/projects/plugins/boost/changelog/boost-react-advanced-critical-css
+++ b/projects/plugins/boost/changelog/boost-react-advanced-critical-css
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Moved store to parent component.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves global store from AdvancedCriticalCss component to parent component (Settings).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-286-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the **Critical Css Advanced** section works as expected and you can dismiss/undismiss issues.

To make the Critical CSS advanced recommendations section show up, you need to break a page in some way and regenerate Critical CSS.

The easiest way to do that is to add the following mu script. It will cause the homepage to return error 500 (don't forget to remove it after you finish testing 😅):
```php
<?php

add_action( 'template_redirect', function () {
	if ( is_home() ) {
		nonexistentfunction();
	}
} );

```

### Meta
![CleanShot 2023-09-26 at 16 32 46](https://github.com/Automattic/jetpack/assets/11799079/3ba1af7b-4c03-4e13-8606-4d9203c2310a)

### Critical CSS advanced page
![CleanShot 2023-09-26 at 16 32 26](https://github.com/Automattic/jetpack/assets/11799079/1049a2b4-4292-45a9-87e0-3a9852731b22)

