### PR TITLE
Add PHPCS ignore rules for simple deployment.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-lint-ignore-rules-for-simple-deployment
+++ b/projects/plugins/jetpack/changelog/add-lint-ignore-rules-for-simple-deployment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: added a PHPCS rule to avoid problems with Simple WordPress.com deployments.

--- a/projects/plugins/jetpack/modules/subscriptions/jetpack-user-content-link-redirection.php
+++ b/projects/plugins/jetpack/modules/subscriptions/jetpack-user-content-link-redirection.php
@@ -19,6 +19,7 @@ function jetpack_user_content_link_redirection() {
 	$query_params = sanitize_text_field( wp_unslash( $_SERVER['QUERY_STRING'] ) );
 	$iframe_url   = "https://subscribe.wordpress.com/?$query_params";
 
+    // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo <<<EOF
 <!DOCTYPE html>
 <html>
@@ -41,6 +42,7 @@ EOF;
 </body>
 </html>
 EOF;
+    // phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The HEREDOC output style breaks WordPress.com deployment because the linter doesn't allow unescaped output. This disable/enable switch allows us to deploy the code.

## Proposed changes:
* Adds a local PHPCS configuration override.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Deploy the daily.

