### PR TITLE
Remove not used Gravatar subdomain

### DIFF
--- a/projects/plugins/crm/changelog/update-gravatar-host
+++ b/projects/plugins/crm/changelog/update-gravatar-host
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Removed not necessary en. subdomain for gravatar urls

--- a/projects/plugins/crm/tests/codeception/_data/55853.sql
+++ b/projects/plugins/crm/tests/codeception/_data/55853.sql
@@ -81,7 +81,7 @@ CREATE TABLE `wp_comments` (
 LOCK TABLES `wp_comments` WRITE;
 /*!40000 ALTER TABLE `wp_comments` DISABLE KEYS */;
 INSERT INTO `wp_comments` VALUES
-(1,1,'A WordPress Commenter','wapuu@wordpress.example','https://wordpress.org/','','2022-07-12 21:17:35','2022-07-12 21:17:35','Hi, this is a comment.\nTo get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.\nCommenter avatars come from <a href=\"https://en.gravatar.com/\">Gravatar</a>.',0,'1','','comment',0,0);
+(1,1,'A WordPress Commenter','wapuu@wordpress.example','https://wordpress.org/','','2022-07-12 21:17:35','2022-07-12 21:17:35','Hi, this is a comment.\nTo get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.\nCommenter avatars come from <a href=\"https://gravatar.com/\">Gravatar</a>.',0,'1','','comment',0,0);
 /*!40000 ALTER TABLE `wp_comments` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/projects/plugins/jetpack/changelog/update-gravatar-host
+++ b/projects/plugins/jetpack/changelog/update-gravatar-host
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Updated gravatar host to exclude not needed en subdomain
+
+

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1389,7 +1389,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$last_name   = '';
 			$url         = $author->comment_author_url;
 			$avatar_url  = $this->api->get_avatar_url( $author );
-			$profile_url = 'https://en.gravatar.com/' . md5( strtolower( trim( $email ) ) );
+			$profile_url = 'https://gravatar.com/' . md5( strtolower( trim( $email ) ) );
 			$nice        = '';
 			$site_id     = -1;
 
@@ -1459,9 +1459,9 @@ abstract class WPCOM_JSON_API_Endpoint {
 						is_private_blog_user( $site_id, get_current_user_id() )
 					);
 				}
-				$profile_url = "https://en.gravatar.com/{$login}";
+				$profile_url = "https://gravatar.com/{$login}";
 			} else {
-				$profile_url = 'https://en.gravatar.com/' . md5( strtolower( trim( $email ) ) );
+				$profile_url = 'https://gravatar.com/' . md5( strtolower( trim( $email ) ) );
 				$site_id     = -1;
 			}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -58,7 +58,7 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 				"nice_name": "apiexamples",
 				"URL": "http://apiexamples.wordpress.com",
 				"avatar_URL": "https://1.gravatar.com/avatar/a2afb7b6c0e23e5d363d8612fb1bd5ad?s=96&d=identicon&r=G",
-				"profile_URL": "https://en.gravatar.com/apiexamples",
+				"profile_URL": "https://gravatar.com/apiexamples",
 				"site_ID": 82974409,
 				"roles": [
 					"administrator"

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
@@ -25,7 +25,7 @@ new WPCOM_JSON_API_Site_User_Endpoint(
 		"name": "binarysmash",
 		"URL": "http:\/\/binarysmash.wordpress.com",
 		"avatar_URL": "http:\/\/0.gravatar.com\/avatar\/a178ebb1731d432338e6bb0158720fcc?s=96&d=identicon&r=G",
-		"profile_URL": "http:\/\/en.gravatar.com\/binarysmash",
+		"profile_URL": "http:\/\/gravatar.com\/binarysmash",
 		"roles": [ "administrator" ]
 	}',
 	)
@@ -56,7 +56,7 @@ new WPCOM_JSON_API_Site_User_Endpoint(
 		"name": "binarysmash",
 		"URL": "http:\/\/binarysmash.wordpress.com",
 		"avatar_URL": "http:\/\/0.gravatar.com\/avatar\/a178ebb1731d432338e6bb0158720fcc?s=96&d=identicon&r=G",
-		"profile_URL": "http:\/\/en.gravatar.com\/binarysmash",
+		"profile_URL": "http:\/\/gravatar.com\/binarysmash",
 		"roles": [ "administrator" ]
 	}',
 	)
@@ -97,7 +97,7 @@ new WPCOM_JSON_API_Site_User_Endpoint(
 		"name": "binarysmash",
 		"URL": "http:\/\/binarysmash.wordpress.com",
 		"avatar_URL": "http:\/\/0.gravatar.com\/avatar\/a178ebb1731d432338e6bb0158720fcc?s=96&d=identicon&r=G",
-		"profile_URL": "http:\/\/en.gravatar.com\/binarysmash",
+		"profile_URL": "http:\/\/gravatar.com\/binarysmash",
 		"roles": [ "administrator" ]
 	}',
 	)

--- a/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -1390,7 +1390,7 @@ new Jetpack_JSON_API_User_Create_Endpoint(
         "name": "binarysmash",
         "URL": "http:\/\/binarysmash.wordpress.com",
         "avatar_URL": "http:\/\/0.gravatar.com\/avatar\/a178ebb1731d432338e6bb0158720fcc?s=96&d=identicon&r=G",
-        "profile_URL": "http:\/\/en.gravatar.com\/binarysmash",
+        "profile_URL": "http:\/\/gravatar.com\/binarysmash",
         "roles": [ "administrator" ]
     }',
 		'example_request'         => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/users/create',

--- a/projects/plugins/jetpack/modules/gravatar-hovercards.php
+++ b/projects/plugins/jetpack/modules/gravatar-hovercards.php
@@ -201,7 +201,7 @@ function grofiles_get_avatar( $avatar, $author ) {
 
 				$response_body = wp_cache_get( $cache_key, $cache_group );
 				if ( false === $response_body ) {
-					$response = wp_remote_get( esc_url_raw( 'https://en.gravatar.com/' . $email_hash . '.json' ) );
+					$response = wp_remote_get( esc_url_raw( 'https://gravatar.com/' . $email_hash . '.json' ) );
 					if ( is_array( $response ) && ! is_wp_error( $response ) ) {
 						$response_body = json_decode( $response['body'] );
 						wp_cache_set( $cache_key, $response_body, $cache_group, 60 * MINUTE_IN_SECONDS );

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -790,9 +790,9 @@ abstract class SAL_Post {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$active_blog = get_active_blog_for_user( $user->ID );
 			$site_id     = $active_blog->blog_id;
-			$profile_URL = "https://en.gravatar.com/{$user->user_login}";
+			$profile_URL = "https://gravatar.com/{$user->user_login}";
 		} else {
-			$profile_URL = 'https://en.gravatar.com/' . md5( strtolower( trim( $user->user_email ) ) );
+			$profile_URL = 'https://gravatar.com/' . md5( strtolower( trim( $user->user_email ) ) );
 			$site_id     = -1;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update `en.gravatar.com` url to `gravatar.com` the `en` subdomain has been removed and is redirecting to the main domain as per pMz3w-iie-p2 

Should be deployed after D123925-code which temporarily fixes the failing test

## Testing instructions:
* Code looks good
* Gravatar user profile (in CRM?) and hovercards work as expected