### PR TITLE
Revert " Fix block view scripts being loaded twice (#33406)"

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-block-view-script-loaded-multiple-times
+++ b/projects/plugins/jetpack/changelog/fix-block-view-script-loaded-multiple-times
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix block view scripts being loaded twice

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -199,7 +199,7 @@ module.exports = [
 						context: path.join( __dirname, '../extensions/blocks' ),
 						noErrorOnMissing: true,
 						// Automatically link scripts and styles
-						transform( content ) {
+						transform( content, absoluteFrom ) {
 							let metadata = {};
 
 							try {
@@ -212,6 +212,7 @@ module.exports = [
 								return metadata;
 							}
 
+							const metadataDir = path.dirname( absoluteFrom );
 							let scriptName = 'editor';
 
 							if ( presetIndex.beta.includes( name ) ) {
@@ -220,14 +221,22 @@ module.exports = [
 								scriptName += '-experimental';
 							}
 
-							// `editorScript` is required for block.json to be valid and WordPress.org to be able
-							// to parse it before building the page at https://wordpress.org/plugins/jetpack/.
-							// Don't add other scripts or styles while block assets are still enqueued manually
-							// in the backend.
 							const result = {
 								...metadata,
 								editorScript: `file:../${ scriptName }.js`,
+								editorStyle: `file:../${ scriptName }.css`,
 							};
+
+							if ( fs.existsSync( path.join( metadataDir, 'view.js' ) ) ) {
+								result.viewScript = 'file:./view.js';
+							}
+
+							if (
+								fs.existsSync( path.join( metadataDir, 'style.scss' ) ) ||
+								fs.existsSync( path.join( metadataDir, 'view.scss' ) )
+							) {
+								result.style = 'file:./view.css';
+							}
 
 							return JSON.stringify( result, null, 4 );
 						},


### PR DESCRIPTION
This reverts commit b3dee2973d3499a702f60fd71fff4a027d0a3bc2.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

