### PR TITLE
[CRM] Allow users with CRM Admin OR administrator role to access API

### DIFF
--- a/projects/plugins/crm/changelog/crm-update-change-workflows-permissions
+++ b/projects/plugins/crm/changelog/crm-update-change-workflows-permissions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Automations is hidden behind feature flag
+
+

--- a/projects/plugins/crm/src/rest-api/v4/class-rest-automation-workflows-controller.php
+++ b/projects/plugins/crm/src/rest-api/v4/class-rest-automation-workflows-controller.php
@@ -305,7 +305,7 @@ final class REST_Automation_Workflows_Controller extends REST_Base_Controller {
 	 * @return true|WP_Error True if the request has read access for the workflows, WP_Error object otherwise.
 	 */
 	public function get_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$can_user_manage_workflows = zeroBSCRM_isZBSAdmin();
+		$can_user_manage_workflows = zeroBSCRM_isZBSAdminOrAdmin();
 
 		if ( is_wp_error( $can_user_manage_workflows ) ) {
 			return $can_user_manage_workflows;

--- a/projects/plugins/crm/tests/php/rest-api/class-rest-base-test-case.php
+++ b/projects/plugins/crm/tests/php/rest-api/class-rest-base-test-case.php
@@ -34,19 +34,17 @@ abstract class REST_Base_Test_Case extends JPCRM_Base_Integration_Test_Case {
 	}
 
 	/**
-	 * Create WordPress user with the 'zerobs_admin' role.
+	 * Create WordPress user.
 	 *
-	 * @param array $args A list of arguments to create the WP user from.
+	 * This user will use the 'zerobs_admin' role by default and can be used
+	 * to test e.g. API endpoints.
+	 *
+	 * @param array  $args A list of arguments to create the WP user from.
 	 *
 	 * @return int
 	 */
 	public function create_wp_jpcrm_admin( $args = array() ) {
 		$user_id = $this->create_wp_user( $args );
-
-		if ( ! is_wp_error( $user_id ) ) {
-			$user = get_userdata( $user_id );
-			$user->add_role( 'zerobs_admin' );
-		}
 
 		return $user_id;
 	}

--- a/projects/plugins/crm/tests/php/rest-api/v4/class-rest-automation-workflows-controller-test.php
+++ b/projects/plugins/crm/tests/php/rest-api/v4/class-rest-automation-workflows-controller-test.php
@@ -18,6 +18,54 @@ require_once JETPACK_CRM_TESTS_ROOT . '/automation/tools/class-automation-faker.
 class REST_Automation_Workflows_Controller_Test extends REST_Base_Test_Case {
 
 	/**
+	 * DataProvider: Roles.
+	 */
+	public function dataprovider_user_roles(): array {
+		return array(
+			'subscriber'    => array( 'subscriber', false ),
+			'administrator' => array( 'administrator', true ),
+			'zerobs_admin'  => array( 'zerobs_admin', true ),
+		);
+	}
+
+	/**
+	 * Auth: Test that specific roles has access to the API.
+	 *
+	 * We use the simple "get all workflows" endpoint to test this since
+	 * all endpoints currently share the same auth logic.
+	 *
+	 * @see REST_Automation_Workflows_Controller::get_items_permissions_check()
+	 *
+	 * @dataProvider dataprovider_user_roles
+	 */
+	public function test_role_access( $role, $expectation ) {
+		// Create and set authenticated user.
+		$jpcrm_admin_id = $this->create_wp_jpcrm_admin( array( 'role' => $role ) );
+		wp_set_current_user( $jpcrm_admin_id );
+
+		// Make request.
+		$request  = new WP_REST_Request(
+			WP_REST_Server::READABLE,
+			'/jetpack-crm/v4/automation/workflows'
+		);
+		$response = rest_do_request( $request );
+
+		if ( $expectation ) {
+			$this->assertSame(
+				200,
+				$response->get_status(),
+				sprintf( 'Role should be allowed: %s', $role )
+			);
+		} else {
+			$this->assertSame(
+				403,
+				$response->get_status(),
+				sprintf( 'Role should not be allowed: %s', $role )
+			);
+		}
+	}
+
+	/**
 	 * GET Workflows: Test that we can successfully access the endpoint.
 	 *
 	 * @return void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Just a small improvement where normal administrators will be allowed to view the API as well (administrators => super admins).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the permissions for our Workflow APIs

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The new `REST_Automation_Workflows_Controller_Test::test_role_access` automated test should be sufficient.