### PR TITLE
VideoPress: Circumvent cases where block script enqueuing is attempted from environments where get_the_content is not fully available

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-initializer-empty-content-check
+++ b/projects/packages/videopress/changelog/fix-videopress-initializer-empty-content-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use a try/catch when calling get_the_content to avoid fatals. See: https://github.com/Automattic/jetpack/issues/33284

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.17.2",
+	"version": "0.17.3-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -360,9 +360,16 @@ class Initializer {
 			add_action(
 				'wp_enqueue_scripts',
 				function () use ( $videopress_video_metadata_file ) {
-					$post_content = get_the_content();
+					// There's been issues with get_the_content on plugins/libs that take an alternate process
+					// and do not get the globals needed for get_the_content to work.
+					// See: https://github.com/Automattic/jetpack/issues/33284
+					try {
+						$post_content = get_the_content();
+					} catch ( \Exception $e ) {
+						return;
+					}
 
-					if ( ! has_block( 'videopress/video', $post_content ) && ! has_shortcode( $post_content, 'videopress' ) ) {
+					if ( empty( $post_content ) || ( ! has_block( 'videopress/video', $post_content ) && ! has_shortcode( $post_content, 'videopress' ) ) ) {
 						return;
 					}
 					self::enqueue_block_assets( $videopress_video_metadata_file );

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -369,7 +369,7 @@ class Initializer {
 						return;
 					}
 
-					if ( empty( $post_content ) || ( ! has_block( 'videopress/video', $post_content ) && ! has_shortcode( $post_content, 'videopress' ) ) ) {
+					if ( ! empty( $post_content ) && ! has_block( 'videopress/video', $post_content ) && ! has_shortcode( $post_content, 'videopress' ) ) {
 						return;
 					}
 					self::enqueue_block_assets( $videopress_video_metadata_file );

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -365,7 +365,9 @@ class Initializer {
 					// See: https://github.com/Automattic/jetpack/issues/33284
 					try {
 						$post_content = get_the_content();
-					} catch ( \Throwable $e ) {
+					} catch ( \TypeError $e ) {
+						return;
+					} catch ( \Exception $e ) {
 						return;
 					}
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -365,7 +365,7 @@ class Initializer {
 					// See: https://github.com/Automattic/jetpack/issues/33284
 					try {
 						$post_content = get_the_content();
-					} catch ( \Exception $e ) {
+					} catch ( \Throwable $e ) {
 						return;
 					}
 

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.17.2';
+	const PACKAGE_VERSION = '0.17.3-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 


### PR DESCRIPTION
Fixes #33284 

## Proposed changes:
Add a try/catch to prevent `get_the_content` throwing a fatal when the globals are not present.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1695930917195839-slack-CDD9LQRSN

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Install and activate Jetpack running on this branch. [Download zip](https://betadownload.jetpack.me/data/jetpack/fix_videopress-initializer-empty-content-check/jetpack-dev.zip) or [Launch a Jurassic Ninja](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack=fix/videopress-initializer-empty-content-check&wp-debug-log)
2. Install and activate the Timber plugin
3. Download, install and activate [the Timber starter theme](https://github.com/timber/starter-theme)
4. Attempt to view any non-admin page

Verify the fatal does not happen anymore