### PR TITLE
Fix Google Doc blocks not rendering in the editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-google-doc-embed-block
+++ b/projects/plugins/jetpack/changelog/fix-google-doc-embed-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix Google Doc blocks not rendering in the editor

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/edit.js
@@ -151,16 +151,13 @@ const GsuiteBlockEdit = props => {
 			<Fragment>
 				<Embed
 					icon={ icon.src }
-					instructions={
-						<p>
-							{ __( 'Copy and paste your document link below.', 'jetpack' ) }
-							<br />
-							{ __(
-								'If your document is private, only readers logged into a Google account with shared access to the document may view it.',
-								'jetpack'
-							) }
-						</p>
-					}
+					instructions={ [
+						__( 'Copy and paste your document link below.', 'jetpack' ),
+						__(
+							'If your document is private, only readers logged into a Google account with shared access to the document may view it.',
+							'jetpack'
+						),
+					].join( ' ' ) }
 					label={ title }
 					patterns={ patterns }
 					placeholder={ _x( 'Enter the link here…', 'Embed block placeholder', 'jetpack' ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fixes the Google Doc blocks not rendering properly in the post editor.
<img width="500" alt="Screenshot 2023-10-02 at 6 33 00 PM" src="https://github.com/Automattic/jetpack/assets/1620183/5a148a92-450a-46af-a3a4-7c81e8c0c984">

Google Doc blocks consume the `Placeholder` component from the `@wordpress/components` and pass, amongst other props, the `instructions` property. This property is [typed as a string](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/placeholder/types.ts#L27), though we've been passing a React element until now without it being an issue. [A recent update in the package](https://github.com/WordPress/gutenberg/commit/955aef63f9b8a667c543d0ab3ac1952bfda9e85b#diff-2f283f2da01fc903a834bbf20a0a127a272c3d78183306f839a7dc4f959ff049R84) requires us to pass an actual string.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch (build the Jetpack plugin).
- Visit `Posts > Add New`.
- Add Google Doc blocks to the page.
- Notice the blocks are rendering as expected.

<img width="500" alt="Screenshot 2023-10-02 at 6 33 43 PM" src="https://github.com/Automattic/jetpack/assets/1620183/a77cb584-dcbd-4a17-b59b-590dfafc01d7">



