### PR TITLE
Blogroll: improve non-frontend rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/update-blogroll-non-frontend-rendering
+++ b/projects/plugins/jetpack/changelog/update-blogroll-non-frontend-rendering
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Beta block improvements
+
+

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -83,6 +83,14 @@ HTML;
 		$placeholder_site_icon = 'empty-site-icon';
 	}
 
+	if ( ! jetpack_is_frontend() ) {
+		return <<<HTML
+			<div style="margin-bottom: 10px;">
+				<a href="$url">$name</a><div>$description</div>
+			</div>
+HTML;
+	}
+
 	$form_buttons = <<<HTML
 		<!-- wp:button {"className":"is-style-fill"} -->
 		<div class="wp-block-button jetpack-blogroll-item-submit-button is-style-fill">

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll.php
@@ -50,7 +50,7 @@ function load_assets( $attr, $content ) {
 	$current_location = home_url( $wp->request );
 	$is_wpcom         = ( defined( 'IS_WPCOM' ) && IS_WPCOM );
 
-	$wpcom_content = <<<HTML
+	$form_content = <<<HTML
 		<form method="post" action="https://subscribe.wordpress.com" accept-charset="utf-8">
 			<input name="action" type="hidden" value="subscribe">
 			<input name="source" type="hidden" value="$current_location">
@@ -59,7 +59,7 @@ function load_assets( $attr, $content ) {
 		</form>
 HTML;
 
-	$blogroll_content = $is_wpcom ? $wpcom_content : $content;
+	$blogroll_content = $is_wpcom && jetpack_is_frontend() ? $form_content : $content;
 
 	return sprintf(
 		'<div class="%1$s">%2$s</div>',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes how the blogroll was rendering outside of the front-end context.

Fixes #
https://github.com/Automattic/wp-calypso/issues/82351
![image](https://github.com/Automattic/jetpack/assets/7000684/680856b1-2275-49ab-99ef-3ea1c12fca5d)


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Render a simple list of links for the targeted case

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test how the block is rendering on the front-end
* Test how the block is rendered in notifications, emails, RSS feed, web & mobile reader








