### PR TITLE
Notifications: Show adminbar icon for redirect if 3rd party cookies disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-masterbar-notes-icon-hiding
+++ b/projects/plugins/jetpack/changelog/remove-masterbar-notes-icon-hiding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Notifications: show wp-admin bar notes icon for redirect when browser doesn't support 3rd party cookies

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -219,21 +219,6 @@ class Jetpack_Notifications {
 	var wpNotesLinkAccountsURL = '<?php echo esc_url( $link_accounts_url ); ?>';
 <?php endif; ?>
 /* ]]> */
-	window.addEventListener('message', function ( event ) {
-		// Confirm that the message is from the right origin.
-		if ('https://widgets.wp.com' !== event.origin) {
-			return;
-		}
-		// Check whether 3rd Party Cookies are blocked
-		var has3PCBlocked = 'WPCOM:3PC:blocked' === event.data;
-
-		var tagerElement = document.getElementById('wp-admin-bar-notes');
-
-		if ( has3PCBlocked && tagerElement ) {
-			// Hide the notification button/icon
-			tagerElement.style.display = 'none';
-		}
-	}, false );
 </script>
 		<?php
 	}


### PR DESCRIPTION
## Proposed changes:

Removes code that hides the notifications icon in the admin bar when a 3rd party cookie check fails

Clicking the icon will now redirect to wordpress.com to view notifications, so there's no reason to hide it any longer.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related to p1695918706401709/1695918447.034349-slack-C014TPFLP4Z

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Setup and connect a jetpack site to wordpress.com (local dev site will need a reverse proxy)
* Make sure the WordPress.com toolbar (masterbar) is enabled in Jetpack > Settings > Writing
* Disable 3rd party cookies for your browser
* Before: the notification icon will not be shown
* With this PR: the icon will be shown and clicking it will take you to wordpress.com/read/notifications