### PR TITLE
Fix erroneous path check in block registration

### DIFF
--- a/projects/packages/blocks/changelog/fix-block-path-check
+++ b/projects/packages/blocks/changelog/fix-block-path-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+ Fix erroneous path check in Blocks class 

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -43,7 +43,7 @@ class Blocks {
 	public static function jetpack_register_block( $slug, $args = array() ) {
 		// Slug doesn't start with `jetpack/`, isn't an absolute path, or doesn't contain a slash
 		// (synonym of a namespace) at all.
-		if ( 0 !== strpos( $slug, 'jetpack/' ) && 0 !== strpos( $slug, '/' ) && ! strpos( $slug, '/' ) ) {
+		if ( 0 !== strpos( $slug, 'jetpack/' ) && ! path_is_absolute( $slug ) && ! strpos( $slug, '/' ) ) {
 			_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', 'Jetpack 9.0.0' );
 			$slug = 'jetpack/' . $slug;
 		}
@@ -54,7 +54,7 @@ class Blocks {
 		// the block.
 		// Note: passing the path directly to register_block_type seems to loose the interactivity of
 		// the block once in the editor once it's out of focus.
-		if ( '/' === substr( $slug, 0, 1 ) ) {
+		if ( path_is_absolute( $slug ) ) {
 			$metadata = self::get_block_metadata_from_file( self::get_path_to_block_metadata( $slug ) );
 			$name     = self::get_block_name_from_metadata( $metadata );
 

--- a/projects/plugins/jetpack/changelog/fix-block-path-check
+++ b/projects/plugins/jetpack/changelog/fix-block-path-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix erroneous path check in Jetpack_Gutenberg class

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -479,7 +479,7 @@ class Jetpack_Gutenberg {
 		}
 
 		// Retrieve the feature from block.json if a path is passed.
-		if ( '/' === substr( $type, 0, 1 ) ) {
+		if ( path_is_absolute( $type ) ) {
 			$metadata = Blocks::get_block_metadata_from_file( Blocks::get_path_to_block_metadata( $type ) );
 			$feature  = Blocks::get_block_feature_from_metadata( $metadata );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #33312

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the `Blocks` and `Jetpack_Gutenberg` classes, the path checks don't take into account Windows paths. This PR fixes it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
Enable beta blocks in the Jetpack constants section if you're using a JN site, or by adding `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` to your `wp-config.php` otherwise.

### Regression Testing
Test that the following blocks are not broken: _Business Hours_, _AI Chat_, _Amazon_, _Blogroll_, _Google Docs_, _Google Sheets_, _Google Slides_, _Recipe_, _Create with Voice_

### Fix

To properly test this, you need a test site that runs on Windows and be able to see PHP logs. After connecting Jetpack, visit `Posts > Add New`. You should **not** see the warning `Function WP_Block_Type_Registry::register was called incorrectly. Block type names must not contain uppercase characters.`.

Alternatively, review the code.
