### PR TITLE
Launchpad: Added calypso_path to launchpad task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/added-calypso-path-to-launchpad-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/added-calypso-path-to-launchpad-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added calypso_path to Launchpad task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -102,6 +102,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => '__return_true',
 			'is_disabled_callback' => '__return_true',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/settings/general/' . $data['site_slug_encoded'];
+			},
 		),
 		'site_launched'                   => array(
 			'get_title'             => function () {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/82276

## Proposed changes:
* This PR adds `calypso_path` to the `setup_general` Launchpad task

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See https://github.com/Automattic/wp-calypso/pull/82277
