### PR TITLE
CRM: tweaks the Base_Step and triggers

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-core-tweaks-base-step-base-trigger-jpcrm-entity
+++ b/projects/plugins/crm/changelog/update-crm-core-tweaks-base-step-base-trigger-jpcrm-entity
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update the Base_Step to use a generic validate_and_execute method. Update the triggers adding a generic listen_to_wp_action method.
+
+

--- a/projects/plugins/crm/src/automation/class-automation-engine.php
+++ b/projects/plugins/crm/src/automation/class-automation-engine.php
@@ -347,7 +347,8 @@ class Automation_Engine {
 				$this->get_logger()->log( '[' . $step->get_slug() . '] Executing step. Type: ' . $step::get_data_type() );
 
 				$data_type = $this->maybe_transform_data_type( $trigger_data_type, $step::get_data_type() );
-				$step->execute( $data_type );
+
+				$step->validate_and_execute( $data_type );
 
 				//todo: return Step instance instead of array
 				$step_id   = $step->get_next_step_id();

--- a/projects/plugins/crm/src/automation/class-base-step.php
+++ b/projects/plugins/crm/src/automation/class-base-step.php
@@ -189,6 +189,21 @@ abstract class Base_Step implements Step {
 	}
 
 	/**
+	 * Validate and execute the step.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param Data_Type $data Data type passed.
+	 * @return void
+	 *
+	 * @throws Data_Type_Exception If the data type passed is not expected.
+	 */
+	public function validate_and_execute( Data_Type $data ): void {
+		$this->validate( $data );
+		$this->execute( $data );
+	}
+
+	/**
 	 * Execute the step.
 	 *
 	 * @since $$next-version$$

--- a/projects/plugins/crm/src/automation/class-base-step.php
+++ b/projects/plugins/crm/src/automation/class-base-step.php
@@ -195,7 +195,7 @@ abstract class Base_Step implements Step {
 	 *
 	 * @param Data_Type $data Data type passed from the trigger.
 	 */
-	abstract public function execute( Data_Type $data );
+	abstract protected function execute( Data_Type $data );
 
 	/**
 	 * Get the slug name of the step.

--- a/projects/plugins/crm/src/automation/class-base-trigger.php
+++ b/projects/plugins/crm/src/automation/class-base-trigger.php
@@ -69,6 +69,19 @@ abstract class Base_Trigger implements Trigger {
 	}
 
 	/**
+	 * Listen to the desired WP hook action.
+	 *
+	 * @param string $hook_name     The hook name to listen to.
+	 * @param int    $priority      The priority of the action.
+	 * @param int    $accepted_args The number of arguments the action accepts.
+	 * @since $$next-version$$
+	 *
+	 */
+	protected function listen_to_wp_action( string $hook_name, int $priority = 10, int $accepted_args = 1 ): void {
+		add_action( $hook_name, array( $this, 'execute_workflow' ), $priority, $accepted_args );
+	}
+
+	/**
 	 * Get the trigger slug.
 	 *
 	 * @since $$next-version$$
@@ -109,6 +122,8 @@ abstract class Base_Trigger implements Trigger {
 	 * call the execute_workflow method when the event happens.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	abstract protected function listen_to_event();
+	abstract protected function listen_to_event(): void;
 }

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-add-contact-log.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-add-contact-log.php
@@ -82,7 +82,7 @@ class Add_Contact_Log extends Base_Action {
 	 *
 	 * @param Data_Type $data Data passed from the trigger.
 	 */
-	public function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	protected function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		global $zbs;
 
 		/** @var Contact $contact */

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-add-remove-contact-tag.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-add-remove-contact-tag.php
@@ -84,7 +84,7 @@ class Add_Remove_Contact_Tag extends Base_Action {
 	 *
 	 * @throws Data_Type_Exception When the data type is not supported.
 	 */
-	public function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	protected function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// Check if the Data_Type passed is the expected.
 		$this->validate( $data );
 

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-add-remove-contact-tag.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-add-remove-contact-tag.php
@@ -85,9 +85,6 @@ class Add_Remove_Contact_Tag extends Base_Action {
 	 * @throws Data_Type_Exception When the data type is not supported.
 	 */
 	protected function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Check if the Data_Type passed is the expected.
-		$this->validate( $data );
-
 		/** @var Contact $contact */
 		$contact = $data->get_data();
 

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-add-remove-contact-tag.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-add-remove-contact-tag.php
@@ -9,7 +9,6 @@
 namespace Automattic\Jetpack\CRM\Automation\Actions;
 
 use Automattic\Jetpack\CRM\Automation\Base_Action;
-use Automattic\Jetpack\CRM\Automation\Data_Type_Exception;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Contact_Data;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type;
 
@@ -81,8 +80,6 @@ class Add_Remove_Contact_Tag extends Base_Action {
 	 * @since $$next-version$$
 	 *
 	 * @param Data_Type $data Data passed from the trigger.
-	 *
-	 * @throws Data_Type_Exception When the data type is not supported.
 	 */
 	protected function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		/** @var Contact $contact */

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-delete-contact.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-delete-contact.php
@@ -10,7 +10,6 @@ namespace Automattic\Jetpack\CRM\Automation\Actions;
 
 use Automattic\Jetpack\CRM\Automation\Attribute_Definition;
 use Automattic\Jetpack\CRM\Automation\Base_Action;
-use Automattic\Jetpack\CRM\Automation\Data_Type_Exception;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Contact_Data;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type;
 
@@ -108,8 +107,6 @@ class Delete_Contact extends Base_Action {
 	 * @since $$next-version$$
 	 *
 	 * @param Data_Type $data Data passed from the trigger.
-	 *
-	 * @throws Data_Type_Exception When the data type is not supported.
 	 */
 	protected function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		global $zbs;

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-delete-contact.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-delete-contact.php
@@ -112,9 +112,6 @@ class Delete_Contact extends Base_Action {
 	 * @throws Data_Type_Exception When the data type is not supported.
 	 */
 	protected function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
-		$this->validate( $data );
-
 		global $zbs;
 
 		/** @var Contact $contact */

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-delete-contact.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-delete-contact.php
@@ -111,7 +111,7 @@ class Delete_Contact extends Base_Action {
 	 *
 	 * @throws Data_Type_Exception When the data type is not supported.
 	 */
-	public function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	protected function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
 		$this->validate( $data );
 

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-new-contact.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-new-contact.php
@@ -81,7 +81,7 @@ class New_Contact extends Base_Action {
 	 *
 	 * @param Data_Type $data Data passed from the trigger.
 	 */
-	public function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	protected function execute( Data_Type $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		global $zbs;
 
 		$zbs->DAL->contacts->addUpdateContact( $this->attributes ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-update-contact-status.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-update-contact-status.php
@@ -116,7 +116,7 @@ class Update_Contact_Status extends Base_Action {
 	 *
 	 * @param Data_Type $data Data passed from the trigger.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 		global $zbs;
 
 		/** @var Contact $contact */

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-update-contact.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-update-contact.php
@@ -84,8 +84,6 @@ class Update_Contact extends Base_Action {
 	 * @param Data_Type $data Data passed from the trigger.
 	 */
 	protected function execute( Data_Type $data ) {
-		$this->validate( $data );
-
 		/** @var Contact $contact */
 		$contact = $data->get_data();
 

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-update-contact.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-update-contact.php
@@ -83,7 +83,7 @@ class Update_Contact extends Base_Action {
 	 *
 	 * @param Data_Type $data Data passed from the trigger.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 		$this->validate( $data );
 
 		/** @var Contact $contact */

--- a/projects/plugins/crm/src/automation/commons/actions/invoice/class-set-invoice-status.php
+++ b/projects/plugins/crm/src/automation/commons/actions/invoice/class-set-invoice-status.php
@@ -85,9 +85,6 @@ class Set_Invoice_Status extends Base_Action {
 	 * @throws Data_Type_Exception Exception when the data type is not supported.
 	 */
 	protected function execute( Data_Type $data ) {
-
-		$this->validate( $data );
-
 		/** @var Invoice $invoice */
 		$invoice = $data->get_data();
 

--- a/projects/plugins/crm/src/automation/commons/actions/invoice/class-set-invoice-status.php
+++ b/projects/plugins/crm/src/automation/commons/actions/invoice/class-set-invoice-status.php
@@ -9,7 +9,6 @@
 namespace Automattic\Jetpack\CRM\Automation\Actions;
 
 use Automattic\Jetpack\CRM\Automation\Base_Action;
-use Automattic\Jetpack\CRM\Automation\Data_Type_Exception;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Invoice_Data;
 use Automattic\Jetpack\CRM\Entities\Invoice;
@@ -80,9 +79,8 @@ class Set_Invoice_Status extends Base_Action {
 	 * Update the DAL with the invoice status.
 	 *
 	 * @since $$next-version$$
-	 * @param Data_Type $data Data passed from the trigger.
 	 *
-	 * @throws Data_Type_Exception Exception when the data type is not supported.
+	 * @param Data_Type $data Data passed from the trigger.
 	 */
 	protected function execute( Data_Type $data ) {
 		/** @var Invoice $invoice */

--- a/projects/plugins/crm/src/automation/commons/actions/invoice/class-set-invoice-status.php
+++ b/projects/plugins/crm/src/automation/commons/actions/invoice/class-set-invoice-status.php
@@ -84,7 +84,7 @@ class Set_Invoice_Status extends Base_Action {
 	 *
 	 * @throws Data_Type_Exception Exception when the data type is not supported.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 
 		$this->validate( $data );
 

--- a/projects/plugins/crm/src/automation/commons/actions/transactions/class-set-transaction-status.php
+++ b/projects/plugins/crm/src/automation/commons/actions/transactions/class-set-transaction-status.php
@@ -86,8 +86,6 @@ class Set_Transaction_Status extends Base_Action {
 	 * @throws Data_Type_Exception If the data do not look valid.
 	 */
 	protected function execute( Data_Type $data ) {
-		$this->validate( $data );
-
 		/** @var Transaction $transaction */
 		$transaction = $data->get_data();
 

--- a/projects/plugins/crm/src/automation/commons/actions/transactions/class-set-transaction-status.php
+++ b/projects/plugins/crm/src/automation/commons/actions/transactions/class-set-transaction-status.php
@@ -85,7 +85,7 @@ class Set_Transaction_Status extends Base_Action {
 	 *
 	 * @throws Data_Type_Exception If the data do not look valid.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 		$this->validate( $data );
 
 		/** @var Transaction $transaction */

--- a/projects/plugins/crm/src/automation/commons/actions/transactions/class-set-transaction-status.php
+++ b/projects/plugins/crm/src/automation/commons/actions/transactions/class-set-transaction-status.php
@@ -9,7 +9,6 @@
 namespace Automattic\Jetpack\CRM\Automation\Actions;
 
 use Automattic\Jetpack\CRM\Automation\Base_Action;
-use Automattic\Jetpack\CRM\Automation\Data_Type_Exception;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Transaction_Data;
 use Automattic\Jetpack\CRM\Entities\Transaction;
@@ -82,8 +81,6 @@ class Set_Transaction_Status extends Base_Action {
 	 * @since $$next-version$$
 	 *
 	 * @param Data_Type $data Data passed from the trigger.
-	 *
-	 * @throws Data_Type_Exception If the data do not look valid.
 	 */
 	protected function execute( Data_Type $data ) {
 		/** @var Transaction $transaction */

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-field-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-field-changed.php
@@ -65,7 +65,7 @@ class Contact_Field_Changed extends Base_Condition {
 	 *
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 
 		/** @var Contact $contact */
 		$contact = $data->get_data();

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-tag.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-tag.php
@@ -75,7 +75,7 @@ class Contact_Tag extends Base_Condition {
 	 *
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 
 		/** @var Contact $contact */
 		$contact = $data->get_data();

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-transitional-status.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-transitional-status.php
@@ -55,17 +55,9 @@ class Contact_Transitional_Status extends Base_Condition {
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
 	protected function execute( Data_Type $data ) {
-		$this->validate( $data );
-
+		/** @var Contact $contact */
 		$contact          = $data->get_data();
 		$previous_contact = $data->get_previous_data();
-
-		if ( ! $previous_contact instanceof Contact ) {
-			$this->logger->log( 'Invalid previous contact status transitional data' );
-			$this->condition_met = false;
-
-			return;
-		}
 
 		$operator   = $this->get_attributes()['operator'];
 		$status_was = $this->get_attributes()['previous_status_was'];

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-transitional-status.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-transitional-status.php
@@ -54,7 +54,7 @@ class Contact_Transitional_Status extends Base_Condition {
 	 *
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 		$this->validate( $data );
 
 		$contact          = $data->get_data();

--- a/projects/plugins/crm/src/automation/commons/conditions/invoices/class-invoice-field-contains.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/invoices/class-invoice-field-contains.php
@@ -63,7 +63,7 @@ class Invoice_Field_Contains extends Base_Condition {
 	 *
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 		$this->validate( $data );
 
 		/** @var Invoice $invoice */

--- a/projects/plugins/crm/src/automation/commons/conditions/invoices/class-invoice-field-contains.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/invoices/class-invoice-field-contains.php
@@ -64,8 +64,6 @@ class Invoice_Field_Contains extends Base_Condition {
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
 	protected function execute( Data_Type $data ) {
-		$this->validate( $data );
-
 		/** @var Invoice $invoice */
 		$invoice = $data->get_data();
 

--- a/projects/plugins/crm/src/automation/commons/conditions/invoices/class-invoice-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/invoices/class-invoice-status-changed.php
@@ -55,9 +55,6 @@ class Invoice_Status_Changed extends Base_Condition {
 	 * @throws Automation_Exception If an invalid operator is used.
 	 */
 	protected function execute( Data_Type $data ) {
-
-		$this->validate( $data );
-
 		/** @var Invoice $invoice */
 		$invoice = $data->get_data();
 

--- a/projects/plugins/crm/src/automation/commons/conditions/invoices/class-invoice-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/invoices/class-invoice-status-changed.php
@@ -54,7 +54,7 @@ class Invoice_Status_Changed extends Base_Condition {
 	 *
 	 * @throws Automation_Exception If an invalid operator is used.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 
 		$this->validate( $data );
 

--- a/projects/plugins/crm/src/automation/commons/conditions/quotes/class-quote-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/quotes/class-quote-status-changed.php
@@ -55,7 +55,7 @@ class Quote_Status_Changed extends Base_Condition {
 	 *
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 		$this->validate( $data );
 
 		/** @var Quote $quote */

--- a/projects/plugins/crm/src/automation/commons/conditions/quotes/class-quote-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/quotes/class-quote-status-changed.php
@@ -56,8 +56,6 @@ class Quote_Status_Changed extends Base_Condition {
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
 	protected function execute( Data_Type $data ) {
-		$this->validate( $data );
-
 		/** @var Quote $quote */
 		$quote = $data->get_data();
 

--- a/projects/plugins/crm/src/automation/commons/conditions/transactions/class-transaction-field.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/transactions/class-transaction-field.php
@@ -67,7 +67,7 @@ class Transaction_Field extends Base_Condition {
 	 *
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
-	public function execute( Data_Type $data ) {
+	protected function execute( Data_Type $data ) {
 		$this->validate( $data );
 
 		/** @var Transaction $transaction */

--- a/projects/plugins/crm/src/automation/commons/conditions/transactions/class-transaction-field.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/transactions/class-transaction-field.php
@@ -68,8 +68,6 @@ class Transaction_Field extends Base_Condition {
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
 	protected function execute( Data_Type $data ) {
-		$this->validate( $data );
-
 		/** @var Transaction $transaction */
 		$transaction = $data->get_data();
 

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-created.php
@@ -75,11 +75,10 @@ class Company_Created extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_company_created',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_company_created' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
@@ -75,11 +75,10 @@ class Company_Deleted extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_company_deleted',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_company_deleted' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
@@ -75,11 +75,10 @@ class Company_Status_Updated extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_company_status_updated',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_company_status_updated' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
@@ -75,11 +75,10 @@ class Company_Updated extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_company_updated',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_company_updated' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
@@ -84,11 +84,10 @@ class Contact_Before_Deleted extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_contact_before_deleted',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_contact_before_deleted' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-created.php
@@ -84,11 +84,10 @@ class Contact_Created extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_contact_created',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_contact_created' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
@@ -84,11 +84,10 @@ class Contact_Deleted extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_contact_deleted',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_contact_deleted' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
@@ -84,11 +84,10 @@ class Contact_Email_Updated extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_contact_email_updated',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_contact_email_updated' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
@@ -84,13 +84,10 @@ class Contact_Status_Updated extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_contact_status_updated',
-			array( $this, 'execute_workflow' ),
-			10,
-			2
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_contact_status_updated', 10, 2 );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
@@ -84,11 +84,10 @@ class Contact_Updated extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_contact_updated',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_contact_updated' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-created.php
@@ -75,11 +75,10 @@ class Invoice_Created extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_invoice_created',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_invoice_created' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
@@ -75,11 +75,10 @@ class Invoice_Deleted extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_invoice_deleted',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_invoice_deleted' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
@@ -75,11 +75,10 @@ class Invoice_Status_Updated extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_invoice_status_updated',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_invoice_status_updated' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
@@ -75,11 +75,10 @@ class Invoice_Updated extends Base_Trigger {
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_invoice_updated',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_invoice_updated' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-accepted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-accepted.php
@@ -75,11 +75,10 @@ class Quote_Accepted extends Base_Trigger {
 	 * Listen to this trigger's target event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_quote_accepted',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_quote_accepted' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-created.php
@@ -75,11 +75,10 @@ class Quote_Created extends Base_Trigger {
 	 * Listen to this trigger's target event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_quote_created',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_quote_created' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-deleted.php
@@ -75,11 +75,10 @@ class Quote_Deleted extends Base_Trigger {
 	 * Listen to this trigger's target event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_quote_delete',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_quote_delete' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-status-updated.php
@@ -75,11 +75,10 @@ class Quote_Status_Updated extends Base_Trigger {
 	 * Listen to this trigger's target event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_quote_status_update',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_quote_status_update' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-updated.php
@@ -75,11 +75,10 @@ class Quote_Updated extends Base_Trigger {
 	 * Listen to this trigger's target event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_quote_update',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_quote_update' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/tasks/class-task-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/tasks/class-task-created.php
@@ -78,9 +78,6 @@ class Task_Created extends Base_Trigger {
 	 * @return void
 	 */
 	protected function listen_to_event(): void {
-		add_action(
-			'jpcrm_task_created',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_wp_action( 'jpcrm_task_created' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/tasks/class-task-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/tasks/class-task-deleted.php
@@ -75,11 +75,10 @@ class Task_Deleted extends Base_Trigger {
 	 * Listen to this trigger's target event.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_task_delete',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_task_delete' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/tasks/class-task-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/tasks/class-task-updated.php
@@ -77,10 +77,7 @@ class Task_Updated extends Base_Trigger {
 	 *
 	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_task_updated',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_task_updated' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
@@ -78,9 +78,6 @@ class Transaction_Created extends Base_Trigger {
 	 * @return void
 	 */
 	protected function listen_to_event(): void {
-		add_action(
-			'jpcrm_transaction_created',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_wp_action( 'jpcrm_transaction_created' );
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
@@ -77,10 +77,7 @@ class Transaction_Updated extends Base_Trigger {
 	 *
 	 * @return void
 	 */
-	protected function listen_to_event() {
-		add_action(
-			'jpcrm_transaction_updated',
-			array( $this, 'execute_workflow' )
-		);
+	protected function listen_to_event(): void {
+		$this->listen_to_wp_action( 'jpcrm_transaction_updated' );
 	}
 }

--- a/projects/plugins/crm/src/automation/interface-step.php
+++ b/projects/plugins/crm/src/automation/interface-step.php
@@ -8,23 +8,12 @@
 
 namespace Automattic\Jetpack\CRM\Automation;
 
-use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type;
-
 /**
  * Interface Step.
  *
  * @since $$next-version$$
  */
 interface Step {
-
-	/**
-	 * Execute the step.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param Data_Type $data Data passed from the trigger.
-	 */
-	public function execute( Data_Type $data );
 
 	/**
 	 * Get the next step.

--- a/projects/plugins/crm/tests/php/automation/contacts/actions/class-add-contact-log-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/actions/class-add-contact-log-test.php
@@ -60,7 +60,7 @@ class Add_Contact_Log_Test extends JPCRM_Base_Integration_Test_Case {
 		$contact_data = new Contact_Data( $contact );
 
 		// Execute the action.
-		$action->execute( $contact_data );
+		$action->validate_and_execute( $contact_data );
 
 		// Verify that our contact has a log.
 		$logs = $zbs->DAL->logs->getLogsForObj(

--- a/projects/plugins/crm/tests/php/automation/contacts/actions/class-add-remove-contact-tag-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/actions/class-add-remove-contact-tag-test.php
@@ -70,7 +70,7 @@ class Add_Remove_Contact_Tag_Test extends JPCRM_Base_Integration_Test_Case {
 		$contact_data = new Contact_Data( $contact );
 
 		// Execute the action.
-		$action_add_remove_contact_tag->execute( $contact_data );
+		$action_add_remove_contact_tag->validate_and_execute( $contact_data );
 
 		// Verify that our contact has the tag.
 		$contact = $zbs->DAL->contacts->getContact( $contact_id, array( 'withTags' => true ) );

--- a/projects/plugins/crm/tests/php/automation/contacts/actions/class-delete-contact-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/actions/class-delete-contact-test.php
@@ -58,7 +58,7 @@ class Delete_Contact_Test extends JPCRM_Base_Integration_Test_Case {
 		);
 
 		// Execute the action.
-		$action_delete_contact->execute( new Contact_Data( $contact ) );
+		$action_delete_contact->validate_and_execute( new Contact_Data( $contact ) );
 
 		// Verify that the contact no longer exists.
 		$contact = $zbs->DAL->contacts->getContact( $contact_id );

--- a/projects/plugins/crm/tests/php/automation/contacts/actions/class-update-contact-status-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/actions/class-update-contact-status-test.php
@@ -54,7 +54,7 @@ class Update_Contact_Status_Test extends JPCRM_Base_Integration_Test_Case {
 			)
 		);
 
-		$action_update_contact->execute( new Contact_Data( $contact ) );
+		$action_update_contact->validate_and_execute( new Contact_Data( $contact ) );
 
 		$contact = $zbs->DAL->contacts->getContact( $contact_id );
 		$this->assertSame( 'Customer', $contact['status'] );

--- a/projects/plugins/crm/tests/php/automation/contacts/actions/class-update-contact-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/actions/class-update-contact-test.php
@@ -61,7 +61,7 @@ class Update_Contact_Test extends JPCRM_Base_Integration_Test_Case {
 		);
 
 		// Execute action.
-		$action->execute( new Contact_Data( $contact ) );
+		$action->validate_and_execute( new Contact_Data( $contact ) );
 
 		// Fetch the contact again and verify the update was successful.
 		$contact = $zbs->DAL->contacts->getContact( $contact_id );

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
@@ -81,12 +81,12 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$contact->status = 'customer';
-		$contact_field_changed_condition->execute( $contact_data );
+		$contact_field_changed_condition->validate_and_execute( $contact_data );
 		$this->assertTrue( $contact_field_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$contact->status = 'lead';
-		$contact_field_changed_condition->execute( $contact_data );
+		$contact_field_changed_condition->validate_and_execute( $contact_data );
 		$this->assertFalse( $contact_field_changed_condition->condition_met() );
 	}
 
@@ -103,12 +103,12 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$contact->status = 'lead';
-		$contact_field_changed_condition->execute( $contact_data );
+		$contact_field_changed_condition->validate_and_execute( $contact_data );
 		$this->assertTrue( $contact_field_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$contact->status = 'customer';
-		$contact_field_changed_condition->execute( $contact_data );
+		$contact_field_changed_condition->validate_and_execute( $contact_data );
 		$this->assertFalse( $contact_field_changed_condition->condition_met() );
 	}
 
@@ -124,7 +124,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$this->expectException( Automation_Exception::class );
 		$this->expectExceptionCode( Automation_Exception::CONDITION_INVALID_OPERATOR );
 
-		$contact_field_changed_condition->execute( new Contact_Data( $contact ) );
+		$contact_field_changed_condition->validate_and_execute( new Contact_Data( $contact ) );
 	}
 
 	/**
@@ -144,7 +144,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 
 		$contact_data = new Contact_Data( $contact, $previous_contact );
 
-		$contact_transitional_status_condition->execute( $contact_data );
+		$contact_transitional_status_condition->validate_and_execute( $contact_data );
 	}
 
 	/**
@@ -165,18 +165,18 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$contact->status          = 'new_status';
 		$previous_contact->status = 'old_status';
 
-		$contact_transitional_status_condition->execute( $contact_data );
+		$contact_transitional_status_condition->validate_and_execute( $contact_data );
 		$this->assertTrue( $contact_transitional_status_condition->condition_met() );
 
 		// Testing when the condition has been not been met for the to field.
 		$contact->status = 'wrong_to';
-		$contact_transitional_status_condition->execute( $contact_data );
+		$contact_transitional_status_condition->validate_and_execute( $contact_data );
 		$this->assertFalse( $contact_transitional_status_condition->condition_met() );
 
 		// Testing when the condition has been not been met for the from field
 		$contact->status          = 'new_status';
 		$previous_contact->status = 'wrong_from';
-		$contact_transitional_status_condition->execute( $contact_data );
+		$contact_transitional_status_condition->validate_and_execute( $contact_data );
 		$this->assertFalse( $contact_transitional_status_condition->condition_met() );
 	}
 
@@ -198,7 +198,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$tag_id = end( $contact->tags )['id'] + 1;
 
 		// Testing when the condition has been not been met because the contact does not have said tag.
-		$contact_tag_condition->execute( $contact_data );
+		$contact_tag_condition->validate_and_execute( $contact_data );
 		$this->assertFalse( $contact_tag_condition->condition_met() );
 
 		// Testing when the condition has been met.
@@ -210,7 +210,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 			'created'     => 1692663412,
 			'lastupdated' => 1692663412,
 		);
-		$contact_tag_condition->execute( $contact_data );
+		$contact_tag_condition->validate_and_execute( $contact_data );
 		$this->assertTrue( $contact_tag_condition->condition_met() );
 
 		// Testing when the condition has been not been met because the previous contact already had said tag.
@@ -223,7 +223,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 			'lastupdated' => 1692663412,
 		);
 
-		$contact_tag_condition->execute( $contact_data );
+		$contact_tag_condition->validate_and_execute( $contact_data );
 		$this->assertFalse( $contact_tag_condition->condition_met() );
 	}
 
@@ -242,7 +242,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$tag_id = end( $contact->tags )['id'] + 1;
 
 		// Testing when the condition has been not been met because the previous contact does not have said tag.
-		$contact_tag_condition->execute( $contact_data );
+		$contact_tag_condition->validate_and_execute( $contact_data );
 		$this->assertFalse( $contact_tag_condition->condition_met() );
 
 		// Testing when the condition has been met.
@@ -254,7 +254,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 			'created'     => 1692663412,
 			'lastupdated' => 1692663412,
 		);
-		$contact_tag_condition->execute( $contact_data );
+		$contact_tag_condition->validate_and_execute( $contact_data );
 		$this->assertTrue( $contact_tag_condition->condition_met() );
 
 		// Testing when the condition has been not been met because the current contact still has said tag.
@@ -266,7 +266,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 			'created'     => 1692663412,
 			'lastupdated' => 1692663412,
 		);
-		$contact_tag_condition->execute( $contact_data );
+		$contact_tag_condition->validate_and_execute( $contact_data );
 		$this->assertFalse( $contact_tag_condition->condition_met() );
 	}
 
@@ -286,7 +286,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$tag_id = end( $contact->tags )['id'] + 1;
 
 		// Testing when the condition has been not been met because the contact does not have said tag.
-		$contact_tag_condition->execute( $contact_data );
+		$contact_tag_condition->validate_and_execute( $contact_data );
 		$this->assertFalse( $contact_tag_condition->condition_met() );
 
 		// Testing when the condition has been met.
@@ -298,7 +298,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 			'created'     => 1692663412,
 			'lastupdated' => 1692663412,
 		);
-		$contact_tag_condition->execute( $contact_data );
+		$contact_tag_condition->validate_and_execute( $contact_data );
 
 		$this->assertTrue( $contact_tag_condition->condition_met() );
 	}

--- a/projects/plugins/crm/tests/php/automation/invoices/class-invoice-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/invoices/class-invoice-condition-test.php
@@ -65,12 +65,12 @@ class Invoice_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$invoice->status = 'paid';
-		$invoice_status_changed_condition->execute( $invoice_data );
+		$invoice_status_changed_condition->validate_and_execute( $invoice_data );
 		$this->assertTrue( $invoice_status_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$invoice->status = 'unpaid';
-		$invoice_status_changed_condition->execute( $invoice_data );
+		$invoice_status_changed_condition->validate_and_execute( $invoice_data );
 		$this->assertFalse( $invoice_status_changed_condition->condition_met() );
 	}
 
@@ -86,12 +86,12 @@ class Invoice_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$invoice->status = 'unpaid';
-		$invoice_status_changed_condition->execute( $invoice_data );
+		$invoice_status_changed_condition->validate_and_execute( $invoice_data );
 		$this->assertTrue( $invoice_status_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$invoice->status = 'paid';
-		$invoice_status_changed_condition->execute( $invoice_data );
+		$invoice_status_changed_condition->validate_and_execute( $invoice_data );
 		$this->assertFalse( $invoice_status_changed_condition->condition_met() );
 	}
 
@@ -108,7 +108,7 @@ class Invoice_Condition_Test extends JPCRM_Base_Test_Case {
 		$this->expectException( Automation_Exception::class );
 		$this->expectExceptionCode( Automation_Exception::CONDITION_INVALID_OPERATOR );
 
-		$invoice_status_changed_condition->execute( $invoice_data );
+		$invoice_status_changed_condition->validate_and_execute( $invoice_data );
 	}
 
 	/**
@@ -123,12 +123,12 @@ class Invoice_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$invoice->status = 'paid';
-		$invoice_field_contains_condition->execute( $invoice_data );
+		$invoice_field_contains_condition->validate_and_execute( $invoice_data );
 		$this->assertTrue( $invoice_field_contains_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$invoice->status = 'draft';
-		$invoice_field_contains_condition->execute( $invoice_data );
+		$invoice_field_contains_condition->validate_and_execute( $invoice_data );
 		$this->assertFalse( $invoice_field_contains_condition->condition_met() );
 	}
 
@@ -144,12 +144,12 @@ class Invoice_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$invoice->status = 'draft';
-		$invoice_field_contains_condition->execute( $invoice_data );
+		$invoice_field_contains_condition->validate_and_execute( $invoice_data );
 		$this->assertTrue( $invoice_field_contains_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$invoice->status = 'paid';
-		$invoice_field_contains_condition->execute( $invoice_data );
+		$invoice_field_contains_condition->validate_and_execute( $invoice_data );
 		$this->assertFalse( $invoice_field_contains_condition->condition_met() );
 	}
 
@@ -166,6 +166,6 @@ class Invoice_Condition_Test extends JPCRM_Base_Test_Case {
 		$this->expectException( Automation_Exception::class );
 		$this->expectExceptionCode( Automation_Exception::CONDITION_INVALID_OPERATOR );
 
-		$invoice_field_contains_condition->execute( $invoice_data );
+		$invoice_field_contains_condition->validate_and_execute( $invoice_data );
 	}
 }

--- a/projects/plugins/crm/tests/php/automation/mocks/mock-class-contact-created-trigger.php
+++ b/projects/plugins/crm/tests/php/automation/mocks/mock-class-contact-created-trigger.php
@@ -42,8 +42,10 @@ class Contact_Created_Trigger extends Base_Trigger {
 
 	/**
 	 * Listen to the desired event
+	 *
+	 * @return void
 	 */
-	protected function listen_to_event() {
+	protected function listen_to_event(): void {
 		$event_emitter = Event_Emitter::instance();
 
 		$event_emitter->on(

--- a/projects/plugins/crm/tests/php/automation/mocks/mock-class-trigger-empty-slug.php
+++ b/projects/plugins/crm/tests/php/automation/mocks/mock-class-trigger-empty-slug.php
@@ -48,7 +48,7 @@ class Empty_Slug_Trigger extends Base_Trigger {
 	/**
 	 * Listen to the desired event
 	 */
-	protected function listen_to_event() {
+	protected function listen_to_event(): void {
 		$event_emitter = Event_Emitter::instance();
 
 		$event_emitter->on(

--- a/projects/plugins/crm/tests/php/automation/quotes/class-quote-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/quotes/class-quote-condition-test.php
@@ -49,13 +49,13 @@ class Quote_Condition_Test extends JPCRM_Base_Test_Case {
 		// Testing when the condition has been met.
 		$quote->accepted = '1';
 		$quote->template = '1';
-		$quote_status_changed_condition->execute( $quote_data );
+		$quote_status_changed_condition->validate_and_execute( $quote_data );
 		$this->assertTrue( $quote_status_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$quote->accepted = '0';
 		$quote->template = '0';
-		$quote_status_changed_condition->execute( $quote_data );
+		$quote_status_changed_condition->validate_and_execute( $quote_data );
 		$this->assertFalse( $quote_status_changed_condition->condition_met() );
 	}
 
@@ -72,13 +72,13 @@ class Quote_Condition_Test extends JPCRM_Base_Test_Case {
 		// Testing when the condition has been met.
 		$quote->accepted = '0';
 		$quote->template = '0';
-		$quote_status_changed_condition->execute( $quote_data );
+		$quote_status_changed_condition->validate_and_execute( $quote_data );
 		$this->assertTrue( $quote_status_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$quote->accepted = '1';
 		$quote->template = '1';
-		$quote_status_changed_condition->execute( $quote_data );
+		$quote_status_changed_condition->validate_and_execute( $quote_data );
 		$this->assertFalse( $quote_status_changed_condition->condition_met() );
 	}
 
@@ -95,6 +95,6 @@ class Quote_Condition_Test extends JPCRM_Base_Test_Case {
 		$this->expectException( Automation_Exception::class );
 		$this->expectExceptionCode( Automation_Exception::CONDITION_INVALID_OPERATOR );
 
-		$quote_status_changed_condition->execute( $quote_data );
+		$quote_status_changed_condition->validate_and_execute( $quote_data );
 	}
 }

--- a/projects/plugins/crm/tests/php/automation/transactions/class-transaction-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/transactions/class-transaction-condition-test.php
@@ -50,12 +50,12 @@ class Transaction_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$transaction->status = 'paid';
-		$transaction_field_changed_condition->execute( $transaction_data );
+		$transaction_field_changed_condition->validate_and_execute( $transaction_data );
 		$this->assertTrue( $transaction_field_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$transaction->status = 'draft';
-		$transaction_field_changed_condition->execute( $transaction_data );
+		$transaction_field_changed_condition->validate_and_execute( $transaction_data );
 		$this->assertFalse( $transaction_field_changed_condition->condition_met() );
 	}
 
@@ -71,12 +71,12 @@ class Transaction_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$transaction->status = 'draft';
-		$transaction_field_changed_condition->execute( $transaction_data );
+		$transaction_field_changed_condition->validate_and_execute( $transaction_data );
 		$this->assertTrue( $transaction_field_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$transaction->status = 'paid';
-		$transaction_field_changed_condition->execute( $transaction_data );
+		$transaction_field_changed_condition->validate_and_execute( $transaction_data );
 		$this->assertFalse( $transaction_field_changed_condition->condition_met() );
 	}
 
@@ -92,12 +92,12 @@ class Transaction_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$transaction->status = 'paid';
-		$transaction_field_changed_condition->execute( $transaction_data );
+		$transaction_field_changed_condition->validate_and_execute( $transaction_data );
 		$this->assertTrue( $transaction_field_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$transaction->status = 'draft';
-		$transaction_field_changed_condition->execute( $transaction_data );
+		$transaction_field_changed_condition->validate_and_execute( $transaction_data );
 		$this->assertFalse( $transaction_field_changed_condition->condition_met() );
 	}
 
@@ -113,12 +113,12 @@ class Transaction_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$transaction->status = 'draft';
-		$transaction_field_changed_condition->execute( $transaction_data );
+		$transaction_field_changed_condition->validate_and_execute( $transaction_data );
 		$this->assertTrue( $transaction_field_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$transaction->status = 'paid';
-		$transaction_field_changed_condition->execute( $transaction_data );
+		$transaction_field_changed_condition->validate_and_execute( $transaction_data );
 		$this->assertFalse( $transaction_field_changed_condition->condition_met() );
 	}
 
@@ -135,6 +135,6 @@ class Transaction_Condition_Test extends JPCRM_Base_Test_Case {
 		$this->expectException( Automation_Exception::class );
 		$this->expectExceptionCode( Automation_Exception::CONDITION_INVALID_OPERATOR );
 
-		$transaction_field_changed_condition->execute( $transaction_data );
+		$transaction_field_changed_condition->validate_and_execute( $transaction_data );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3352

## Proposed changes:

- Update `Base_Step` to use `validate_and_execute` method to ensure the validation of the data. Now `execute` is protected. The Workflow execution uses `validate_and_execute`.
- Update the triggers for using the `listen_to_wp_action` generic method, so the triggers only have to call it with the hook name. Also, trigger could listen to other third-party events if they want instead of WP hook/actions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Check the code.
- Test should pass.

