### PR TITLE
Subscriptions: Fix condition for showing modal

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-modal-not-loading
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-modal-not-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Fix conditions for showing modal.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -193,7 +193,7 @@ HTML;
 		// Don't show if post is for subscribers only or has paywall block
 		global $post;
 		$access_level              = get_post_meta( $post->ID, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
-		$is_accessible_by_everyone = Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY === $access_level;
+		$is_accessible_by_everyone = Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY === $access_level || empty( $access_level );
 		if ( ! $is_accessible_by_everyone ) {
 			return false;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes conditional for showing subscribe modal. We were checking post access level, but need to add a check in case the post meta for access level is not set at all. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Use the bin command below to load this branch in your sandbox. Then sandbox the url of a WordPress simple test site. 
2) Login to your simple site, go to Settings > Newsletter, and enable the subscribe pop-up. 
3) In a separate browser where you are not logged in, open up a single post on the front end, scroll, and confirm the modal shows. 

Note the subscribe modal only shows....
   - on WordPress.com simple/atomic sites
   - on single blog posts
   - if logged out (cannot be logged in as an admin and see it)
   - if you are not already subscribed to the site
   - if post itself doesn't already require subscribing (ie, won't show if post is subscribers only or has paywall block)
   - if 'Enable subscriber pop-up' setting is turned on at Settings > Newsletters



