### PR TITLE
AI Excerpt: set docs link depending on site type

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-update-doc-link
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-update-doc-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: set docs link depending on site type

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -6,6 +6,7 @@ import {
 	ERROR_QUOTA_EXCEEDED,
 	useAiSuggestions,
 } from '@automattic/jetpack-ai-client';
+import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { TextareaControl, ExternalLink, Button, Notice, BaseControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
@@ -155,10 +156,14 @@ ${ postContent }
 
 	const isQuotaExceeded = error?.code === ERROR_QUOTA_EXCEEDED;
 
-	const docsLink = __(
-		'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt',
-		'jetpack'
-	);
+	// Set the docs link depending on the site type
+	const docsLink =
+		isAtomicSite() || isSimpleSite()
+			? __(
+					'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt',
+					'jetpack'
+			  )
+			: __( 'https://wordpress.com/support/excerpts/', 'jetpack' );
 
 	return (
 		<div className="jetpack-ai-post-excerpt">

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -159,11 +159,8 @@ ${ postContent }
 	// Set the docs link depending on the site type
 	const docsLink =
 		isAtomicSite() || isSimpleSite()
-			? __(
-					'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt',
-					'jetpack'
-			  )
-			: __( 'https://wordpress.com/support/excerpts/', 'jetpack' );
+			? __( 'https://wordpress.com/support/excerpts/', 'jetpack' )
+			: __( 'https://jetpack.com/support/create-better-post-excerpts-with-ai/', 'jetpack' );
 
 	return (
 		<div className="jetpack-ai-post-excerpt">

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -155,6 +155,11 @@ ${ postContent }
 
 	const isQuotaExceeded = error?.code === ERROR_QUOTA_EXCEEDED;
 
+	const docsLink = __(
+		'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt',
+		'jetpack'
+	);
+
 	return (
 		<div className="jetpack-ai-post-excerpt">
 			<TextareaControl
@@ -166,12 +171,7 @@ ${ postContent }
 				disabled={ isTextAreaDisabled }
 			/>
 
-			<ExternalLink
-				href={ __(
-					'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt',
-					'jetpack'
-				) }
-			>
+			<ExternalLink href={ docsLink }>
 				{ __( 'Learn more about manual excerpts', 'jetpack' ) }
 			</ExternalLink>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR updates the AI Excerpt docs link depending on the site type (Simple, Atomic and Jetpack)

Fixes https://github.com/Automattic/jetpack/issues/32995

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: set docs link depending on site type

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test the changes in Simple, Atomic, and Jetpack sites.

* Go to the block editor
* Open the post sidebar 
* Identify docs link of the AI Excerpt panel

<img width="313" alt="Screenshot 2023-10-09 at 09 29 26" src="https://github.com/Automattic/jetpack/assets/77539/dc062942-035e-4bd6-840c-9d9284052a80">


* Confirm the docs link leads to the proper docs page:

Simple: https://wordpress.com/support/excerpts/
Atomic: https://wordpress.com/support/excerpts/
Jetpack: https://jetpack.com/support/create-better-post-excerpts-with-ai/ (Not published yet)