### PR TITLE
Prevent memberships to use cache sites data

### DIFF
--- a/projects/plugins/jetpack/changelog/add-memberships-prevent-use-of-cached-site-data
+++ b/projects/plugins/jetpack/changelog/add-memberships-prevent-use-of-cached-site-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+[Memberships] Prevent data to be retrieved from cache sites on WPCOM

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -123,28 +123,27 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	 * @return bool Whether the user has access to the content.
 	 */
 	protected function user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, $post_id, $user_abbreviated_subscriptions ) {
-		$has_access = false;
 
 		if ( is_user_logged_in() && current_user_can( 'edit_post', $post_id ) ) {
 			// Admin has access
 			$has_access = true;
-		}
-
-		if ( empty( $has_access ) && ( empty( $access_level ) || $access_level === self::POST_ACCESS_LEVEL_EVERYBODY ) ) {
-			// empty level means the post is not gated for paid users
-			$has_access = true;
-		}
-
-		if ( empty( $has_access ) && ( $access_level === self::POST_ACCESS_LEVEL_SUBSCRIBERS ) ) {
-			$has_access = $is_blog_subscriber || $is_paid_subscriber;
-		}
-
-		if ( empty( $has_access ) && ( $access_level === self::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS ) ) {
-			$has_access = $is_paid_subscriber;
-		}
-
-		if ( empty( $has_access ) && ( $access_level === self::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS ) ) {
-			$has_access = $is_paid_subscriber && ! $this->maybe_gate_access_for_user_if_post_tier( $post_id, $user_abbreviated_subscriptions );
+		} else {
+			switch ( $access_level ) {
+				case self::POST_ACCESS_LEVEL_EVERYBODY:
+				default:
+					$has_access = true;
+					break;
+				case self::POST_ACCESS_LEVEL_SUBSCRIBERS:
+					$has_access = $is_blog_subscriber || $is_paid_subscriber;
+					break;
+				case self::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS:
+					$has_access = $is_paid_subscriber;
+					break;
+				case self::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS:
+					$has_access = $is_paid_subscriber &&
+						! $this->maybe_gate_access_for_user_if_post_tier( $post_id, $user_abbreviated_subscriptions );
+					break;
+			}
 		}
 
 		do_action( 'earn_user_has_access', $access_level, $has_access, $is_blog_subscriber, $is_paid_subscriber, $post_id );

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -262,7 +262,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 
 			$subscription_post = null;
 			foreach ( $all_plans as $plan ) {
-				if ( intval( $this->find_metadata( $plan, 'jetpack_memberships_product_id' ) ) === $subscription_plan_id ) {
+				if ( intval( $this->find_metadata( $plan, 'jetpack_memberships_product_id' ) ) === intval( $subscription_plan_id ) ) {
 					$subscription_post = $plan;
 					break;
 				}

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -655,7 +655,8 @@ class Jetpack_Memberships {
 			$list            = Memberships_Product::get_product_list( get_current_blog_id(), null, null, $only_newsletter, $allow_deleted );
 			return array_map(
 				function ( $product ) {
-					return $product->to_array()['id']; }, // Returning only post ids
+					return $product['id'];
+				}, // Returning only post ids
 				$list
 			);
 		}

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -651,8 +651,8 @@ class Jetpack_Memberships {
 			// On cached site on WPCOM
 			require_lib( 'memberships' );
 			$only_newsletter = true;
-			$allow_deleted   = true; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-			$list            = Memberships_Product::get_product_list( get_current_blog_id(), null, null, $only_newsletter );
+			$allow_deleted   = true;
+			$list            = Memberships_Product::get_product_list( get_current_blog_id(), null, null, $only_newsletter, $allow_deleted );
 			return array_map(
 				function ( $product ) {
 					return $product->to_array()['id']; }, // Returning only post ids

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -610,7 +610,7 @@ class Jetpack_Memberships {
 		if ( ! self::is_enabled_jetpack_recurring_payments() ) {
 			return array();
 		}
-		
+
 		// We can retrieve the data directly except on a Jetpack/Atomic cached site or
 		$is_cached_site = ( new Host() )->is_wpcom_simple() && is_jetpack_site();
 		if ( ! $is_cached_site ) {
@@ -635,7 +635,7 @@ class Jetpack_Memberships {
 	 * @return array<Memberships_Product>
 	 */
 	public static function get_all_newsletter_plans() {
-		
+
 		if ( ! self::is_enabled_jetpack_recurring_payments() ) {
 			return array();
 		}
@@ -643,7 +643,7 @@ class Jetpack_Memberships {
 		// We can retrieve the data directly except on a Jetpack/Atomic cached site or
 		$is_cached_site = ( new Host() )->is_wpcom_simple() && is_jetpack_site();
 		if ( ! $is_cached_site ) {
-			return get_posts(
+			$posts = get_posts(
 				array(
 					'posts_per_page' => -1,
 					'fields'         => 'ids',
@@ -659,7 +659,7 @@ class Jetpack_Memberships {
 				},
 				$posts
 			);
-			
+
 		} else {
 			// On cached site on WPCOM
 			require_lib( 'memberships' );
@@ -668,7 +668,7 @@ class Jetpack_Memberships {
 			return Memberships_Product::get_product_list( get_current_blog_id(), null, null, $only_newsletter, $allow_deleted );
 		}
 	}
-	
+
 	/**
 	 * Return all membership plans ids (deleted or not)
 	 * This function is used both on WPCOM or on Jetpack self-hosted.
@@ -677,9 +677,9 @@ class Jetpack_Memberships {
 	 * @return array
 	 */
 	public static function get_all_newsletter_plan_ids() {
-		
+
 		$list = static::get_all_newsletter_plans();
-		
+
 		return array_map(
 			function ( $product ) {
 				return $product['id'];
@@ -687,7 +687,7 @@ class Jetpack_Memberships {
 			$list
 		);
 	}
-	
+
 	/**
 	 * Register the Recurring Payments Gutenberg block
 	 */


### PR DESCRIPTION
Fixes https://github.com/Automattic/gold/issues/174

See p81Rsd-1u6-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When getting data from cache sites, use proper source of truth 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


#### Self-hosted
* Create a JN site or an atomic site
* Turn OFF Jetpack Sync
* Make sure Paid-Newsletters, tiers or any membership blocks to work as expected

#### WPCOM
* Make sure paid-newsletters/tiers keep working as expected