### PR TITLE
Repo Gardening: mark revert PRs with a label.

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/add-repo-gardening-revert-flag
+++ b/projects/github-actions/repo-gardening/changelog/add-repo-gardening-revert-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Label automations: mark revert PRs with a label.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -103,9 +103,10 @@ function cleanName( name ) {
  * @param {string} repo    - Repository name.
  * @param {string} number  - PR number.
  * @param {boolean} isDraft  - Whether the pull request is a draft.
+ * @param {boolean} isRevert  - Whether the pull request is a revert.
  * @returns {Promise<Array>} Promise resolving to an array of keywords we'll search for.
  */
-async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
+async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert ) {
 	const keywords = new Set();
 
 	// Get next valid milestone.
@@ -289,6 +290,11 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 		keywords.add( '[Status] In Progress' );
 	}
 
+	// Add '[Type] Revert' for revert PRs
+	if ( isRevert ) {
+		keywords.add( '[Type] Revert' );
+	}
+
 	return [ ...keywords ];
 }
 
@@ -301,10 +307,15 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 async function addLabels( payload, octokit ) {
 	const { number, repository, pull_request } = payload;
 	const { owner, name } = repository;
+	const { draft, title } = pull_request;
 
 	// Get labels to add to the PR.
-	const isDraft = !! ( pull_request && pull_request.draft );
-	const labels = await getLabelsToAdd( octokit, owner.login, name, number, isDraft );
+	const isDraft = !! ( pull_request && draft );
+
+	// If the PR title includes the word "revert", mark it as such.
+	const isRevert = title.toLowerCase().includes( 'revert' );
+
+	const labels = await getLabelsToAdd( octokit, owner.login, name, number, isDraft, isRevert );
 
 	if ( ! labels.length ) {
 		debug( 'add-labels: Could not find labels to add to that PR. Aborting' );


### PR DESCRIPTION
Fixes 4024-gh-dotcom-forge

## Proposed changes:

> If we detect “Revert” as the first word in the title of a PR, can we do some GitHub action around that?

Let's introduce a new label, "[Type] Revert", that will get added to all PRs that include "revert" in their title.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 4024-gh-dotcom-forge
* p1695858808610489-slack-CQD1HH4MA

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This cannot be tested in this repo, but can be tested in 'trunk' in a fork:

https://github.com/jeherve/jetpack/pull/100
