### PR TITLE
CRM: Resolves 3336, 3350, and 3351 - PHP 8.2 deprecation notices

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3336+3350+3351-PHP_deprecation_notices
+++ b/projects/plugins/crm/changelog/fix-crm-3336+3350+3351-PHP_deprecation_notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Better PHP 8.2 support

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.php
@@ -29,8 +29,6 @@ class zeroBSCRM_Edit{
     private $plural = false;
     // renamed listViewSlug v3.0+ private $postPage = false;
     private $listViewSlug = false;
-    // Discontinued from v3.0 private $tag = false; // this is now retrieved from DAL centralised vars by objTypeID above, v3.0+
-    // Discontinued from v3.0 private $postType = false; // this is now retrieved from DAL centralised vars by objTypeID above, v3.0+
 
     private $langLabels = false;
     private $bulkActions = false;
@@ -57,8 +55,6 @@ class zeroBSCRM_Edit{
             'objType'   => false,   //transaction
             'singular'   => false,  //Transaction
             'plural' => false,      //Transactions
-            'tag' => false,         // Discontinued v3.0 + zerobs_transactiontag
-            'postType' => false,    // Discontinued v3.0 + //zerobs_transaction
             'listViewSlug' => false,    //manage-transactions
 
             'langLabels' => array(

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -157,9 +157,9 @@ function zeroBSCRM_stripSlashesFromArr( $value ) { // phpcs:ignore WordPress.Nam
 		return array_map( 'zeroBSCRM_stripSlashesFromArr', $value );
 	} elseif ( is_string( $value ) ) {
 		return stripslashes( $value );
-	} else {
-		return $value;
-	}
+	} 
+	return $value;
+
 }
 
    # from http://wordpress.stackexchange.com/questions/91900/how-to-force-a-404-on-wordpress

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -141,15 +141,26 @@ function zerobscrm_doing_it_wrong( $function, $message, $version ) {
 
 	}
 
-
-	function zeroBSCRM_stripSlashesFromArr($value){
-	    $value = is_array($value) ?
-	                array_map('zeroBSCRM_stripSlashesFromArr', $value) :
-	                stripslashes($value);
-
-	    return $value;
+/**
+ * Recursively strips slashes from an array.
+ *
+ * Quite similar to zeroBSCRM_stripSlashes(), but that given
+ * its legacy status any changes to there and its returns may
+ * have negative implications
+ *
+ * @param array|string|null $value Some value to strip.
+ *
+ * @return array|string|null
+ */
+function zeroBSCRM_stripSlashesFromArr( $value ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+	if ( is_array( $value ) ) {
+		return array_map( 'zeroBSCRM_stripSlashesFromArr', $value );
+	} elseif ( is_string( $value ) ) {
+		return stripslashes( $value );
+	} else {
+		return $value;
 	}
-
+}
 
    # from http://wordpress.stackexchange.com/questions/91900/how-to-force-a-404-on-wordpress
 	function zeroBSCRM_force_404() {

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -157,9 +157,8 @@ function zeroBSCRM_stripSlashesFromArr( $value ) { // phpcs:ignore WordPress.Nam
 		return array_map( 'zeroBSCRM_stripSlashesFromArr', $value );
 	} elseif ( is_string( $value ) ) {
 		return stripslashes( $value );
-	} 
+	}
 	return $value;
-
 }
 
    # from http://wordpress.stackexchange.com/questions/91900/how-to-force-a-404-on-wordpress

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
@@ -79,7 +79,6 @@
             $this->coOrgLabel = jpcrm_label_company();
 
             // set these
-            // DAL3 switched for objType $this->postType = 'zerobs_customer';
             $this->objType = 'company';
             $this->metaboxID = 'zerobs-company-edit';
             $this->metaboxTitle = $this->coOrgLabel.' '.__('Details','zero-bs-crm');
@@ -430,7 +429,6 @@ class zeroBS__Metabox_CompanyContacts extends zeroBS__Metabox{
         // oldschool.
         $this->coOrgLabel = jpcrm_label_company();
     
-        // DAL3 switched for objType $this->postType = 'zerobs_customer';
         $this->objType = 'company';
         $this->metaboxID = 'zerobs-company-contacts';
         $this->metaboxTitle = __('Associated Contacts',"zero-bs-crm");
@@ -1013,7 +1011,6 @@ class zeroBS__Metabox_Company_Activity extends zeroBS__Metabox {
 
     public function __construct( $plugin_file ) {
     
-        $this->postType = 'zerobs_company';
         $this->metaboxID = 'zbs-company-activity-metabox';
         $this->metaboxTitle = __('Activity', 'zero-bs-crm');
         $this->metaboxIcon = 'heartbeat';

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -2200,7 +2200,8 @@ class zeroBS__Metabox_ContactLogs extends zeroBS__Metabox_LogsV2{
 
     public function __construct( $plugin_file ) {
     
-        $this->objtypeid = 1; // until db2 ZBS_TYPE_CONTACT;
+		$this->objtypeid = ZBS_TYPE_CONTACT;
+
         $this->objType = 'contact';
         $this->metaboxID = 'zerobs-customer-logs';
         $this->metaboxTitle = __('Activity Log',"zero-bs-crm");

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -142,7 +142,6 @@
         public function __construct( $plugin_file ) {
 
             // set these
-            // DAL3 switched for objType $this->postType = 'zerobs_customer';
             $this->objType = 'contact';
             $this->metaboxID = 'zerobs-customer-edit';
             $this->metaboxTitle = __('Contact Details',"zero-bs-crm");
@@ -650,7 +649,6 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
 
     public function __construct( $plugin_file ) {
     
-        // DAL3 switched for objType $this->postType = 'zerobs_customer';
         $this->objType = 'contact';
         $this->metaboxID = 'zerobs-customer-actions';
         $this->metaboxTitle = __('Contact Actions',"zero-bs-crm");
@@ -803,7 +801,6 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
 
         public function __construct( $plugin_file, $idOverride='',$titleOverride='' ) {
 
-            // DAL3 switched for objType $this->postType = 'zerobs_customer';
             $this->objType = 'contact';
             $this->metaboxID = 'zerobs-customer-custom-files';
             $this->metaboxTitle = __('Other Files',"zero-bs-crm");
@@ -1103,7 +1100,6 @@ add_action('add_meta_boxes', 'zeroBS__addCustomerMetaBoxes');  */
 
         public function __construct( $plugin_file ) {
 
-            // DAL3 switched for objType $this->postType = 'zerobs_customer';
             $this->objType = 'contact';
             $this->metaboxID = 'zerobs-customer-files';
             $this->metaboxTitle = __('Other Files',"zero-bs-crm");
@@ -1435,7 +1431,6 @@ class zeroBS__Metabox_ContactPortal extends zeroBS__Metabox{
 
     public function __construct( $plugin_file, $metabox_screen = 'zbs-add-edit-contact-edit' ) {
 
-        // DAL3 switched for objType $this->postType = 'zerobs_customer';
         $this->objType = 'contact';
         $this->metaboxID = 'zerobs-customer-portal';
         $this->metaboxTitle = __('Client Portal',"zero-bs-crm");
@@ -1755,7 +1750,6 @@ class zeroBS__Metabox_ContactSocial extends zeroBS__Metabox{
 
     public function __construct( $plugin_file ) {
     
-        // DAL3 switched for objType $this->postType = 'zerobs_customer';
         $this->objType = 'contact';
         $this->metaboxID = 'zerobs-customer-social';
         $this->metaboxTitle = __('Social Profiles',"zero-bs-crm");
@@ -1845,7 +1839,6 @@ class zeroBS__Metabox_ContactAKA extends zeroBS__Metabox{
 
     public function __construct( $plugin_file ) {
     
-        // DAL3 switched for objType $this->postType = 'zerobs_customer';
         $this->objType = 'contact';
         $this->metaboxID = 'zerobs-customer-aka';
         $this->metaboxTitle = __('Contact Aliases (AKA)',"zero-bs-crm");
@@ -2180,7 +2173,6 @@ class zeroBS__Metabox_ContactTags extends zeroBS__Metabox_Tags{
     public function __construct( $plugin_file ) {
     
         $this->objTypeID = ZBS_TYPE_CONTACT;
-        // DAL3 switched for objType $this->postType = 'zerobs_customer';
         $this->objType = 'contact';
         $this->metaboxID = 'zerobs-customer-tags';
         $this->metaboxTitle = __('Contact Tags',"zero-bs-crm");
@@ -2220,7 +2212,6 @@ class zeroBS__Metabox_ContactLogs extends zeroBS__Metabox_LogsV2{
     public function __construct( $plugin_file ) {
     
         $this->objtypeid = 1; // until db2 ZBS_TYPE_CONTACT;
-        // DAL3 switched for objType $this->postType = 'zerobs_customer';
         $this->objType = 'contact';
         $this->metaboxID = 'zerobs-customer-logs';
         $this->metaboxTitle = __('Activity Log',"zero-bs-crm");
@@ -2265,7 +2256,6 @@ class zeroBS__Metabox_ContactCompany extends zeroBS__Metabox{
         $companyOrOrg = zeroBSCRM_getSetting('coororg');
         $companyLabel = jpcrm_label_company();
     
-        // DAL3 switched for objType $this->postType = 'zerobs_customer';
         $this->objType = 'contact';
         $this->metaboxID = 'zerobs-customer-company';
         $this->metaboxTitle = __($companyLabel, "zero-bs-crm");
@@ -2410,7 +2400,6 @@ class zeroBS__Metabox_Contact_Activity extends zeroBS__Metabox {
 
     public function __construct( $plugin_file ) {
     
-        $this->postType = 'zerobs_customer';
         $this->metaboxID = 'zbs-contact-activity-metabox';
         $this->metaboxTitle = __('Activity', 'zero-bs-crm');
         $this->metaboxIcon = 'heartbeat';

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -1044,20 +1044,9 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
                                             ///update_post_meta($contact_id, 'zbs_customer_files', $zbsCustomerFiles);  
                                             zeroBSCRM_updateCustomerFiles($contact_id,$zbsCustomerFiles);                                            
 
-                                            // AND associate with this 'slot'
-                                            if ($zbs->isDAL2()){
-                                                
-                                                // DAL2
                                                 // actually got wrappers now :) $zbs->updateMeta(ZBS_TYPE_CONTACT,$contact_id,'cfile_'.$cfSubKey,$upload['file']);
                                                 // this'll override any prev in that slot, too
                                                 zeroBSCRM_fileslots_addToSlot($cfSubKey,$upload['file'],$contact_id,ZBS_TYPE_CONTACT,true);        
-
-                                            } else {
-
-                                                // DAL1
-                                                update_post_meta($contact_id,'cfile_'.$cfSubKey,$upload['file']);
-
-                                            }
 
                                             // Fire any 'post-upload-processing' (e.g. CPP makes thumbnails of pdf, jpg, etc.)
                                             do_action('zbs_post_upload_contact',$upload);

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.ExternalSources.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.ExternalSources.php
@@ -24,6 +24,14 @@
 
         private $acceptableTypes = array('contact','company','transaction','invoice');
 
+	/**
+	 * The object type ID using this metabox.
+	 *
+	 * @since $$next-version$$
+	 * @var int
+	 */
+	private $objTypeID; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
         public function __construct( $plugin_file, $objType='contact',$metaboxScreen='zbs-add-edit-contact-edit' ) {
 
             global $zbs;

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
@@ -717,6 +717,9 @@
 
         public function html( $quote, $metabox ) {
 
+		if ( $quote === false ) {
+			$quote = array();
+		}
             global $zbs;
 
             // localise ID & content

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.TagManager.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.TagManager.php
@@ -76,6 +76,13 @@
 
     class zeroBS__Metabox_TagList extends zeroBS__Metabox{ 
 
+	/**
+	 * The legacy object name (e.g. 'zerobs_customer')
+	 *
+	 * @var string
+	 */
+	private $postType; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
         public function __construct( $plugin_file, $typeInt = ZBS_TYPE_CONTACT ) {
 
           global $zbs;
@@ -89,7 +96,6 @@
             $this->metaboxArea = 'normal';
             $this->metaboxLocation = 'high';
             $this->saveOrder = 1;
-
             // headless!
             $this->headless = true;
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.TagManager.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.TagManager.php
@@ -204,6 +204,12 @@
 
     class zeroBS__Metabox_TagAdd extends zeroBS__Metabox_Tags{
 
+	/**
+	 * The legacy object name (e.g. 'zerobs_customer')
+	 *
+	 * @var string
+	 */
+	private $postType; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
 
         public function __construct( $plugin_file, $typeInt = ZBS_TYPE_CONTACT) {
 

--- a/projects/plugins/crm/includes/class-learn-menu.php
+++ b/projects/plugins/crm/includes/class-learn-menu.php
@@ -12,6 +12,7 @@ defined( 'ZEROBSCRM_PATH' ) || exit;
 
 /**
  * Learn menu class
+ * This is a bit of a misnomer, as it really refers to the page titlebar (under the top menu).
  */
 class Learn_Menu {
 
@@ -29,6 +30,104 @@ class Learn_Menu {
 	 * @var string
 	 */
 	protected $override_slug;
+
+	/**
+	 * Title of page
+	 *
+	 * @var string
+	 */
+	private $page_title;
+
+	/**
+	 * HTML to the left of the page header, often containing buttons
+	 *
+	 * @var string
+	 */
+	private $left_buttons;
+
+	/**
+	 * HTML to the right of the page header, often containing buttons
+	 *
+	 * @var string
+	 */
+	private $right_buttons;
+
+	/**
+	 * Whether or not to show the learn button
+	 *
+	 * @var bool
+	 */
+	private $show_learn;
+
+	/**
+	 * The learn box title
+	 *
+	 * @var string
+	 */
+	private $learn_title;
+
+	/**
+	 * The learn box content (HTML)
+	 *
+	 * @var string
+	 */
+	private $learn_content;
+
+	/**
+	 * The "learn more" link url
+	 *
+	 * @var string
+	 */
+	private $learn_more_url;
+
+	/**
+	 * The learn image url
+	 *
+	 * @var string
+	 */
+	private $learn_image_url;
+
+	/**
+	 * The learn video url
+	 *
+	 * @var string
+	 */
+	private $learn_video_url;
+
+	/**
+	 * Any extra JS to output
+	 *
+	 * @var string
+	 */
+	private $extra_js;
+
+	/**
+	 * Any extra css styles to add to the popup element
+	 *
+	 * @var string
+	 */
+	private $popup_extra_css;
+
+	/**
+	 * If $learn_video_url is provided, specify a video title here
+	 *
+	 * @var string
+	 */
+	private $learn_video_title;
+
+	/**
+	 * An icon to show before the page title
+	 *
+	 * @var string
+	 */
+	private $icon_class;
+
+	/**
+	 * The slug to use for a "back to list" link, or false if not used
+	 *
+	 * @var string|bool
+	 */
+	private $back_slug;
 
 	/**
 	 * Setup learn menu.

--- a/projects/plugins/crm/tests/codeception/_support/Helper/RunProcess.php
+++ b/projects/plugins/crm/tests/codeception/_support/Helper/RunProcess.php
@@ -51,7 +51,7 @@ class RunProcess {
 	public function stop() {
 		try {
 			$result = shell_exec( sprintf( 'kill %d 2>&1', $this->pid ) );
-			if ( ! preg_match( '/No such process/', $result ) ) {
+			if ( is_string( $result ) && ! preg_match( '/No such process/', $result ) ) {
 				return true;
 			}
 		} catch ( Exception $e ) {

--- a/projects/plugins/crm/tests/codeception/acceptance.suite.dist.yml
+++ b/projects/plugins/crm/tests/codeception/acceptance.suite.dist.yml
@@ -29,3 +29,4 @@ modules:
             server_host: 'localhost:8000'
             wp_path: '/path/to/test/file/must-overwrite-it-in-acceptance.suite.yml'
 step_decorators: ~
+error_level: E_ALL


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3336, Automattic/zero-bs-crm#3350, and Automattic/zero-bs-crm#3351 - PHP 8.2 deprecation notices

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This catches several deprecation notices that appear in PHP 8.2, of various types:

* Dynamic class properties: in most cases the fix was to declare them, and in a few cases they weren't used so they were removed
* Errant assignment of an array key/value to a `bool`: we now make this an empty array before assigning a key/value
* Errant passing of `null` to `stripslashes()`: we don't have details on how this was triggered (something in their settings), but I added a fallback to prevent it

---

I also updated Codeception's configuration to show errors in its output as relevant, and patched a deprecation in its `RunProcess.php` extension (we can't update, as Codeception 5 requires PHP 8). However, I believe this only affects PHP errors that are generated by the test code rather than by the pageloads it's testing, so unfortunately this doesn't help us too much.

It'd be nice if we found a way to get Codeception to output errors when deprecation notices popped up on our pages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Make sure you're on PHP 8.2.

In `trunk`, bounce around to each page (including new, edit, and view pages). You'll see deprecation notices throughout, even on non-CRM pages.

In `fix/crm/3336+3350+3351-PHP_deprecation_notices` the deprecation notices are all gone.