### PR TITLE
AMP Plugin Removal: Remove WPCOM-specific AMP references from endpoints

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-wpcom-amp-enabled
+++ b/projects/plugins/jetpack/changelog/remove-wpcom-amp-enabled
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Removed WPCOM-specific references from site settings endpoint.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -111,7 +111,6 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 			'markdown_supported'                      => '(bool) Whether markdown is supported for this site',
 			'wpcom_publish_posts_with_markdown'       => '(bool) Whether markdown is enabled for posts',
 			'wpcom_publish_comments_with_markdown'    => '(bool) Whether markdown is enabled for comments',
-			'amp_is_enabled'                          => '(bool) Whether AMP is enabled for this site',
 			'site_icon'                               => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 			'api_cache'                               => '(bool) Turn on/off the Jetpack JSON API cache',
 			'posts_per_page'                          => '(int) Number of posts to show on blog pages',
@@ -441,9 +440,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'site_icon'                        => $this->get_cast_option_value_or_null( 'site_icon', 'intval' ),
 						Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => get_option( Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION, '' ),
 						Jetpack_SEO_Titles::TITLE_FORMATS_OPTION => get_option( Jetpack_SEO_Titles::TITLE_FORMATS_OPTION, array() ),
-						'amp_is_supported'                 => (bool) function_exists( 'wpcom_is_amp_supported' ) && wpcom_is_amp_supported( $blog_id ),
-						'amp_is_enabled'                   => (bool) function_exists( 'wpcom_is_amp_enabled' ) && wpcom_is_amp_enabled( $blog_id ),
-						'amp_is_deprecated'                => (bool) function_exists( 'wpcom_is_amp_deprecated' ) && wpcom_is_amp_deprecated( $blog_id ),
 						'api_cache'                        => $api_cache,
 						'posts_per_page'                   => (int) get_option( 'posts_per_page' ),
 						'posts_per_rss'                    => (int) get_option( 'posts_per_rss' ),
@@ -989,15 +985,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						}
 					} elseif ( update_option( $key, $coerce_value ) ) { // If the option already exists use update_option.
 						$updated[ $key ] = $coerce_value;
-					}
-					break;
-
-				case 'amp_is_enabled':
-					if ( function_exists( 'wpcom_update_amp_enabled' ) ) {
-						$saved = wpcom_update_amp_enabled( $blog_id, $value );
-						if ( $saved ) {
-							$updated[ $key ] = (bool) $value;
-						}
 					}
 					break;
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -99,7 +99,6 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint(
 			Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
 			Jetpack_SEO_Titles::TITLE_FORMATS_OPTION  => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
 			'verification_services_codes'             => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex, facebook',
-			'amp_is_enabled'                          => '(bool) Whether AMP is enabled for this site',
 			'podcasting_archive'                      => '(string) The post category, if any, used for publishing podcasts',
 			'site_icon'                               => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 			'api_cache'                               => '(bool) Turn on/off the Jetpack JSON API cache',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -99,7 +99,6 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint(
 			Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
 			Jetpack_SEO_Titles::TITLE_FORMATS_OPTION  => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
 			'verification_services_codes'             => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex, facebook',
-			'amp_is_enabled'                          => '(bool) Whether AMP is enabled for this site',
 			'podcasting_archive'                      => '(string) The post category, if any, used for publishing podcasts',
 			'site_icon'                               => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 			'api_cache'                               => '(bool) Turn on/off the Jetpack JSON API cache',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -107,7 +107,6 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
 			Jetpack_SEO_Titles::TITLE_FORMATS_OPTION  => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
 			'verification_services_codes'             => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex, facebook',
-			'amp_is_enabled'                          => '(bool) Whether AMP is enabled for this site',
 			'podcasting_archive'                      => '(string) The post category, if any, used for publishing podcasts',
 			'site_icon'                               => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 			'api_cache'                               => '(bool) Turn on/off the Jetpack JSON API cache',

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -255,7 +255,6 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 					Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
 					Jetpack_SEO_Titles::TITLE_FORMATS_OPTION => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
 					'verification_services_codes'          => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex, facebook',
-					'amp_is_enabled'                       => '(bool) Whether AMP is enabled for this site',
 					'podcasting_archive'                   => '(string) The post category, if any, used for publishing podcasts',
 					'site_icon'                            => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 					'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache',


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/4019

Blocked by https://github.com/Automattic/wp-calypso/pull/82482

## Proposed changes:

Removes `amp_is_supported`, `amp_is_enabled`, and `amp_is_deprecated` from the WPCOM site settings endpoints.

The underlying functions no longer exist as of D124297-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Tests should pass. Open to other testing ideas, too.