### PR TITLE
AI Chat block: Fix button text wrapping in Firefox

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-chat-button-wrapping
+++ b/projects/plugins/jetpack/changelog/fix-ai-chat-button-wrapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Chat block: Fix text wrapping in botton for Firefox.

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
@@ -28,6 +28,7 @@
 			flex: auto;
 			flex-grow: 1;
 			text-wrap: nowrap;
+			white-space: -moz-pre-space;
 			margin-left: 10px;
 			height: 53px;
 			display: block;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #33516 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`text-wrap` is [not supported](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap) in Firefox, which led to the text overflowing in FF. 

Before:
<img width="752" alt="image" src="https://github.com/Automattic/jetpack/assets/7129409/8536aa59-84eb-43e7-8ec2-22a2675b6fb5">

After: 
<img width="777" alt="image" src="https://github.com/Automattic/jetpack/assets/7129409/db6a0c15-3b99-4caf-9bc9-53b68dd2090a">


## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set a long string as the button text
* Look at the button on front end view in FF
* With this patch, it should not overflow
* Make sure it still looks good in other browsers. 

