### PR TITLE
Earn/fix/memberships meta product

### DIFF
--- a/projects/plugins/jetpack/changelog/earn-fix-memberships-meta-product_id
+++ b/projects/plugins/jetpack/changelog/earn-fix-memberships-meta-product_id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add jetpack_memberships_product_id to the list of post meta to sync.

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -162,6 +162,9 @@ class Jetpack_Memberships {
 			'site_subscriber' => array(
 				'meta' => $meta_prefix . 'site_subscriber',
 			),
+			'product_id' => array(
+				'meta' => $meta_prefix . 'product_id',
+			),
 		);
 		return $properties;
 	}

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -162,7 +162,7 @@ class Jetpack_Memberships {
 			'site_subscriber' => array(
 				'meta' => $meta_prefix . 'site_subscriber',
 			),
-			'product_id' => array(
+			'product_id'      => array(
 				'meta' => $meta_prefix . 'product_id',
 			),
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See D123279-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the product_id to the list of synced metadata for the memberships CPT.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I couldn't figure out how to test this.  (At least in my testing the meta wasn't getting synced so I believe that this just has to get merged).  Need a confidence check from Jetpack maintainers.
*