### PR TITLE
Fix Jetpack Sync tests with newest WordPress Core revision mechanisms.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-trunk-8.2-tests
+++ b/projects/plugins/jetpack/changelog/fix-trunk-8.2-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack Sync: fix unit tests to be compatible with the new WordPress Core revision saving mechanism.

--- a/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
+++ b/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
@@ -24,30 +24,48 @@ class Jetpack_Sync_Server_Eventstore {
 		);
 	}
 
-	public function get_all_events( $action_name = null, $blog_id = null ) {
+	/**
+	 * Returns all Sync events of a certain action type, of a certain blog, and filtered if necessary.
+	 *
+	 * @param String   $action_name Sync action slug, e.g. jetpack_sync_save_post.
+	 * @param Integer  $blog_id Blog ID filter - only return events for a given blog ID, defaults to current blog.
+	 * @param Callable $filter a custom callable to pass the event object to to be filtered.
+	 **/
+	public function get_all_events( $action_name = null, $blog_id = null, $filter = null ) {
 		$blog_id = isset( $blog_id ) ? $blog_id : get_current_blog_id();
 
 		if ( ! isset( $this->events[ $blog_id ] ) ) {
 			return array();
 		}
 
-		if ( $action_name ) {
-			$events = array();
+		$events = array();
 
+		if ( $action_name ) {
 			foreach ( $this->events[ $blog_id ] as $event ) {
 				if ( $event->action === $action_name ) {
 					$events[] = $event;
 				}
 			}
-
-			return $events;
+		} else {
+			$events = $this->events[ $blog_id ];
 		}
 
-		return $this->events[ $blog_id ];
+		if ( is_callable( $filter ) ) {
+			$events = array_filter( $events, $filter );
+		}
+
+		return $events;
 	}
 
-	public function get_most_recent_event( $action_name = null, $blog_id = null ) {
-		$events_list = $this->get_all_events( $action_name, $blog_id );
+	/**
+	 * Returns a most recent event of a certain action type, of a certain blog, and filtered if necessary.
+	 *
+	 * @param String   $action_name Sync action slug, e.g. jetpack_sync_save_post.
+	 * @param Integer  $blog_id Blog ID filter - only return events for a given blog ID, defaults to current blog.
+	 * @param Callable $filter a custom callable to pass the event object to to be filtered.
+	 **/
+	public function get_most_recent_event( $action_name = null, $blog_id = null, $filter = null ) {
+		$events_list = $this->get_all_events( $action_name, $blog_id, $filter );
 
 		if ( count( $events_list ) > 0 ) {
 			return $events_list[ count( $events_list ) - 1 ];

--- a/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
+++ b/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
@@ -51,7 +51,7 @@ class Jetpack_Sync_Server_Eventstore {
 		}
 
 		if ( is_callable( $filter ) ) {
-			$events = array_filter( $events, $filter );
+			$events = array_values( array_filter( $events, $filter ) );
 		}
 
 		return $events;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes PHPUnit tests in WordPress trunk.

## Proposed changes:
* Adds a new filtering mechanism to the test event storage class.
* Uses the filtering mechanism to filter out revisions added by [the recent Core change](https://core.trac.wordpress.org/changeset/56714).

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Docker PHPUnit won't work to test this, so you'll have to set up the old fashioned local MySQL server and the WordPress development checkout with the test file.
* Run `WP_DEVELOP_DIR=~/workspace/wordpress-develop/tests/phpunit/ ./vendor/bin/phpunit --filter=WP_Test_Jetpack_Sync_Post`, make sure no tests fail.

