### PR TITLE
Internal release: add was_hosting_trial flag to indicate if site ever had a hosting free trial

### DIFF
--- a/projects/plugins/jetpack/changelog/fht-add_was_hosting_trial_flag
+++ b/projects/plugins/jetpack/changelog/fht-add_was_hosting_trial_flag
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-527 - Sites API: add was_migration_trial flag to data returned for site details.[D[D[D[D[D
+527 - Sites API: add was_hosting_trial flag to data returned for site details.

--- a/projects/plugins/jetpack/changelog/fht-add_was_hosting_trial_flag
+++ b/projects/plugins/jetpack/changelog/fht-add_was_hosting_trial_flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+527 - Sites API: add was_migration_trial flag to data returned for site details.[D[D[D[D[D

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -80,6 +80,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'user_interactions'           => '(array) An array of user interactions with a site.',
 		'was_ecommerce_trial'         => '(bool) If the site ever used an eCommerce trial.',
 		'was_migration_trial'         => '(bool) If the site ever used a migration trial.',
+		'was_hosting_trial'           => '(bool) If the site ever used a hosting trial.',
 		'wpcom_site_setup'            => '(string) The WP.com site setup identifier.',
 	);
 
@@ -230,6 +231,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_staging_site',
 		'was_ecommerce_trial',
 		'was_migration_trial',
+		'was_hosting_trial',
 	);
 
 	/**
@@ -283,6 +285,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	public static $jetpack_enabled_trials = array(
 		'was_ecommerce_trial' => 'ecommerce',
 		'was_migration_trial' => 'migration',
+		'was_hosting_trial'   => 'hosting',
 	);
 
 	/**
@@ -597,6 +600,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'was_migration_trial':
 				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials['was_migration_trial'] );
+				break;
+			case 'was_hosting_trial':
+				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials['was_hosting_trial'] );
 				break;
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -75,6 +75,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'is_wpcom_staging_site'       => '(bool) If the site is a WP.com staging site.',
 		'was_ecommerce_trial'         => '(bool) If the site ever used an eCommerce trial.',
 		'was_migration_trial'         => '(bool) If the site ever used a migration trial.',
+		'was_hosting_trial'           => '(bool) If the site ever used a hosting trial.',
 	);
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* add a flag to site endpoint responses, `was_hosting_trial`. This flag is used internally by the Hosting Free Trial project. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test instructions added to internal issue. 

