### PR TITLE
Launchpad: Changed email verification task visibility

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-email-task-visibility
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-email-task-visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed email verification visibility

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "4.13.x-dev"
+			"dev-trunk": "4.14.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.13.0",
+	"version": "4.14.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.13.0';
+	const PACKAGE_VERSION = '4.14.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -122,11 +122,12 @@ function wpcom_launchpad_get_task_definitions() {
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
 		'verify_email'                    => array(
-			'get_title'           => function () {
+			'get_title'            => function () {
 				return __( 'Verify email address', 'jetpack-mu-wpcom' );
 			},
-			'is_visible_callback' => 'wpcom_launchpad_is_email_unverified',
-			'get_calypso_path'    => function () {
+			'is_complete_callback' => 'wpcom_launchpad_is_email_verified',
+			'is_disabled_callback' => 'wpcom_launchpad_is_email_verified',
+			'get_calypso_path'     => function () {
 				return '/me/account';
 			},
 		),
@@ -1077,17 +1078,17 @@ function wpcom_launchpad_launch_task_listener_atomic( $old_value, $new_value ) {
 }
 
 /**
- * Callback for email verification visibility.
+ * Callback for email verification completion.
  *
- * @return bool True if email is unverified, false otherwise.
+ * @return bool True if email is verified, false otherwise.
  */
-function wpcom_launchpad_is_email_unverified() {
+function wpcom_launchpad_is_email_verified() {
 	// TODO: handle the edge case where an Atomic user can be unverified.
 	if ( ! class_exists( 'Email_Verification' ) ) {
-		return false;
+		return true;
 	}
 
-	return Email_Verification::is_email_unverified();
+	return ! Email_Verification::is_email_unverified();
 }
 
 /**

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-email-task-visibility
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-email-task-visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated lock file

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_23"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_0_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "78a6144caf030a56ba260562aabcaee606cc548e"
+                "reference": "ce1f24583f10fa776d7127077f5d6ee2e80be754"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.13.x-dev"
+                    "dev-trunk": "4.14.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {
@@ -2774,5 +2774,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -2774,5 +2774,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.23
+ * Version: 1.7.0-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.23",
+	"version": "1.7.0-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80028

## Proposed changes:

* This PR changes the visibility of the email verification Launchpad task.
* It makes the task always visible
* It makes the task disabled when the task is completed

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Apply this PR to your sandbox
* Create a new `build` site (`/start`) with an unverified user
* Follow the onboarding and launch the site
* Check that the `Verify email address` is visible, enabled, and not completed;

![image](https://github.com/Automattic/jetpack/assets/3801502/fe8219a8-4f78-4bab-9069-78d41b7640bb)


* Verify the email
* Check that the task is now visible, marked as completed, and is disabled

![image](https://github.com/Automattic/jetpack/assets/3801502/d6ea3711-fa54-48ae-ac45-8ebdde07d25e)
