### PR TITLE
CRM: Resolves #3359 - catch PHP 8.2 deprecated notice on contact edit

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3359-deprecated_notice_on_contact_edit
+++ b/projects/plugins/crm/changelog/fix-crm-3359-deprecated_notice_on_contact_edit
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Catch PHP deprecation notice
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Logs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Logs.php
@@ -147,6 +147,13 @@ class zeroBS__Metabox_LogsV2 extends zeroBS__Metabox {
     public $objtypeid = false; // child fills out e.g. ZBS_TYPE_CONTACT
     public $metaboxLocation = 'normal';
 
+	/**
+	 * The legacy object name (e.g. 'zerobs_customer')
+	 *
+	 * @var string
+	 */
+	private $postType; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
     public function __construct( $plugin_file ) {
 
         // call this 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: Resolves Automattic/zero-bs-crm#3359 - catch deprecated notice on contact edit

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #33421 I missed an obvious "deprecated" notice (PHP 8.2, dynamic class property) that occurs when on the contact edit page. This PR declares the `$postType` class property in the `zeroBS__Metabox_LogsV2` class.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Ensure you are using PHP 8.2 prior to testing.

1. Create a new contact: `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact`

In `trunk`, one gets a deprecation notice when the contact edit page loads (both on creation of the new contact and navigating to the contact edit page manually).

In the `fix/crm/3359-deprecated_notice_on_contact_edit` branch, the notice is no more.