### PR TITLE
Blogroll: front-end styling improvements

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blogroll-fe-styles
+++ b/projects/plugins/jetpack/changelog/fix-blogroll-fe-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Blogroll: small front-end styling fixes
+
+

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -118,8 +118,11 @@ HTML;
 
 	$subscribe_button_html = '';
 	$fieldset              = '';
+	$has_subscription_form = defined( 'IS_WPCOM' ) && IS_WPCOM;
+	$classes               = Blocks::classes( FEATURE_NAME, $attr );
 
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	if ( $has_subscription_form ) {
+		$classes              .= ' has-subscription-form';
 		$form_buttons_html     = do_blocks( $form_buttons );
 		$subscribe_button_html = do_blocks( $subscribe_button );
 
@@ -153,7 +156,7 @@ HTML;
 		'<div class="%1$s">
 			<div class="jetpack-blogroll-item-slider">%2$s</div>
 		</div>',
-		esc_attr( Blocks::classes( FEATURE_NAME, $attr ) ),
+		esc_attr( $classes ),
 		$content
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -92,16 +92,20 @@ HTML;
 	}
 
 	$form_buttons = <<<HTML
-		<!-- wp:button {"className":"is-style-fill"} -->
-		<div class="wp-block-button jetpack-blogroll-item-submit-button is-style-fill">
-			<button type="submit" name="blog_id" value="$id" class="wp-block-button__link wp-element-button">$submit_text</button>
-		</div>
-		<!-- /wp:button -->
+		<!-- wp:buttons {"style":{"spacing":{"blockGap":"10px"}}} -->
+		<div class="wp-block-buttons">
+			<!-- wp:button {"className":"is-style-fill"} -->
+			<div class="wp-block-button jetpack-blogroll-item-submit-button is-style-fill">
+				<button type="submit" name="blog_id" value="$id" class="wp-block-button__link wp-element-button">$submit_text</button>
+			</div>
+			<!-- /wp:button -->
 
-		<!-- wp:button {"className":"is-style-outline"} -->
-		<div class="wp-block-button jetpack-blogroll-item-cancel-button is-style-outline">
-			<button type="reset" class="wp-block-button__link wp-element-button">$cancel_text</button>
+			<!-- wp:button {"className":"is-style-outline"} -->
+			<div class="wp-block-button jetpack-blogroll-item-cancel-button is-style-outline">
+				<button type="reset" class="wp-block-button__link wp-element-button">$cancel_text</button>
+			</div>
 		</div>
+		<!-- /wp:buttons -->
 HTML;
 
 	$subscribe_button = <<<HTML

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/common.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/common.scss
@@ -1,7 +1,15 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
+$jetpack-blogroll-item-container: bitem;
+
+@mixin break-bloroll-container-mobile() {
+	@container #{ ($jetpack-blogroll-item-container)} (min-width: #{ ($break-mobile) }) {
+		@content;
+	}
+}
+
 .wp-block-jetpack-blogroll {
-	@include break-mobile() {
+	@include break-bloroll-container-mobile() {
 		padding: 24px;
 	}
 
@@ -28,6 +36,11 @@
 		}
 	}
 
+	.wp-block-jetpack-blogroll-item {
+		container-type: inline-size;
+		container-name: bitem;
+	}
+
 	.wp-block-jetpack-blogroll-item .jetpack-blogroll-item-information {
 		display: flex;
 		padding: 20px 8px;
@@ -35,7 +48,7 @@
 		flex-direction: column;
 		align-items: flex-start;
 
-		@include break-mobile() {
+		@include break-bloroll-container-mobile() {
 			flex-direction: row;
 			align-items: center;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
@@ -59,7 +59,7 @@
 		}
 
 		.jetpack-blogroll-item-subscribe-button {
-			@include break-mobile() {
+			@include break-bloroll-container-mobile() {
 				margin-left: auto;
 				align-self: center;
 			}
@@ -77,21 +77,28 @@
 			font: inherit;
 			border: 1px solid #8c8f94;
 			border-radius: 0;
-			flex: 1;
 			width: 100%;
-		}
-
-		.jetpack-blogroll-item-submit {
-			width: 100%;
-			display: flex;
-			gap: 10px;
-			align-items: center;
+			box-sizing: border-box;
 		}
 
 		.jetpack-blogroll-item-submit {
 			width: 100%;
 			border: none;
 			padding: 0;
+			margin: 0;
+			display: flex;
+			gap: 10px;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
+
+			@include break-bloroll-container-mobile() {
+				flex-direction: row;
+
+				.jetpack-blogroll-item-email-input {
+					flex: 1;
+				}
+			}
 		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
@@ -77,6 +77,7 @@
 
 		.jetpack-blogroll-item-email-input {
 			padding: 14px;
+			margin: 0;
 			font: inherit;
 			border: 1px solid #8c8f94;
 			border-radius: 0;

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
@@ -4,8 +4,11 @@
 	.wp-block-jetpack-blogroll-item {
 		overflow-x: clip;
 
-		.jetpack-blogroll-item-slider {
+		&.has-subscription-form .jetpack-blogroll-item-slider {
 			width: 200%;
+		}
+
+		.jetpack-blogroll-item-slider {
 			display: flex;
 			transition: transform 0.3s ease-in-out;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
This PR addresses two issues. We were using responsive breakpoints and not accounting for the fact that the block can be included in columns rows etc. This PR changes this targeting to be based on the container width.
Also on smaller devices, the subscribe submission form was not styled well. This is addressed here to have a column instead of a row direction.


Fixes #
https://github.com/Automattic/wp-calypso/issues/82665

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Improve styling

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the admin and in a new post, add a 2 column block. In the first one add a paragraph and in the second one the blogroll.
* Add again the blogroll in the same post but outside of the column. We will use this one to compare the style targetting fixes.
* Save the post and visit the post url.
* The blogroll in the column, should have column direction, and the blogroll outside of the column should have row direction. Also when clicking subscribe, the form shown should show differently for the blogroll blocks

