### PR TITLE
AI Excerpt: avoid errors on post types that do not support excerpts

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-content-lens-fatal
+++ b/projects/plugins/jetpack/changelog/fix-ai-content-lens-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Excerpts: avoid errors on Custom Post Types that do not support excerpts.

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -47,7 +47,7 @@ function AiPostExcerpt() {
 
 		return {
 			excerpt: getEditedPostAttribute( 'excerpt' ) ?? '',
-			postId: getCurrentPostId() ?? [],
+			postId: getCurrentPostId() ?? 0,
 		};
 	}, [] );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -9,7 +9,7 @@ import {
 import { TextareaControl, ExternalLink, Button, Notice, BaseControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { store as editorStore } from '@wordpress/editor';
+import { store as editorStore, PostTypeSupportCheck } from '@wordpress/editor';
 import { useState, useEffect } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { count } from '@wordpress/wordcount';
@@ -249,11 +249,13 @@ ${ postContent }
 }
 
 export const PluginDocumentSettingPanelAiExcerpt = () => (
-	<PluginDocumentSettingPanel
-		className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
-		name="ai-content-lens-plugin"
-		title={ __( 'Excerpt', 'jetpack' ) }
-	>
-		<AiPostExcerpt />
-	</PluginDocumentSettingPanel>
+	<PostTypeSupportCheck supportKeys="excerpt">
+		<PluginDocumentSettingPanel
+			className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
+			name="ai-content-lens-plugin"
+			title={ __( 'Excerpt', 'jetpack' ) }
+		>
+			<AiPostExcerpt />
+		</PluginDocumentSettingPanel>
+	</PostTypeSupportCheck>
 );

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -9,6 +9,7 @@ import {
 import { TextareaControl, ExternalLink, Button, Notice, BaseControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { store as editorStore } from '@wordpress/editor';
 import { useState, useEffect } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { count } from '@wordpress/wordcount';
@@ -41,12 +42,15 @@ type ContentLensMessageContextProps = {
 };
 
 function AiPostExcerpt() {
-	const excerpt = useSelect(
-		select => select( 'core/editor' ).getEditedPostAttribute( 'excerpt' ),
-		[]
-	);
+	const { excerpt, postId } = useSelect( select => {
+		const { getEditedPostAttribute, getCurrentPostId } = select( editorStore );
 
-	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId(), [] );
+		return {
+			excerpt: getEditedPostAttribute( 'excerpt' ) ?? '',
+			postId: getCurrentPostId() ?? [],
+		};
+	}, [] );
+
 	const { editPost } = useDispatch( 'core/editor' );
 
 	// Post excerpt words number
@@ -72,7 +76,7 @@ function AiPostExcerpt() {
 	// Pick raw post content
 	const postContent = useSelect(
 		select => {
-			const content = select( 'core/editor' ).getEditedPostContent();
+			const content = select( editorStore ).getEditedPostContent();
 			if ( ! content ) {
 				return '';
 			}


### PR DESCRIPTION
Fixes #33438

## Proposed changes:

Avoid issues when trying to use the excerpt feature on post types that do not support excerpts. On such posts, we should not even display the excerpt box.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1696256126106919-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Create a CPT:

```php
add_action(
	'init',
	function() {
		register_post_type( 'test_cpt', [ 'public' => true, 'supports' => [ 'title', 'editor' ], 'show_in_rest' => true ] );
	}
);
```

* Go to the block editor for that post type.
* Open the post side panel
* You should not see an excerpt panel.
* You shoulod not see any fatal error.
* Go to Posts > Add New
* Open the post side panel
* You should see an excerpt panel
* The AI excerpt features should work.
