### PR TITLE
Fix block exception throw in Site Editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blocks-site-editor-exception
+++ b/projects/plugins/jetpack/changelog/fix-blocks-site-editor-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix block exception throw in Site Editor

--- a/projects/plugins/jetpack/extensions/editor.js
+++ b/projects/plugins/jetpack/extensions/editor.js
@@ -86,14 +86,21 @@ function setBetaBlockTitle( settings, name ) {
 	const { title, keywords } = settings;
 	const titleSuffix = '(beta)';
 	const betaKeyword = 'beta';
-
-	return {
+	const result = {
 		...settings,
-		title: title.toLowerCase().endsWith( titleSuffix )
-			? title
-			: `${ settings.title } ${ titleSuffix }`,
-		kewords: keywords.includes( betaKeyword ) ? keywords : [ ...keywords, betaKeyword ],
 	};
+
+	if ( title ) {
+		result.title = title.toLowerCase().endsWith( titleSuffix )
+			? title
+			: `${ settings.title } ${ titleSuffix }`;
+	}
+
+	if ( Array.isArray( keywords ) ) {
+		result.keywords = keywords.includes( betaKeyword ) ? keywords : [ ...keywords, betaKeyword ];
+	}
+
+	return result;
 }
 
 addFilter( 'blocks.registerBlockType', 'jetpack/label-beta-blocks-title', setBetaBlockTitle );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/82023

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Some recently refactored blocks ([Business Hours](https://github.com/Automattic/jetpack/pull/32698) and [beta blocks](https://github.com/Automattic/jetpack/pull/32815)) caused the following exception to be thrown in the site editor.
<img width="330" alt="Screenshot 2023-09-27 at 9 29 37 AM" src="https://github.com/Automattic/jetpack/assets/1620183/c86a93ea-6667-4bb1-8627-3a7595e40d84">

In the refactoring, moving the title from the `settings` argument passed to `registerJetpackBlock` to a `block.json` metadata file caused the title to be undefined in the callback of the `blocks.registerBlockType` filter hook. This PR fixes this by adding guards in the callback to prevent undefined settings from calling methods.

While this prevents the above exception, the `The block "jetpack/block-name" must have a title.` errors can be seen in the console. However, this doesn't seem to affect how blocks are rendered and behave, and blocks can be searched by their name in the block inserter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch.
- Visit `wp-admin/site-editor.php?canvas=edit`.
- The above exception should not be thrown anymore.
- The following blocks should behave as expected: Business Hours, AI Chat, Amazon, Blogroll, Google Docs Embed (Google Docs, Google Sheets, and Google Slides), Recipe, Create with Voice.

