### PR TITLE
renovate: Work around renovate bug

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -22,4 +22,3 @@ resolution-mode = highest
 
 # @automattic/jetpack-webpack-config looks for this.
 jetpack-webpack-config-resolve-conditions=jetpack:src
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Renovate has [a bug][1] where they modify `.npmrc` and don't clean up after themselves, resulting in those modifications being included in the diff when post-upgrade commands are used.

Further, it seems they're reluctant to even admit this is actually a bug, and would rather cast aspersions than collaborate on a fix.

Work around it by manually reverting the file in the post-upgrade script.

[1]: https://href.li?https://github.com/renovatebot/renovate/issues/23528

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Fork, merge this, then run renovate in the fork and see that it creates diffs without mangling `.npmrc`.
  * Or look at https://github.com/anomiex/jetpack/pull/19 where I already did that.
