### PR TITLE
Blogroll: fix notices from registered setting

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blogroll-notice
+++ b/projects/plugins/jetpack/changelog/fix-blogroll-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fixed php notice for beta block
+
+

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
@@ -76,9 +76,32 @@ function site_recommendations_settings() {
 		'general',
 		'Blogroll Recommendations', // Visible to the user see: https://github.com/WordPress/gutenberg/issues/41637
 		array(
-			'type'          => 'array',
-			'show_in_rest'  => true,
 			'description'   => __( 'Site Recommendations', 'jetpack' ),
+			'type'          => 'array',
+			'show_in_rest'  => array(
+				'schema' => array(
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'          => array(
+								'type' => 'string',
+							),
+							'name'        => array(
+								'type' => 'string',
+							),
+							'icon'        => array(
+								'type' => 'string',
+							),
+							'url'         => array(
+								'type' => 'string',
+							),
+							'description' => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+			),
 			'auth_callback' => function () {
 				return current_user_can( 'edit_posts' );
 			},

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
@@ -84,19 +84,24 @@ function site_recommendations_settings() {
 						'type'       => 'object',
 						'properties' => array(
 							'id'          => array(
-								'type' => 'string',
+								'type'   => 'string',
+								'format' => 'text-field',
 							),
 							'name'        => array(
-								'type' => 'string',
+								'type'   => 'string',
+								'format' => 'text-field',
 							),
 							'icon'        => array(
-								'type' => 'string',
+								'type'   => 'string',
+								'format' => 'uri',
 							),
 							'url'         => array(
-								'type' => 'string',
+								'type'   => 'string',
+								'format' => 'uri',
 							),
 							'description' => array(
-								'type' => 'string',
+								'type'   => 'string',
+								'format' => 'text-field',
 							),
 						),
 					),


### PR DESCRIPTION
The registered blogroll setting was causing PHP notices

![2023-09-26_09-43-32](https://github.com/Automattic/jetpack/assets/7000684/27bcf393-7be6-4ee1-8091-b4d3f541a201)

This PR improves the way this is registered to fix the notice.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Supply schema when registering the setting

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and add the blogroll block
* Run `tail` to see errors happening on the backend
* Reload the editor page
* The notices should not be present with this PR

