### PR TITLE
 Fix block view scripts being loaded twice

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-block-view-script-loaded-multiple-times
+++ b/projects/plugins/jetpack/changelog/fix-block-view-script-loaded-multiple-times
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix block view scripts being loaded twice

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -199,7 +199,7 @@ module.exports = [
 						context: path.join( __dirname, '../extensions/blocks' ),
 						noErrorOnMissing: true,
 						// Automatically link scripts and styles
-						transform( content, absoluteFrom ) {
+						transform( content ) {
 							let metadata = {};
 
 							try {
@@ -212,7 +212,6 @@ module.exports = [
 								return metadata;
 							}
 
-							const metadataDir = path.dirname( absoluteFrom );
 							let scriptName = 'editor';
 
 							if ( presetIndex.beta.includes( name ) ) {
@@ -221,22 +220,14 @@ module.exports = [
 								scriptName += '-experimental';
 							}
 
+							// `editorScript` is required for block.json to be valid and WordPress.org to be able
+							// to parse it before building the page at https://wordpress.org/plugins/jetpack/.
+							// Don't add other scripts or styles while block assets are still enqueued manually
+							// in the backend.
 							const result = {
 								...metadata,
 								editorScript: `file:../${ scriptName }.js`,
-								editorStyle: `file:../${ scriptName }.css`,
 							};
-
-							if ( fs.existsSync( path.join( metadataDir, 'view.js' ) ) ) {
-								result.viewScript = 'file:./view.js';
-							}
-
-							if (
-								fs.existsSync( path.join( metadataDir, 'style.scss' ) ) ||
-								fs.existsSync( path.join( metadataDir, 'view.scss' ) )
-							) {
-								result.style = 'file:./view.css';
-							}
 
 							return JSON.stringify( result, null, 4 );
 						},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1695989732543079/1694788078.746839-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The block registration method introduced in https://github.com/Automattic/jetpack/pull/33326 made possible the loading of assets defined in a `block.json` file. However, block assets are still enqueued explicitly in the backend at the moment. This caused assets to be loaded twice. This PR fixes by removing assets definition from `block.json` files for the moment.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch.
- Visit `Posts > Add New`.
- Add a Blogroll block to this page.
- Open the dev console and check the page preview.
- Notice `wp-content/plugins/jetpack/_inc/blocks/blogroll/view.js` is loaded only once.