### PR TITLE
Blogroll: Hide subscribe button on atomic

### DIFF
--- a/projects/plugins/jetpack/changelog/Hide subscribe buttons on atomic sites
+++ b/projects/plugins/jetpack/changelog/Hide subscribe buttons on atomic sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+

--- a/projects/plugins/jetpack/changelog/Hide subscribe buttons on atomic sites
+++ b/projects/plugins/jetpack/changelog/Hide subscribe buttons on atomic sites
@@ -1,4 +1,5 @@
 Significance: patch
 Type: enhancement
+Comment: Hide subscribe button on atomic sites
 
 

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -61,11 +61,11 @@ function load_assets( $attr, $content, $block ) {
 	$disabled_subscribe_button = '';
 	$subscribe_button_class    = 'is-style-fill';
 	$is_following              = ( function_exists( 'wpcom_subs_is_subscribed' ) && wpcom_subs_is_subscribed(
-				array(
-					'user_id' => get_current_user_id(),
-					'blog_id' => $id,
-				)
-			) ) || isset( $_GET['blogid'] ) && $id === $_GET['blogid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
+		array(
+			'user_id' => get_current_user_id(),
+			'blog_id' => $id,
+		)
+	) ) || isset( $_GET['blogid'] ) && $id === $_GET['blogid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
 
 	if ( $is_following ) {
 		$subscribe_text            = esc_html__( 'Subscribed', 'jetpack' );
@@ -90,7 +90,7 @@ function load_assets( $attr, $content, $block ) {
 		</div>
 HTML;
 
-	$subscribe_button      = <<<HTML
+	$subscribe_button = <<<HTML
 		<!-- wp:button {"className":"$subscribe_button_class"} -->
 		<div class="wp-block-button jetpack-blogroll-item-subscribe-button $subscribe_button_class">
 			<button type="button" class="wp-block-button__link wp-element-button" {$disabled_subscribe_button}>$subscribe_text</button>
@@ -99,10 +99,10 @@ HTML;
 HTML;
 
 	$subscribe_button_html = '';
-	$fieldset = '';
+	$fieldset              = '';
 
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$form_buttons_html = do_blocks( $form_buttons );
+		$form_buttons_html     = do_blocks( $form_buttons );
 		$subscribe_button_html = do_blocks( $subscribe_button );
 
 		$fieldset = <<<HTML

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -61,11 +61,11 @@ function load_assets( $attr, $content, $block ) {
 	$disabled_subscribe_button = '';
 	$subscribe_button_class    = 'is-style-fill';
 	$is_following              = ( function_exists( 'wpcom_subs_is_subscribed' ) && wpcom_subs_is_subscribed(
-		array(
-			'user_id' => get_current_user_id(),
-			'blog_id' => $id,
-		)
-	) ) || isset( $_GET['blogid'] ) && $id === $_GET['blogid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
+				array(
+					'user_id' => get_current_user_id(),
+					'blog_id' => $id,
+				)
+			) ) || isset( $_GET['blogid'] ) && $id === $_GET['blogid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
 
 	if ( $is_following ) {
 		$subscribe_text            = esc_html__( 'Subscribed', 'jetpack' );
@@ -77,7 +77,7 @@ function load_assets( $attr, $content, $block ) {
 		$icon = 'https://s0.wp.com/i/webclip.png';
 	}
 
-	$form_buttons      = <<<HTML
+	$form_buttons = <<<HTML
 		<!-- wp:button {"className":"is-style-fill"} -->
 		<div class="wp-block-button jetpack-blogroll-item-submit-button is-style-fill">
 			<button type="submit" name="blog_id" value="$id" class="wp-block-button__link wp-element-button">$submit_text</button>
@@ -89,7 +89,6 @@ function load_assets( $attr, $content, $block ) {
 			<button type="reset" class="wp-block-button__link wp-element-button">$cancel_text</button>
 		</div>
 HTML;
-	$form_buttons_html = do_blocks( $form_buttons );
 
 	$subscribe_button      = <<<HTML
 		<!-- wp:button {"className":"$subscribe_button_class"} -->
@@ -98,7 +97,22 @@ HTML;
 		</div>
 		<!-- /wp:button -->
 HTML;
-	$subscribe_button_html = do_blocks( $subscribe_button );
+
+	$subscribe_button_html = '';
+	$fieldset = '';
+
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		$form_buttons_html = do_blocks( $form_buttons );
+		$subscribe_button_html = do_blocks( $subscribe_button );
+
+		$fieldset = <<<HTML
+	<fieldset disabled class="jetpack-blogroll-item-submit">
+		<input type="hidden" name="_wpnonce" value="$wp_nonce">
+		<input type="email" name="email" placeholder="Email address" value="$email" class="jetpack-blogroll-item-email-input">
+		$form_buttons_html
+	</fieldset>
+HTML;
+	}
 
 	/**
 	 * Build the block content.
@@ -114,11 +128,7 @@ HTML;
 			</div>
 			$subscribe_button_html
 		</div>
-		<fieldset disabled class="jetpack-blogroll-item-submit">
-			<input type="hidden" name="_wpnonce" value="$wp_nonce">
-			<input type="email" name="email" placeholder="Email address" value="$email" class="jetpack-blogroll-item-email-input">
-			$form_buttons_html
-		</fieldset>
+		$fieldset
 HTML;
 
 	return sprintf(

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
@@ -48,8 +48,9 @@ function load_assets( $attr, $content ) {
 	 */
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 	$current_location = home_url( $wp->request );
+	$is_wpcom         = ( defined( 'IS_WPCOM' ) && IS_WPCOM );
 
-	$content = <<<HTML
+	$wpcom_content = <<<HTML
 		<form method="post" action="https://subscribe.wordpress.com" accept-charset="utf-8">
 			<input name="action" type="hidden" value="subscribe">
 			<input name="source" type="hidden" value="$current_location">
@@ -58,10 +59,12 @@ function load_assets( $attr, $content ) {
 		</form>
 HTML;
 
+	$blogroll_content = $is_wpcom ? $wpcom_content : $content;
+
 	return sprintf(
 		'<div class="%1$s">%2$s</div>',
 		esc_attr( Blocks::classes( FEATURE_NAME, $attr ) ),
-		$content
+		$blogroll_content
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
@@ -14,6 +14,10 @@
 			}
 		}
 
+		.jetpack-blogroll-item-wpcom-blogroll {
+			width: 100%;
+		}
+
 		&.open {
 			.jetpack-blogroll-item-slider {
 				transform: translateX(-50%);

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
@@ -14,10 +14,6 @@
 			}
 		}
 
-		.jetpack-blogroll-item-wpcom-blogroll {
-			width: 100%;
-		}
-
 		&.open {
 			.jetpack-blogroll-item-slider {
 				transform: translateX(-50%);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/82346

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hide the subscribe button on Atomic sites for now, this may get reverted in the future once we add atomic site support.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Pull and run this branch
- Open a simple site that uses blogroll and you should see the subscribe button available 
- Open an atomic site that uses blogroll and the buttons should not be visible.

Atomic:
<img width="814" alt="image" src="https://github.com/Automattic/jetpack/assets/2653810/1b1a3f11-e0ce-4637-aa76-e019eead3b64">


Simple:
<img width="835" alt="image" src="https://github.com/Automattic/jetpack/assets/2653810/c1024bf0-44cb-47f5-b30b-2c94b2a87101">


