### PR TITLE
AI Chat: Better state handling, better error handling

### DIFF
--- a/projects/plugins/jetpack/changelog/sitebot-erros-2
+++ b/projects/plugins/jetpack/changelog/sitebot-erros-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enhanced error presentation for ai chat

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/components/display-error/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/components/display-error/index.js
@@ -1,10 +1,9 @@
 import { __ } from '@wordpress/i18n';
 
-export default function DisplayError( { error } ) {
+export default function DisplayError() {
 	return (
 		<div className="jetpack-ai-chat-error-container">
-			{ __( 'Sorry, there was an error: ', 'jetpack' ) }
-			{ error.message }
+			{ __( 'There was an error while generating the answer. Please try again later.', 'jetpack' ) }
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
@@ -47,6 +47,7 @@ function ShowLittleByLittle( { html, showAnimation, onAnimationDone } ) {
 				}, 50 * tokens.length );
 			} else {
 				setDisplayedRawHTML( html );
+				onAnimationDone();
 			}
 		},
 		// eslint-disable-next-line

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
@@ -7,7 +7,7 @@ import { useState } from '@wordpress/element';
 export default function useSubmitQuestion( blogType, blogId ) {
 	const [ question, setQuestion ] = useState( '' );
 
-	const [ answer, setAnswer ] = useState();
+	const [ answer, setAnswer ] = useState( null );
 	const [ cacheKey, setCacheKey ] = useState( '' );
 	const [ askError, setAskError ] = useState( false );
 	const [ references, setReferences ] = useState( [] );
@@ -31,6 +31,9 @@ export default function useSubmitQuestion( blogType, blogId ) {
 				setReferences( res.urls );
 			} )
 			.catch( err => {
+				setCacheKey( '' );
+				setAnswer( null );
+				setReferences( [] );
 				setAskError( err );
 			} )
 			.finally( () => {


### PR DESCRIPTION
This PR fixes a few state inconsistencies found in Call for testing

## Proposed changes:
* Solves #33335 
* Clears out details of previous answer when new one is submitted
* All around state management
* Stop displaying the backend error message. I don't think we should be showing it on the frontend of the site, as the user cannot really do anything.


<img width="705" alt="Zrzut ekranu 2023-09-28 o 19 12 55" src="https://github.com/Automattic/jetpack/assets/3775068/ee4fec99-2c9f-4d32-b9d3-4b477488c896">




## Does this pull request change what data or activity we track or use?
NO

## Testing instructions:
* Check out everything, sandbox
* Break the endpoint
* See result,
* Submit different question, see error cleared
* 

