### PR TITLE
[CRM] Automation: Add more attribute config

### DIFF
--- a/projects/plugins/crm/changelog/crm-add-automation-add-more-attribute-config
+++ b/projects/plugins/crm/changelog/crm-add-automation-add-more-attribute-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Automations is behind a feature flag
+
+

--- a/projects/plugins/crm/src/automation/class-attribute-definition.php
+++ b/projects/plugins/crm/src/automation/class-attribute-definition.php
@@ -60,28 +60,12 @@ class Attribute_Definition {
 	const DATE = 'date';
 
 	/**
-	 * Represents a date and time input.
-	 *
-	 * @since $$next-version$$
-	 * @var string
-	 */
-	const DATETIME = 'datetime';
-
-	/**
 	 * Represents a numerical input.
 	 *
 	 * @since $$next-version$$
 	 * @var string
 	 */
 	const NUMBER = 'number';
-
-	/**
-	 * Represents a password input.
-	 *
-	 * @since $$next-version$$
-	 * @var string
-	 */
-	const PASSWORD = 'password';
 
 	/**
 	 * The slug (key) that identifies this attribute.

--- a/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
@@ -1,4 +1,4 @@
-import { SelectControl, TextareaControl, TextControl } from '@wordpress/components';
+import { DatePicker, SelectControl, TextareaControl, TextControl } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { store } from 'crm/state/store';
 import { useCallback } from 'react';
@@ -12,6 +12,8 @@ type AttributeConfigProps = {
 	definition: AttributeDefinition;
 };
 
+type NewValue = string | number | boolean;
+
 export const AttributeConfig: React.FC< AttributeConfigProps > = ( {
 	workflowId,
 	stepId,
@@ -19,7 +21,7 @@ export const AttributeConfig: React.FC< AttributeConfigProps > = ( {
 	definition,
 } ) => {
 	const onChange = useCallback(
-		( newValue: string ) =>
+		( newValue: NewValue ) =>
 			dispatch( store ).setAttribute( workflowId, stepId, definition.slug, newValue ),
 		[ workflowId, stepId, definition.slug ]
 	);
@@ -37,7 +39,7 @@ export const AttributeConfig: React.FC< AttributeConfigProps > = ( {
 const getEditValue = (
 	value: AttributeValue,
 	definition: AttributeDefinition,
-	onChange: ( newValue: string ) => void
+	onChange: ( newValue: NewValue ) => void
 ) => {
 	switch ( definition.type ) {
 		case 'select':
@@ -58,12 +60,20 @@ const getEditValue = (
 			return <TextControl value={ value.toString() } onChange={ onChange } />;
 		case 'checkbox':
 		case 'textarea':
-			return <TextareaControl value={ value } onChange={ onChange } />;
+			return <TextareaControl value={ value as string } onChange={ onChange } />;
 		case 'date':
-		case 'datetime':
+			return (
+				<div className={ styles.datepicker }>
+					<DatePicker
+						currentDate={ value ? new Date( value as string | number ) : new Date() }
+						onChange={ ( selectedDate: Date ) => {
+							onChange( selectedDate.getTime() );
+						} }
+					/>
+				</div>
+			);
 		case 'number':
 			return <TextControl type="number" value={ value } onChange={ onChange } />;
-		case 'password':
 		default:
 			return `${ definition.type } is not implemented`;
 	}

--- a/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
@@ -65,7 +65,7 @@ const getEditValue = (
 				/>
 			);
 		case 'text':
-			return <TextControl value={ value.toString() } onChange={ onChange } />;
+			return <TextControl value={ value } onChange={ onChange } />;
 		case 'checkbox':
 			return (
 				<CheckboxControl

--- a/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
@@ -1,4 +1,10 @@
-import { DatePicker, SelectControl, TextareaControl, TextControl } from '@wordpress/components';
+import {
+	CheckboxControl,
+	DatePicker,
+	SelectControl,
+	TextareaControl,
+	TextControl,
+} from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { store } from 'crm/state/store';
 import { useCallback } from 'react';
@@ -30,7 +36,9 @@ export const AttributeConfig: React.FC< AttributeConfigProps > = ( {
 
 	return (
 		<div className={ styles.container }>
-			<div className={ styles.title }>{ definition.title }</div>
+			{ definition.type !== 'checkbox' && (
+				<div className={ styles.title }>{ definition.title }</div>
+			) }
 			{ editValue }
 		</div>
 	);
@@ -59,6 +67,13 @@ const getEditValue = (
 		case 'text':
 			return <TextControl value={ value.toString() } onChange={ onChange } />;
 		case 'checkbox':
+			return (
+				<CheckboxControl
+					label={ definition.title }
+					checked={ value as boolean }
+					onChange={ onChange }
+				/>
+			);
 		case 'textarea':
 			return <TextareaControl value={ value as string } onChange={ onChange } />;
 		case 'date':

--- a/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
@@ -81,8 +81,12 @@ const getEditValue = (
 				<div className={ styles.datepicker }>
 					<DatePicker
 						currentDate={ value ? new Date( value as string | number ) : new Date() }
-						onChange={ ( selectedDate: Date ) => {
-							onChange( selectedDate.getTime() );
+						onChange={ ( selectedDate: string ) => {
+							// selectedDate is a string in the format `YYYY-MM-DDTHH:MM:SS` but CRM
+							// is using timestamps, so we pass it to a Date object before converting
+							// it back to a timestamp for Redux.
+							const newDate = new Date( selectedDate );
+							onChange( newDate.getTime() );
 						} }
 					/>
 				</div>

--- a/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
@@ -61,6 +61,7 @@ const getEditValue = (
 		case 'date':
 		case 'datetime':
 		case 'number':
+			return <TextControl type="number" value={ value } onChange={ onChange } />;
 		case 'password':
 		default:
 			return `${ definition.type } is not implemented`;

--- a/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/index.tsx
@@ -1,4 +1,4 @@
-import { SelectControl, TextControl } from '@wordpress/components';
+import { SelectControl, TextareaControl, TextControl } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { store } from 'crm/state/store';
 import { useCallback } from 'react';
@@ -58,6 +58,7 @@ const getEditValue = (
 			return <TextControl value={ value.toString() } onChange={ onChange } />;
 		case 'checkbox':
 		case 'textarea':
+			return <TextareaControl value={ value } onChange={ onChange } />;
 		case 'date':
 		case 'datetime':
 		case 'number':

--- a/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/styles.module.scss
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/styles.module.scss
@@ -3,11 +3,9 @@
 		margin-bottom: 0;
 	}
 
-	select {
-		font-size: var(--font-body) !important;
-	}
-
-	input {
+	input,
+	select,
+	textarea {
 		font-size: var(--font-body) !important;
 	}
 }

--- a/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/styles.module.scss
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/attribute-config/styles.module.scss
@@ -4,14 +4,22 @@
 	}
 
 	select {
-		font-size: 16px !important;
+		font-size: var(--font-body) !important;
 	}
 
 	input {
-		font-size: 16px !important;
+		font-size: var(--font-body) !important;
 	}
 }
 
 .title {
 	margin-bottom: 8px;
+}
+
+.datepicker {
+	background: var(--jp-white);
+	padding: var(--jp-modal-padding-small) var(--jp-modal-padding);
+	/* Adding styling that matches the WordPress default input styling. */
+	border: 1px solid #949494;
+	border-radius: 2px;
 }

--- a/projects/plugins/crm/src/js/components/automations-admin/components/edit-modal/styles.module.scss
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/edit-modal/styles.module.scss
@@ -14,6 +14,7 @@
 	}
 
 	:global(.components-checkbox-control__label) {
+		font-size: var(--font-body);
 		margin-bottom: 0;
 		font-weight: 400;
 	}

--- a/projects/plugins/crm/src/js/components/automations-admin/components/edit-modal/styles.module.scss
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/edit-modal/styles.module.scss
@@ -17,6 +17,10 @@
 		margin-bottom: 0;
 		font-weight: 400;
 	}
+
+	:global(.is-scrollable) {
+		box-shadow: none;
+	}
 }
 
 .container {

--- a/projects/plugins/crm/src/js/components/automations-admin/components/edit-modal/styles.module.scss
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/edit-modal/styles.module.scss
@@ -12,6 +12,11 @@
 	:global(.components-modal__content) {
 		padding: 0 32px 32px 32px;
 	}
+
+	:global(.components-checkbox-control__label) {
+		margin-bottom: 0;
+		font-weight: 400;
+	}
 }
 
 .container {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds the remaining attribution config displays we need for the first iteration of automations.

_This PR still has to assume some foundational things because the https://github.com/Automattic/zero-bs-crm/issues/3203 is still being worked on._

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update text attribute since `.toString()` was causing a fatal error
* Add checkbox attribute
* Add textarea attribute
* Add date attribute
* Add number attribute
* Remove `DateTime` and `Password` attributes since we do not need them for feature parity with Automations v1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1HpG7-mCz-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Manual testing

**Manual testing prep work**

1. Make sure the following feature flags are enabled on your site:

```php
add_filter( 'jetpack_crm_feature_flag_api_v4', '__return_true' );
add_filter( 'jetpack_crm_feature_flag_automations', '__return_true' );
```

2. Make sure you have a workflow in your database that uses the `Update_Contact_Status` action. You can use the below snippet to add one if needed.

```php
$workflow = new \Automattic\Jetpack\CRM\Automation\Automation_Workflow(
	[
		'name'         => 'New contact: Set status to "Customer"',
		'description'  => 'This automation will change the status of a contact to "Customer" when they are created.',
		'category'     => 'contact',
		'active'       => true,
		'triggers'     => [
			\Automattic\Jetpack\CRM\Automation\Triggers\Contact_Created::get_slug(),
		],
		'initial_step' => 1,
		'steps'        => [
			1 => [
				'slug'       => \Automattic\Jetpack\CRM\Automation\Actions\Update_Contact_Status::get_slug(),
				'attributes' => [
					'new_status' => 'Customer',
				],
				'next_step_true'  => null,
				'next_step_false' => null,
			],
		],
	]
);

$repo = new \Automattic\Jetpack\CRM\Automation\Workflow\Workflow_Repository();
$workflow = $repo->persist(  $workflow );
```

3. Replace `set_attribute_definitions` in `Update_Contact_Status::__construct()` with the below snippet to display a bunch of attributes at one time.

```php
$this->set_attribute_definitions(
	array(
		new Attribute_Definition(
			'new_status',
			__( 'New status', 'zero-bs-crm' ),
			__( 'The status that will be used for the contact.', 'zero-bs-crm' ),
			Attribute_Definition::SELECT,
			$statuses
		),
		new Attribute_Definition(
			'new_number',
			__( 'Number', 'zero-bs-crm' ),
			__( 'Test', 'zero-bs-crm' ),
			Attribute_Definition::NUMBER
		),
		new Attribute_Definition(
			'new_text',
			__( 'Text', 'zero-bs-crm' ),
			__( 'Test', 'zero-bs-crm' ),
			Attribute_Definition::TEXT
		),
		new Attribute_Definition(
			'date',
			__( 'Date', 'zero-bs-crm' ),
			__( 'Test', 'zero-bs-crm' ),
			Attribute_Definition::DATE
		),
		new Attribute_Definition(
			'textarea',
			__( 'Textarea', 'zero-bs-crm' ),
			__( 'Test', 'zero-bs-crm' ),
			Attribute_Definition::TEXTAREA
		),
		new Attribute_Definition(
			'checkbox1',
			__( 'Checkbox', 'zero-bs-crm' ),
			__( 'Test', 'zero-bs-crm' ),
			Attribute_Definition::CHECKBOX
		),
		new Attribute_Definition(
			'checkbox2',
			__( 'Checkbox', 'zero-bs-crm' ),
			__( 'Test', 'zero-bs-crm' ),
			Attribute_Definition::CHECKBOX
		),
		new Attribute_Definition(
			'checkbox3',
			__( 'Checkbox', 'zero-bs-crm' ),
			__( 'Test', 'zero-bs-crm' ),
			Attribute_Definition::CHECKBOX
		),
	)
);
```

4. Go to `/wp-admin/admin.php?page=jpcrm-automations#/automations` and open the workflow created above.

## Screenshot(s)

![Screenshot 2023-09-30 at 01 17 17](https://github.com/Automattic/jetpack/assets/3846700/63f141e4-66b9-4c2f-8d5e-d4481903feb1)

