### PR TITLE
SSO: ignore linting rule for URL that will never appear on wp.com

### DIFF
--- a/projects/plugins/jetpack/changelog/temp-fix-sniffer-errpr
+++ b/projects/plugins/jetpack/changelog/temp-fix-sniffer-errpr
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Ignoring a phpcs rule, no need for a changelog
+
+

--- a/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
+++ b/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
@@ -168,7 +168,7 @@ class Jetpack_Force_2FA {
 		 */
 		return apply_filters(
 			'jetpack_force_2fa_login_error_message',
-			sprintf( 'For added security, please log in using your WordPress.com account.<br /><br />Note: Your account must have <a href="%1$s" target="_blank">Two Step Authentication</a> enabled, which can be configured from <a href="%2$s" target="_blank">Security Settings</a>.', 'https://support.wordpress.com/security/two-step-authentication/', 'https://wordpress.com/me/security/two-step' )
+			sprintf( 'For added security, please log in using your WordPress.com account.<br /><br />Note: Your account must have <a href="%1$s" target="_blank">Two Step Authentication</a> enabled, which can be configured from <a href="%2$s" target="_blank">Security Settings</a>.', 'https://support.wordpress.com/security/two-step-authentication/', 'https://wordpress.com/me/security/two-step' ) // phpcs:ignore WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl
 		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue with the Simple deploy that is catching this URL. The longer-term solution may be wrapping it in a Jetpack Redirect call, but this is meant to be 
a bandaid PR to allow for the daily deploys to continue while a better fix is confirmed.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ignore phpcs rule for wp.com for an URL that never will appear on wp.com (SSO is never used on WP.com since it *is* wp.com :) )

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Attempt daily deploy, I suppose.

