### PR TITLE
Docs: improve awareness of first-time build requirement

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -161,7 +161,7 @@ Running the script will tell you if you have your environment already set up and
 
 If you're ready to start, you should see all green `SUCCESS` messages. If the script detect issues, you will see a red `FAILED` note and a link that will help you figure out what you need to change/fix to address the issue.
 
-Once you're all set here, you can continue to developing. If you're setting up an local environment and want to start testing immediately, please ensure you build the projects you need.
+Once you're all set here, you can continue developing. If you're setting up an local environment and want to start testing immediately, please ensure you build the projects you need.
 
 `jetpack build` will provide prompts to determine the project you need or you can pass it a complete command, like `jetpack build plugins/jetpack --with-deps`
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -161,6 +161,10 @@ Running the script will tell you if you have your environment already set up and
 
 If you're ready to start, you should see all green `SUCCESS` messages. If the script detect issues, you will see a red `FAILED` note and a link that will help you figure out what you need to change/fix to address the issue.
 
+Once you're all set here, you can continue to developing. If you're setting up an local environment and want to start testing immediately, please ensure you build the projects you need.
+
+`jetpack build` will provide prompts to determine the project you need or you can pass it a complete command, like `jetpack build plugins/jetpack --with-deps`
+
 # Development workflow
 
 Once you have a local copy of Jetpack and all development tools installed, you can start developing.

--- a/projects/plugins/jetpack/changelog/improve-no-composer-error
+++ b/projects/plugins/jetpack/changelog/improve-no-composer-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Just a small update to error text only seen by developers building Jetpack itself.
+
+

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -171,11 +171,12 @@ if ( is_readable( $jetpack_autoloader ) && is_readable( $jetpack_module_headings
 						/* translators: Placeholder is a link to a support document. */
 						__( 'Your installation of Jetpack is incomplete. If you installed Jetpack from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Jetpack must have Composer dependencies installed and built via the build command: <code>jetpack build plugins/jetpack --with-deps</code>', 'jetpack' ),
 						array(
-							'a' => array(
+							'a'    => array(
 								'href'   => array(),
-								'target' => array(),
 								'rel'    => array(),
+								'target' => array(),
 							),
+							'code' => array(),
 						)
 					),
 					'https://github.com/Automattic/jetpack/blob/trunk/docs/development-environment.md#building-your-project'

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -169,7 +169,7 @@ if ( is_readable( $jetpack_autoloader ) && is_readable( $jetpack_module_headings
 				printf(
 					wp_kses(
 						/* translators: Placeholder is a link to a support document. */
-						__( 'Your installation of Jetpack is incomplete. If you installed Jetpack from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Jetpack must have Composer dependencies installed and built via the build command.', 'jetpack' ),
+						__( 'Your installation of Jetpack is incomplete. If you installed Jetpack from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Jetpack must have Composer dependencies installed and built via the build command: <code>jetpack build plugins/jetpack --with-deps</code>', 'jetpack' ),
 						array(
 							'a' => array(
 								'href'   => array(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

For the first time setting up the environment, let's help folks know to a build step is required.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the error message when Composer deps are not installed.
* Update the docs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. --><!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a clean everything (`jetpack clean`) and do the steps to setup Docker `jetpack docker uninstall && jetpack docker up -d && jetpack docker install`)
* See wp-admin of the local Docker with Jetpack activated. See the error about the Composer needing to be built. logs too (WP_DEBUG true).
* Run `jetpack build plugins/jetpack --with-deps`
* Jetpack loads now.

