### PR TITLE
Blogroll: Fix blogroll subscribe on simple site

### DIFF
--- a/projects/plugins/jetpack/changelog/Fix blogroll subscriptions
+++ b/projects/plugins/jetpack/changelog/Fix blogroll subscriptions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Fix submission form for a better block
+
+

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -64,7 +64,7 @@ function load_assets( $attr, $content, $block ) {
 			'user_id' => get_current_user_id(),
 			'blog_id' => $id,
 		)
-	);
+	) || $id === isset( $_GET['blogid'] );  // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
 
 	if ( $is_following ) {
 		$subscribe_text            = esc_html__( 'Subscribed', 'jetpack' );
@@ -106,7 +106,7 @@ HTML;
 		</div>
 		<fieldset disabled class="jetpack-blogroll-item-submit">
 			<input type="hidden" name="_wpnonce" value="$wp_nonce">
-			<input type="email" placeholder="Email address" value="$email" class="jetpack-blogroll-item-email-input">
+			<input type="email" name="email" placeholder="Email address" value="$email" class="jetpack-blogroll-item-email-input">
 			$buttons_html
 		</fieldset>
 HTML;

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -64,7 +64,7 @@ function load_assets( $attr, $content, $block ) {
 			'user_id' => get_current_user_id(),
 			'blog_id' => $id,
 		)
-	) || $id === isset( $_GET['blogid'] );  // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
+	) || $id === isset( $_GET['blogid'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
 
 	if ( $is_following ) {
 		$subscribe_text            = esc_html__( 'Subscribed', 'jetpack' );

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -59,12 +59,12 @@ function load_assets( $attr, $content, $block ) {
 	$submit_text               = esc_html__( 'Submit', 'jetpack' );
 	$cancel_text               = esc_html__( 'Cancel', 'jetpack' );
 	$disabled_subscribe_button = '';
-	$is_following              = function_exists( 'wpcom_subs_is_subscribed' ) && wpcom_subs_is_subscribed(
+	$is_following              = ( function_exists( 'wpcom_subs_is_subscribed' ) && wpcom_subs_is_subscribed(
 		array(
 			'user_id' => get_current_user_id(),
 			'blog_id' => $id,
 		)
-	) || $id === isset( $_GET['blogid'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
+	) ) || isset( $_GET['blogid'] ) && $id === $_GET['blogid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
 
 	if ( $is_following ) {
 		$subscribe_text            = esc_html__( 'Subscribed', 'jetpack' );

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
@@ -41,16 +41,19 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  * @return string
  */
 function load_assets( $attr, $content ) {
+	global $wp;
+
 	/*
 	 * Enqueue necessary scripts and styles.
 	 */
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
+	$current_location = home_url( $wp->request );
 
 	$content = <<<HTML
 		<form method="post" action="https://subscribe.wordpress.com" accept-charset="utf-8">
 			<input name="action" type="hidden" value="subscribe">
-			<input name="source" type="hidden" value="jetpack_blogroll">
-			<input name="sub-type" type="hidden" value="blogroll-follow">
+			<input name="source" type="hidden" value="$current_location">
+			<input name="sub-type" type="hidden" value="jetpack_blogroll">
 			$content
 		</form>
 HTML;

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
@@ -41,19 +41,15 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  * @return string
  */
 function load_assets( $attr, $content ) {
-	global $wp;
-
 	/*
 	 * Enqueue necessary scripts and styles.
 	 */
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
-	$current_location = home_url( $wp->request );
-
 	$content = <<<HTML
 		<form method="post" action="https://subscribe.wordpress.com" accept-charset="utf-8">
 			<input name="action" type="hidden" value="subscribe">
-			<input name="source" type="hidden" value="$current_location">
+			<input name="source" type="hidden" value="jetpack_blogroll">
 			<input name="sub-type" type="hidden" value="blogroll-follow">
 			$content
 		</form>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82124

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes an issue for logged-out users when trying to subscribe to a blog/site using blogroll
* This fix applies only to simple sites, atomic sites will be handled in another PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this branch
* Make sure you have your simple site sandboxed
* Navigate to your simple site using incognito or logged-out user
* Subscribe to a site should work.
