### PR TITLE
Frontend email nag for custom domain 

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-domains-email-nag
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-domains-email-nag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add plugin to show frontend email nag for domains with unverified email address

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -40,6 +40,7 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_marketplace_products_updater' ) );
 
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_first_posts_stream_helpers' ) );
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_domain_email_nag' ) );
 
 		// Unified navigation fix for changes in WordPress 6.2.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'unbind_focusout_on_wp_admin_bar_menu_toggle' ) );
@@ -94,6 +95,12 @@ class Jetpack_Mu_Wpcom {
 	 */
 	public static function load_launchpad() {
 		require_once __DIR__ . '/features/launchpad/launchpad.php';
+	}
+	/**
+	 * Load the Launchpad feature.
+	 */
+	public static function load_domain_email_nag() {
+		require_once __DIR__ . '/features/domain-email-nag/domain-email-nag.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -97,7 +97,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/launchpad/launchpad.php';
 	}
 	/**
-	 * Load the Launchpad feature.
+	 * Load the domain email nag feature.
 	 */
 	public static function load_domain_email_nag() {
 		require_once __DIR__ . '/features/domain-email-nag/domain-email-nag.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -22,14 +22,13 @@ function should_show_domain_frontend_email_nag() {
 }
 
 /**
- * Returns account url for fixing email issue
- *
- * @param string $domain the domain that is unverified.
+ * Returns the domain url for site that has a domain with an
+ * univerified email address.
  *
  * @return string account url
  */
-function get_account_url( $domain ) {
-	return 'https://wordpress.com/domains/manage/' . $domain;
+function get_account_url() {
+	return 'https://wordpress.com/domains/manage/' . wpcom_get_site_slug();
 }
 
 /**
@@ -76,7 +75,7 @@ function domain_email_nag() {
 	<div class="wp-domain-nag-sticky-message">
 		<div class="wp-domain-nag-inner">
 			<p class="wp-domain-nag-text"><?php echo wp_kses( $notice, array( 'strong' => array() ) ); ?></p>
-			<a class="button" href="<?php echo esc_url( get_account_url( $domain ) ); ?>"><?php esc_html_e( 'Fix', 'jetpack-mu-wpcom' ); ?></a>
+			<a class="button" href="<?php echo esc_url( get_account_url() ); ?>"><?php esc_html_e( 'Fix', 'jetpack-mu-wpcom' ); ?></a>
 		</div>
 	</div>
 	<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -18,23 +18,36 @@ function should_show_domain_frontend_email_nag() {
 	if ( ! is_front_page() || ( is_front_page() && ! is_user_logged_in() ) ) {
 		return false;
 	}
-
-	if ( ! class_exists( 'Email_Verification' ) ) {
-		return false;
-	}
-
-	$should_show = \Email_Verification::is_domain_email_unverified();
-
-	return apply_filters( 'a8c_show_domain_frontend_email_nag', $should_show );
+	return true;
 }
 
 /**
  * Returns account url for fixing email issue
  *
+ * @param string $domain the domain that is unverified.
+ *
  * @return string account url
  */
-function get_account_url() {
-	return 'https://wordpress.com/me/account';
+function get_account_url( $domain ) {
+	return 'https://wordpress.com/domains/manage/' . $domain;
+}
+
+/**
+ * Find the domain, if any, that has an unverified email address.
+ */
+function get_domain_with_unverified_email() {
+	if ( ! class_exists( 'Domain_Management' ) ) {
+		return false;
+	}
+
+	$domains = \Domain_Management::get_paid_domains_with_icann_verification_status();
+
+	foreach ( $domains as $domain ) {
+		if ( $domain['is_pending_icann_verification'] === true ) {
+			return $domain['domain'];
+		}
+	}
+	return false;
 }
 
 /**
@@ -45,20 +58,25 @@ function domain_email_nag() {
 		return;
 	}
 
+	$domain = get_domain_with_unverified_email();
+
+	if ( ! $domain ) {
+		return;
+	}
+
 	wp_enqueue_style( 'wpcom-domain-email-nag-style', plugins_url( 'domain-nag.style.css', __FILE__ ), array(), Jetpack_Mu_Wpcom::PACKAGE_VERSION );
 
 	$notice = sprintf(
 	/* translators: %1 User's email address, %2 current domain */
-		__( 'You need to confirm your email address <strong>%1$s</strong> to avoid having your domain <strong>%2$s</strong> suspended. Please check your inbox.', 'jetpack-mu-wpcom' ),
-		wp_get_current_user()->user_email,
-		wp_parse_url( site_url(), PHP_URL_HOST )
+		__( 'You need to confirm your domain email address to avoid having your domain <strong>%1$s</strong> suspended. Please check your inbox.', 'jetpack-mu-wpcom' ),
+		$domain
 	);
 
 	?>
 	<div class="wp-domain-nag-sticky-message">
 		<div class="wp-domain-nag-inner">
 			<p class="wp-domain-nag-text"><?php echo wp_kses( $notice, array( 'strong' => array() ) ); ?></p>
-			<a class="button" href="<?php echo esc_url( get_account_url() ); ?>"><?php esc_html_e( 'Fix', 'jetpack-mu-wpcom' ); ?></a>
+			<a class="button" href="<?php echo esc_url( get_account_url( $domain ) ); ?>"><?php esc_html_e( 'Fix', 'jetpack-mu-wpcom' ); ?></a>
 		</div>
 	</div>
 	<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -23,7 +23,7 @@ function should_show_domain_frontend_email_nag() {
 		return false;
 	}
 
-	$should_show = Email_Verification::is_domain_email_unverified();
+	$should_show = \Email_Verification::is_domain_email_unverified();
 
 	return apply_filters( 'a8c_show_domain_frontend_email_nag', $should_show );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -7,29 +7,61 @@
 
 namespace A8C\Domain\Frontend_Email_Nag;
 
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
 /**
  * Determines whether the email nag should be shown.
  *
  * @return boolean
  */
 function should_show_domain_frontend_email_nag() {
-	if ( ! is_front_page() && ! is_user_logged_in() && ! current_user_can( 'edit_post' ) ) {
+	if ( ! is_front_page() || ( is_front_page() && ! is_user_logged_in() ) ) {
 		return false;
 	}
 
-	$should_show = ( (int) get_user_attribute( get_current_user_id(), 'is_email_unverified' ) === 1 );
+	if ( ! class_exists( 'Email_Verification' ) ) {
+		return false;
+	}
+
+	$should_show = Email_Verification::is_domain_email_unverified();
 
 	return apply_filters( 'a8c_show_domain_frontend_email_nag', $should_show );
 }
 
 /**
- * Decides whether to render to the email nag.
+ * Returns account url for fixing email issue
  *
- * @param string $template The template to render.
+ * @return string account url
  */
-function domain_email_nag( $template ) {
-	if ( ! should_show_domain_frontend_email_nag() ) {
-		return $template;
-	}
+function get_account_url() {
+	return 'https://wordpress.com/me/account';
 }
-add_filter( 'template_include', __NAMESPACE__ . '\domain_email_nag' );
+
+/**
+ * Decides whether to render to the email nag.
+ */
+function domain_email_nag() {
+	if ( ! should_show_domain_frontend_email_nag() ) {
+		return;
+	}
+
+	wp_enqueue_style( 'wpcom-domain-email-nag-style', plugins_url( 'domain-nag.style.css', __FILE__ ), array(), Jetpack_Mu_Wpcom::PACKAGE_VERSION );
+
+	$notice = sprintf(
+	/* translators: %1 User's email address, %2 current domain */
+		__( 'You need to confirm your email address <strong>%1$s</strong> to avoid having your domain <strong>%2$s</strong> suspended. Please check your inbox.', 'jetpack-mu-wpcom' ),
+		wp_get_current_user()->user_email,
+		wp_parse_url( site_url(), PHP_URL_HOST )
+	);
+
+	?>
+	<div class="wp-domain-nag-sticky-message">
+		<div class="wp-domain-nag-inner">
+			<p class="wp-domain-nag-text"><?php echo wp_kses( $notice, array( 'strong' => array() ) ); ?></p>
+			<a class="button" href="<?php echo esc_url( get_account_url() ); ?>"><?php esc_html_e( 'Fix', 'jetpack-mu-wpcom' ); ?></a>
+		</div>
+	</div>
+	<?php
+}
+add_action( 'wp_footer', __NAMESPACE__ . '\domain_email_nag' );
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Frontend Domain Email Nag
+ *
+ * @package A8C\Domain\Frontend_Email_Nag
+ */
+
+namespace A8C\Domain\Frontend_Email_Nag;
+
+/**
+ * Determines whether the email nag should be shown.
+ *
+ * @return boolean
+ */
+function should_show_domain_frontend_email_nag() {
+	if ( ! is_front_page() && ! is_user_logged_in() && ! current_user_can( 'edit_post' ) ) {
+		return false;
+	}
+
+	$should_show = ( (int) get_user_attribute( get_current_user_id(), 'is_email_unverified' ) === 1 );
+
+	return apply_filters( 'a8c_show_domain_frontend_email_nag', $should_show );
+}
+
+/**
+ * Decides whether to render to the email nag.
+ *
+ * @param string $template The template to render.
+ */
+function domain_email_nag( $template ) {
+	if ( ! should_show_domain_frontend_email_nag() ) {
+		return $template;
+	}
+}
+add_filter( 'template_include', __NAMESPACE__ . '\domain_email_nag' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-nag.style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-nag.style.css
@@ -1,0 +1,35 @@
+.wp-domain-nag-sticky-message {
+    position: sticky;
+    bottom: 10px;
+    width: 50%;
+    margin: auto;
+    background-color: #333;
+    border-radius: 2px;
+    color: #fff;
+    padding: 10px;
+}
+
+.wp-domain-nag-inner {
+    display: inline-block;
+}
+
+.wp-domain-nag-text {
+    display: inline;
+}
+
+.wp-domain-nag-sticky-message .button {
+    background: #fff;
+	border-radius: 2px;
+	border: 1px solid #fff;
+	box-sizing: border-box;
+	display: inline-block;
+	line-height: 21px;
+	padding: 8px;
+	text-align: center;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	transition: opacity .15s ease-out;
+	white-space: nowrap;
+    width: 120px;
+    margin-left: 16px;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-nag.style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-nag.style.css
@@ -3,7 +3,7 @@
     bottom: 10px;
     width: 50%;
     margin: auto;
-    background-color: #333;
+    background-color: #d9534f;
     border-radius: 2px;
     color: #fff;
     padding: 10px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/3950

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Show a frontend email nag for users with unverified email address of a custom domain
* 
![image](https://github.com/Automattic/jetpack/assets/6851384/b12ff581-602c-433f-9352-c45bf3ca0085)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Patch your sandbox using `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/domains-email-nag`
* Buy a domain with an account that has an unverified email address and map domain to a site
* Go to sites frontend while logged in and confirm you see a nag.
* Confirm clicking `Fix` takes you to /me/account