### PR TITLE
Update/paywall use magic link again

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-use-magic-link-again
+++ b/projects/plugins/jetpack/changelog/update-paywall-use-magic-link-again
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+this is how it use to work two hours ago

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1140,7 +1140,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 
 	$sign_in = '';
 	if ( ! is_user_logged_in() && ( new Host() )->is_wpcom_simple() ) {
-		$sign_in_link = wpcom_logmein_redirect_url( get_current_url() );
+		$sign_in_link = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
 		$sign_in      = '<!-- wp:paragraph {"align":"center", "typography":{"fontSize":"14px","fontWeight":"400";"color":"#646970"}} -->
 <p class="has-text-align-center" style="font-size:14px;font-weight:400;color:#646970">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '" class="jetpack-subscriber-paywall-login" style="font-size:14px;font-weight:400;color:#646970">' . esc_html__( 'Log in', 'jetpack' ) . '</a></p>
 <!-- /wp:paragraph -->';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1695650415430789-slack-C052XEUUBL4

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* D123623-code was deployed and we can use it to create a magic link that logs you in to custom domains.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1695947521387159-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a session without 3rd party cookies.
* WPCOM Logged out, visit a site with a paywall and a custom domain and that you are already a subscriber.
* Access link flow should redirect to the post.
* Start a clean new session without 3rd party cookies.
* Log in to WPCOM.
* Visit a site with a paywall and a custom domain and that you are already a subscriber.
* Access link should offer the magic link flow.