### PR TITLE
MyJetpack: add has_required_plan for VideoPress product class

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-videopress-upgrade-path
+++ b/projects/packages/my-jetpack/changelog/fix-videopress-upgrade-path
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add has_required_plan method for VideoPress product class, check plan purchase exists for site

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -74,7 +74,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.8.x-dev"
+			"dev-trunk": "3.9.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.8.2",
+	"version": "3.9.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.8.2';
+	const PACKAGE_VERSION = '3.9.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -156,4 +156,24 @@ class Videopress extends Hybrid_Product {
 			return admin_url( 'admin.php?page=jetpack#/settings?term=videopress' );
 		}
 	}
+
+	/**
+	 * Checks whether the current plan (or purchases) of the site already supports the product
+	 *
+	 * @return boolean
+	 */
+	public static function has_required_plan() {
+		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
+			return false;
+		}
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				if ( 0 === strpos( $purchase->product_slug, static::get_wpcom_product_slug() ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
@@ -163,17 +164,7 @@ class Videopress extends Hybrid_Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
-		$purchases_data = Wpcom_Products::get_site_current_purchases();
-		if ( is_wp_error( $purchases_data ) ) {
-			return false;
-		}
-		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
-			foreach ( $purchases_data as $purchase ) {
-				if ( 0 === strpos( $purchase->product_slug, static::get_wpcom_product_slug() ) ) {
-					return true;
-				}
-			}
-		}
-		return false;
+		// using second argument `true` to force fetching from wpcom
+		return Current_Plan::supports( 'videopress-1tb-storage', true );
 	}
 }

--- a/projects/plugins/backup/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/backup/changelog/fix-videopress-upgrade-path
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -899,7 +899,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "f03839036e98449c2c740dca99d1f84ffe2b20af"
+                "reference": "76b8ab03a2bcc2f1702f5d4d43838badf9df7480"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -929,7 +929,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/boost/changelog/fix-videopress-upgrade-path
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -954,7 +954,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "f03839036e98449c2c740dca99d1f84ffe2b20af"
+                "reference": "76b8ab03a2bcc2f1702f5d4d43838badf9df7480"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -984,7 +984,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/jetpack/changelog/fix-videopress-upgrade-path
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1703,7 +1703,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "f03839036e98449c2c740dca99d1f84ffe2b20af"
+                "reference": "76b8ab03a2bcc2f1702f5d4d43838badf9df7480"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1733,7 +1733,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/migration/changelog/fix-videopress-upgrade-path
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -899,7 +899,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "f03839036e98449c2c740dca99d1f84ffe2b20af"
+                "reference": "76b8ab03a2bcc2f1702f5d4d43838badf9df7480"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -929,7 +929,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/protect/changelog/fix-videopress-upgrade-path
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "f03839036e98449c2c740dca99d1f84ffe2b20af"
+                "reference": "76b8ab03a2bcc2f1702f5d4d43838badf9df7480"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -844,7 +844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/search/changelog/fix-videopress-upgrade-path
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "f03839036e98449c2c740dca99d1f84ffe2b20af"
+                "reference": "76b8ab03a2bcc2f1702f5d4d43838badf9df7480"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -844,7 +844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/social/changelog/fix-videopress-upgrade-path
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "f03839036e98449c2c740dca99d1f84ffe2b20af"
+                "reference": "76b8ab03a2bcc2f1702f5d4d43838badf9df7480"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -844,7 +844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/starter-plugin/changelog/fix-videopress-upgrade-path
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "f03839036e98449c2c740dca99d1f84ffe2b20af"
+                "reference": "76b8ab03a2bcc2f1702f5d4d43838badf9df7480"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -844,7 +844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/videopress/changelog/fix-videopress-upgrade-path
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "f03839036e98449c2c740dca99d1f84ffe2b20af"
+                "reference": "76b8ab03a2bcc2f1702f5d4d43838badf9df7480"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -844,7 +844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
This PR adds the method override for VideoPress product class to perform the necessary purchase checks for the site

Fixes #33222 

## Proposed changes:
The issue described a circular flow where the purchase would go into the wrong upgrade path, but this all was coming from the wrong flag on the product details as `has_required_plan` was returning the parent's class default `true`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Start with a site with no VP subscription. Upload a video to exhaust the free quota.

Go to My Jetpack. See the VideoPress card now reads "Purchase" and shows as inactive. Click "Purchase" and follow the flow, purchase with credits. 

You should be taken back to My Jetpack screen to now show the VideoPress card active and with a "Manage" button as CTA. 

