### PR TITLE
CRM: Resolves #3349 - catch PHP fatal on workflow NULL timestamp

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3349-catch_php_fatal_on_workflow_null_timestamp
+++ b/projects/plugins/crm/changelog/fix-crm-3349-catch_php_fatal_on_workflow_null_timestamp
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Handle null timestamp in workflow rows
+
+

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -305,9 +305,9 @@ class Automation_Workflow {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int
+	 * @return int|null
 	 */
-	public function get_created_at(): int {
+	public function get_created_at(): ?int {
 		return $this->created_at;
 	}
 
@@ -316,9 +316,9 @@ class Automation_Workflow {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int
+	 * @return int|null
 	 */
-	public function get_updated_at(): int {
+	public function get_updated_at(): ?int {
 		return $this->updated_at;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3349 - catch PHP fatal on workflow NULL timestamp

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We allow a timestamp value of `NULL` in the workflow created and updated fields. In the edge case that someone adds a workflow to the database manually and omits a timestamp, they'll get a PHP fatal when trying to retrieve workflows.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Set `REST_Automation_Workflows_Controller::get_item_permissions_check` to return `true`.
2. In the database, change a workflow timestamp to have a value of `NULL`.

In `trunk`, one gets one of the following:
```
PHP Fatal error:  Uncaught TypeError: Return value of Automattic\Jetpack\CRM\Automation\Automation_Workflow::get_created_at() must be of the type int, null returned in /src/automation/class-automation-workflow.php:311
PHP Fatal error:  Uncaught TypeError: Return value of Automattic\Jetpack\CRM\Automation\Automation_Workflow::get_created_at() must be of the type int, null returned in /src/automation/class-automation-workflow.php:322
```

In the `fix/crm/3349-catch_php_fatal_on_workflow_null_timestamp` branch, all is well.