### PR TITLE
Subscribe Block: Exclude social followers count from count summary on inspector panel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriber-count-exclude-social-followers
+++ b/projects/plugins/jetpack/changelog/update-subscriber-count-exclude-social-followers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Subscribe Block: Exclude social followers count from count summary on inspector panel.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -93,29 +93,20 @@ export function SubscriptionEdit( props ) {
 		successMessage,
 	} = validatedAttributes;
 
-	const { subscriberCount, subscriberCountString } = useSelect( select => {
-		if ( ! isModuleActive ) {
-			return {
-				subscriberCounts: 0,
-				subscriberCountString: '',
-			};
-		}
-		const { emailSubscribers, socialFollowers } =
-			select( membershipProductsStore ).getSubscriberCounts();
-		let count = emailSubscribers;
-		if ( includeSocialFollowers ) {
-			count += socialFollowers;
-		}
+	const { emailSubscribers: emailSubscriberCount, socialFollowers: socialFollowerCount } =
+		useSelect( select => {
+			if ( ! isModuleActive ) {
+				return {
+					emailSubscribers: 0,
+					socialFollowers: 0,
+				};
+			}
+			return select( membershipProductsStore ).getSubscriberCounts();
+		} );
 
-		return {
-			subscriberCount: count,
-			subscriberCountString: sprintf(
-				/* translators: Placeholder is a number of subscribers. */
-				_n( 'Join %s other subscriber', 'Join %s other subscribers', count, 'jetpack' ),
-				count
-			),
-		};
-	} );
+	const advertisedSubscriberCount = includeSocialFollowers
+		? emailSubscriberCount + socialFollowerCount
+		: emailSubscriberCount;
 
 	const { data: newsletterCategories, enabled: newsletterCategoriesEnabled } =
 		useNewsletterCategories();
@@ -281,7 +272,7 @@ export function SubscriptionEdit( props ) {
 					setTextColor={ setTextColor }
 					showSubscribersTotal={ showSubscribersTotal }
 					spacing={ spacing }
-					subscriberCount={ subscriberCount }
+					subscriberCount={ emailSubscriberCount }
 					textColor={ textColor }
 					buttonWidth={ buttonWidth }
 					successMessage={ successMessage }
@@ -336,7 +327,18 @@ export function SubscriptionEdit( props ) {
 					</div>
 				</div>
 				{ showSubscribersTotal && (
-					<div className="wp-block-jetpack-subscriptions__subscount">{ subscriberCountString }</div>
+					<div className="wp-block-jetpack-subscriptions__subscount">
+						{ sprintf(
+							/* translators: Placeholder is a number of subscribers. */
+							_n(
+								'Join %s other subscriber',
+								'Join %s other subscribers',
+								advertisedSubscriberCount,
+								'jetpack'
+							),
+							advertisedSubscriberCount
+						) }
+					</div>
 				) }
 			</div>
 		</>


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Exclude social followers count from count summary on inspector panel.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1696229107093149-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on a site where you have social connections connected via "Tools > Marketing < Connection".
* Apply this patch on your sandbox using the script below.
* Go to post editor and add a Subscribe Block.
* You should see the count on inspect panel only shows your email subscribers count.
* Toggle "Show subscriber count" and "Include social followers in count".
* They should work just fine.


<img width="1274" alt="image" src="https://github.com/Automattic/jetpack/assets/1287077/f689c9cb-1bf1-4e2e-b7b3-9d345b5c3fca">
