### PR TITLE
[CRM] Add static workflow step data to API responses

### DIFF
--- a/projects/plugins/crm/changelog/crm-update-add-missing-step-data-to-api
+++ b/projects/plugins/crm/changelog/crm-update-add-missing-step-data-to-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Automations is hidden behind feature flag
+
+

--- a/projects/plugins/crm/src/automation/class-base-condition.php
+++ b/projects/plugins/crm/src/automation/class-base-condition.php
@@ -25,22 +25,6 @@ abstract class Base_Condition extends Base_Step implements Condition {
 	protected $logger;
 
 	/**
-	 * The next step if the condition is met.
-	 *
-	 * @since $$next-version$$
-	 * @var array|null
-	 */
-	protected $next_step_true = null;
-
-	/**
-	 * The next step if the condition is not met.
-	 *
-	 * @since $$next-version$$
-	 * @var array|null
-	 */
-	protected $next_step_false = null;
-
-	/**
 	 * If the condition is met or not.
 	 *
 	 * @since $$next-version$$
@@ -66,9 +50,7 @@ abstract class Base_Condition extends Base_Step implements Condition {
 	public function __construct( array $step_data ) {
 		parent::__construct( $step_data );
 
-		$this->next_step_true  = $step_data['next_step_true'] ?? null;
-		$this->next_step_false = $step_data['next_step_false'] ?? null;
-		$this->logger          = Automation_Logger::instance();
+		$this->logger = Automation_Logger::instance();
 	}
 
 	/**
@@ -76,9 +58,9 @@ abstract class Base_Condition extends Base_Step implements Condition {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int|null The next step data.
+	 * @return string|int|null The next step data.
 	 */
-	public function get_next_step_id(): ?int {
+	public function get_next_step_id() {
 		return ( $this->condition_met ? $this->next_step_true : $this->next_step_false );
 	}
 

--- a/projects/plugins/crm/src/automation/class-base-step.php
+++ b/projects/plugins/crm/src/automation/class-base-step.php
@@ -35,12 +35,20 @@ abstract class Base_Step implements Step {
 	protected $attribute_definitions = array();
 
 	/**
-	 * Next linked step.
+	 * The next step if the current one is successful.
 	 *
 	 * @since $$next-version$$
 	 * @var int|string|null
 	 */
-	protected $next_step_id = null;
+	protected $next_step_true = null;
+
+	/**
+	 * The next step if not successful.
+	 *
+	 * @since $$next-version$$
+	 * @var int|string|null
+	 */
+	protected $next_step_false = null;
 
 	/**
 	 * Base_Step constructor.
@@ -50,7 +58,9 @@ abstract class Base_Step implements Step {
 	 * @param array $step_data An array of data for the current step.
 	 */
 	public function __construct( array $step_data ) {
-		$this->attributes = $step_data['attributes'] ?? array();
+		$this->attributes      = $step_data['attributes'] ?? array();
+		$this->next_step_true  = $step_data['next_step_true'] ?? null;
+		$this->next_step_false = $step_data['next_step_false'] ?? null;
 	}
 
 	/**
@@ -98,25 +108,62 @@ abstract class Base_Step implements Step {
 	}
 
 	/**
-	 * Set the next step.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param int|string|null $step_id The next linked step id.
-	 */
-	public function set_next_step( $step_id ) {
-		$this->next_step = $step_id;
-	}
-
-	/**
 	 * Get the next step.
+	 *
+	 * Unless anything else is defined, then we assume to only continue with the
+	 * next step if the current one is successful.
+	 * One example of this will be conditions where a certain criteria has not been met.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @return int|string|null The next linked step id.
 	 */
 	public function get_next_step_id() {
-		return $this->next_step_id;
+		return $this->get_next_step_true();
+	}
+
+	/**
+	 * Get the next step if the current one is successful.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int|string|null The next linked step id.
+	 */
+	public function get_next_step_true() {
+		return $this->next_step_true;
+	}
+
+	/**
+	 * Set the next step if the current one is successful.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int|string|null The next linked step id.
+	 */
+	public function set_next_step_true() {
+		return $this->next_step_true;
+	}
+
+	/**
+	 * Get the next step if the current one is falsy.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int|string|null The next linked step id.
+	 */
+	public function get_next_step_false() {
+		return $this->next_step_false;
+	}
+
+	/**
+	 * Set the next step if the current one is falsy.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int|string|null The next linked step id.
+	 */
+	public function set_next_step_false() {
+		return $this->next_step_false;
 	}
 
 	/**
@@ -192,4 +239,33 @@ abstract class Base_Step implements Step {
 	 * @return string|null The category of the step.
 	 */
 	abstract public static function get_category(): ?string;
+
+	/**
+	 * Get the step as an array.
+	 *
+	 * The main use-case to get the step as an array is to prepare
+	 * the items for an API response.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array The step as an array.
+	 */
+	public function to_array(): array {
+		$step = array(
+			'title'                 => static::get_title(),
+			'description'           => static::get_description(),
+			'slug'                  => static::get_slug(),
+			'category'              => static::get_category(),
+			'next_step_true'        => $this->get_next_step_true(),
+			'next_step_false'       => $this->get_next_step_false(),
+			'attributes'            => $this->get_attributes(),
+			'attribute_definitions' => array(),
+		);
+
+		foreach ( $this->get_attribute_definitions() as $attribute_definition ) {
+			$step['attribute_definitions'][ $attribute_definition->get_slug() ] = $attribute_definition->to_array();
+		}
+
+		return $step;
+	}
 }

--- a/projects/plugins/crm/src/automation/class-base-step.php
+++ b/projects/plugins/crm/src/automation/class-base-step.php
@@ -138,10 +138,11 @@ abstract class Base_Step implements Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int|string|null The next linked step id.
+	 * @param string|int|null $step_id The next linked step id.
+	 * @return void
 	 */
-	public function set_next_step_true() {
-		return $this->next_step_true;
+	public function set_next_step_true( $step_id ): void {
+		$this->next_step_true = $step_id;
 	}
 
 	/**
@@ -160,10 +161,11 @@ abstract class Base_Step implements Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int|string|null The next linked step id.
+	 * @param string|int|null $step_id The next linked step id.
+	 * @return void
 	 */
-	public function set_next_step_false() {
-		return $this->next_step_false;
+	public function set_next_step_false( $step_id ): void {
+		$this->next_step_false = $step_id;
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/class-base-step.php
+++ b/projects/plugins/crm/src/automation/class-base-step.php
@@ -256,6 +256,7 @@ abstract class Base_Step implements Step {
 			'description'           => static::get_description(),
 			'slug'                  => static::get_slug(),
 			'category'              => static::get_category(),
+			'step_type'             => is_subclass_of( $this, Action::class ) ? 'action' : 'condition',
 			'next_step_true'        => $this->get_next_step_true(),
 			'next_step_false'       => $this->get_next_step_false(),
 			'attributes'            => $this->get_attributes(),

--- a/projects/plugins/crm/src/automation/interface-step.php
+++ b/projects/plugins/crm/src/automation/interface-step.php
@@ -36,13 +36,40 @@ interface Step {
 	public function get_next_step_id();
 
 	/**
-	 * Set the next step.
+	 * Get the next step if the current one is successful.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param int|string|null $step_id The next linked step.
+	 * @return int|string|null The next linked step id.
 	 */
-	public function set_next_step( $step_id );
+	public function get_next_step_true();
+
+	/**
+	 * Set the next step if the current one is successful.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int|string|null The next linked step id.
+	 */
+	public function set_next_step_true();
+
+	/**
+	 * Get the next step if the current one is falsy.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int|string|null The next linked step id.
+	 */
+	public function get_next_step_false();
+
+	/**
+	 * Set the next step if the current one is falsy.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int|string|null The next linked step id.
+	 */
+	public function set_next_step_false();
 
 	/**
 	 * Get the step attribute definitions.
@@ -124,4 +151,16 @@ interface Step {
 	 * @return string|null The category of the step.
 	 */
 	public static function get_category(): ?string;
+
+	/**
+	 * Get the step as an array.
+	 *
+	 * The main use-case to get the step as an array is to prepare
+	 * the items for an API response.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array The step as an array.
+	 */
+	public function to_array(): array;
 }

--- a/projects/plugins/crm/src/automation/interface-step.php
+++ b/projects/plugins/crm/src/automation/interface-step.php
@@ -49,9 +49,10 @@ interface Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int|string|null The next linked step id.
+	 * @param string|int|null $step_id The next linked step id.
+	 * @return void
 	 */
-	public function set_next_step_true();
+	public function set_next_step_true( $step_id ): void;
 
 	/**
 	 * Get the next step if the current one is falsy.
@@ -67,9 +68,10 @@ interface Step {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int|string|null The next linked step id.
+	 * @param string|int|null $step_id The next linked step id.
+	 * @return void
 	 */
-	public function set_next_step_false();
+	public function set_next_step_false( $step_id ): void;
 
 	/**
 	 * Get the step attribute definitions.

--- a/projects/plugins/crm/src/rest-api/v4/class-rest-automation-workflows-controller.php
+++ b/projects/plugins/crm/src/rest-api/v4/class-rest-automation-workflows-controller.php
@@ -363,15 +363,11 @@ final class REST_Automation_Workflows_Controller extends REST_Base_Controller {
 			$workflow = $workflow->to_array();
 		}
 
-		// Append attribute definitions to each step.
+		// Provide full context about steps (title, description, attribute definitions, etc.).
 		if ( is_array( $workflow['steps'] ) ) {
 			foreach ( $workflow['steps'] as $index => $step ) {
-				$workflow['steps'][ $index ]['attribute_definitions'] = array();
-
-				$hydrated_step = $this->automation_engine->get_registered_step( $step );
-				foreach ( $hydrated_step->get_attribute_definitions() as $attribute_definition ) {
-					$workflow['steps'][ $index ]['attribute_definitions'][ $attribute_definition->get_slug() ] = $attribute_definition->to_array();
-				}
+				$hydrated_step               = $this->automation_engine->get_registered_step( $step );
+				$workflow['steps'][ $index ] = $hydrated_step->to_array();
 			}
 		}
 

--- a/projects/plugins/crm/tests/php/automation/class-automation-workflow-test.php
+++ b/projects/plugins/crm/tests/php/automation/class-automation-workflow-test.php
@@ -8,6 +8,7 @@ use Automattic\Jetpack\CRM\Automation\Automation_Logger;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Contact_Data;
+use Automattic\Jetpack\CRM\Automation\Tests\Mocks\Contact_Condition;
 use Automattic\Jetpack\CRM\Automation\Tests\Mocks\Dummy_Step;
 use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Updated;
 use Automattic\Jetpack\CRM\Automation\Workflow_Exception;
@@ -275,6 +276,7 @@ class Automation_Workflow_Test extends JPCRM_Base_Test_Case {
 		$automation = new Automation_Engine();
 		$automation->set_automation_logger( $logger );
 		$automation->register_trigger( Contact_Created_Trigger::class );
+		$automation->register_step( Contact_Condition::class );
 		$automation->register_step( Dummy_Step::class );
 
 		$workflow_data = $this->automation_faker->workflow_with_condition_action();
@@ -312,6 +314,7 @@ class Automation_Workflow_Test extends JPCRM_Base_Test_Case {
 		$automation = new Automation_Engine();
 		$automation->set_automation_logger( $logger );
 		$automation->register_trigger( Contact_Created_Trigger::class );
+		$automation->register_step( Contact_Condition::class );
 		$automation->register_step( Dummy_Step::class );
 
 		$workflow_data = $this->automation_faker->workflow_with_condition_action();

--- a/projects/plugins/crm/tests/php/automation/contacts/actions/class-add-remove-contact-tag-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/actions/class-add-remove-contact-tag-test.php
@@ -103,14 +103,14 @@ class Add_Remove_Contact_Tag_Test extends JPCRM_Base_Integration_Test_Case {
 		$workflow_data = $this->automation_faker->workflow_with_condition_customizable_trigger_action(
 			Contact_Created::get_slug(),
 			array(
-				'slug'       => Add_Remove_Contact_Tag::get_slug(),
-				'attributes' => array(
+				'slug'           => Add_Remove_Contact_Tag::get_slug(),
+				'attributes'     => array(
 					'mode'      => 'replace',
 					'tag_input' => array(
 						$tag_id,
 					),
 				),
-				'next_step'  => null,
+				'next_step_true' => null,
 			)
 		);
 

--- a/projects/plugins/crm/tests/php/automation/invoices/actions/class-set-invoice-status-test.php
+++ b/projects/plugins/crm/tests/php/automation/invoices/actions/class-set-invoice-status-test.php
@@ -54,11 +54,11 @@ class Set_Invoice_Status_Test extends JPCRM_Base_Integration_Test_Case {
 			'initial_step' => 0,
 			'steps'        => array(
 				0 => array(
-					'slug'       => Set_Invoice_Status::get_slug(),
-					'attributes' => array(
+					'slug'           => Set_Invoice_Status::get_slug(),
+					'attributes'     => array(
 						'new_status' => 'Paid',
 					),
-					'next_step'  => null,
+					'next_step_true' => null,
 				),
 			),
 		);

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -78,12 +78,12 @@ class Automation_Faker {
 			'steps'        => array(
 				// Step 0
 				0 => array(
-					'slug'       => 'send_email_action',
-					'attributes' => array(
+					'slug'           => 'send_email_action',
+					'attributes'     => array(
 						'to'       => 'admin@example.com',
 						'template' => 'send_welcome_email',
 					),
-					'next_step'  => null,
+					'next_step_true' => null,
 				),
 			),
 		);

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -7,6 +7,7 @@ use Automattic\Jetpack\CRM\Automation\Automation_Logger;
 use Automattic\Jetpack\CRM\Automation\Conditions\Contact_Field_Changed;
 use Automattic\Jetpack\CRM\Automation\Data_Type_Exception;
 use Automattic\Jetpack\CRM\Automation\Tests\Mocks\Contact_Condition;
+use Automattic\Jetpack\CRM\Automation\Tests\Mocks\Dummy_Step;
 use Automattic\Jetpack\CRM\Entities\Company;
 use Automattic\Jetpack\CRM\Entities\Contact;
 use Automattic\Jetpack\CRM\Entities\Factories\Company_Factory;
@@ -202,19 +203,21 @@ class Automation_Faker {
 			'steps'        => array(
 				// Step 0
 				0 => array(
-					'slug'            => 'contact_status',
-					'class_name'      => Contact_Condition::class,
+					'slug'            => Contact_Condition::get_slug(),
+					'next_step_true'  => 1,
+					'next_step_false' => null,
 					'attributes'      => array(
 						'field'    => 'status',
 						'operator' => 'is',
 						'value'    => 'lead',
 					),
-					'next_step_true'  => 1,
-					'next_step_false' => null,
 				),
 				// Step 1
 				1 => array(
-					'slug' => 'dummy_step',
+					'slug'            => Dummy_Step::get_slug(),
+					'next_step_true'  => null,
+					'next_step_false' => null,
+					'attributes'      => array(),
 				),
 			),
 		);

--- a/projects/plugins/crm/tests/php/automation/transactions/actions/class-set-transaction-status-test.php
+++ b/projects/plugins/crm/tests/php/automation/transactions/actions/class-set-transaction-status-test.php
@@ -54,11 +54,11 @@ class Set_Transaction_Status_Test extends JPCRM_Base_Integration_Test_Case {
 			'initial_step' => 0,
 			'steps'        => array(
 				0 => array(
-					'slug'       => Set_Transaction_Status::get_slug(),
-					'attributes' => array(
+					'slug'           => Set_Transaction_Status::get_slug(),
+					'attributes'     => array(
 						'new_status' => 'Paid',
 					),
-					'next_step'  => null,
+					'next_step_true' => null,
 				),
 			),
 		);

--- a/projects/plugins/crm/tests/php/rest-api/v4/class-rest-automation-workflows-controller-test.php
+++ b/projects/plugins/crm/tests/php/rest-api/v4/class-rest-automation-workflows-controller-test.php
@@ -311,11 +311,16 @@ class REST_Automation_Workflows_Controller_Test extends REST_Base_Test_Case {
 			'initial_step' => 'updated_step_2',
 			'steps'        => array(
 				'updated_step_1' => array(
-					'slug'           => Contact_Condition::get_slug(),
-					'next_step_true' => 'updated_step_2',
+					'slug'            => Contact_Condition::get_slug(),
+					'next_step_true'  => 'updated_step_2',
+					'next_step_false' => null,
+					'attributes'      => array(),
 				),
 				'updated_step_2' => array(
-					'slug' => Contact_Condition::get_slug(),
+					'slug'            => Contact_Condition::get_slug(),
+					'next_step_true'  => null,
+					'next_step_false' => null,
+					'attributes'      => array(),
 				),
 			),
 		);
@@ -385,10 +390,19 @@ class REST_Automation_Workflows_Controller_Test extends REST_Base_Test_Case {
 	 * @return array The pruned workflow data.
 	 */
 	protected function prune_workflow_response( array $workflow_data ): array {
+		$static_step_fields = array(
+			'title',
+			'description',
+			'category',
+			'attribute_definitions',
+		);
+
 		if ( ! empty( $workflow_data['steps'] ) && is_array( $workflow_data['steps'] ) ) {
 			foreach ( $workflow_data['steps'] as $index => $step ) {
-				if ( isset( $step['attribute_definitions'] ) ) {
-					unset( $step['attribute_definitions'] );
+				foreach ( $static_step_fields as $field ) {
+					if ( isset( $step[ $field ] ) ) {
+						unset( $step[ $field ] );
+					}
 				}
 
 				$workflow_data['steps'][ $index ] = $step;

--- a/projects/plugins/crm/tests/php/rest-api/v4/class-rest-automation-workflows-controller-test.php
+++ b/projects/plugins/crm/tests/php/rest-api/v4/class-rest-automation-workflows-controller-test.php
@@ -394,6 +394,7 @@ class REST_Automation_Workflows_Controller_Test extends REST_Base_Test_Case {
 			'title',
 			'description',
 			'category',
+			'step_type',
 			'attribute_definitions',
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR will add missing static Step information to workflow responses.

The reason we need to expose this is to the UI can display all relevant information about steps.
The current information would limit the UI to only show attribute labels without any further context.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Add a unified way to get a full version of steps (including static information like title and attribute definition + dynamic values like attributes and "next step").
* Use the above mentioned unified way to fetch step data to expose static values via the API.
* Fix an edge-case bug where we forced "next step" to be an integer, but we allow strings. This could break future hardcoded workflows.
* Unify how we store "next step" amongst all steps (read: conditions + actions).
* Update some of the existing tests to include more up-to-date dummy data (e.g.: there's no reason for us to define "class_name" on steps anymore). This also made it easier for me to do direct comparisons between the original workflow before and after update/create.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

* pbhBOz-3Wf-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Automated tests

All of the tests should obviously pass, but looking at the following automated tests should suffice:

* `REST_Automation_Workflows_Controller_Test`: Updated so all the existing tests do not try to compare actual workflows with API responses that includes static information like step title and description.

### Manual testing

**Manual testing prep work**

1. Make sure the following feature flags are enabled on your site:

```php
add_filter( 'jetpack_crm_feature_flag_api_v4', '__return_true' );
add_filter( 'jetpack_crm_feature_flag_automations', '__return_true' );
```

2. Modify `REST_Automation_Workflows_Controller::get_item_permissions_check` to return `true` at the top.

_We do this to make it easier to call the endpoints. This should allow you to do it from any client you want (e.g. Postman) without having to worry about WP Logged in cookies, nonce, etc._

3. Make sure you have a workflow in your database. You can use the below snippet to add one.

```php
$workflow = new \Automattic\Jetpack\CRM\Automation\Automation_Workflow(
	[
		'name'         => 'New contact: Set status to "Customer"',
		'description'  => 'This automation will change the status of a contact to "Customer" when they are created.',
		'category'     => 'contact',
		'active'       => true,
		'triggers'     => [
			\Automattic\Jetpack\CRM\Automation\Triggers\Contact_Created::get_slug(),
		],
		'initial_step' => 1,
		'steps'        => [
			1 => [
				'slug'       => \Automattic\Jetpack\CRM\Automation\Actions\Update_Contact_Status::get_slug(),
				'attributes' => [
					'new_status' => 'Customer',
				],
				'next_step_true'  => null,
				'next_step_false' => null,
			],
		],
	]
);

$repo = new \Automattic\Jetpack\CRM\Automation\Workflow\Workflow_Repository();
$workflow = $repo->persist(  $workflow );
```

**GET All Workflows**

* Method: `GET`
* Path: `/wp-json/jetpack-crm/v4/automation/workflows`
* Payload: N/A

**GET Workflow**

* Method: `GET`
* Path: `/wp-json/jetpack-crm/v4/automation/workflows/{id}`
* Payload: N/A

## New Workflow Response Example

```json
{
    "id": "1",
    "zbs_site": -1,
    "zbs_owner": -1,
    "name": "New contact: Set status to \"Customer\"",
    "description": "This automation will change the status of a contact to \"Customer\" when they are created.",
    "category": "jpcrm/contact",
    "triggers": [
        "jpcrm/contact_created"
    ],
    "steps": {
        "1": {
            "title": "Update Contact Status Action",
            "description": "Action to update the contact status",
            "slug": "jpcrm/update_contact_status",
            "category": "Contact",
            "step_type": "action",
            "next_step_true": null,
            "next_step_false": null,
            "attributes": {
                "new_status": "Customer"
            },
            "attribute_definitions": {
                "new_status": {
                    "slug": "new_status",
                    "title": "New status",
                    "description": "The status that will be used for the contact.",
                    "type": "select",
                    "data": {
                        "Lead": "Lead",
                        "Customer": "Customer",
                        "Refused": "Refused",
                        "Blacklisted": "Blacklisted",
                        "Cancelled by Customer": "Cancelled by Customer",
                        "Cancelled by Us (Pre-Quote)": "Cancelled by Us (Pre-Quote)",
                        "Cancelled by Us (Post-Quote)": "Cancelled by Us (Post-Quote)"
                    }
                }
            }
        }
    },
    "initial_step": "1",
    "active": true,
    "version": 1,
    "created_at": 1695767766,
    "updated_at": 1695767766
}
```

## Previous/Old Workflow Response Example

```json
{
    "id": "1",
    "zbs_site": -1,
    "zbs_owner": -1,
    "name": "New contact: Set status to \"Customer\"",
    "description": "This automation will change the status of a contact to \"Customer\" when they are created.",
    "category": "contact",
    "triggers": [
        "jpcrm/contact_created"
    ],
    "steps": {
        "1": {
            "slug": "jpcrm/update_contact_status",
            "attributes": {
                "new_status": "Customer"
            },
            "next_step_true": null,
            "next_step_false": null,
            "attribute_definitions": {
                "new_status": {
                    "slug": "new_status",
                    "title": "New status",
                    "description": "The status that will be used for the contact.",
                    "type": "select",
                    "data": {
                        "Lead": "Lead",
                        "Customer": "Customer",
                        "Refused": "Refused",
                        "Blacklisted": "Blacklisted",
                        "Cancelled by Customer": "Cancelled by Customer",
                        "Cancelled by Us (Pre-Quote)": "Cancelled by Us (Pre-Quote)",
                        "Cancelled by Us (Post-Quote)": "Cancelled by Us (Post-Quote)"
                    }
                }
            }
        }
    },
    "initial_step": "1",
    "active": true,
    "version": 1,
    "created_at": 1695767341,
    "updated_at": 1695767341
}
```