### PR TITLE
Subscriptions module: fix critical error when enabled on plugin enabled site

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-33465
+++ b/projects/plugins/jetpack/changelog/fix-33465
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix error on Subscribe Modal

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -179,7 +179,11 @@ HTML;
 
 		// Don't show if post is for subscribers only or has paywall block
 		global $post;
-		$access_level              = get_post_meta( $post->ID, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
+		if ( defined( 'Automattic\\Jetpack\\Extensions\\Subscriptions\\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS' ) ) {
+			$access_level = get_post_meta( $post->ID, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
+		} else {
+			$access_level = get_post_meta( $post->ID, '_jetpack_newsletter_access', true );
+		}
 		$is_accessible_by_everyone = Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY === $access_level || empty( $access_level );
 		if ( ! $is_accessible_by_everyone ) {
 			return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #33465

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check if constant is defined before using it

@millerf should we probably move [these constants](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/blocks/subscriptions/constants.php)
 somewhere more global?
 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You'll need a jurassic-connected jetpack site for testing.
* Go to Settings > Newsletter and enable the subscribe modal. 
* In a non-logged in browser or incognito window, open up a single blog post on the frontend, scroll, and confirm that Subscribe Modal loads. 
     - If you've already closed the modal once, then you'll need to delete the jetpack_modal_dismissed cookie. 
* Bonus: To test on simple sites, run the bin command below to load this branch in your sandbox, sandbox public-api and the domain of your test site, go to your simple site admin and then Settings > Newsletter, enable the subscribe modal, go to a single blog post in a non-logged in browser or incognito window, scroll, and confirm the modal loads. 

