### PR TITLE
Newsletter categories: exposes value of wpcom_newsletter_categories_location to JavaScript

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-newsletter-categories-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-newsletter-categories-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Expose newsletter_categories_location to JavaScript

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -48,6 +48,8 @@ class Jetpack_Mu_Wpcom {
 		// Load the Map block settings.
 		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_map_block_settings' ), 999 );
 
+		// Load the Newsletter category settings.
+		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_newsletter_categories_settings' ), 999 );
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
 		 *
@@ -141,6 +143,26 @@ class Jetpack_Mu_Wpcom {
 
 		$map_provider = apply_filters( 'wpcom_map_block_map_provider', 'mapbox' );
 		wp_localize_script( 'jetpack-blocks-editor', 'Jetpack_Maps', array( 'provider' => $map_provider ) );
+	}
+
+	/**
+	 * Adds a global variable containing the map provider in a map_block_settings object to the window object.
+	 */
+	public static function load_newsletter_categories_settings() {
+		if (
+			! function_exists( 'get_current_screen' )
+			|| \get_current_screen() === null
+		) {
+			return;
+		}
+
+		// Return early if we are not in the block editor.
+		if ( ! wp_should_load_block_editor_scripts_and_styles() ) {
+			return;
+		}
+
+		$newsletter_categories_location = apply_filters( 'wpcom_newsletter_categories_location', 'block' );
+		wp_localize_script( 'jetpack-blocks-editor', 'Jetpack_Subscriptions', array( 'newsletter_categories_location' => $newsletter_categories_location ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -146,7 +146,7 @@ class Jetpack_Mu_Wpcom {
 	}
 
 	/**
-	 * Adds a global variable containing the where the newsletter categories should be shown.
+	 * Adds a global variable containing where the newsletter categories should be shown.
 	 */
 	public static function load_newsletter_categories_settings() {
 		if (

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -146,7 +146,7 @@ class Jetpack_Mu_Wpcom {
 	}
 
 	/**
-	 * Adds a global variable containing the map provider in a map_block_settings object to the window object.
+	 * Adds a global variable containing the where the newsletter categories should be shown.
 	 */
 	public static function load_newsletter_categories_settings() {
 		if (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82322

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Follow the testing instructions below to apply to your sandbox
- Create a new post
- Inspect the `post-new.php` iframe in your devtools:

![CleanShot 2023-09-28 at 11 30 02@2x](https://github.com/Automattic/jetpack/assets/528287/1b1a0547-db14-4694-a4aa-c0b2d1922479)

- Output the value of `Jetpack_Subscriptions` it should be `block`
- Insert these lines inside `0-sandbox.php` and refresh:

```
function wpcom_newsletter_categories_location() {
	return 'modal';
}

add_filter( 'wpcom_newsletter_categories_location', 'wpcom_newsletter_categories_location', 10 );
```

- `modal` should now be returned
