### PR TITLE
JITM: update woo color

### DIFF
--- a/projects/packages/jitm/changelog/update-jitm-woo-color
+++ b/projects/packages/jitm/changelog/update-jitm-woo-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update color of WooCommerce logo

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -231,7 +231,7 @@ class JITM {
 				.st0{clip-path:url(#SVGID_2_);enable-background:new    ;}
 				.st1{clip-path:url(#SVGID_4_);}
 				.st2{clip-path:url(#SVGID_6_);}
-				.st3{clip-path:url(#SVGID_8_);fill:#8F567F;}
+				.st3{clip-path:url(#SVGID_8_);fill:#7F54B3;}
 				.st4{clip-path:url(#SVGID_10_);fill:#FFFFFE;}
 				.st5{clip-path:url(#SVGID_12_);fill:#FFFFFE;}
 				.st6{clip-path:url(#SVGID_14_);fill:#FFFFFE;}


### PR DESCRIPTION
Fixes #33488

## Proposed changes:

Update the color of the Woo logo to match requirements mentioned in #33488

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test here, you can check if the color matches the one used on https://woocommerce.com/ for example
