### PR TITLE
Social: Update editor connection icon to X

### DIFF
--- a/projects/js-packages/components/changelog/update-connection-social-icon-x
+++ b/projects/js-packages/components/changelog/update-connection-social-icon-x
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed Twitter Icon to new X icon

--- a/projects/js-packages/components/components/icons/index.tsx
+++ b/projects/js-packages/components/components/icons/index.tsx
@@ -273,6 +273,14 @@ export const TwitterIcon: React.FC< SocialIconWrapperProps > = ( { fill, size, c
 	);
 };
 
+export const XIcon: React.FC< SocialIconWrapperProps > = ( { fill, size, className } ) => {
+	return (
+		<SocialIconWrapper fill={ fill } size={ size } className={ classNames( styles.x, className ) }>
+			<Path d="M12.5984 10.0201 18.5086 3.15H17.108L11.9762 9.1152 7.8775 3.15H3.15L9.3482 12.1705 3.15 19.3749H4.5506L9.97 13.0754 14.2985 19.3749H19.026L12.598 10.0201H12.5984ZM10.68 12.25 10.052 11.3517 5.0552 4.2043H7.2065L11.2389 9.9725 11.867 10.8707 17.1087 18.3685H14.9574L10.68 12.2504V12.25Z" />
+		</SocialIconWrapper>
+	);
+};
+
 export const LinkedinIcon: React.FC< SocialIconWrapperProps > = ( { fill, size, className } ) => {
 	return (
 		<SocialIconWrapper
@@ -361,7 +369,7 @@ const jetpackIcons = {
 const socialIcons = {
 	facebook: FacebookIcon,
 	instagram: InstagramIcon,
-	twitter: TwitterIcon,
+	twitter: XIcon,
 	linkedin: LinkedinIcon,
 	tumblr: TumblrIcon,
 	google: GoogleIcon,

--- a/projects/js-packages/components/components/icons/style.module.scss
+++ b/projects/js-packages/components/components/icons/style.module.scss
@@ -21,6 +21,9 @@
 	&.twitter {
 		fill: var( --color-twitter );
 	}
+	&.x {
+		fill: var( --color-x );
+	}
 	&.linkedin {
 		fill: var( --color-linkedin );
 	}

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.43.0",
+	"version": "0.44.0-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/publicize-components/changelog/update-connection-social-icon-x
+++ b/projects/js-packages/publicize-components/changelog/update-connection-social-icon-x
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed Twitter Icon to new X icon

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.40.0",
+	"version": "0.41.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/plugins/jetpack/_inc/client/scss/variables/_colors.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/variables/_colors.scss
@@ -77,6 +77,7 @@ $dashboard-number-border: #cbd7e1;
 //Social media colors
 $color-facebook: #1877f2;
 $color-twitter: #55acee;
+$color-x: #000000;
 $color-gplus: #df4a32;
 $color-tumblr: #35465c;
 $color-linkedin: #0976b4;

--- a/projects/plugins/jetpack/changelog/update-connection-social-icon-x
+++ b/projects/plugins/jetpack/changelog/update-connection-social-icon-x
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Changed social icon of Twitter to X


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This patch changes the icon of Twitter in the Gutenberg editor to be the new X icon. It should be only visible for deprecated Twitter connections.

- Added new SVG for X

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/orgs/Automattic/projects/733/views/2?pane=issue&itemId=40161685
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out this PR.
* If you do not have a Twitter connection anymore, you could change the `serviceName` to be `'twitter'` in `projects/js-packages/publicize-components/src/components/connection-icon/index.jsx`

<img width="275" alt="CleanShot 2023-10-09 at 14 07 44 png" src="https://github.com/Automattic/jetpack/assets/36671565/dcb97aa3-1df0-49fb-8a40-e36ca8b02faa">

