### PR TITLE
[CRM] Fix a few Attribute_Definition docs inconsistencies

### DIFF
--- a/projects/plugins/crm/changelog/crm-update-attribute-definition-code-standards
+++ b/projects/plugins/crm/changelog/crm-update-attribute-definition-code-standards
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Changed some Attribute_Definition documentation incosistencies but no actual code was impacted, so it does not make sense to expose this change to users.
+
+

--- a/projects/plugins/crm/src/automation/class-attribute-definition.php
+++ b/projects/plugins/crm/src/automation/class-attribute-definition.php
@@ -9,76 +9,78 @@
 namespace Automattic\Jetpack\CRM\Automation;
 
 /**
- * Step Attribute.
+ * Attribute Definition.
  *
- * The Step Attribute represents
+ * An attribute represents how a step is configured. For example, a step that
+ * sends an email to a contact may have an attribute that represents the email
+ * subject, another attribute that represents the email body, and so on.
  *
  * @since $$next-version$$
  */
 class Attribute_Definition {
 
 	/**
-	* Represents a dropdown selection input.
-	*
-	* @since $$next-version$$
-	* @var string
-	*/
+	 * Represents a dropdown selection input.
+	 *
+	 * @since $$next-version$$
+	 * @var string
+	 */
 	const SELECT = 'select';
 
 	/**
-	* Represents a checkbox input.
-	*
-	* @since $$next-version$$
-	* @var string
-	*/
+	 * Represents a checkbox input.
+	 *
+	 * @since $$next-version$$
+	 * @var string
+	 */
 	const CHECKBOX = 'checkbox';
 
 	/**
-	* Represents a textarea input.
-	*
-	* @since $$next-version$$
-	* @var string
-	*/
+	 * Represents a textarea input.
+	 *
+	 * @since $$next-version$$
+	 * @var string
+	 */
 	const TEXTAREA = 'textarea';
 
 	/**
-	* Represents a text input.
-	*
-	* @since $$next-version$$
-	* @var string
-	*/
+	 * Represents a text input.
+	 *
+	 * @since $$next-version$$
+	 * @var string
+	 */
 	const TEXT = 'text';
 
 	/**
-	* Represents a date input.
-	*
-	* @since $$next-version$$
-	* @var string
-	*/
+	 * Represents a date input.
+	 *
+	 * @since $$next-version$$
+	 * @var string
+	 */
 	const DATE = 'date';
 
 	/**
-	* Represents a date and time input.
-	*
-	* @since $$next-version$$
-	* @var string
-	*/
+	 * Represents a date and time input.
+	 *
+	 * @since $$next-version$$
+	 * @var string
+	 */
 	const DATETIME = 'datetime';
 
 	/**
-	* Represents a numerical input.
-	*
-	* @since $$next-version$$
-	* @var string
-	*/
+	 * Represents a numerical input.
+	 *
+	 * @since $$next-version$$
+	 * @var string
+	 */
 	const NUMBER = 'number';
 
 	/**
-	* Represents a password input.
-	*
-	* @since $$next-version$$
-	* @var string
-	*/
+	 * Represents a password input.
+	 *
+	 * @since $$next-version$$
+	 * @var string
+	 */
 	const PASSWORD = 'password';
 
 	/**
@@ -107,7 +109,7 @@ class Attribute_Definition {
 
 	/**
 	 * Attribute type (is it a select? an input?). The const values of this class
-	 * should be used here (e.g. Step_Attribute::NUMBER).
+	 * should be used here (e.g. Attribute_Definition::NUMBER).
 	 *
 	 * @since $$next-version$$
 	 * @var string
@@ -127,11 +129,11 @@ class Attribute_Definition {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param string     $slug        The slug (key) that identifies this attribute.
-	 * @param string     $title       The title (label) for this attribute.
+	 * @param string     $slug The slug (key) that identifies this attribute.
+	 * @param string     $title The title (label) for this attribute.
 	 * @param string     $description The description for this attribute.
-	 * @param string     $type        Attribute type.
-	 * @param array|null $data        Data needed by this attribute.
+	 * @param string     $type Attribute type.
+	 * @param array|null $data Data needed by this attribute.
 	 */
 	public function __construct( $slug, $title, $description, $type, $data = null ) {
 		$this->slug        = $slug;

--- a/projects/plugins/crm/src/automation/class-base-step.php
+++ b/projects/plugins/crm/src/automation/class-base-step.php
@@ -80,7 +80,7 @@ abstract class Base_Step implements Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return Step_Attribute[] The attribute definitions of the step.
+	 * @return Attribute_Definition[] The attribute definitions of the step.
 	 */
 	public function get_attribute_definitions(): ?array {
 		return $this->attribute_definitions;
@@ -91,7 +91,7 @@ abstract class Base_Step implements Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param Step_Attribute[] $attribute_definitions Set the step attributes.
+	 * @param Attribute_Definition[] $attribute_definitions Set the step attributes.
 	 */
 	public function set_attribute_definitions( array $attribute_definitions ) {
 		$this->attribute_definitions = $attribute_definitions;

--- a/projects/plugins/crm/src/automation/interface-step.php
+++ b/projects/plugins/crm/src/automation/interface-step.php
@@ -49,7 +49,7 @@ interface Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return Step_Attribute[] The attribute definitions of the step.
+	 * @return Attribute_Definition[] The attribute definitions of the step.
 	 */
 	public function get_attribute_definitions(): ?array;
 
@@ -58,7 +58,7 @@ interface Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param Step_Attribute[] $attribute_definitions Set the attribute definitions.
+	 * @param Attribute_Definition[] $attribute_definitions Set the attribute definitions.
 	 */
 	public function set_attribute_definitions( array $attribute_definitions );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fix a few documentation inconsistencies.

The origin PR (#32610) had a conversation about using `Attribute_Definition` or `Step_Attribute` as the class name, so this is probably a leftover.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix `Attribute_Definition` vs `Step_Attribute` in docblocks
* Unify indentation for docblocks

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Automated tests should still pass.
This is purely a docblock related change, so no testing should be required.

