### PR TITLE
Crowdsignal shortcodes: improve validation of attributes

### DIFF
--- a/projects/plugins/jetpack/changelog/update-crowdsignal-validate-attributes
+++ b/projects/plugins/jetpack/changelog/update-crowdsignal-validate-attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Shortcodes: improve validation of attributes dislayed with the Crowdsignal shhortcode.

--- a/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php
+++ b/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php
@@ -259,7 +259,7 @@ if (
 				}
 
 				$rating    = (int) $attributes['rating'];
-				$unique_id = preg_replace( '/[^\-_a-z0-9]/i', '', wp_strip_all_tags( $attributes['unique_id'] ) );
+				$unique_id = sanitize_key( wp_strip_all_tags( $attributes['unique_id'] ) );
 				$item_id   = wp_strip_all_tags( $attributes['item_id'] );
 				$item_id   = preg_replace( '/[^_a-z0-9]/i', '', $item_id );
 
@@ -350,7 +350,7 @@ if (
 
 				$poll_js   = sprintf( 'https://secure.polldaddy.com/p/%d.js', $poll );
 				$poll_link = sprintf(
-					'<a href="%s" target="_blank">%s</a>',
+					'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
 					esc_url( $poll_url ),
 					esc_html( $attributes['title'] )
 				);
@@ -514,7 +514,13 @@ if (
 							$survey_url = 'https://polldaddy.com/s/' . $survey;
 						}
 					} elseif ( isset( $attributes['domain'] ) && isset( $attributes['id'] ) ) {
-						$survey_url = 'https://' . $attributes['domain'] . '.survey.fm/' . $attributes['id'];
+						$survey_domain = preg_replace( '/[^a-z0-9\-]/i', '', $attributes['domain'] );
+						$survey_id     = preg_replace( '/[\/\?&\{\}]/', '', $attributes['id'] );
+						$survey_url    = sprintf(
+							'https://%1$s.survey.fm/%2$s',
+							$survey_domain,
+							$survey_id
+						);
 					}
 
 					$survey_link = sprintf(
@@ -585,8 +591,8 @@ if (
 							);
 						}
 					} else {
-						$text_color = preg_replace( '/[^a-f0-9]/i', '', $attributes['text_color'] );
-						$back_color = preg_replace( '/[^a-f0-9]/i', '', $attributes['back_color'] );
+						$text_color = sanitize_hex_color_no_hash( $attributes['text_color'] );
+						$back_color = sanitize_hex_color_no_hash( $attributes['back_color'] );
 
 						if (
 							! in_array(

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.crowdsignal.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.crowdsignal.php
@@ -66,7 +66,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			sprintf(
-				'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="{&quot;url&quot;:&quot;https:\/\/secure.polldaddy.com\/p\/%1$d.js&quot;}" style=""></div><div id="PD_superContainer"></div><noscript><a href="https://polldaddy.com/p/%1$d" target="_blank">Take Our Poll</a></noscript>',
+				'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="{&quot;url&quot;:&quot;https:\/\/secure.polldaddy.com\/p\/%1$d.js&quot;}" style=""></div><div id="PD_superContainer"></div><noscript><a href="https://polldaddy.com/p/%1$d" target="_blank" rel="noopener noreferrer">Take Our Poll</a></noscript>',
 				$id
 			),
 			$shortcode_content
@@ -87,7 +87,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			sprintf(
-				'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="{&quot;url&quot;:&quot;https:\/\/secure.polldaddy.com\/p\/%1$d.js&quot;}" style=""></div><div id="PD_superContainer"></div><noscript><a href="https://poll.fm/%1$d" target="_blank">Take Our Poll</a></noscript>',
+				'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="{&quot;url&quot;:&quot;https:\/\/secure.polldaddy.com\/p\/%1$d.js&quot;}" style=""></div><div id="PD_superContainer"></div><noscript><a href="https://poll.fm/%1$d" target="_blank" rel="noopener noreferrer">Take Our Poll</a></noscript>',
 				$id
 			),
 			$shortcode_content
@@ -108,7 +108,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			sprintf(
-				'<div class="cs-embed pd-embed" data-settings="{&quot;type&quot;:&quot;slider&quot;,&quot;embed&quot;:&quot;poll&quot;,&quot;delay&quot;:100,&quot;visit&quot;:&quot;single&quot;,&quot;id&quot;:%1$d,&quot;site&quot;:&quot;crowdsignal.com&quot;}"></div><noscript><a href="https://poll.fm/%1$d" target="_blank">Take Our Poll</a></noscript>',
+				'<div class="cs-embed pd-embed" data-settings="{&quot;type&quot;:&quot;slider&quot;,&quot;embed&quot;:&quot;poll&quot;,&quot;delay&quot;:100,&quot;visit&quot;:&quot;single&quot;,&quot;id&quot;:%1$d,&quot;site&quot;:&quot;crowdsignal.com&quot;}"></div><noscript><a href="https://poll.fm/%1$d" target="_blank" rel="noopener noreferrer">Take Our Poll</a></noscript>',
 				$id
 			),
 			$shortcode_content


### PR DESCRIPTION
## Proposed changes:

- Rely on core functions when possible instead of using our own regexes.
- Ensure that subdomains are properly validated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1696305792460289-slack-CRA4UEQQ3

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Writing and enable the shortcodes feature.
* Go to Posts > Add New
* Add a shortcode block
* Try some of the shortcodes listed here: https://github.com/Automattic/jetpack/blob/bea1b945e8854ff5240ce4641f2787a685d1731a/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php#L6-L16
