### PR TITLE
[CRM] Make Attribute_Definition methods snake_case

### DIFF
--- a/projects/plugins/crm/changelog/crm-update-attribute-definition-method-names
+++ b/projects/plugins/crm/changelog/crm-update-attribute-definition-method-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Automations are hidden behind a feature flag
+
+

--- a/projects/plugins/crm/src/automation/class-attribute-definition.php
+++ b/projects/plugins/crm/src/automation/class-attribute-definition.php
@@ -108,8 +108,10 @@ class Attribute_Definition {
 	protected $description;
 
 	/**
-	 * Attribute type (is it a select? an input?). The const values of this class
-	 * should be used here (e.g. Attribute_Definition::NUMBER).
+	 * Attribute type.
+	 *
+	 * This is a string that represents the type of the attribute.
+	 * E.g.: 'text', 'number', 'select', etc.
 	 *
 	 * @since $$next-version$$
 	 * @var string
@@ -135,7 +137,7 @@ class Attribute_Definition {
 	 * @param string     $type Attribute type.
 	 * @param array|null $data Data needed by this attribute.
 	 */
-	public function __construct( $slug, $title, $description, $type, $data = null ) {
+	public function __construct( string $slug, string $title, string $description, string $type, ?array $data = null ) {
 		$this->slug        = $slug;
 		$this->title       = $title;
 		$this->description = $description;
@@ -150,7 +152,7 @@ class Attribute_Definition {
 	 *
 	 * @return string
 	 */
-	public function getSlug(): string {
+	public function get_slug(): string {
 		return $this->slug;
 	}
 
@@ -161,7 +163,7 @@ class Attribute_Definition {
 	 *
 	 * @param string $slug The slug (key) that identifies this attribute.
 	 */
-	public function setSlug( string $slug ): void {
+	public function set_slug( string $slug ): void {
 		$this->slug = $slug;
 	}
 
@@ -172,7 +174,7 @@ class Attribute_Definition {
 	 *
 	 * @return string
 	 */
-	public function getTitle(): string {
+	public function get_title(): string {
 		return $this->title;
 	}
 
@@ -183,7 +185,7 @@ class Attribute_Definition {
 	 *
 	 * @param string $title The title (label) for this attribute.
 	 */
-	public function setTitle( string $title ): void {
+	public function set_title( string $title ): void {
 		$this->title = $title;
 	}
 
@@ -194,7 +196,7 @@ class Attribute_Definition {
 	 *
 	 * @return string
 	 */
-	public function getDescription(): string {
+	public function get_description(): string {
 		return $this->description;
 	}
 
@@ -205,7 +207,7 @@ class Attribute_Definition {
 	 *
 	 * @param string $description The description for this attribute.
 	 */
-	public function setDescription( string $description ): void {
+	public function set_description( string $description ): void {
 		$this->description = $description;
 	}
 
@@ -216,7 +218,7 @@ class Attribute_Definition {
 	 *
 	 * @return string
 	 */
-	public function getType(): string {
+	public function get_type(): string {
 		return $this->type;
 	}
 
@@ -227,7 +229,7 @@ class Attribute_Definition {
 	 *
 	 * @param string $type The attribute type.
 	 */
-	public function setType( string $type ): void {
+	public function set_type( string $type ): void {
 		$this->type = $type;
 	}
 
@@ -238,7 +240,7 @@ class Attribute_Definition {
 	 *
 	 * @return array|null
 	 */
-	public function getData(): ?array {
+	public function get_data(): ?array {
 		return $this->data;
 	}
 
@@ -249,7 +251,7 @@ class Attribute_Definition {
 	 *
 	 * @param array|null $data The data needed by this attribute.
 	 */
-	public function setData( ?array $data ): void {
+	public function set_data( ?array $data ): void {
 		$this->data = $data;
 	}
 }

--- a/projects/plugins/crm/src/automation/class-base-step.php
+++ b/projects/plugins/crm/src/automation/class-base-step.php
@@ -50,7 +50,7 @@ abstract class Base_Step implements Step {
 	 * @param array $step_data An array of data for the current step.
 	 */
 	public function __construct( array $step_data ) {
-		$this->attributes = ( isset( $step_data['attributes'] ) && is_array( $step_data['attributes'] ) ) ? $step_data['attributes'] : array();
+		$this->attributes = $step_data['attributes'] ?? array();
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/class-base-step.php
+++ b/projects/plugins/crm/src/automation/class-base-step.php
@@ -32,7 +32,7 @@ abstract class Base_Step implements Step {
 	 * @since $$next-version$$
 	 * @var array
 	 */
-	protected $attribute_definitions;
+	protected $attribute_definitions = array();
 
 	/**
 	 * Next linked step.
@@ -50,7 +50,7 @@ abstract class Base_Step implements Step {
 	 * @param array $step_data An array of data for the current step.
 	 */
 	public function __construct( array $step_data ) {
-		$this->attributes = $step_data['attributes'] ?? array();
+		$this->attributes = ( isset( $step_data['attributes'] ) && is_array( $step_data['attributes'] ) ) ? $step_data['attributes'] : array();
 	}
 
 	/**
@@ -82,7 +82,7 @@ abstract class Base_Step implements Step {
 	 *
 	 * @return Attribute_Definition[] The attribute definitions of the step.
 	 */
-	public function get_attribute_definitions(): ?array {
+	public function get_attribute_definitions(): array {
 		return $this->attribute_definitions;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The main objective of this PR is to change method names of `Attribute_Definition` to be snake_case so it follows WP standards; _but a few code standard also snuck in_.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change `Attribute_Definition` methods to be snake_case.
* Make a couple of type changes to make it more strings and reflect DocBlocks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Existing automated tests should pass; besides that we don't really need any more testing since the methods aren't being used anywhere.
