### PR TITLE
Launchpad: Adds the body prop to the tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-task-body
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-task-body
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds basic functionality for adding body to the tasks. This will allow us for example to add text or buttons to the task.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -370,6 +370,11 @@ class Launchpad_Task_Lists {
 			}
 		}
 
+		$extended_content = $this->load_extended_content( $task );
+		if ( $extended_content ) {
+			$built_task['extended_content'] = $extended_content;
+		}
+
 		return $built_task;
 	}
 
@@ -443,6 +448,38 @@ class Launchpad_Task_Lists {
 			$task['subtitle'];
 		}
 		return '';
+	}
+
+	/**
+	 * Loads the extended content for a task.
+	 *
+	 * @param Task $task A task definition.
+	 * @return array|null The extended content for the task.
+	 */
+	private function load_extended_content( $task ) {
+		if ( ! isset( $task['extended_content'] ) ) {
+			return null;
+		}
+
+		$extended_content_context = array();
+
+		foreach ( $task['extended_content'] as $context => $extended_content ) {
+			$loaded_extended_context = array();
+
+			$actions = $this->load_value_from_callback( $extended_content, 'actions', null, $task['id'] );
+			if ( $actions ) {
+				$loaded_extended_context['actions'] = $actions;
+			}
+
+			$content = $this->load_value_from_callback( $extended_content, 'content', null, $task['id'] );
+			if ( $actions ) {
+				$loaded_extended_context['content'] = $content;
+			}
+
+			$extended_content_context[ $context ] = $loaded_extended_context;
+		}
+
+		return $extended_content_context;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -386,6 +386,9 @@ function wpcom_launchpad_get_task_definitions() {
 				// that are not in the Customer Home page. We should find a better way to handle this.
 				return '/domains/add/' . $data['site_slug_encoded'] . '?from=my-home';
 			},
+			'extended_content'     => array(
+				wpcom_launchpad_add_task_extended_context( array( 'launchpad-navigator' ) ),
+			),
 		),
 
 		'share_site'                      => array(
@@ -1895,3 +1898,72 @@ function wpcom_launchpad_mark_theme_selected_complete( $new_theme, $old_theme ) 
 	wpcom_mark_launchpad_task_complete( 'site_theme_selected' );
 }
 add_action( 'jetpack_sync_current_theme_support', 'wpcom_launchpad_mark_theme_selected_complete', 10, 2 );
+
+/**
+ * Adds a task component.
+ *
+ * @param string $type    The type of the component ('text' or 'link').
+ * @param string $content The content of the component.
+ * @param array  $options Additional options for the component (optional).
+ * @return array The task component.
+ */
+function wpcom_launchpad_add_task_component( $type, $content, $options = array() ) {
+	// Add validation and sanitization checks if necessary.
+
+	return array(
+		'type'    => $type,
+		'content' => $content,
+		'options' => $options,
+	);
+}
+
+/**
+ * Adds a link task action.
+ *
+ * @param string $label The label (text) of the link.
+ * @param string $href  The URL of the link.
+ * @return array The link task component.
+ */
+function wpcom_launchpad_task_action_link( $label, $href ) {
+	return wpcom_launchpad_add_task_component( 'link', $label, array( 'href' => $href ) );
+}
+
+/**
+ * Adds the extended context for a task.
+ *
+ * @param string $contexts The contexts in which the task should be shown.
+ * @param string $actions_callback The callback to use for the task actions.
+ * @param string $content_callback The callback to use for the task content.
+ * @return array The extended context.
+ */
+function wpcom_launchpad_add_task_extended_context( $contexts, $actions_callback = 'wpcom_launchpad_customize_task_actions', $content_callback = 'wpcom_launchpad_customize_task_content' ) {
+	return array(
+		'contexts' => $contexts,
+		'actions'  => $actions_callback,
+		'content'  => $content_callback,
+	);
+}
+
+/**
+ * Adds custom actions to tasks.
+ *
+ * @param array      $extended_content The extended content for the task.
+ * @param array|null $default The default array with actions for the task.
+ * @param string     $task_id The task ID.
+ * @return array The array with actions for the task.
+ */
+function wpcom_launchpad_customize_task_actions( $extended_content, $default, $task_id ) {
+	return apply_filters( 'wpcom_launchpad_customize_task_actions', null, $task_id );
+}
+
+/**
+ * Adds custom content to tasks.
+ *
+ * @param array      $extended_content The extended content for the task.
+ * @param array|null $default The default array with actions for the task.
+ * @param string     $task_id The task ID.
+ * @return string The content for the task.
+ */
+function wpcom_launchpad_customize_task_content( $extended_content, $default, $task_id ) {
+	return apply_filters( 'wpcom_launchpad_customize_task_content', null, $task_id );
+}

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-task-body
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-task-body
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* For my 20% time, I decided to test an idea we discussed in one of our calls with @daledupreez & @nuriapenya. The idea is to have a body with a description of the task and some other components like buttons, links, images, videos, etc.
* I added a fundamental data structure that allows us to render components on the front end. For now, I only made available a Text and Link component.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox:
```shell
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-task-body
```
* Edit your `0-sandbox.php` file and add the following code:
```php

function wpcom_launchpad_domain_customize_actions_filter( $actions, $task_id ) {
	if ( $task_id !== 'domain_customize' ) {
		return $actions;
	}
	return array(
		wpcom_launchpad_task_action_link(
			__( 'Learn more about', 'jetpack-mu-wpcom' ),
			'https://wordpress.com/support/domains/customize-your-domain/'
		),
		wpcom_launchpad_task_action_link(
			__( 'Help', 'jetpack-mu-wpcom' ),
			'https://wordpress.com/support/domains/customize-your-domain/'
		),
	);
}
add_filter( 'wpcom_launchpad_customize_task_actions', 'wpcom_launchpad_domain_customize_actions_filter', 10, 2 );

function wpcom_launchpad_domain_customize_content_filter( $content, $task_id ) {
	if ( $task_id !== 'domain_customize' ) {
		return $content;
	}
	return __( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque in tellus id eros scelerisque eleifend eget quis dui. Aenean eget sem non ex pulvinar commodo. Aliquam vel justo id ex rutrum faucibus id eu mi.', 'jetpack-mu-wpcom' );
}
add_filter( 'wpcom_launchpad_customize_task_content', 'wpcom_launchpad_domain_customize_content_filter', 10, 2 );

```
* Navigate to the developer console: https://developer.wordpress.com/docs/api/console/
* Make a `GET` request to `WP REST API -> wpcom/v2 -> /sites/:siteSlug/launchpad?_locale=user&checklist_slug=intent-build`
* Ensure you can see the `extended_content` property under the "Customize your domain" task.

![Screen Shot 2023-10-30 at 11 19 05](https://github.com/Automattic/jetpack/assets/1234758/13a05212-0d30-4515-aee3-d44b5155fb43)

