### PR TITLE
i18n-check-webpack-plugin: Provide a way to not break with webpack's mangleExports

### DIFF
--- a/projects/js-packages/i18n-check-webpack-plugin/README.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/README.md
@@ -32,6 +32,31 @@ Parameters recognized by the plugin are:
    - `babelOptions`: Supply options for Babel.
    - `functions`: Supply a custom list of i18n functions to recognize.
 
+## Export mangling
+
+Webpack's [optimization.mangleExports option](https://webpack.js.org/configuration/optimization/#optimizationmangleexports), enabled by default in production mode, can on occasion mangle an export to the name of one of the i18n functions this module looks for.
+
+If you want export mangling and run into this issue, a slightly modified copy of Webpack's internal `MangleExportsPlugin` is provided. Require it as
+```
+const I18nSafeMangleExportsPlugin = require( '@automattic/i18n-check-webpack-plugin/I18nSafeMangleExportsPlugin' );
+```
+or
+```
+import I18nSafeMangleExportsPlugin from '@automattic/i18n-check-webpack-plugin/I18nSafeMangleExportsPlugin';
+```
+and add it to the `plugins` section of your Webpack config like
+```js
+{
+	plugins: [
+		new I18nSafeMangleExportsPlugin(),
+	],
+};
+```
+
+Parameters recognized by the plugin are:
+
+- `deterministic`: Set false to use the 'size' mode.
+
 ## Known problematic code patterns
 
 These are some code patterns that are known to cause translations to be mangled.

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-i18n-check-mangleExports
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-i18n-check-mangleExports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a sub-plugin, `I18nSafeMangleExportsPlugin`, to allow for avoiding problems with Webpack's `optimization.mangleExports` option occasionally mangling an export to one of the i18n function names.

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.0.36",
+	"version": "1.1.0-alpha",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-check-webpack-plugin/#readme",
 	"bugs": {
@@ -35,6 +35,7 @@
 	},
 	"exports": {
 		".": "./src/I18nCheckPlugin.js",
+		"./I18nSafeMangleExportsPlugin": "./src/I18nSafeMangleExportsPlugin.js",
 		"./GettextExtractor": "./src/GettextExtractor.js",
 		"./GettextEntries": "./src/GettextEntries.js",
 		"./GettextEntry": "./src/GettextEntry.js"

--- a/projects/js-packages/i18n-check-webpack-plugin/src/I18nSafeMangleExportsPlugin.js
+++ b/projects/js-packages/i18n-check-webpack-plugin/src/I18nSafeMangleExportsPlugin.js
@@ -1,0 +1,178 @@
+/**
+ * Webpack plugin to make export mangling safe to use with I18nCheckWebapckPlugin.
+ *
+ * Based on Webpack's MangleExportsPlugin. This is the same except for the
+ * addition of some default values in the `usedNames` set and the options
+ * accepted by the constructor.
+ */
+
+const {
+	UsageState,
+	Template: {
+		numberToIdentifier,
+		NUMBER_OF_IDENTIFIER_START_CHARS,
+		NUMBER_OF_IDENTIFIER_CONTINUATION_CHARS,
+	},
+	util: {
+		comparators: { compareSelect, compareStringsNumeric },
+	},
+} = require( 'webpack' );
+const { assignDeterministicIds } = require( 'webpack/lib/ids/IdHelpers' );
+
+/** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../ExportsInfo")} ExportsInfo */
+/** @typedef {import("../ExportsInfo").ExportInfo} ExportInfo */
+
+/**
+ * Determine if we can mangle.
+ * @param {ExportsInfo} exportsInfo - exports info
+ * @returns {boolean} mangle is possible
+ */
+const canMangle = exportsInfo => {
+	if ( exportsInfo.otherExportsInfo.getUsed( undefined ) !== UsageState.Unused ) {
+		return false;
+	}
+	let hasSomethingToMangle = false;
+	for ( const exportInfo of exportsInfo.exports ) {
+		if ( exportInfo.canMangle === true ) {
+			hasSomethingToMangle = true;
+		}
+	}
+	return hasSomethingToMangle;
+};
+
+// Sort by name
+const comparator = compareSelect( e => e.name, compareStringsNumeric );
+/**
+ * Mangle exports.
+ * @param {boolean} deterministic - use deterministic names
+ * @param {ExportsInfo} exportsInfo - exports info
+ * @param {boolean | undefined} isNamespace - is namespace object
+ * @returns {void}
+ */
+const mangleExportsInfo = ( deterministic, exportsInfo, isNamespace ) => {
+	if ( ! canMangle( exportsInfo ) ) {
+		return;
+	}
+	const usedNames = new Set( [ '__', '_x', '_n', '_nx' ] );
+	/** @type {ExportInfo[]} */
+	const mangleableExports = [];
+
+	// Avoid to renamed exports that are not provided when
+	// 1. it's not a namespace export: non-provided exports can be found in prototype chain
+	// 2. there are other provided exports and deterministic mode is chosen:
+	//    non-provided exports would break the determinism
+	let avoidMangleNonProvided = ! isNamespace;
+	if ( ! avoidMangleNonProvided && deterministic ) {
+		for ( const exportInfo of exportsInfo.ownedExports ) {
+			if ( exportInfo.provided !== false ) {
+				avoidMangleNonProvided = true;
+				break;
+			}
+		}
+	}
+	for ( const exportInfo of exportsInfo.ownedExports ) {
+		const name = exportInfo.name;
+		if ( ! exportInfo.hasUsedName() ) {
+			if (
+				// Can the export be mangled?
+				exportInfo.canMangle !== true ||
+				// Never rename 1 char exports
+				( name.length === 1 && /^[a-zA-Z0-9_$]/.test( name ) ) ||
+				// Don't rename 2 char exports in deterministic mode
+				( deterministic &&
+					name.length === 2 &&
+					/^[a-zA-Z_$][a-zA-Z0-9_$]|^[1-9][0-9]/.test( name ) ) ||
+				// Don't rename exports that are not provided
+				( avoidMangleNonProvided && exportInfo.provided !== true )
+			) {
+				exportInfo.setUsedName( name );
+				usedNames.add( name );
+			} else {
+				mangleableExports.push( exportInfo );
+			}
+		}
+		if ( exportInfo.exportsInfoOwned ) {
+			const used = exportInfo.getUsed( undefined );
+			if ( used === UsageState.OnlyPropertiesUsed || used === UsageState.Unused ) {
+				mangleExportsInfo( deterministic, exportInfo.exportsInfo, false );
+			}
+		}
+	}
+	if ( deterministic ) {
+		assignDeterministicIds(
+			mangleableExports,
+			e => e.name,
+			comparator,
+			( e, id ) => {
+				const name = numberToIdentifier( id );
+				const size = usedNames.size;
+				usedNames.add( name );
+				if ( size === usedNames.size ) {
+					return false;
+				}
+				e.setUsedName( name );
+				return true;
+			},
+			[
+				NUMBER_OF_IDENTIFIER_START_CHARS,
+				NUMBER_OF_IDENTIFIER_START_CHARS * NUMBER_OF_IDENTIFIER_CONTINUATION_CHARS,
+			],
+			NUMBER_OF_IDENTIFIER_CONTINUATION_CHARS,
+			usedNames.size
+		);
+	} else {
+		const usedExports = [];
+		const unusedExports = [];
+		for ( const exportInfo of mangleableExports ) {
+			if ( exportInfo.getUsed( undefined ) === UsageState.Unused ) {
+				unusedExports.push( exportInfo );
+			} else {
+				usedExports.push( exportInfo );
+			}
+		}
+		usedExports.sort( comparator );
+		unusedExports.sort( comparator );
+		let i = 0;
+		for ( const list of [ usedExports, unusedExports ] ) {
+			for ( const exportInfo of list ) {
+				let name;
+				do {
+					name = numberToIdentifier( i++ );
+				} while ( usedNames.has( name ) );
+				exportInfo.setUsedName( name );
+			}
+		}
+	}
+};
+
+class MangleExportsPlugin {
+	constructor( options ) {
+		this._deterministic = options?.deterministic ?? true;
+	}
+	/**
+	 * Apply the plugin
+	 * @param {Compiler} compiler - the compiler instance
+	 * @returns {void}
+	 */
+	apply( compiler ) {
+		const { _deterministic: deterministic } = this;
+		compiler.hooks.compilation.tap( 'MangleExportsPlugin', compilation => {
+			const moduleGraph = compilation.moduleGraph;
+			compilation.hooks.optimizeCodeGeneration.tap( 'MangleExportsPlugin', modules => {
+				if ( compilation.moduleMemCaches ) {
+					throw new Error(
+						"optimization.mangleExports can't be used with cacheUnaffected as export mangling is a global effect"
+					);
+				}
+				for ( const module of modules ) {
+					const isNamespace = module.buildMeta && module.buildMeta.exportsType === 'namespace';
+					const exportsInfo = moduleGraph.getExportsInfo( module );
+					mangleExportsInfo( deterministic, exportsInfo, isNamespace );
+				}
+			} );
+		} );
+	}
+}
+
+module.exports = MangleExportsPlugin;

--- a/projects/js-packages/i18n-check-webpack-plugin/tests/__snapshots__/build.test.js.snap
+++ b/projects/js-packages/i18n-check-webpack-plugin/tests/__snapshots__/build.test.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Webpack \`I18nSafeMangleExportsPlugin\`: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`I18nSafeMangleExportsPlugin\`: Webpack build files 1`] = `
+[
+  "control.js",
+  "plugin.js",
+]
+`;
+
+exports[`Webpack \`I18nSafeMangleExportsPlugin\`: Webpack build stats 1`] = `
+{
+  "children": [
+    {
+      "errors": [],
+      "name": undefined,
+      "warnings": [],
+    },
+    {
+      "errors": [],
+      "name": undefined,
+      "warnings": [],
+    },
+  ],
+  "errors": [],
+  "warnings": [],
+}
+`;
+
 exports[`Webpack \`basic-test\`: Webpack build error 1`] = `null`;
 
 exports[`Webpack \`basic-test\`: Webpack build files 1`] = `

--- a/projects/js-packages/i18n-check-webpack-plugin/tests/fixtures/I18nSafeMangleExportsPlugin/src/foo.mjs
+++ b/projects/js-packages/i18n-check-webpack-plugin/tests/fixtures/I18nSafeMangleExportsPlugin/src/foo.mjs
@@ -1,0 +1,10 @@
+// We need at least three exports to trigger the bug.
+
+export function matchQuery(){
+}
+
+export function abc(){
+}
+
+export function def(){
+}

--- a/projects/js-packages/i18n-check-webpack-plugin/tests/fixtures/I18nSafeMangleExportsPlugin/src/index.mjs
+++ b/projects/js-packages/i18n-check-webpack-plugin/tests/fixtures/I18nSafeMangleExportsPlugin/src/index.mjs
@@ -1,0 +1,3 @@
+import { matchQuery } from "./foo.mjs";
+
+matchQuery();

--- a/projects/js-packages/i18n-check-webpack-plugin/tests/fixtures/I18nSafeMangleExportsPlugin/webpack.config.js
+++ b/projects/js-packages/i18n-check-webpack-plugin/tests/fixtures/I18nSafeMangleExportsPlugin/webpack.config.js
@@ -1,0 +1,33 @@
+const I18nSafeMangleExportsPlugin = require( '../../../src/I18nSafeMangleExportsPlugin.js' );
+
+module.exports = [
+	{
+		mode: 'production',
+		entry: './src/index.mjs',
+		devtool: false,
+		node: false,
+		output: {
+			filename: 'control.js',
+		},
+		optimization: {
+			concatenateModules: false,
+			mangleExports: true,
+		},
+	},
+	{
+		mode: 'production',
+		entry: './src/index.mjs',
+		devtool: false,
+		node: false,
+		output: {
+			filename: 'plugin.js',
+		},
+		optimization: {
+			concatenateModules: false,
+			mangleExports: false,
+		},
+		plugins: [
+			new I18nSafeMangleExportsPlugin(),
+		],
+	},
+];

--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -96,7 +96,14 @@ This is an object suited for spreading some default values into Webpack's `outpu
 
 #### `optimization`
 
-`optimization` is an object suitable for spreading some defaults into Webpack's `optimization` setting. It sets `minimize` based on the mode, configures a default `minimizer` with `TerserPlugin` and `CssMinimizerPlugin`, and sets `concatenateModules` to false as that setting [may mangle WordPress's i18n function names](https://github.com/Automattic/jetpack/issues/21204).
+`optimization` is an object suitable for spreading some defaults into Webpack's `optimization` setting. It sets the following:
+
+* `minimize` is set based on the mode.
+* `minimizer` is configured with `TerserPlugin` and `CssMinimizerPlugin` configured as described below.
+* `emitOnErrors` is set true to facilitate debugging.
+* `concatenateModules` is set to false as that setting [may mangle WordPress's i18n function names](https://github.com/Automattic/jetpack/issues/21204).
+* `moduleIds` is set to false in production mode, as `PnpmDeterministicModuleIdsPlugin` is intended to be used instead. The Webpack default 'name' is set in development mode.
+* `mangleExports` is set to false in production mode, as `I18nSafeMangleExportsPlugin` is intended to be used instead.
 
 #### `TerserPlugin( options )`
 
@@ -138,7 +145,7 @@ plugins: {
 }
 ```
 
-Note that I18nCheckPlugin is only included by default in production mode.
+Note that I18nCheckPlugin, PnpmDeterministicModuleIdsPlugin, and I18nSafeMangleExportsPlugin are only included by default in production mode. They can be turned on in development mode by passing an options object.
 
 ##### `DefinePlugin( defines )`
 
@@ -187,6 +194,14 @@ Note that if the plugin actually does anything in your build, you'll need to spe
 This provides an instance of [@wordpress/i18n-check-webpack-plugin](https://www.npmjs.com/package/@wordpress/i18n-check-webpack-plugin). The `options` are passed to the plugin.
 
 The default configuration sets a filter that excludes `node_modules` other than `@automattic/*`. This may be accessed as `I18nCheckPlugin.defaultFilter`.
+
+##### `I18nSafeMangleExportsPlugin( options )`
+
+This provides an instance of [@wordpress/i18n-check-webpack-plugin](https://www.npmjs.com/package/@wordpress/i18n-check-webpack-plugin)'s I18nSafeMangleExportsPlugin. The `options` are passed to the plugin.
+
+##### `PnpmDeterministicModuleIdsPlugin( options )`
+
+This provides an slightly modified instance of Webpack's built-in DeterministicModuleIdsPlugin that does a better job of handling the paths produced by pnpm. The `options` are passed to the plugin.
 
 #### Module rules and loaders
 

--- a/projects/js-packages/webpack-config/changelog/fix-i18n-check-mangleExports
+++ b/projects/js-packages/webpack-config/changelog/fix-i18n-check-mangleExports
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Disable `optimization.mangleExports` in production mode in favor of the `I18nSafeMangleExportsPlugin` from `@automattic/i18n-check-webpack-plugin`. This is technically a breaking change, as if someone had been disabling `mangleExports` for other reasons this will effectively re-enable it.

--- a/projects/js-packages/webpack-config/changelog/fix-i18n-check-mangleExports#2
+++ b/projects/js-packages/webpack-config/changelog/fix-i18n-check-mangleExports#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Finally document PnpmDeterministicModuleIdsPlugin that was added way back in 1.2.0.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "1.6.0",
+	"version": "2.0.0-alpha",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -1,6 +1,7 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const I18nCheckWebpackPlugin = require( '@automattic/i18n-check-webpack-plugin' );
+const I18nSafeMangleExportsPlugin = require( '@automattic/i18n-check-webpack-plugin/I18nSafeMangleExportsPlugin' );
 const I18nLoaderWebpackPlugin = require( '@automattic/i18n-loader-webpack-plugin' );
 const WebpackRTLPlugin = require( '@automattic/webpack-rtl-plugin' );
 const DuplicatePackageCheckerWebpackPlugin = require( '@cerner/duplicate-package-checker-webpack-plugin' );
@@ -30,6 +31,7 @@ const output = {
 const optimization = {
 	minimize: isProduction,
 	minimizer: [ TerserPlugin(), MyCssMinimizerPlugin() ],
+	mangleExports: false,
 	concatenateModules: false,
 	moduleIds: isProduction ? false : 'named',
 	emitOnErrors: true,
@@ -121,12 +123,17 @@ const MyPnpmDeterministicModuleIdsPlugin = options => [
 	new PnpmDeterministicModuleIdsPlugin( options ),
 ];
 
+const MyI18nSafeMangleExportsPlugin = options => [ new I18nSafeMangleExportsPlugin( options ) ];
+
 const StandardPlugins = ( options = {} ) => {
 	if ( typeof options.I18nCheckPlugin === 'undefined' && isDevelopment ) {
 		options.I18nCheckPlugin = false;
 	}
 	if ( typeof options.PnpmDeterministicModuleIdsPlugin === 'undefined' && isDevelopment ) {
 		options.PnpmDeterministicModuleIdsPlugin = false;
+	}
+	if ( typeof options.I18nSafeMangleExportsPlugin === 'undefined' && isDevelopment ) {
+		options.I18nSafeMangleExportsPlugin = false;
 	}
 
 	return [
@@ -152,6 +159,9 @@ const StandardPlugins = ( options = {} ) => {
 		...( options.PnpmDeterministicModuleIdsPlugin === false
 			? []
 			: MyPnpmDeterministicModuleIdsPlugin( options.PnpmDeterministicModuleIdsPlugin ) ),
+		...( options.I18nSafeMangleExportsPlugin === false
+			? []
+			: MyI18nSafeMangleExportsPlugin( options.I18nSafeMangleExportsPlugin ) ),
 	];
 };
 
@@ -183,6 +193,7 @@ module.exports = {
 	DuplicatePackageCheckerPlugin,
 	I18nLoaderPlugin,
 	PnpmDeterministicModuleIdsPlugin: MyPnpmDeterministicModuleIdsPlugin,
+	I18nSafeMangleExportsPlugin: MyI18nSafeMangleExportsPlugin,
 	// Module rules and loaders.
 	TranspileRule,
 	CssRule,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Webpack's optimization.mangleExports option, enabled by default in production mode, can on occasion mangle an export to the name of one of the i18n functions this module looks for.

To fix this, we provide a slightly modified copy of Webpack's internal `MangleExportsPlugin` that will never mangle to `__`, `_n`, `_x`, or `_nx`.

Then update our webpack-config package to disable `mangleExports` in favor of this new plugin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1695921976230749-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Check out c9c8b51924c21b35fa54dbd08fed694da3b68d9a, cherry-pick this, and see if `jetpack build -v --production plugins/crm` now works.