### PR TITLE
Newsletter Categories: Add conditional rendering for newsletter categories based on the `wpcom_newsletter_categories_location` filter

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-categories-settings-check
+++ b/projects/plugins/jetpack/changelog/add-newsletter-categories-settings-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add conditional rendering for newsletter categories based on the wpcom_newsletter_categories_location filter

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/hooks/use-newsletter-categories.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/hooks/use-newsletter-categories.js
@@ -22,7 +22,13 @@ const useNewsletterCategories = () => {
 			}
 		};
 
-		fetchData();
+		const newsletter_categories_location =
+			window.Jetpack_Subscriptions?.newsletter_categories_location ?? 'block';
+
+		// only fetch newsletter categories if they should be shown in the block (or the setting isn't defined)
+		if ( newsletter_categories_location === 'block' ) {
+			fetchData();
+		}
 	}, [] );
 
 	return { data, enabled, error, loading };

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/hooks/use-newsletter-categories.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/hooks/use-newsletter-categories.js
@@ -28,6 +28,8 @@ const useNewsletterCategories = () => {
 		// only fetch newsletter categories if they should be shown in the block (or the setting isn't defined)
 		if ( newsletter_categories_location === 'block' ) {
 			fetchData();
+		} else {
+			setLoading( false );
 		}
 	}, [] );
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -264,6 +264,12 @@ function fetch_newsletter_categories() {
  * @return array
  */
 function get_newsletter_categories() {
+	// opt out of rendering when we display newsletter catgeories in the subscribe modal
+	$should_render_newsletter_categories = apply_filters( 'wpcom_newsletter_categories_location', 'block' ) === 'block';
+	if ( ! $should_render_newsletter_categories ) {
+		return array();
+	}
+
 	$response = fetch_newsletter_categories();
 
 	if (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82323 

## Proposed changes:
- This PR disabled the rendering of the newsletter categories when the value of wpcom_newsletter_categories_location is something else than "block"

The changes are twofold:
1. When rendering the block on a site (with PHP), the filter value is checked in the part of the code that fetched the newsletter categories. If the filter value is something else than "block" (which is the default value when undefined), an empty array is returned. This empty array prevents the block from rendering inside `render_newsletter_categories`.
2. In the editor, the value of `window.Jetpack_Subscriptions?.newsletter_categories_location` is read inside the `useNewsletterCategories` hook. This property contains the value of the wpcom_newsletter_categories_location filter (see #33374). If this value is not set we set it to `block`, otherwise we use the defined value. The newsletter category data is only fetched when this value is set to block. Without data being fetched, the pills won't render.

After we've made the switch to show the categories in the Subscribe Modal, we'll do a follow-up PR to remove all traces of newsletter categories in the subscribe block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add this PR to your sandbox, following the instructions below
2. Enable newsletter categories & select some categories
3. Add a subscribe block: newsletter categories should show in the editor & the site itself
4. Also apply this jetpack-mu-wpcom PR to your sandbox by following the testing instructions: #33374
5. Add this to `0-sandbox.php`:

```
function wpcom_newsletter_categories_location() {
	return 'modal';
}

add_filter( 'wpcom_newsletter_categories_location', 'wpcom_newsletter_categories_location', 10 );
```
6. Newsletter categories should be gone in both the editor & the site itself
7. Change to:

```
function wpcom_newsletter_categories_location() {
	return 'block';
}

add_filter( 'wpcom_newsletter_categories_location', 'wpcom_newsletter_categories_location', 10 );
```

8. The newsletter categories should show in the editor & the site itself