### PR TITLE
Backport mu-wpcom-plugin 1.6.23, jetpack 12.7-a.5 Changes

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.43.0] - 2023-10-03
+### Added
+- Added new sharing icon [#33244]
+
 ## [0.42.5] - 2023-09-25
 ### Added
 - Added WhatsApp social icon. [#33074]
@@ -826,6 +830,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.43.0]: https://github.com/Automattic/jetpack-components/compare/0.42.5...0.43.0
 [0.42.5]: https://github.com/Automattic/jetpack-components/compare/0.42.4...0.42.5
 [0.42.4]: https://github.com/Automattic/jetpack-components/compare/0.42.3...0.42.4
 [0.42.3]: https://github.com/Automattic/jetpack-components/compare/0.42.2...0.42.3

--- a/projects/js-packages/components/changelog/add-one-click-sharing-section
+++ b/projects/js-packages/components/changelog/add-one-click-sharing-section
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added new sharing icon

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.43.0-alpha",
+	"version": "0.43.0",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2023-10-03
+### Added
+- Add a sub-plugin, `I18nSafeMangleExportsPlugin`, to allow for avoiding problems with Webpack's `optimization.mangleExports` option occasionally mangling an export to one of the i18n function names. [#33392]
+
 ## [1.0.36] - 2023-09-13
 ### Changed
 - Updated package dependencies. [#33001]
@@ -172,6 +176,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.1.0]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.36...v1.1.0
 [1.0.36]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.35...v1.0.36
 [1.0.35]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.34...v1.0.35
 [1.0.34]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.33...v1.0.34

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-i18n-check-mangleExports
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-i18n-check-mangleExports
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a sub-plugin, `I18nSafeMangleExportsPlugin`, to allow for avoiding problems with Webpack's `optimization.mangleExports` option occasionally mangling an export to one of the i18n function names.

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.1.0-alpha",
+	"version": "1.1.0",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-check-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.0] - 2023-10-03
+### Added
+- Added a new post-publish panel for quick sharing [#33244]
+
 ## [0.39.1] - 2023-09-28
 ### Added
 - Added Copy to clipboard button to sharing buttons [#33261]
@@ -443,6 +447,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.40.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.39.1...v0.40.0
 [0.39.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.39.0...v0.39.1
 [0.39.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.37.0...v0.38.0

--- a/projects/js-packages/publicize-components/changelog/add-post-publish-one-click-sharing-panel
+++ b/projects/js-packages/publicize-components/changelog/add-post-publish-one-click-sharing-panel
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added a new post-publish panel for quick sharing

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.40.0-alpha",
+	"version": "0.40.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2023-10-03
+### Added
+- Document PnpmDeterministicModuleIdsPlugin that was added way back in 1.2.0. [#33392]
+
+### Changed
+- Disable `optimization.mangleExports` in production mode in favor of the `I18nSafeMangleExportsPlugin` from `@automattic/i18n-check-webpack-plugin`. This is technically a breaking change, as if someone had been disabling `mangleExports` for other reasons this will effectively re-enable it. [#33392]
+
 ## 1.6.0 - 2023-09-13
 ### Changed
 - Updated package dependencies. [#33001]

--- a/projects/js-packages/webpack-config/changelog/fix-i18n-check-mangleExports
+++ b/projects/js-packages/webpack-config/changelog/fix-i18n-check-mangleExports
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-Disable `optimization.mangleExports` in production mode in favor of the `I18nSafeMangleExportsPlugin` from `@automattic/i18n-check-webpack-plugin`. This is technically a breaking change, as if someone had been disabling `mangleExports` for other reasons this will effectively re-enable it.

--- a/projects/js-packages/webpack-config/changelog/fix-i18n-check-mangleExports#2
+++ b/projects/js-packages/webpack-config/changelog/fix-i18n-check-mangleExports#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Finally document PnpmDeterministicModuleIdsPlugin that was added way back in 1.2.0.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "2.0.0-alpha",
+	"version": "2.0.0",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.13.0] - 2023-10-03
+### Added
+- Add new task for user to confirm email when purchasing a domain. [#33373]
+- Add plugin to show frontend email nag for domains with unverified email address [#33390]
+- Adds a URL param to identify the source of the navigation on the Customize domain task. [#33404]
+
 ## [4.12.0] - 2023-09-28
 ### Added
 - Added calypso_path to Launchpad task [#33355]
@@ -378,6 +384,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[4.13.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.12.0...v4.13.0
 [4.12.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.11.0...v4.12.0
 [4.11.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.10.0...v4.11.0
 [4.10.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.9.0...v4.10.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-domains-email-nag
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-domains-email-nag
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add plugin to show frontend email nag for domains with unverified email address

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-from-param-domain-customize-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-from-param-domain-customize-task
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Adds a URL param to identify the source of the navigation on the Customize domain task.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-task_for_email_verification_when_custom_domain_present
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-task_for_email_verification_when_custom_domain_present
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add new task for user to confirm email when purchasing a domain.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.13.0-alpha",
+	"version": "4.13.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.13.0-alpha';
+	const PACKAGE_VERSION = '4.13.0';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.0] - 2023-10-03
+### Added
+- Display a new section on My Jetpack to display the stats of the site. [#33283]
+
 ## [3.7.0] - 2023-09-28
 ### Added
 - Add a section to display stats from Jetpack Stats in My Jetpack [#33160]
@@ -1040,6 +1044,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[3.8.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.7.0...3.8.0
 [3.7.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.6.0...3.7.0
 [3.6.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.5.0...3.6.0
 [3.5.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.4.5...3.5.0

--- a/projects/packages/my-jetpack/changelog/add-stats-backend-data-to-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-stats-backend-data-to-my-jetpack
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Display a new section on My Jetpack to display the stats of the site.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.8.0-alpha",
+	"version": "3.8.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.8.0-alpha';
+	const PACKAGE_VERSION = '3.8.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.0] - 2023-10-03
+### Added
+- Add a setting for Jetpack AI Search [#33432]
+
 ## [0.38.8] - 2023-09-19
 ### Changed
 - Updated Jetpack submenu sort order so individual features are alpha-sorted. [#32958]
@@ -804,6 +808,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.39.0]: https://github.com/Automattic/jetpack-search/compare/v0.38.8...v0.39.0
 [0.38.8]: https://github.com/Automattic/jetpack-search/compare/v0.38.7...v0.38.8
 [0.38.7]: https://github.com/Automattic/jetpack-search/compare/v0.38.6...v0.38.7
 [0.38.6]: https://github.com/Automattic/jetpack-search/compare/v0.38.5...v0.38.6

--- a/projects/packages/search/changelog/ai-chat-release
+++ b/projects/packages/search/changelog/ai-chat-release
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a setting for Jetpack AI Search

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.39.0-alpha",
+	"version": "0.39.0",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.39.0-alpha';
+	const VERSION = '0.39.0';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.3] - 2023-10-03
+### Fixed
+- Use a try/catch when calling get_the_content to avoid fatals. See: https://github.com/Automattic/jetpack/issues/33284 [#33394]
+
 ## [0.17.2] - 2023-09-28
 ### Added
 - Add error handling for .vtt track files upload process [#33249]
@@ -1126,6 +1130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.17.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.16.0...v0.17.0

--- a/projects/packages/videopress/changelog/fix-videopress-initializer-empty-content-check
+++ b/projects/packages/videopress/changelog/fix-videopress-initializer-empty-content-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Use a try/catch when calling get_the_content to avoid fatals. See: https://github.com/Automattic/jetpack/issues/33284

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.17.3-alpha",
+	"version": "0.17.3",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.17.3-alpha';
+	const PACKAGE_VERSION = '0.17.3';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,11 +2,41 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.7-a.5 - 2023-10-03
+### Enhancements
+- AI Chat: Enhanced error presentation and UX improvements. [#33387] [#33401]
+- AI Search Block: release the Jetpack AI Search Block. [#33432]
+- Block Editor: add a new post publish panel for quick sharing. [#33244]
+- Block Editor: display the SEO and Sharing editor panels in the block editor under the Jetpack side menu. [#33258] [#33226]
+- Blogroll Block: Update blogroll appender styling and functionality. [#33328]
+- Sharing: add X sharing button. [#33134]
+- Social Menu & Social Media Icons: Add support for the X icon. [#33118]
+- SSO: offer ability to force a site to use Jetpack SSO with Two-Factor Authentication for certain roles. [#33259]
+- Subscription block: drop unnecessary .0 from big subscriber counts. [#33430]
+
+### Bug fixes
+- AI Excerpts: avoid errors on Custom Post Types that do not support excerpts. [#33439]
+- Carousel: avoid invalid markup notices in Google Pagespeed insights. [#33413]
+- External Media: do not surface the endpoint to contributors, are unable to upload media anyway. [#33451]
+- Google Doc block: fix Google Doc blocks not rendering in the editor. [#33441]
+- Shortcodes: improve validation of attributes dislayed with the Crowdsignal shortcode. [#33450]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- AI Assistant: Enable backend prompts for 10% of production sites. [#33356]
+- Add user content link tracking and redirection for links coming from emails. [#32832]
+- Blocks: change the way Social Previews are registered, from a block to a plugin. [#33238]
+- Fix block view scripts being loaded twice. [#33406]
+- Fix description for jetpack_sitemap_video_skip_post. [#33379]
+- Subscriptions: fix broken Paywall login link for custom domains [#33363]
+- Likes: move editor plugin to the plugins' directory. [#33241]
+- Plugin assets: add spanish version of our banners. [#33436]
+- SEO Tools: move editor plugin to the plugins' directory, since this is not a block. [#33240]
+- Standardize block description phrasing. [#33382]
+
 ## 12.7-a.3 - 2023-09-28
 ### Enhancements
 - AI Excerpt: Add `Beta` label to sidebar panel. [#33302]
 - AI Excerpt: disable `Generate` button when there's no post content. [#33304]
-
 - AI Extension: Add keyboard shortcut to stop action on forms. [#33271]
 - Blogroll: Disable blogroll appender sites that have been added to blogroll block. [#33327]
 - Fix styling of multiple elements in the ai-chat block. [#33352]

--- a/projects/plugins/jetpack/changelog/Hide subscribe buttons on atomic sites
+++ b/projects/plugins/jetpack/changelog/Hide subscribe buttons on atomic sites
@@ -1,5 +1,0 @@
-Significance: patch
-Type: enhancement
-Comment: Hide subscribe button on atomic sites
-
-

--- a/projects/plugins/jetpack/changelog/add-force-2fa
+++ b/projects/plugins/jetpack/changelog/add-force-2fa
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-SSO: offer ability to force a site to use Jetpack SSO with Two-Factor Authentication for certain roles.

--- a/projects/plugins/jetpack/changelog/add-href-to-carousel-download
+++ b/projects/plugins/jetpack/changelog/add-href-to-carousel-download
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Carousel: avoid invalid markup notices in Google Pagespeed insights.

--- a/projects/plugins/jetpack/changelog/add-lint-ignore-rules-for-simple-deployment
+++ b/projects/plugins/jetpack/changelog/add-lint-ignore-rules-for-simple-deployment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: added a PHPCS rule to avoid problems with Simple WordPress.com deployments.

--- a/projects/plugins/jetpack/changelog/add-post-publish-one-click-sharing-panel
+++ b/projects/plugins/jetpack/changelog/add-post-publish-one-click-sharing-panel
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Added a new post publish panel for quick sharing

--- a/projects/plugins/jetpack/changelog/add-user-content-link-track-and-redirection
+++ b/projects/plugins/jetpack/changelog/add-user-content-link-track-and-redirection
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Added user content link tracking and redirection for links coming from emails.

--- a/projects/plugins/jetpack/changelog/add-x-icon
+++ b/projects/plugins/jetpack/changelog/add-x-icon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Social Menu & Social Media Icons: Add support for the X icon.

--- a/projects/plugins/jetpack/changelog/ai-chat-fix-buttons-2
+++ b/projects/plugins/jetpack/changelog/ai-chat-fix-buttons-2
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Improve UX of the AI CHat block

--- a/projects/plugins/jetpack/changelog/ai-chat-release
+++ b/projects/plugins/jetpack/changelog/ai-chat-release
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Release the Jetpack AI Search Block

--- a/projects/plugins/jetpack/changelog/ai-chat-release#2
+++ b/projects/plugins/jetpack/changelog/ai-chat-release#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-ai-content-lens-fatal
+++ b/projects/plugins/jetpack/changelog/fix-ai-content-lens-fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Excerpts: avoid errors on Custom Post Types that do not support excerpts.

--- a/projects/plugins/jetpack/changelog/fix-block-view-script-loaded-multiple-times
+++ b/projects/plugins/jetpack/changelog/fix-block-view-script-loaded-multiple-times
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix block view scripts being loaded twice

--- a/projects/plugins/jetpack/changelog/fix-google-doc-embed-block
+++ b/projects/plugins/jetpack/changelog/fix-google-doc-embed-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix Google Doc blocks not rendering in the editor

--- a/projects/plugins/jetpack/changelog/fix-subscriber-count-zero
+++ b/projects/plugins/jetpack/changelog/fix-subscriber-count-zero
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscription block: drop unnecessary .0 from big subscriber counts

--- a/projects/plugins/jetpack/changelog/improve-no-composer-error
+++ b/projects/plugins/jetpack/changelog/improve-no-composer-error
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Just a small update to error text only seen by developers building Jetpack itself.
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 12.7-a.6
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 12.7-a.4
-
-

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/sitebot-erros-2
+++ b/projects/plugins/jetpack/changelog/sitebot-erros-2
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Enhanced error presentation for ai chat

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-enable-backend-prompts-on-production
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-enable-backend-prompts-on-production
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Enable backend prompts for 10% of production sites.

--- a/projects/plugins/jetpack/changelog/update-blocks-description
+++ b/projects/plugins/jetpack/changelog/update-blocks-description
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Standardize block description phrasing

--- a/projects/plugins/jetpack/changelog/update-blocks-seo-tools-discoverability
+++ b/projects/plugins/jetpack/changelog/update-blocks-seo-tools-discoverability
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Jetpack Seo: display the Seo editor panel with an invitation to activate the feature when it is disabled.

--- a/projects/plugins/jetpack/changelog/update-blocks-sharing-discoverability
+++ b/projects/plugins/jetpack/changelog/update-blocks-sharing-discoverability
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Jetpack Sharing: display the Sharing editor panel with an invitation to activate the feature when it is disabled.

--- a/projects/plugins/jetpack/changelog/update-blogroll-appender-edge-cases-i1
+++ b/projects/plugins/jetpack/changelog/update-blogroll-appender-edge-cases-i1
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Blogroll: Update blogroll appender styling and functionality

--- a/projects/plugins/jetpack/changelog/update-crowdsignal-validate-attributes
+++ b/projects/plugins/jetpack/changelog/update-crowdsignal-validate-attributes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Shortcodes: improve validation of attributes dislayed with the Crowdsignal shhortcode.

--- a/projects/plugins/jetpack/changelog/update-external-media-api-access
+++ b/projects/plugins/jetpack/changelog/update-external-media-api-access
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-External Media: do not surface the endpoint to contributors, who do not need athe feature since they cannot upload media.

--- a/projects/plugins/jetpack/changelog/update-gravatar-host
+++ b/projects/plugins/jetpack/changelog/update-gravatar-host
@@ -1,5 +1,0 @@
-Significance: patch
-Type: enhancement
-Comment: Updated gravatar host to exclude not needed en subdomain
-
-

--- a/projects/plugins/jetpack/changelog/update-jetpack-plugin-assets-es
+++ b/projects/plugins/jetpack/changelog/update-jetpack-plugin-assets-es
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Plugin assets: add spanish version of our banners.

--- a/projects/plugins/jetpack/changelog/update-jetpack_sitemap_video_skip_post-descrpition
+++ b/projects/plugins/jetpack/changelog/update-jetpack_sitemap_video_skip_post-descrpition
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed description for jetpack_sitemap_video_skip_post

--- a/projects/plugins/jetpack/changelog/update-likes-location
+++ b/projects/plugins/jetpack/changelog/update-likes-location
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Likes: move editor plugin to the plugins' directory.

--- a/projects/plugins/jetpack/changelog/update-paywall-login-link
+++ b/projects/plugins/jetpack/changelog/update-paywall-login-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-fix link

--- a/projects/plugins/jetpack/changelog/update-paywall-use-magic-link-again
+++ b/projects/plugins/jetpack/changelog/update-paywall-use-magic-link-again
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-this is how it use to work two hours ago

--- a/projects/plugins/jetpack/changelog/update-seo-location
+++ b/projects/plugins/jetpack/changelog/update-seo-location
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-SEO Tools: move editor plugin to the plugins' directory, since this is not a block.

--- a/projects/plugins/jetpack/changelog/update-social-previews-location
+++ b/projects/plugins/jetpack/changelog/update-social-previews-location
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Blocks: change the way Social Previews are registered, from a block to a plugin.

--- a/projects/plugins/jetpack/changelog/update-twitter-sharing
+++ b/projects/plugins/jetpack/changelog/update-twitter-sharing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Sharing: add X sharing button.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -104,7 +104,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_a_4",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_a_5",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -104,7 +104,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_a_5",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_a_6",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.7-a.4
+ * Version: 12.7-a.5
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.7-a.4' );
+define( 'JETPACK__VERSION', '12.7-a.5' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.7-a.5
+ * Version: 12.7-a.6
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.7-a.5' );
+define( 'JETPACK__VERSION', '12.7-a.6' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -72,7 +72,7 @@ class Jetpack_SSO {
 		 *
 		 * @todo Provide a UI to enable/disable the feature.
 		 *
-		 * @since $$next-version$$
+		 * @since 12.7
 		 * @module SSO
 		 * @return bool
 		 */

--- a/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
+++ b/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
@@ -39,7 +39,7 @@ class Jetpack_Force_2FA {
 		 *
 		 * @param string $role The role to force 2FA for.
 		 * @return string
-		 * @since $$next-version$$
+		 * @since 12.7
 		 * @module SSO
 		 */
 		$this->role = apply_filters( 'jetpack_force_2fa_cap', 'manage_options' );
@@ -63,7 +63,7 @@ class Jetpack_Force_2FA {
 		 *
 		 * @param bool $display_notice Whether to display the notice.
 		 * @return bool
-		 * @since $$next-version$$
+		 * @since 12.7
 		 * @module SSO
 		 */
 		if ( apply_filters( 'jetpack_force_2fa_dependency_notice', true ) && current_user_can( $this->role ) ) {
@@ -163,7 +163,7 @@ class Jetpack_Force_2FA {
 		 *
 		 * @param string $message The login error message.
 		 * @return string
-		 * @since $$next-version$$
+		 * @since 12.7
 		 * @module SSO
 		 */
 		return apply_filters(

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.7.0-a.5",
+	"version": "12.7.0-a.6",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.7.0-a.4",
+	"version": "12.7.0-a.5",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -1,123 +1,59 @@
-## Jetpack 12.5
+## Jetpack 12.7
 
 ### Before you start:
 
 - **At any point during your testing, remember to [check your browser's JavaScript console](https://wordpress.org/support/article/using-your-browser-to-diagnose-javascript-errors/#step-3-diagnosis) and see if there are any errors reported by Jetpack there.**
 - Use the "Debug Bar" or "Query Monitor" WordPress plugins to help make PHP notices and warnings more noticeable and report anything of note you see.
 
-### WooCommerce Analytics
+### SEO Tools/Sharing Sidebar
 
-Ensure correct values for cart/checkout blocks/shortcode use are tracked correctly when using WooCommerce Blocks templates after WC Blocks 10.6.0
-- Ensure site is connected, WooCommerce is installed, products, payment methods, and shipping methods are available. (Cash on Delivery and Free shipping will be fine).
-- Install WooCommerce 7.8.0 and a blocks theme e.g. Twenty Twenty-Three.
-- Ensure WooCommerce analytics is running.
-- Go to Pages -> Cart. Change its content to contain the shortcode block, and have it display the WooCommerce cart. (`[woocommerce_cart]`).
-- Do the same for Pages -> Checkout and enter `[woocommerce_checkout]` into the shortcode block.
+There are some new options in the Jetpack sidebar in the block editor. To test:
 
-☝️ **Between each checkout it is necessary to clear out the transient: `jetpack_woocommerce_analytics_cart_checkout_info_cache` - you can install [Options View](https://wordpress.org/plugins/options-view/) to easily do this.**
+- Go to Posts > Add New.
+- Click on the Jetpack plugin sidebar.
+- Click on the "SEO" panel title.
+- Click on the button.
+- Verify that the module is enabled and working as expected.
+- Click on the "Likes and Sharing" panel title.
+- Click on the button.
+- Verify that the module is enabled and working as expected.
 
-- Add an item to your cart and go to the checkout.
-- Check out and then visit Tracks and find your event. (I spoofed my user agent so I could find the event easily)
-- Check the event for the following properties:
-  - `cart_page_contains_cart_block`: `false` (or 0)
-  - `cart_page_contains_cart_shortcode`: `true` (or 1)
-  - `checkout_page_contains_checkout_block`: `false` (or 0)
-  - `checkout_page_contains_checkout_shortcode`: `true` (or 1)
-- Go back to the pages from the earlier steps, remove the shortcodes and replace them with the Cart and Checkout blocks.
-- Add an item to your cart and check out again, the new values should be:
-  - `cart_page_contains_cart_block`: `true` (or 1)
-  - `cart_page_contains_cart_shortcode`: `false` (or 0)
-  - `checkout_page_contains_checkout_block`: `true` (or 1)
-  - `checkout_page_contains_checkout_shortcode`: `false` (or 0)
-- Feel free to change the setup so one page has the shortcode and one page doesn't and mix it up.
-- Update to WooCommerce 8.0
-- Repeat the steps above, however when you go to Pages -> Checkout and Pages -> Cart you should notice that it opens the site editor instead of the usual post editor.
-- Repeat with a classic theme, e.g Storefront
+### Jetpack AI Search Block
 
-Remove logic that prevents site admins being tracked and add store_admin property to WooCommerce analytics events
-- Ensure site is connected, WooCommerce is installed, products, payment methods, and shipping methods are available. (Cash on Delivery and Free shipping will be fine).
-- Ensure WooCommerce analytics is running.
-- As an admin user: add an item to your cart and go to the checkout.
-- Check out and then visit Tracks and find your event. (I spoofed my user agent so I could find the event easily)
-- Check the event for the `store_admin` property, which should be `1`
-- Repeat as a logged _out_ (e.g. guest) user, the event should be logged, and should have the `store_admin` property but it should be `0`
-- Repeat as a logged in, but _not_ admin user, (e.g. a customer), the event should be logged, and should have the `store_admin` property but it should be `0`
+We've launched and AI Search block, moving it from beta to production! To test, create a new post and add the AI Chat bot. Play around with the block and the sidebar settings and make sure things work in the editor and on the front end.
 
-Add Logic to track My account page
-- On a connected, live, WordPress account, check if existing tracks are being sent (either from the track page or using the Tracks - Vigilante extension).
-On the My Account page, test that:
-- `woocommerceanalytics_my_account_tab_click` with prop tab: logout is triggered when you click log out.
-- `woocommerceanalytics_my_account_page_view` with the prop tab: $tabName is being triggered on each top level tab you visit.
-- `woocommerceanalytics_my_account_order_number_click` Is being triggered if you clicked an order number in the orders view.
-woocommerceanalytics_my_account_order_action_click is being triggered with prop action: view if you click the view button, and action: pay if you click the pay button, and action: cancel if you click the cancel button.
-To see the pay and cancel buttons, change the order status to pending payment.
-- `woocommerceanalytics_my_account_address_click` with prop address: billing | shipping when you click on the button to edit an address.
-- `woocommerceanalytics_my_account_address_save` with prop address: billing | shipping when you save an address you edited.
-- `woocommerceanalytics_my_account_details_save` When you click save on the Accounts Details page.
-- For those you will need a payment method installed like Stripe or WCPay:
-Check that:
-- `woocommerceanalytics_my_account_payment_add` Is being triggered when you add a new payment method.
-- `woocommerceanalytics_my_account_payment_save` Is being triggered when you save a payment method you're adding.
-- `woocommerceanalytics_my_account_payment_delete` Is being triggered when you delete a payment method.
+## Known Issues:
 
-### Enabling beta blocks
+- Button styling can be improved.
+- It can sometimes be very slow.
+- The search can be very hit or miss depending on keywords used in the question.
+- It can only chat with posts & pages reliably. Products are harder to find.
 
-Testing most features on this list requires enabling Jetpack beta blocks. You can be the one of the first to test upcoming features by adding this constant as a snippet, or directly into your configuration file:
+### New Quick Share Options
 
-```
-define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
-```
+We've added the quick-share options to the block editor panel. To test:
 
-### Social Auto Conversion
+* Open up a new post, there should not be anything new.
+* After publishing you should see the new Quick share Button if our panel is open
+* Clicking the icon should open the Quick share dropdown
+* Clicking on any of the icons there should work
+* Clicking the learn more on the dropdown should open the help modal and close the dropdown.
 
-- Turn off Social and have Jetpack enabled.
-  - Go to the Jetpack settings page and turn on the auto conversion setting.
-  - Open up the editor and create a new post.
-  - Select a media file that is convertible, but not valid for some connections - for example a 10Mb jpg image.
-  - You should see the notice that it will be converted. If you dismissed already, remove the `jetpack_social_dismissed_notices` option to bring it back.
-  - On the notice click change settings button. It should open up Jetpack settings on the sharing screen.
-  - Turn off the auto conversion.
-  - Go back to the editor, the page should reflect the changes without needing to refresh.
-- Do the same with Jetpack Social enabled only. The only difference is that the button should direct you to the social admin page.
+### Add Forced 2FA Functionality when SSO is enabled
 
-### AI Excerpt helper
+We have a new filter that will allow someone to force 2FA to be enabled when SSO is also enabled. There's no UI for this yet, but it would be good to do some functionality testing. To do so:
 
-To properly test this ensure that beta blocks are enabled.
+* Jetpack connnected + SSO enabled.
+* Connect an account that does not have 2fa enabled to the Jetpack site (either cycle the connection or make a new admin user connected to a non-2fa WP.com account.)
+* Create a new user with subscriber or contributor role.
+* Log out and log back into admin account with regular WP creds (not SSO) This should work.
+* Enable flag via `add_filter( 'jetpack_force_2fa', '__return_true' );`
+* Log out and log back in with regular WP creds. It should fail.
+* Log in with WP.com SSO with an account that has 2fa enabled. It should work.
+* Log out and login with the non-2fa WP.com account via SSO. It should fail.
+* Add a filter to modify the cap, e.g. `add_filter( 'jetpack_force_2fa_cap, function() { return 'read' } );`
+* Verify that the contributor forces SSO.
 
-- Go to the block editor.
-- Open the post sidebar.
-- Confirm the Excerpt panel is there when:
-  -	beta extensions are enabled;
-  - AI Assistant block is enabled.
-
-- Go to the block editor, open the block sidebar.
-- Look at the AI Excerpt panel.
-- Confirm that the Accept button is initially disabled.
-- Request an excerpt.
-- Confirm that you can discard the changes by clicking on the Discard button.
-- Request an excerpt.
-- Confirm that Accept button gets enabled once the requests finishes.
-- Confirm you can use the suggestion by clicking on the button.
-- Confirm the Generate button gets disabled when the request is done.
-- Confirm the Generate button gets enabled right after clicking on the Accept or Discard button.
-- Request an excerpt
-- Confirm that after changing the number or words the Generate button gets enabled again.
-
-### Create with Voice AI helper
-
-To properly test this ensure that beta blocks are enabled.
-
-- Go to the block editor.
-- Create a "Create with voice" block instance and confirm that the block shows its toolbar.
-- Confirm now it's possible to remove the block.
-- Start to record/pause/resume.
-- Confirm how the block button changes according to the recording status.
-- Start to record.
-- Confirm the block shows the current time duration.
-- Stop recording.
-- Confirm the Done button is there, and start, pause, and resume actions work fine.
-- Confirm the block shows the audio player.
-- Confirm you can listen to the recorded audio.
 
 ### And More!
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.23 - 2023-10-03
+- Minor internal updates.
+
 ## 1.6.22 - 2023-09-28
 ### Changed
 - Minor internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-task_for_email_verification_when_custom_domain_present
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-task_for_email_verification_when_custom_domain_present
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_23_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_23"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.23-alpha
+ * Version: 1.6.23
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.23-alpha",
+	"version": "1.6.23",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 1.6.23, jetpack 12.7-a.5

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.