### PR TITLE
phpcs-filter: Ignore `--basepath` option

### DIFF
--- a/projects/packages/phpcs-filter/README.md
+++ b/projects/packages/phpcs-filter/README.md
@@ -41,7 +41,6 @@ and any files that happen to be in parent directories should not affect the oper
 The base directory is determined by the first of these that are available:
 
 * The `jetpack-filter-basedir` config setting.
-* The `--basepath` command line option.
 * The current working directory.
 
 ### Per-directory configuration file name: `jetpack-filter-perdir-file`

--- a/projects/packages/phpcs-filter/changelog/fix-phpcs-filter-ignore-basepath
+++ b/projects/packages/phpcs-filter/changelog/fix-phpcs-filter-ignore-basepath
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ignore `--basepath` command line option. It doesn't mean what we thought it means.

--- a/projects/packages/phpcs-filter/src/PhpcsFilter.php
+++ b/projects/packages/phpcs-filter/src/PhpcsFilter.php
@@ -124,9 +124,6 @@ class PhpcsFilter extends Filter {
 
 		$dir = $config->getConfigData( 'jetpack-filter-basedir' );
 		if ( null === $dir ) {
-			$dir = $config->basepath;
-		}
-		if ( null === $dir ) {
 			$dir = '.';
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
I had thought the use of this would be to point to the base of the monorepo. But it seems likely IDEs like VSCode are using it to point to various subdirectories of the monorepo instead.

Since, on re-reading the help docs for the parameter, that does seem like a valid use for the parameter, we shouldn't try to use it to determine the base of the monorepo after all.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf4qpu-3P-p2#comment-33

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run something like `vendor/bin/phpcs -p -s --basepath=projects/packages/assets/src/ projects/packages/assets/src/class-assets.php`