### PR TITLE
Boost: Remove global state from from critical css related components

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CloudCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CloudCssMeta.svelte
@@ -5,13 +5,14 @@
 		criticalCssState,
 		isFatalError,
 	} from '../../../stores/critical-css-state';
-	import { criticalCssIssues } from '../../../stores/critical-css-state-errors';
+	import { criticalCssIssues, primaryErrorSet } from '../../../stores/critical-css-state-errors';
 	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
 	import { modulesState } from '../../../stores/modules';
 	import CriticalCssShowStopperError from './CriticalCssShowStopperError.svelte';
 	import CriticalCssStatus from './CriticalCssStatus.svelte';
 
 	$: status = $criticalCssState.status;
+	$: criticalCssStatusError = $criticalCssState.status_error;
 	$: successCount = $criticalCssState.providers.filter(
 		provider => provider.status === 'success'
 	).length;
@@ -23,7 +24,12 @@
 </script>
 
 {#if $isFatalError}
-	<CriticalCssShowStopperError supportLink="https://jetpackme.wordpress.com/contact-support/" />
+	<CriticalCssShowStopperError
+		supportLink="https://jetpackme.wordpress.com/contact-support/"
+		{status}
+		primaryErrorSet={$primaryErrorSet}
+		statusError={criticalCssStatusError}
+	/>
 {:else}
 	<CriticalCssStatus
 		{isCloudCssAvailable}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CloudCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CloudCssMeta.svelte
@@ -1,14 +1,38 @@
 <script lang="ts">
 	import { __ } from '@wordpress/i18n';
-	import { isFatalError } from '../../../stores/critical-css-state';
+	import {
+		criticalCssProgress,
+		criticalCssState,
+		isFatalError,
+	} from '../../../stores/critical-css-state';
+	import { criticalCssIssues } from '../../../stores/critical-css-state-errors';
+	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
+	import { modulesState } from '../../../stores/modules';
 	import CriticalCssShowStopperError from './CriticalCssShowStopperError.svelte';
 	import CriticalCssStatus from './CriticalCssStatus.svelte';
+
+	$: status = $criticalCssState.status;
+	$: successCount = $criticalCssState.providers.filter(
+		provider => provider.status === 'success'
+	).length;
+	$: updated = $criticalCssState.updated;
+	$: isCloudCssAvailable = $modulesState.cloud_css?.available;
+	$: issues = $criticalCssIssues;
+	$: progress = $criticalCssProgress;
+	$: suggestRegenerate = suggestRegenerateDS.store;
 </script>
 
 {#if $isFatalError}
 	<CriticalCssShowStopperError supportLink="https://jetpackme.wordpress.com/contact-support/" />
 {:else}
 	<CriticalCssStatus
+		{isCloudCssAvailable}
+		{status}
+		{successCount}
+		{issues}
+		{updated}
+		{progress}
+		{suggestRegenerate}
 		generateText={__(
 			'Jetpack Boost will generate Critical CSS for you automatically.',
 			'jetpack-boost'

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CloudCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CloudCssMeta.svelte
@@ -1,43 +1,35 @@
 <script lang="ts">
 	import { __ } from '@wordpress/i18n';
-	import {
-		criticalCssProgress,
-		criticalCssState,
-		isFatalError,
-	} from '../../../stores/critical-css-state';
-	import { criticalCssIssues, primaryErrorSet } from '../../../stores/critical-css-state-errors';
-	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
-	import { modulesState } from '../../../stores/modules';
+	import { CriticalCssState } from '../../../stores/critical-css-state-types';
 	import CriticalCssShowStopperError from './CriticalCssShowStopperError.svelte';
 	import CriticalCssStatus from './CriticalCssStatus.svelte';
 
-	$: status = $criticalCssState.status;
-	$: criticalCssStatusError = $criticalCssState.status_error;
-	$: successCount = $criticalCssState.providers.filter(
-		provider => provider.status === 'success'
-	).length;
-	$: updated = $criticalCssState.updated;
-	$: isCloudCssAvailable = $modulesState.cloud_css?.available;
-	$: issues = $criticalCssIssues;
-	$: progress = $criticalCssProgress;
-	$: suggestRegenerate = suggestRegenerateDS.store;
+	export let cssState: CriticalCssState;
+	export let isCloudCssAvailable: boolean;
+	export let criticalCssProgress: number;
+	export let issues: CriticalCssState[ 'providers' ] = [];
+	export let isFatalError: boolean;
+	export let primaryErrorSet;
+	export let suggestRegenerate;
+
+	$: successCount = cssState.providers.filter( provider => provider.status === 'success' ).length;
 </script>
 
-{#if $isFatalError}
+{#if isFatalError}
 	<CriticalCssShowStopperError
 		supportLink="https://jetpackme.wordpress.com/contact-support/"
-		{status}
-		primaryErrorSet={$primaryErrorSet}
-		statusError={criticalCssStatusError}
+		status={cssState.status}
+		{primaryErrorSet}
+		statusError={cssState.status_error}
 	/>
 {:else}
 	<CriticalCssStatus
 		{isCloudCssAvailable}
-		{status}
+		status={cssState.status}
 		{successCount}
 		{issues}
-		{updated}
-		{progress}
+		updated={cssState.updated}
+		progress={criticalCssProgress}
 		{suggestRegenerate}
 		generateText={__(
 			'Jetpack Boost will generate Critical CSS for you automatically.',

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CloudCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CloudCssMeta.svelte
@@ -11,6 +11,7 @@
 	export let isFatalError: boolean;
 	export let primaryErrorSet;
 	export let suggestRegenerate;
+	export let regenerateCriticalCss;
 
 	$: successCount = cssState.providers.filter( provider => provider.status === 'success' ).length;
 </script>
@@ -21,6 +22,7 @@
 		status={cssState.status}
 		{primaryErrorSet}
 		statusError={cssState.status_error}
+		{regenerateCriticalCss}
 	/>
 {:else}
 	<CriticalCssStatus

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
@@ -7,11 +7,24 @@
 		criticalCssState,
 		isFatalError,
 	} from '../../../stores/critical-css-state';
+	import { criticalCssIssues } from '../../../stores/critical-css-state-errors';
+	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
+	import { modulesState } from '../../../stores/modules';
 	import CriticalCssShowStopperError from './CriticalCssShowStopperError.svelte';
 	import CriticalCssStatus from './CriticalCssStatus.svelte';
+
+	$: status = $criticalCssState.status;
+	$: successCount = $criticalCssState.providers.filter(
+		provider => provider.status === 'success'
+	).length;
+	$: updated = $criticalCssState.updated;
+	$: isCloudCssAvailable = $modulesState.cloud_css?.available;
+	$: issues = $criticalCssIssues;
+	$: progress = $criticalCssProgress;
+	$: suggestRegenerate = suggestRegenerateDS.store;
 </script>
 
-{#if $criticalCssState.status === 'pending'}
+{#if status === 'pending'}
 	<div class="jb-critical-css-progress">
 		<ProgressActivityLabel>
 			{__(
@@ -24,5 +37,13 @@
 {:else if $isFatalError}
 	<CriticalCssShowStopperError />
 {:else}
-	<CriticalCssStatus />
+	<CriticalCssStatus
+		{isCloudCssAvailable}
+		{status}
+		{successCount}
+		{updated}
+		{issues}
+		{progress}
+		{suggestRegenerate}
+	/>
 {/if}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
@@ -2,30 +2,22 @@
 	import { __ } from '@wordpress/i18n';
 	import ProgressActivityLabel from '../../../elements/ProgressActivityLabel.svelte';
 	import ProgressBar from '../../../elements/ProgressBar.svelte';
-	import {
-		criticalCssProgress,
-		criticalCssState,
-		isFatalError,
-	} from '../../../stores/critical-css-state';
-	import { criticalCssIssues, primaryErrorSet } from '../../../stores/critical-css-state-errors';
-	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
-	import { modulesState } from '../../../stores/modules';
+	import { CriticalCssState } from '../../../stores/critical-css-state-types';
 	import CriticalCssShowStopperError from './CriticalCssShowStopperError.svelte';
 	import CriticalCssStatus from './CriticalCssStatus.svelte';
 
-	$: status = $criticalCssState.status;
-	$: criticalCssStatusError = $criticalCssState.status_error;
-	$: successCount = $criticalCssState.providers.filter(
-		provider => provider.status === 'success'
-	).length;
-	$: updated = $criticalCssState.updated;
-	$: isCloudCssAvailable = $modulesState.cloud_css?.available;
-	$: issues = $criticalCssIssues;
-	$: progress = $criticalCssProgress;
-	$: suggestRegenerate = suggestRegenerateDS.store;
+	export let cssState: CriticalCssState;
+	export let isCloudCssAvailable: boolean;
+	export let criticalCssProgress: number;
+	export let issues: CriticalCssState[ 'providers' ] = [];
+	export let isFatalError: boolean;
+	export let primaryErrorSet;
+	export let suggestRegenerate;
+
+	$: successCount = cssState.providers.filter( provider => provider.status === 'success' ).length;
 </script>
 
-{#if status === 'pending'}
+{#if cssState.status === 'pending'}
 	<div class="jb-critical-css-progress">
 		<ProgressActivityLabel>
 			{__(
@@ -33,22 +25,22 @@
 				'jetpack-boost'
 			)}
 		</ProgressActivityLabel>
-		<ProgressBar progress={$criticalCssProgress} />
+		<ProgressBar progress={criticalCssProgress} />
 	</div>
-{:else if $isFatalError}
+{:else if isFatalError}
 	<CriticalCssShowStopperError
-		{status}
-		primaryErrorSet={$primaryErrorSet}
-		statusError={criticalCssStatusError}
+		status={cssState.status}
+		{primaryErrorSet}
+		statusError={cssState.status_error}
 	/>
 {:else}
 	<CriticalCssStatus
 		{isCloudCssAvailable}
-		{status}
+		status={cssState.status}
 		{successCount}
-		{updated}
+		updated={cssState.updated}
 		{issues}
-		{progress}
+		progress={criticalCssProgress}
 		{suggestRegenerate}
 	/>
 {/if}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
@@ -13,6 +13,7 @@
 	export let isFatalError: boolean;
 	export let primaryErrorSet;
 	export let suggestRegenerate;
+	export let regenerateCriticalCss;
 
 	$: successCount = cssState.providers.filter( provider => provider.status === 'success' ).length;
 </script>
@@ -32,6 +33,7 @@
 		status={cssState.status}
 		{primaryErrorSet}
 		statusError={cssState.status_error}
+		{regenerateCriticalCss}
 	/>
 {:else}
 	<CriticalCssStatus

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
@@ -7,13 +7,14 @@
 		criticalCssState,
 		isFatalError,
 	} from '../../../stores/critical-css-state';
-	import { criticalCssIssues } from '../../../stores/critical-css-state-errors';
+	import { criticalCssIssues, primaryErrorSet } from '../../../stores/critical-css-state-errors';
 	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
 	import { modulesState } from '../../../stores/modules';
 	import CriticalCssShowStopperError from './CriticalCssShowStopperError.svelte';
 	import CriticalCssStatus from './CriticalCssStatus.svelte';
 
 	$: status = $criticalCssState.status;
+	$: criticalCssStatusError = $criticalCssState.status_error;
 	$: successCount = $criticalCssState.providers.filter(
 		provider => provider.status === 'success'
 	).length;
@@ -35,7 +36,11 @@
 		<ProgressBar progress={$criticalCssProgress} />
 	</div>
 {:else if $isFatalError}
-	<CriticalCssShowStopperError />
+	<CriticalCssShowStopperError
+		{status}
+		primaryErrorSet={$primaryErrorSet}
+		statusError={criticalCssStatusError}
+	/>
 {:else}
 	<CriticalCssStatus
 		{isCloudCssAvailable}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
@@ -8,7 +8,6 @@
 	import { __ } from '@wordpress/i18n';
 	import ErrorNotice from '../../../elements/ErrorNotice.svelte';
 	import FoldingElement from '../../../elements/FoldingElement.svelte';
-	import { regenerateCriticalCss } from '../../../stores/critical-css-state';
 	import { CriticalCssState } from '../../../stores/critical-css-state-types';
 	import CriticalCssErrorDescription from './CriticalCssErrorDescription.svelte';
 
@@ -16,6 +15,7 @@
 	export let status: CriticalCssState[ 'status' ];
 	export let primaryErrorSet;
 	export let statusError;
+	export let regenerateCriticalCss;
 
 	// Show a Provider Key error if the process succeeded but there were errors.
 	$: showProviderError = primaryErrorSet && status === 'generated';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
@@ -8,15 +8,18 @@
 	import { __ } from '@wordpress/i18n';
 	import ErrorNotice from '../../../elements/ErrorNotice.svelte';
 	import FoldingElement from '../../../elements/FoldingElement.svelte';
-	import { criticalCssState, regenerateCriticalCss } from '../../../stores/critical-css-state';
-	import { primaryErrorSet } from '../../../stores/critical-css-state-errors';
+	import { regenerateCriticalCss } from '../../../stores/critical-css-state';
+	import { CriticalCssState } from '../../../stores/critical-css-state-types';
 	import CriticalCssErrorDescription from './CriticalCssErrorDescription.svelte';
 
 	export let supportLink = 'https://wordpress.org/support/plugin/jetpack-boost/';
+	export let status: CriticalCssState[ 'status' ];
+	export let primaryErrorSet;
+	export let statusError;
 
 	// Show a Provider Key error if the process succeeded but there were errors.
-	let showingProviderError = false;
-	$: showingProviderError = $primaryErrorSet && $criticalCssState.status === 'generated';
+	$: showProviderError = primaryErrorSet && status === 'generated';
+
 	onDestroy( () => {
 		firstTime = false;
 	} );
@@ -36,21 +39,21 @@
 			  )}
 	</p>
 
-	{#if showingProviderError || $criticalCssState.status_error}
+	{#if showProviderError || statusError}
 		<FoldingElement
 			showLabel={__( 'See error message', 'jetpack-boost' )}
 			hideLabel={__( 'Hide error message', 'jetpack-boost' )}
 		>
 			<div class="raw-error" transition:slide|local>
-				{#if showingProviderError}
+				{#if showProviderError}
 					<CriticalCssErrorDescription
-						errorSet={$primaryErrorSet}
+						errorSet={primaryErrorSet}
 						showSuggestion={true}
 						showClosingParagraph={false}
 						foldRawErrors={false}
 					/>
 				{:else}
-					{$criticalCssState.status_error}
+					{statusError}
 				{/if}
 			</div>
 		</FoldingElement>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -2,27 +2,24 @@
 	import { __, _n, sprintf } from '@wordpress/i18n';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
 	import TimeAgo from '../../../elements/TimeAgo.svelte';
-	import {
-		criticalCssProgress,
-		criticalCssState,
-		regenerateCriticalCss,
-	} from '../../../stores/critical-css-state';
-	import { criticalCssIssues } from '../../../stores/critical-css-state-errors';
-	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
-	import { modulesState } from '../../../stores/modules';
+	import { regenerateCriticalCss } from '../../../stores/critical-css-state';
+	import { CriticalCssState } from '../../../stores/critical-css-state-types';
 	import InfoIcon from '../../../svg/info.svg';
 	import RefreshIcon from '../../../svg/refresh.svg';
 	import actionLinkTemplateVar from '../../../utils/action-link-template-var';
 	import routerHistory from '../../../utils/router-history';
 
+	export let status: CriticalCssState[ 'status' ];
+	export let successCount = 0;
+	export let updated: CriticalCssState[ 'updated' ];
+	export let isCloudCssAvailable = false;
+	export let issues: CriticalCssState[ 'providers' ] = [];
+	export let progress: number;
+	export let suggestRegenerate;
 	export let generateText = '';
 	export let generateMoreText = '';
-	const { navigate } = routerHistory;
-	const suggestRegenerate = suggestRegenerateDS.store;
 
-	$: successCount = $criticalCssState.providers.filter(
-		provider => provider.status === 'success'
-	).length;
+	const { navigate } = routerHistory;
 </script>
 
 <div class="jb-critical-css__meta">
@@ -36,21 +33,21 @@
 					_n( '%d file generated', '%d files generated', successCount, 'jetpack-boost' ),
 					successCount
 				)}
-				{#if $criticalCssState.updated}
-					<TimeAgo time={new Date( $criticalCssState.updated * 1000 )} />.
+				{#if updated}
+					<TimeAgo time={new Date( updated * 1000 )} />.
 				{/if}
-				{#if ! $modulesState.cloud_css?.available}
+				{#if ! isCloudCssAvailable}
 					{__(
 						'Remember to regenerate each time you make changes that affect your HTML or CSS structure.',
 						'jetpack-boost'
 					)}
 				{/if}
-				{#if $criticalCssProgress < 100}
+				{#if progress < 100}
 					<span>{generateMoreText}</span>
 				{/if}
 			</div>
 
-			{#if $criticalCssState.status !== 'pending' && $criticalCssIssues.length > 0}
+			{#if status !== 'pending' && issues.length > 0}
 				<div class="failures">
 					<InfoIcon />
 
@@ -60,10 +57,10 @@
 							_n(
 								'%d file could not be automatically generated. Visit the <advanced>advanced recommendations page</advanced> to optimize this file.',
 								'%d files could not be automatically generated. Visit the <advanced>advanced recommendations page</advanced> to optimize these files.',
-								$criticalCssIssues.length,
+								issues.length,
 								'jetpack-boost'
 							),
-							$criticalCssIssues.length
+							issues.length
 						)}
 						vars={{
 							...actionLinkTemplateVar( () => navigate( 'critical-css-advanced' ), 'advanced' ),
@@ -73,11 +70,11 @@
 			{/if}
 		{/if}
 	</div>
-	{#if $criticalCssState.status !== 'pending'}
+	{#if status !== 'pending'}
 		<button
 			type="button"
 			class="components-button"
-			class:is-link={! $suggestRegenerate || $modulesState.cloud_css?.available}
+			class:is-link={! suggestRegenerate || isCloudCssAvailable}
 			on:click={regenerateCriticalCss}
 		>
 			<RefreshIcon />

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -18,7 +18,10 @@
 		criticalCssState,
 		continueGeneratingLocalCriticalCss,
 		regenerateCriticalCss,
+		criticalCssProgress,
+		isFatalError,
 	} from '../../../stores/critical-css-state';
+	import { criticalCssIssues, primaryErrorSet } from '../../../stores/critical-css-state-errors';
 	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
 	import { imageCdnQuality } from '../../../stores/image-cdn';
 	import { minifyJsExcludesStore, minifyCssExcludesStore } from '../../../stores/minify';
@@ -102,7 +105,15 @@
 		</div>
 
 		<div slot="meta">
-			<CriticalCssMeta />
+			<CriticalCssMeta
+				cssState={$criticalCssState}
+				isCloudCssAvailable={$modulesState.cloud_css?.available}
+				criticalCssProgress={$criticalCssProgress}
+				issues={$criticalCssIssues}
+				isFatalError={$isFatalError}
+				primaryErrorSet={$primaryErrorSet}
+				suggestRegenerate={$suggestRegenerate}
+			/>
 		</div>
 
 		<div slot="notice">

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -169,7 +169,15 @@
 		</div>
 
 		<div slot="meta" class="jb-feature-toggle__meta">
-			<CloudCssMeta />
+			<CloudCssMeta
+				cssState={$criticalCssState}
+				isCloudCssAvailable={$modulesState.cloud_css?.available}
+				criticalCssProgress={$criticalCssProgress}
+				issues={$criticalCssIssues}
+				isFatalError={$isFatalError}
+				primaryErrorSet={$primaryErrorSet}
+				suggestRegenerate={$suggestRegenerate}
+			/>
 		</div>
 	</Module>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -113,6 +113,7 @@
 				isFatalError={$isFatalError}
 				primaryErrorSet={$primaryErrorSet}
 				suggestRegenerate={$suggestRegenerate}
+				{regenerateCriticalCss}
 			/>
 		</div>
 
@@ -177,6 +178,7 @@
 				isFatalError={$isFatalError}
 				primaryErrorSet={$primaryErrorSet}
 				suggestRegenerate={$suggestRegenerate}
+				{regenerateCriticalCss}
 			/>
 		</div>
 	</Module>

--- a/projects/plugins/boost/changelog/boost-react-critical-css-components
+++ b/projects/plugins/boost/changelog/boost-react-critical-css-components
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove state from critical css related components by moving it to the parent.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove state from CriticalCssStatus, CriticalCssShowStopperError, CriticalCssMeta and CloudCssMeta;
* State is now passed down from ancestors.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-286-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure that Critical/Cloud CSS generation works as expected and the UI behaves properly.
* You can cause the show stopper error to show up by causing the front-end to error 500.