### PR TITLE
[CRM] Add "Delete Workflow" endpoint

### DIFF
--- a/projects/plugins/crm/changelog/crm-add-automation-delete-workflow-endpoint
+++ b/projects/plugins/crm/changelog/crm-add-automation-delete-workflow-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Automations and the new API is hidden behind feature flags
+
+

--- a/projects/plugins/crm/src/rest-api/v4/class-rest-automation-workflows-controller.php
+++ b/projects/plugins/crm/src/rest-api/v4/class-rest-automation-workflows-controller.php
@@ -118,6 +118,11 @@ final class REST_Automation_Workflows_Controller extends REST_Base_Controller {
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => $this->create_update_args( false ),
 				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
 			)
 		);
 	}
@@ -196,6 +201,44 @@ final class REST_Automation_Workflows_Controller extends REST_Base_Controller {
 			}
 
 			$this->workflow_repository->persist( $workflow );
+		} catch ( Workflow_Exception $e ) {
+			return new WP_Error(
+				'rest_workflow_exception',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'rest_unknown_error',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response( $this->prepare_item_for_response( $workflow, $request ) );
+	}
+
+	/**
+	 * Delete workflow.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function delete_item( $request ) {
+		try {
+			$workflow = $this->workflow_repository->find( $request->get_param( 'id' ) );
+
+			if ( ! $workflow instanceof Automation_Workflow ) {
+				return new WP_Error(
+					'rest_invalid_workflow_id',
+					__( 'Invalid workflow ID.', 'zero-bs-crm' ),
+					array( 'status' => 404 )
+				);
+			}
+
+			$this->workflow_repository->delete( $workflow );
 		} catch ( Workflow_Exception $e ) {
 			return new WP_Error(
 				'rest_workflow_exception',

--- a/projects/plugins/crm/tests/php/rest-api/v4/class-rest-authentication-test.php
+++ b/projects/plugins/crm/tests/php/rest-api/v4/class-rest-authentication-test.php
@@ -37,6 +37,10 @@ class REST_Authentication_Test extends REST_Base_Test_Case {
 				WP_REST_Server::CREATABLE,
 				'/jetpack-crm/v4/automation/workflows/123',
 			),
+			'automation_workflows::delete_item' => array(
+				WP_REST_Server::DELETABLE,
+				'/jetpack-crm/v4/automation/workflows/123',
+			),
 		);
 	}
 

--- a/projects/plugins/crm/tests/php/rest-api/v4/class-rest-automation-workflows-controller-test.php
+++ b/projects/plugins/crm/tests/php/rest-api/v4/class-rest-automation-workflows-controller-test.php
@@ -284,6 +284,36 @@ class REST_Automation_Workflows_Controller_Test extends REST_Base_Test_Case {
 	}
 
 	/**
+	 * DELETE Workflow: Test that we can successfully delete a workflow.
+	 *
+	 * @return void
+	 */
+	public function test_delete_workflow_success() {
+		// Create and set authenticated user.
+		$jpcrm_admin_id = $this->create_wp_jpcrm_admin();
+		wp_set_current_user( $jpcrm_admin_id );
+
+		$workflow = $this->create_workflow(
+			array(
+				'name' => 'test_get_workflow_success',
+			)
+		);
+
+		// Make request.
+		$request = new WP_REST_Request(
+			WP_REST_Server::DELETABLE,
+			sprintf( '/jetpack-crm/v4/automation/workflows/%d', $workflow->get_id() )
+		);
+
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		// Verify that the workflow was deleted.
+		$repo = new Workflow_Repository();
+		$this->assertFalse( $repo->find( $workflow->get_id() ) );
+	}
+
+	/**
 	 * Generate a workflow for testing.
 	 *
 	 * @param array $data (Optional) Workflow data.


### PR DESCRIPTION
# This PR was merged by mistake: https://github.com/Automattic/jetpack/pull/33324

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add an endpoint that can delete an automation workflow.

Fixes https://github.com/Automattic/zero-bs-crm/issues/3229

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `[DELETE] /wp-json/jetpack-crm/v4/automation/workflows/{id}` endpoint.
* Add test to verify that the endpoint works.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

* pbhBOz-3ss-p2
* pbhBOz-2ES-p2
* pbhBOz-3uX-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Automated tests

All of the tests should obviously pass, but looking at the following automated tests should suffice:

* `REST_Authentication_Test`: Updated to include our new endpoint.
* `REST_Automation_Workflows_Controller_Test`: Updated with a new test to verify the endpoint works.

### Manual testing

**Manual testing prep work**

1. Make sure the following feature flags are enabled on your site:

```php
add_filter( 'jetpack_crm_feature_flag_api_v4', '__return_true' );
add_filter( 'jetpack_crm_feature_flag_automations', '__return_true' );
```

2. Modify `REST_Automation_Workflows_Controller::get_item_permissions_check` to return `true` at the top.

_We do this to make it easier to call the endpoints. This should allow you to do it from any client you want (e.g. Postman) without having to worry about WP Logged in cookies, nonce, etc._

**Delete Workflow**

* Method: `DELETE`
* Path: `/wp-json/jetpack-crm/v4/automation/workflows/{id}`
* Payload: N/A
