### PR TITLE
AI Chat: delegate adding the beta suffix to filter

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-chat-remove-beta-suffix-from-title
+++ b/projects/plugins/jetpack/changelog/update-ai-chat-remove-beta-suffix-from-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Chat: delegate adding the beta suffix to filter

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "jetpack/ai-chat",
-	"title": "AI Chat (Beta)",
+	"title": "AI Chat",
 	"description": "Provides summarized chat across a site’s content, powered by AI magic.",
 	"keywords": [ "AI", "GPT", "Chat", "Search" ],
 	"version": "12.5.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR removes the ` (Beta)` suffix from the title of the AI Chat block. The [setBetaBlockTitle()](https://github.com/Automattic/jetpack/blob/fd59614760e36281236d09de76196dee9b3d73d5/projects/plugins/jetpack/extensions/editor.js#L81) function will take over adding the prefix and do not add it when the feature is moved to production.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Chat: delegate adding the beta suffix to filter

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create an AI Chat block instance
* Confirm the block title still shows the ` (beta)` suffix 

<img width="291" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/f9696d1b-4859-447b-9d5c-96659784ee9f">

<img width="730" alt="Screenshot 2023-09-27 at 13 14 57" src="https://github.com/Automattic/jetpack/assets/77539/50ad52e4-f3c8-4c9d-8a49-b519fcaf93e6">



