### PR TITLE
AI Excerpt: do not save the post before tp request the excerpt

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-do-not-save-post
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-do-not-save-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: do not save the post before tp request the excerpt

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -18,7 +18,6 @@ import React from 'react';
  */
 import UpgradePrompt from '../../../../blocks/ai-assistant/components/upgrade-prompt';
 import { isBetaExtension } from '../../../../editor';
-import useAutosaveAndRedirect from '../../../../shared/use-autosave-and-redirect';
 import { AiExcerptControl } from '../../components/ai-excerpt-control';
 /**
  * Types and constants
@@ -46,9 +45,6 @@ function AiPostExcerpt() {
 		select => select( 'core/editor' ).getEditedPostAttribute( 'excerpt' ),
 		[]
 	);
-
-	// Use the hook only to get the autosave function. It won't be used for redirect.
-	const { autosave } = useAutosaveAndRedirect();
 
 	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId(), [] );
 	const { editPost } = useDispatch( 'core/editor' );
@@ -112,12 +108,9 @@ function AiPostExcerpt() {
 	/**
 	 * Request AI for a new excerpt.
 	 *
-	 * @param {React.MouseEvent} ev - The click event.
 	 * @returns {void}
 	 */
-	async function requestExcerpt( ev: React.MouseEvent ): Promise< void > {
-		await autosave( ev );
-
+	function requestExcerpt(): void {
 		// Enable Generate button
 		setReenable( false );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When we started to work on this feature, the idea was to be able to collect the post content from the server. In order to guarantee to get the content updated, the app saves the post just before requesting the excerpt.
Now, since the post content is added in the request payload, we don't need to save the post.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: do not save the post before tp request the excerpt

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Use the AI Excerpt feature
* It should work as expect 
* Confirm that the post is not saved before to request the excert 

<img width="691" alt="Screenshot 2023-09-28 at 08 52 45" src="https://github.com/Automattic/jetpack/assets/77539/3d51707d-b50a-41b7-93ab-ec4693129312">

* Additionally, you could check the request send the post content

<img width="676" alt="Screenshot 2023-09-28 at 08 53 36" src="https://github.com/Automattic/jetpack/assets/77539/7bb49f60-451e-4fe5-9d22-1371132d9806">

