### PR TITLE
Notifications: remove on block editor pages for Gutenberg compat

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-notifications-n-keydown
+++ b/projects/plugins/jetpack/changelog/fix-notifications-n-keydown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Notifications: temporarily disable the notifications admin bar menu on any block editor page to allow for Gutenberg 16.7 compat

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -385,7 +385,7 @@ class Masterbar {
 		$this->add_reader_submenu( $wp_admin_bar );
 
 		// Right part.
-		if ( Jetpack::is_module_active( 'notes' ) && ! Jetpack_Notifications::is_block_editor() ) {
+		if ( Jetpack::is_module_active( 'notes' ) && ! \Jetpack_Notifications::is_block_editor() ) {
 			$this->add_notifications( $wp_admin_bar );
 		}
 

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -385,7 +385,7 @@ class Masterbar {
 		$this->add_reader_submenu( $wp_admin_bar );
 
 		// Right part.
-		if ( Jetpack::is_module_active( 'notes' ) ) {
+		if ( Jetpack::is_module_active( 'notes' ) && ! Jetpack_Notifications::is_block_editor() ) {
 			$this->add_notifications( $wp_admin_bar );
 		}
 

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -105,6 +105,9 @@ class Jetpack_Notifications {
 	 * @return void
 	 */
 	public function styles_and_scripts() {
+		if ( self::is_block_editor() ) {
+			return;
+		}
 		$is_rtl = is_rtl();
 
 		if ( Jetpack::is_module_active( 'masterbar' ) ) {
@@ -160,6 +163,10 @@ class Jetpack_Notifications {
 		global $wp_admin_bar;
 
 		if ( ! is_object( $wp_admin_bar ) ) {
+			return;
+		}
+
+		if ( self::is_block_editor() ) {
 			return;
 		}
 
@@ -229,6 +236,19 @@ class Jetpack_Notifications {
 	}, false );
 </script>
 		<?php
+	}
+
+	/**
+	 * Checks to see if we're in the block editor.
+	 */
+	public static function is_block_editor() {
+		if ( function_exists( 'get_current_screen' ) ) {
+			$current_screen = get_current_screen();
+			if ( ! empty( $current_screen ) && $current_screen->is_block_editor() ) {
+				return true;
+			}
+		}
+		return false;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue where the Notifications 'n' shortcut is bubbled up to the iframe when in the block editor, thus making it impossible to type `n`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* As a temporary bandaid until a real cause and resolution, remove the notifications bubble only on the block editor pages. The Site Editor does not an admin 
bar ever and the Post Editor has an option to show it, but WP defaults to not for new installs it appears.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Jetpack + Gutenberg 16.7
* Connect Jetpack and confirm that Notifications are active.
* Open the post editor and try to type "I do not like this bug"
* At the `n`, before the patch, it would not type. If the admin bar is displayed, the notifications panel would open.
* After the patch, there is no notifications item in the admin bar for only the post block editor page and you can type the full sample text.

