### PR TITLE
Revert "Fix missing block translations"

### DIFF
--- a/projects/packages/blocks/changelog/fix-block-translations
+++ b/projects/packages/blocks/changelog/fix-block-translations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix missing block translations

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -50,11 +50,18 @@ class Blocks {
 
 		$block_type = $slug;
 
-		// If a path is passed, make sure to get the block.json file from the build directory and get
-		// the block name from that file.
+		// If a path is passed, find the slug in the file then create a block type object to register
+		// the block.
+		// Note: passing the path directly to register_block_type seems to loose the interactivity of
+		// the block once in the editor once it's out of focus.
 		if ( path_is_absolute( $slug ) ) {
-			$block_type = self::get_path_to_block_metadata( $slug );
-			$slug       = self::get_block_name( $block_type );
+			$metadata = self::get_block_metadata_from_file( self::get_path_to_block_metadata( $slug ) );
+			$name     = self::get_block_name_from_metadata( $metadata );
+
+			if ( ! empty( $name ) ) {
+				$slug       = $name;
+				$block_type = new \WP_Block_Type( $slug, array_merge( $metadata, $args ) );
+			}
 		}
 
 		if (

--- a/projects/plugins/jetpack/changelog/fix-block-translations
+++ b/projects/plugins/jetpack/changelog/fix-block-translations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix missing block translations

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -30,7 +30,7 @@ type BlockSettingsProps = {
 };
 
 export const isAiAssistantSupportExtensionEnabled =
-	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ AI_ASSISTANT_SUPPORT_NAME ];
+	window?.Jetpack_Editor_Initial_State.available_blocks?.[ AI_ASSISTANT_SUPPORT_NAME ];
 
 /**
  * Check if it is possible to extend the block.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/constants.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/constants.ts
@@ -1,7 +1,7 @@
 export const JETPACK_FORM_AI_COMPOSITION_EXTENSION = 'ai-assistant-form-support' as const;
 
 export const isJetpackFromBlockAiCompositionAvailable =
-	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ JETPACK_FORM_AI_COMPOSITION_EXTENSION ]
+	window?.Jetpack_Editor_Initial_State.available_blocks?.[ JETPACK_FORM_AI_COMPOSITION_EXTENSION ]
 		?.available;
 
 // All blocks to extend

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/editor.js
@@ -7,6 +7,8 @@ import './editor.scss';
 import './components/feedback/style.scss';
 
 registerJetpackBlockFromMetadata( metadata, {
+	// The API version needs to be explicitly specified in this instance for styles to be loaded.
+	apiVersion: metadata.apiVersion,
 	edit,
 	save,
 } );

--- a/projects/plugins/jetpack/extensions/blocks/amazon/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/amazon/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/amazon",
 	"title": "Amazon (Beta)",
 	"description": "Promote Amazon products and earn a commission from sales.",

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/business-hours",
 	"title": "Business Hours",
 	"description": "Display opening hours for your business.",

--- a/projects/plugins/jetpack/extensions/blocks/recipe/recipe.php
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/recipe.php
@@ -9,60 +9,55 @@
 
 use Automattic\Jetpack\Blocks;
 
-add_action(
-	'init',
-	function () {
-		Blocks::jetpack_register_block(
-			__DIR__,
-			array(
-				'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render' ),
-			)
-		);
+Blocks::jetpack_register_block(
+	__DIR__,
+	array(
+		'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render' ),
+	)
+);
 
-		Blocks::jetpack_register_block(
-			'jetpack/recipe-details',
-			array(
-				'parent' => array( 'jetpack/recipe' ),
-			)
-		);
+Blocks::jetpack_register_block(
+	'jetpack/recipe-details',
+	array(
+		'parent' => array( 'jetpack/recipe' ),
+	)
+);
 
-		Blocks::jetpack_register_block(
-			'jetpack/recipe-hero',
-			array(
-				'parent'          => array( 'jetpack/recipe' ),
-				'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render_hero' ),
-			)
-		);
+Blocks::jetpack_register_block(
+	'jetpack/recipe-hero',
+	array(
+		'parent'          => array( 'jetpack/recipe' ),
+		'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render_hero' ),
+	)
+);
 
-		Blocks::jetpack_register_block(
-			'jetpack/recipe-ingredients-list',
-			array(
-				'parent' => array( 'jetpack/recipe' ),
-			)
-		);
+Blocks::jetpack_register_block(
+	'jetpack/recipe-ingredients-list',
+	array(
+		'parent' => array( 'jetpack/recipe' ),
+	)
+);
 
-		Blocks::jetpack_register_block(
-			'jetpack/recipe-ingredient-item',
-			array(
-				'parent' => array( 'jetpack/recipe' ),
-			)
-		);
+Blocks::jetpack_register_block(
+	'jetpack/recipe-ingredient-item',
+	array(
+		'parent' => array( 'jetpack/recipe' ),
+	)
+);
 
-		Blocks::jetpack_register_block(
-			'jetpack/recipe-steps',
-			array(
-				'parent' => array( 'jetpack/recipe' ),
-			)
-		);
+Blocks::jetpack_register_block(
+	'jetpack/recipe-steps',
+	array(
+		'parent' => array( 'jetpack/recipe' ),
+	)
+);
 
-		Blocks::jetpack_register_block(
-			'jetpack/recipe-step',
-			array(
-				'parent'          => array( 'jetpack/recipe' ),
-				'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render_step' ),
-			)
-		);
-	}
+Blocks::jetpack_register_block(
+	'jetpack/recipe-step',
+	array(
+		'parent'          => array( 'jetpack/recipe' ),
+		'render_callback' => array( 'Automattic\\Jetpack\\Extensions\\Recipe\\Jetpack_Recipe_Block', 'render_step' ),
+	)
 );
 
 require_once __DIR__ . '/class-jetpack-recipe-block.php';

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
@@ -13,7 +13,7 @@ import { aiExcerptPluginName, aiExcerptPluginSettings } from '.';
 export const AI_CONTENT_LENS = 'ai-content-lens';
 
 const isAiAssistantSupportExtensionEnabled =
-	window?.Jetpack_Editor_Initial_State?.available_blocks[ 'ai-content-lens' ];
+	window?.Jetpack_Editor_Initial_State.available_blocks[ 'ai-content-lens' ];
 
 /**
  * Extend the editor with AI Content Lens features,

--- a/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
+++ b/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
@@ -12,21 +12,15 @@ const JETPACK_PREFIX = 'jetpack/';
 /**
  * Registers a gutenberg block if the availability requirements are met.
  *
- * @param {string} nameOrMetadata - The block's name or metadata object. Jetpack blocks must be
- * registered with a name prefixed with `jetpack/`. This function accepts an unprefixed name too,
- * though (it'd handle both `business-hours` and `jetpack/business-hours` similarly, for instance).
+ * @param {string} name - The block's name. Jetpack blocks must be registered with a name prefixed
+ * with `jetpack/`. This function accepts an unprefixed name too, though (it'd handle both
+ * `business-hours` and `jetpack/business-hours` similarly, for instance).
  * @param {object} settings - The block's settings.
  * @param {object} childBlocks - The block's child blocks.
  * @param {boolean} prefix - Should this block be prefixed with `jetpack/`?
  * @returns {object|boolean} Either false if the block is not available, or the results of `registerBlockType`
  */
-export default function registerJetpackBlock(
-	nameOrMetadata,
-	settings,
-	childBlocks = [],
-	prefix = true
-) {
-	const name = typeof nameOrMetadata === 'string' ? nameOrMetadata : nameOrMetadata.name;
+export default function registerJetpackBlock( name, settings, childBlocks = [], prefix = true ) {
 	const isNamePrefixed = name.startsWith( JETPACK_PREFIX );
 	const rawName = isNamePrefixed ? name.slice( JETPACK_PREFIX.length ) : name;
 
@@ -46,10 +40,7 @@ export default function registerJetpackBlock(
 	}
 
 	const prefixedName = jpPrefix + rawName;
-	const result = registerBlockType(
-		nameOrMetadata === 'object' ? nameOrMetadata : prefixedName,
-		settings
-	);
+	const result = registerBlockType( prefixedName, settings );
 
 	if ( requiredPlan ) {
 		addFilter(
@@ -78,14 +69,14 @@ export default function registerJetpackBlock(
  * @returns {object|boolean} Either false if the block is not available, or the results of `registerBlockType`
  */
 export function registerJetpackBlockFromMetadata( metadata, settings, childBlocks, prefix ) {
-	const mergedSettings = {
+	const clientSettings = {
 		...settings,
 		icon: getBlockIconProp( metadata ),
 	};
 	const { variations } = metadata;
 
 	if ( Array.isArray( variations ) && variations.length > 0 ) {
-		mergedSettings.variations = variations.map( variation => {
+		clientSettings.variations = variations.map( variation => {
 			return {
 				...variation,
 				icon: getBlockIconProp( variation ),
@@ -93,5 +84,5 @@ export function registerJetpackBlockFromMetadata( metadata, settings, childBlock
 		} );
 	}
 
-	return registerJetpackBlock( metadata, mergedSettings, childBlocks, prefix );
+	return registerJetpackBlock( metadata.name, clientSettings, childBlocks, prefix );
 }


### PR DESCRIPTION
Reverts Automattic/jetpack#33326

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1696016984865389/1696008479.242239-slack-C01U2KGS2PQ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
#33326 caused the modal not to open when selecting a source with the Image block. This PR reverts it.

The reason why this happens is not clear yet.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
 
  - Download this branch.
  - Build the plugin: `jetpack build plugins/jetpack`.
  - Remote sync the plugin with your WPcom sandbox (see PCYsg-eg0-p2).
  - On your sandbox test site, create a new post or open the site editor.
  - Add an Image Block and click _Select an image_.
  - Select an option. The modal should open.
 
<img width="655" alt="Screenshot 2023-10-02 at 12 35 28 PM" src="https://github.com/Automattic/jetpack/assets/1620183/003d4a7e-a5d7-48b2-ae7b-b729bb1d6383">
<img width="838" alt="Screenshot 2023-10-02 at 12 35 33 PM" src="https://github.com/Automattic/jetpack/assets/1620183/a13780a8-d080-4951-b824-0fb6be2e0d71">

