### PR TITLE
External Media: update API access to authors and above

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -174,7 +174,7 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 	 * Checks if a given request has access to external media libraries.
 	 */
 	public function permission_callback() {
-		return current_user_can( 'edit_posts' );
+		return current_user_can( 'upload_files' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-external-media-api-access
+++ b/projects/plugins/jetpack/changelog/update-external-media-api-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+External Media: do not surface the endpoint to contributors, who do not need athe feature since they cannot upload media.


### PR DESCRIPTION
## Proposed changes:

Folks who cannot upload media do not need access to the feature, since they can only insert images using an existing URL.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1696305792460289-slack-CRA4UEQQ3

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

In this case, you'll want to check that the feature continues to work for Authors and above. On a site that's connected to WordPress.com, 

1. Go to Posts > Add New
2. Add an image block
3. Click on the button to select an existing image
4. Try inserting an image from Pexels.
5. Try connecting the site to your Google Photos account.
6. Try disconnecting from Google if you are already connected.
