### PR TITLE
Fix missing block translations

### DIFF
--- a/projects/packages/blocks/changelog/fix-block-translations
+++ b/projects/packages/blocks/changelog/fix-block-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix missing block translations

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -50,18 +50,11 @@ class Blocks {
 
 		$block_type = $slug;
 
-		// If a path is passed, find the slug in the file then create a block type object to register
-		// the block.
-		// Note: passing the path directly to register_block_type seems to loose the interactivity of
-		// the block once in the editor once it's out of focus.
+		// If a path is passed, make sure to get the block.json file from the build directory and get
+		// the block name from that file.
 		if ( path_is_absolute( $slug ) ) {
-			$metadata = self::get_block_metadata_from_file( self::get_path_to_block_metadata( $slug ) );
-			$name     = self::get_block_name_from_metadata( $metadata );
-
-			if ( ! empty( $name ) ) {
-				$slug       = $name;
-				$block_type = new \WP_Block_Type( $slug, array_merge( $metadata, $args ) );
-			}
+			$block_type = self::get_path_to_block_metadata( $slug );
+			$slug       = self::get_block_name( $block_type );
 		}
 
 		if (

--- a/projects/plugins/jetpack/changelog/fix-block-translations
+++ b/projects/plugins/jetpack/changelog/fix-block-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix missing block translations

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -30,7 +30,7 @@ type BlockSettingsProps = {
 };
 
 export const isAiAssistantSupportExtensionEnabled =
-	window?.Jetpack_Editor_Initial_State.available_blocks?.[ AI_ASSISTANT_SUPPORT_NAME ];
+	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ AI_ASSISTANT_SUPPORT_NAME ];
 
 /**
  * Check if it is possible to extend the block.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/constants.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/constants.ts
@@ -1,7 +1,7 @@
 export const JETPACK_FORM_AI_COMPOSITION_EXTENSION = 'ai-assistant-form-support' as const;
 
 export const isJetpackFromBlockAiCompositionAvailable =
-	window?.Jetpack_Editor_Initial_State.available_blocks?.[ JETPACK_FORM_AI_COMPOSITION_EXTENSION ]
+	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ JETPACK_FORM_AI_COMPOSITION_EXTENSION ]
 		?.available;
 
 // All blocks to extend

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/editor.js
@@ -7,8 +7,6 @@ import './editor.scss';
 import './components/feedback/style.scss';
 
 registerJetpackBlockFromMetadata( metadata, {
-	// The API version needs to be explicitly specified in this instance for styles to be loaded.
-	apiVersion: metadata.apiVersion,
 	edit,
 	save,
 } );

--- a/projects/plugins/jetpack/extensions/blocks/amazon/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/amazon/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 3,
+	"apiVersion": 1,
 	"name": "jetpack/amazon",
 	"title": "Amazon (Beta)",
 	"description": "Promote Amazon products and earn a commission from sales.",

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 3,
+	"apiVersion": 1,
 	"name": "jetpack/business-hours",
 	"title": "Business Hours",
 	"description": "Display opening hours for your business.",

--- a/projects/plugins/jetpack/extensions/blocks/recipe/recipe.php
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/recipe.php
@@ -9,55 +9,67 @@
 
 use Automattic\Jetpack\Blocks;
 
-Blocks::jetpack_register_block(
-	__DIR__,
-	array(
-		'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render' ),
-	)
-);
+add_action(
+	'init',
+	function () {
+		Blocks::jetpack_register_block(
+			__DIR__,
+			array(
+				'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render' ),
+			)
+		);
 
-Blocks::jetpack_register_block(
-	'jetpack/recipe-details',
-	array(
-		'parent' => array( 'jetpack/recipe' ),
-	)
-);
+		Blocks::jetpack_register_block(
+			__DIR__,
+			array(
+				'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render' ),
+			)
+		);
 
-Blocks::jetpack_register_block(
-	'jetpack/recipe-hero',
-	array(
-		'parent'          => array( 'jetpack/recipe' ),
-		'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render_hero' ),
-	)
-);
+		Blocks::jetpack_register_block(
+			'jetpack/recipe-details',
+			array(
+				'parent' => array( 'jetpack/recipe' ),
+			)
+		);
 
-Blocks::jetpack_register_block(
-	'jetpack/recipe-ingredients-list',
-	array(
-		'parent' => array( 'jetpack/recipe' ),
-	)
-);
+		Blocks::jetpack_register_block(
+			'jetpack/recipe-hero',
+			array(
+				'parent'          => array( 'jetpack/recipe' ),
+				'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render_hero' ),
+			)
+		);
 
-Blocks::jetpack_register_block(
-	'jetpack/recipe-ingredient-item',
-	array(
-		'parent' => array( 'jetpack/recipe' ),
-	)
-);
+		Blocks::jetpack_register_block(
+			'jetpack/recipe-ingredients-list',
+			array(
+				'parent' => array( 'jetpack/recipe' ),
+			)
+		);
 
-Blocks::jetpack_register_block(
-	'jetpack/recipe-steps',
-	array(
-		'parent' => array( 'jetpack/recipe' ),
-	)
-);
+		Blocks::jetpack_register_block(
+			'jetpack/recipe-ingredient-item',
+			array(
+				'parent' => array( 'jetpack/recipe' ),
+			)
+		);
 
-Blocks::jetpack_register_block(
-	'jetpack/recipe-step',
-	array(
-		'parent'          => array( 'jetpack/recipe' ),
-		'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render_step' ),
-	)
+		Blocks::jetpack_register_block(
+			'jetpack/recipe-steps',
+			array(
+				'parent' => array( 'jetpack/recipe' ),
+			)
+		);
+
+		Blocks::jetpack_register_block(
+			'jetpack/recipe-step',
+			array(
+				'parent'          => array( 'jetpack/recipe' ),
+				'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render_step' ),
+			)
+		);
+	}
 );
 
 require_once __DIR__ . '/class-jetpack-recipe-block.php';

--- a/projects/plugins/jetpack/extensions/blocks/recipe/recipe.php
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/recipe.php
@@ -20,13 +20,6 @@ add_action(
 		);
 
 		Blocks::jetpack_register_block(
-			__DIR__,
-			array(
-				'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render' ),
-			)
-		);
-
-		Blocks::jetpack_register_block(
 			'jetpack/recipe-details',
 			array(
 				'parent' => array( 'jetpack/recipe' ),

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
@@ -13,7 +13,7 @@ import { aiExcerptPluginName, aiExcerptPluginSettings } from '.';
 export const AI_CONTENT_LENS = 'ai-content-lens';
 
 const isAiAssistantSupportExtensionEnabled =
-	window?.Jetpack_Editor_Initial_State.available_blocks[ 'ai-content-lens' ];
+	window?.Jetpack_Editor_Initial_State?.available_blocks[ 'ai-content-lens' ];
 
 /**
  * Extend the editor with AI Content Lens features,

--- a/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
+++ b/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
@@ -12,15 +12,21 @@ const JETPACK_PREFIX = 'jetpack/';
 /**
  * Registers a gutenberg block if the availability requirements are met.
  *
- * @param {string} name - The block's name. Jetpack blocks must be registered with a name prefixed
- * with `jetpack/`. This function accepts an unprefixed name too, though (it'd handle both
- * `business-hours` and `jetpack/business-hours` similarly, for instance).
+ * @param {string} nameOrMetadata - The block's name or metadata object. Jetpack blocks must be
+ * registered with a name prefixed with `jetpack/`. This function accepts an unprefixed name too,
+ * though (it'd handle both `business-hours` and `jetpack/business-hours` similarly, for instance).
  * @param {object} settings - The block's settings.
  * @param {object} childBlocks - The block's child blocks.
  * @param {boolean} prefix - Should this block be prefixed with `jetpack/`?
  * @returns {object|boolean} Either false if the block is not available, or the results of `registerBlockType`
  */
-export default function registerJetpackBlock( name, settings, childBlocks = [], prefix = true ) {
+export default function registerJetpackBlock(
+	nameOrMetadata,
+	settings,
+	childBlocks = [],
+	prefix = true
+) {
+	const name = typeof nameOrMetadata === 'string' ? nameOrMetadata : nameOrMetadata.name;
 	const isNamePrefixed = name.startsWith( JETPACK_PREFIX );
 	const rawName = isNamePrefixed ? name.slice( JETPACK_PREFIX.length ) : name;
 
@@ -40,7 +46,10 @@ export default function registerJetpackBlock( name, settings, childBlocks = [], 
 	}
 
 	const prefixedName = jpPrefix + rawName;
-	const result = registerBlockType( prefixedName, settings );
+	const result = registerBlockType(
+		nameOrMetadata === 'object' ? nameOrMetadata : prefixedName,
+		settings
+	);
 
 	if ( requiredPlan ) {
 		addFilter(
@@ -69,14 +78,14 @@ export default function registerJetpackBlock( name, settings, childBlocks = [], 
  * @returns {object|boolean} Either false if the block is not available, or the results of `registerBlockType`
  */
 export function registerJetpackBlockFromMetadata( metadata, settings, childBlocks, prefix ) {
-	const clientSettings = {
+	const mergedSettings = {
 		...settings,
 		icon: getBlockIconProp( metadata ),
 	};
 	const { variations } = metadata;
 
 	if ( Array.isArray( variations ) && variations.length > 0 ) {
-		clientSettings.variations = variations.map( variation => {
+		mergedSettings.variations = variations.map( variation => {
 			return {
 				...variation,
 				icon: getBlockIconProp( variation ),
@@ -84,5 +93,5 @@ export function registerJetpackBlockFromMetadata( metadata, settings, childBlock
 		} );
 	}
 
-	return registerJetpackBlock( metadata.name, clientSettings, childBlocks, prefix );
+	return registerJetpackBlock( metadata, mergedSettings, childBlocks, prefix );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1694788078746839-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
https://github.com/Automattic/jetpack/pull/32698, https://github.com/Automattic/jetpack/pull/32815, and https://github.com/Automattic/jetpack/pull/33073 introduced localization issues for simple sites: block titles and descriptions were displayed in English no matter the user's selected language. This PR fixes it.

The blocks involved are: Business Hours, AI Chat, Amazon, Blogroll, Google Docs Embed (Google Docs, Google Sheets, and Google Slides), Recipe, Create with Voice.

In more details:
- On the server side, block localization requires `register_block_type` to be called with the path to `block.json` or its parent directory. `jetpack_register_block` is updated accordingly.
- On the client side, `registerBlockType` requires to be called with the metadata object. `registerJetpackBlock` is updated to allow that.
- The above change requires to lower the API version of some blocks, so that their `render` functions work correctly.
- It also requires the registration of the _Recipe_ block to happen on an `init` action, to prevent an exception being thrown.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Regression Testing

  - Enable beta blocks in the Jetpack constants section if you're using a JN site, or by adding `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` to your `wp-config.php` otherwise.
  - Create a new post.
  - Notice that the aforementioned blocks are not broken.
 
### Localization Testing
  - Download this branch.
  - Build the plugin: `jetpack build plugins/jetpack`.
  - Remote sync the plugin with your sandbox (see PCYsg-eg0-p2).
  - Change the language of your WordPress.com account to something different than English.
  - In WordPress.com, select the site linked to your sandbox and create a new post.
  - In the block inserter, notice that the block titles and descriptions for the blocks above are translated.

_Blocks info translated to French_
<img width="300" alt="Screenshot 2023-09-19 at 9 47 38 AM" src="https://github.com/Automattic/jetpack/assets/1620183/b6cb23e4-b0de-4be5-ae59-ce82a9148aab">
<img width="300" alt="Screenshot 2023-09-19 at 9 47 49 AM" src="https://github.com/Automattic/jetpack/assets/1620183/0d71c2ba-d0c6-4d50-93da-55d5018763fe">
<img width="300" alt="Screenshot 2023-09-19 at 9 47 57 AM" src="https://github.com/Automattic/jetpack/assets/1620183/6788636c-ee1b-4a50-a2e6-e31305607da0">
<img width="300" alt="Screenshot 2023-09-19 at 9 48 04 AM" src="https://github.com/Automattic/jetpack/assets/1620183/cbd3d4d2-22de-476e-90e5-8f672d93b6a6">
<img width="300" alt="Screenshot 2023-09-19 at 9 48 15 AM" src="https://github.com/Automattic/jetpack/assets/1620183/d6d95720-2cbf-46a4-8a8d-ee140ec7b038">
<img width="300" alt="Screenshot 2023-09-19 at 9 48 23 AM" src="https://github.com/Automattic/jetpack/assets/1620183/31266c4f-a5eb-4887-8a6f-917d6d5519a4">
<img width="300" alt="Screenshot 2023-09-19 at 9 48 31 AM" src="https://github.com/Automattic/jetpack/assets/1620183/0b336b00-4d24-4f5e-b041-391ea003141e">

