### PR TITLE
AI Excerpt: update label and help of "words" control

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-rename-label-and-help
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-rename-label-and-help
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: update label and help of "words" control

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
@@ -127,13 +127,13 @@ export function AiExcerptControl( {
 			) }
 
 			<RangeControl
-				label={ __( 'Choose length', 'jetpack' ) }
+				label={ __( 'Desired length', 'jetpack' ) }
 				value={ words }
 				onChange={ onWordsNumberChange }
 				min={ minWords }
 				max={ maxWords }
 				help={ __(
-					'Sets the limit for words in auto-generated excerpts. The final count may vary slightly due to sentence structure.',
+					'Sets the desired length in words for the auto-generated excerpt. The final count may vary due to how AI works.',
 					'jetpack'
 				) }
 				showTooltip={ false }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

It updates the label and the help text of the number of words control.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: update label and help of "words" control

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the post sidebar
* Identify the AI Excerpt panel
* Confirm the changes

Before (trunk) | After (This PR)
---------|-----------
<img width="366" alt="Screenshot 2023-09-27 at 09 35 08" src="https://github.com/Automattic/jetpack/assets/77539/fc34db80-518a-443f-9924-7cf034b2c202"> | <img width="364" alt="Screenshot 2023-09-27 at 09 34 12" src="https://github.com/Automattic/jetpack/assets/77539/d7593b38-eb5d-45b0-b83f-3807a5b8fe46">


