### PR TITLE
Paywall Block: Refactor Plan/Stripe setup dialog into its own component.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-block-dialog-component
+++ b/projects/plugins/jetpack/changelog/update-paywall-block-dialog-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+refactor

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -2,8 +2,6 @@ import './editor.scss';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 import {
-	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
-	__experimentalConfirmDialog as ConfirmDialog,
 	MenuGroup,
 	MenuItem,
 	PanelBody,
@@ -16,14 +14,13 @@ import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { arrowDown, Icon, people, check } from '@wordpress/icons';
+import PlansSetupDialog from '../../shared/components/plans-setup-dialog';
 import {
 	accessOptions,
 	META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
 } from '../../shared/memberships/constants';
 import { useAccessLevel } from '../../shared/memberships/edit';
 import { getReachForAccessLevelKey } from '../../shared/memberships/settings';
-import { getPaidPlanLink } from '../../shared/memberships/utils';
-import useAutosaveAndRedirect from '../../shared/use-autosave-and-redirect';
 import { store as membershipProductsStore } from '../../store/membership-products';
 
 function PaywallEdit( { className } ) {
@@ -38,8 +35,6 @@ function PaywallEdit( { className } ) {
 			hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
 		};
 	} );
-	const paidLink = getPaidPlanLink( hasNewsletterPlans );
-	const { autosaveAndRedirect } = useAutosaveAndRedirect( paidLink );
 
 	const [ showDialog, setShowDialog ] = useState( false );
 	const closeDialog = () => setShowDialog( false );
@@ -144,27 +139,7 @@ function PaywallEdit( { className } ) {
 					) }
 				</ToolbarDropdownMenu>
 			</BlockControls>
-			<ConfirmDialog
-				onRequestClose={ closeDialog }
-				cancelButtonText={ __( 'Not now', 'jetpack' ) }
-				confirmButtonText={ __( 'Get started', 'jetpack' ) }
-				isOpen={ showDialog }
-				onCancel={ closeDialog }
-				onConfirm={ autosaveAndRedirect }
-				style={ { maxWidth: 400 } }
-			>
-				<h2>{ __( 'Set up payments', 'jetpack' ) }</h2>
-				<p>{ __( 'To start collecting payments, you’ll just need to:', 'jetpack' ) }</p>
-				<ol>
-					<li>
-						{ __(
-							'Create a payment offer and choose a price for access to paid content',
-							'jetpack'
-						) }
-					</li>
-					<li>{ __( 'Set up or connect your Stripe account', 'jetpack' ) }</li>
-				</ol>
-			</ConfirmDialog>
+			<PlansSetupDialog closeDialog={ closeDialog } showDialog={ showDialog } />
 			<InspectorControls>
 				<PanelBody
 					className="jetpack-subscribe-newsletters-panel"

--- a/projects/plugins/jetpack/extensions/shared/components/plans-setup-dialog/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/plans-setup-dialog/index.jsx
@@ -1,0 +1,45 @@
+import {
+	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { getPaidPlanLink } from '../../memberships/utils';
+import useAutosaveAndRedirect from '../../use-autosave-and-redirect';
+
+export default function PlansSetupDialog( { showDialog, closeDialog } ) {
+	const { hasNewsletterPlans } = useSelect( select => {
+		const { getNewsletterProducts, getConnectUrl } = select( 'jetpack/membership-products' );
+		return {
+			stripeConnectUrl: getConnectUrl(),
+			hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
+		};
+	} );
+
+	const paidLink = getPaidPlanLink( hasNewsletterPlans );
+	const { autosaveAndRedirect } = useAutosaveAndRedirect( paidLink );
+
+	return (
+		<ConfirmDialog
+			onRequestClose={ closeDialog }
+			cancelButtonText={ __( 'Not now', 'jetpack' ) }
+			confirmButtonText={ __( 'Get started', 'jetpack' ) }
+			isOpen={ showDialog }
+			onCancel={ closeDialog }
+			onConfirm={ autosaveAndRedirect }
+			style={ { maxWidth: 400 } }
+		>
+			<h2>{ __( 'Set up payments', 'jetpack' ) }</h2>
+			<p>{ __( 'To start collecting payments, you’ll just need to:', 'jetpack' ) }</p>
+			<ol>
+				<li>
+					{ __(
+						'Create a payment offer and choose a price for access to paid content',
+						'jetpack'
+					) }
+				</li>
+				<li>{ __( 'Set up or connect your Stripe account', 'jetpack' ) }</li>
+			</ol>
+		</ConfirmDialog>
+	);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refactors the Dialog that we show when selecting Paid subscribers without Plans or Stripe configured.
* Next step – use this same component in the Access Document Panel.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the dialog still shows up when selecting Paid Subscribers from the toolbar or from the block settings Panel.


