### PR TITLE
Social: Add instagram aspect-ratio validation for images

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-add-instagram-image-dimension-validation
+++ b/projects/js-packages/publicize-components/changelog/fix-add-instagram-image-dimension-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added aspect-ratio validation for Instagram images

--- a/projects/js-packages/publicize-components/src/components/media-picker/index.js
+++ b/projects/js-packages/publicize-components/src/components/media-picker/index.js
@@ -85,7 +85,11 @@ export default function MediaPicker( {
 								naturalHeight={ previewHeight || height }
 								isInline
 							>
-								<img src={ previewUrl } alt="" className={ styles[ 'preview-image' ] } />
+								<img
+									src={ previewUrl || sourceUrl }
+									alt=""
+									className={ styles[ 'preview-image' ] }
+								/>
 							</ResponsiveWrapper>
 						) }
 					</button>

--- a/projects/js-packages/publicize-components/src/components/media-picker/index.js
+++ b/projects/js-packages/publicize-components/src/components/media-picker/index.js
@@ -37,8 +37,11 @@ export default function MediaPicker( {
 	onChange,
 	wrapperClassName,
 } ) {
-	const { mediaData: { width, height, sourceUrl } = {}, metaData: { mime, length = null } = {} } =
-		mediaDetails;
+	const {
+		mediaData: { width, height, sourceUrl } = {},
+		metaData: { mime, length = null } = {},
+		previewData: { width: previewWidth, height: previewHeight, sourceUrl: previewUrl } = {},
+	} = mediaDetails;
 
 	const isImageLoading = ! sourceUrl || ! width || ! height || ! mime;
 
@@ -75,15 +78,30 @@ export default function MediaPicker( {
 								duration={ length }
 							></VideoPreview>
 						) : (
-							<ResponsiveWrapper naturalWidth={ width } naturalHeight={ height } isInline>
-								<img src={ sourceUrl } alt="" className={ styles[ 'preview-image' ] } />
+							<ResponsiveWrapper
+								naturalWidth={ previewWidth || width }
+								naturalHeight={ previewHeight || height }
+								isInline
+							>
+								<img src={ previewUrl } alt="" className={ styles[ 'preview-image' ] } />
 							</ResponsiveWrapper>
 						) }
 					</button>
 				</div>
 			);
 		},
-		[ height, length, mime, onRemoveMedia, sourceUrl, width, wrapperClassName ]
+		[
+			height,
+			length,
+			mime,
+			onRemoveMedia,
+			previewHeight,
+			previewUrl,
+			previewWidth,
+			sourceUrl,
+			width,
+			wrapperClassName,
+		]
 	);
 
 	const renderPicker = useCallback(

--- a/projects/js-packages/publicize-components/src/components/media-picker/index.js
+++ b/projects/js-packages/publicize-components/src/components/media-picker/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, closeSmall } from '@wordpress/icons';
 import classNames from 'classnames';
 import { isVideo } from '../../hooks/use-media-restrictions';
-import { SELECTABLE_IMAGE_TYPES } from '../../hooks/use-media-restrictions/restrictions';
+import { SELECTABLE_MEDIA_TYPES } from '../../hooks/use-media-restrictions/restrictions';
 import VideoPreview from '../video-preview';
 import styles from './styles.module.scss';
 
@@ -27,6 +27,7 @@ const clickHandler = open => e => {
  * @param {object} props.mediaDetails - The details of the media for preview
  * @param {Function} props.onChange - A callback that can be passed to parent for validation
  * @param {string} props.wrapperClassName - A class name to be added to the wrapper
+ * @param {object} props.allowedMediaTypes - Custom allowed media types
  * @returns {object} The media section.
  */
 export default function MediaPicker( {
@@ -36,6 +37,7 @@ export default function MediaPicker( {
 	mediaDetails = {},
 	onChange,
 	wrapperClassName,
+	allowedMediaTypes = null,
 } ) {
 	const {
 		mediaData: { width, height, sourceUrl } = {},
@@ -143,7 +145,7 @@ export default function MediaPicker( {
 		<ThemeProvider>
 			<MediaUploadCheck>
 				<MediaUpload
-					allowedTypes={ SELECTABLE_IMAGE_TYPES }
+					allowedTypes={ allowedMediaTypes ?? SELECTABLE_MEDIA_TYPES }
 					title={ buttonLabel }
 					onSelect={ onUpdateMedia }
 					render={ setMediaRender }

--- a/projects/js-packages/publicize-components/src/hooks/use-media-details/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-details/index.js
@@ -53,7 +53,7 @@ const getMediaDetails = async media => {
 
 	const sizes = media?.media_details?.sizes ?? {};
 
-	if ( Object.keys( sizes ).length === 0 ) {
+	if ( ! sizes.full ) {
 		return {
 			mediaData: {
 				width: media.media_details.width,
@@ -64,15 +64,22 @@ const getMediaDetails = async media => {
 		};
 	}
 
-	const mediaObject = sizes.large || sizes.thumbnail;
+	// We use medium image size for previews to decrease the load time.
+	const previewSize = sizes.medium || sizes.large;
+	const previewData = {
+		width: previewSize.width,
+		height: previewSize.height,
+		sourceUrl: previewSize.source_url,
+	};
 
 	return {
 		mediaData: {
-			width: mediaObject.width,
-			height: mediaObject.height,
-			sourceUrl: mediaObject.source_url,
+			width: sizes.full.width,
+			height: sizes.full.height,
+			sourceUrl: sizes.full.source_url,
 		},
 		metaData,
+		previewData,
 	};
 };
 

--- a/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/index.js
@@ -56,11 +56,31 @@ const isMediaConvertible = metaData => {
  * This function is used to check if the provided image is valid based on it's size and type.
  *
  * @param {number} sizeInMb - The fileSize in bytes.
- * @param {number} maxImageSize - The maximum size to check against.
+ * @param {number} width - Width of the image.
+ * @param {number} height - Height of the image.
+ * @param {object} imageLimits - Has the properties to check against
  * @returns {FILE_SIZE_ERROR} Returns validation error.
  */
-const getImageValidationError = ( sizeInMb, maxImageSize ) =>
-	! sizeInMb || sizeInMb > maxImageSize ? FILE_SIZE_ERROR : null;
+const getImageValidationError = ( sizeInMb, width, height, imageLimits ) => {
+	const {
+		maxSize = GLOBAL_MAX_SIZE,
+		minWidth = 0,
+		maxWidth = GLOBAL_MAX_SIZE,
+		aspectRatio = DEFAULT_RESTRICTIONS.image.aspectRatio,
+	} = imageLimits;
+
+	const ratio = width / height;
+	if (
+		ratio < aspectRatio.min ||
+		ratio > aspectRatio.max ||
+		width > maxWidth ||
+		width < minWidth
+	) {
+		return DIMENSION_ERROR;
+	}
+
+	return ! sizeInMb || sizeInMb > maxSize ? FILE_SIZE_ERROR : null;
+};
 
 /**
  * This function is used to check if the provided video is valid based on it's size and type and length.
@@ -138,7 +158,7 @@ const getValidationError = ( metaData, mediaData, serviceName, shouldUploadAttac
 				mediaData?.height,
 				restrictions.video
 		  )
-		: getImageValidationError( sizeInMb, restrictions.image.maxSize );
+		: getImageValidationError( sizeInMb, mediaData?.width, mediaData?.height, restrictions.image );
 };
 
 /**

--- a/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/index.js
@@ -148,17 +148,21 @@ const getValidationError = ( metaData, mediaData, serviceName, shouldUploadAttac
 		return FILE_TYPE_ERROR;
 	}
 
+	if ( ! mediaData?.width || ! mediaData?.height ) {
+		return DIMENSION_ERROR;
+	}
+
 	const sizeInMb = fileSize ? fileSize / Math.pow( 1000, 2 ) : null;
 
 	return isVideo( mime )
 		? getVideoValidationError(
 				sizeInMb,
 				metaData.length,
-				mediaData?.width,
-				mediaData?.height,
+				mediaData.width,
+				mediaData.height,
 				restrictions.video
 		  )
-		: getImageValidationError( sizeInMb, mediaData?.width, mediaData?.height, restrictions.image );
+		: getImageValidationError( sizeInMb, mediaData.width, mediaData.height, restrictions.image );
 };
 
 /**

--- a/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
@@ -178,13 +178,15 @@ export const PHOTON_CONVERTIBLE_TYPES = [
 
 /**
  * These are the types that can be selected in the media picker.
- * Contains all the allowed types, plus the Photon convertible types.
+ * Contains all the allowed types, plus the Photon convertible types, plus the videos.
  */
-export const SELECTABLE_IMAGE_TYPES = [
+export const SELECTABLE_MEDIA_TYPES = [
 	...new Set( [
 		...allowedImageTypes,
 		...facebookImageTypes,
 		...mastodonImageTypes,
+		...facebookVideoTypes,
+		...mastodonVideoTypes,
 		...PHOTON_CONVERTIBLE_TYPES,
 	] ),
 ];

--- a/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
@@ -10,7 +10,7 @@ const VIDEOPRESS = 'video/videopress';
 const allowedImageTypes = [ 'image/jpeg', 'image/jpg', 'image/png' ];
 const facebookImageTypes = allowedImageTypes.concat( [
 	'image/gif',
-	// We do not support tiff image, because Wordpress Core cannot display it.
+	// We do not support tiff image, because WordPress Core cannot display it.
 	// 'image/tiff',
 	// 'image/tif',
 	'image/bmp',
@@ -168,7 +168,7 @@ export const PHOTON_CONVERTIBLE_TYPES = [
 	'image/png',
 	'image/jpeg',
 	'image/jpg',
-	// We do not support tiff image, because Wordpress Core cannot display it.
+	// We do not support tiff image, because WordPress Core cannot display it.
 	// 'image/tiff',
 	// 'image/tif',
 	'image/heic',

--- a/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
@@ -64,6 +64,12 @@ export const DEFAULT_RESTRICTIONS = {
 	allowedMediaTypes: allowedImageTypes.concat( [ MP4, VIDEOPRESS, MOV ] ),
 	image: {
 		maxSize: 4,
+		minWidth: 0,
+		maxWidth: GLOBAL_MAX_SIZE,
+		aspectRatio: {
+			min: 0,
+			max: GLOBAL_MAX_SIZE,
+		},
 	},
 	video: {
 		minLength: 0,
@@ -126,6 +132,12 @@ export const RESTRICTIONS = {
 		allowedMediaTypes: [ 'image/jpg', 'image/jpeg', MP4, MOV, VIDEOPRESS ],
 		image: {
 			maxSize: 8,
+			minWidth: 320,
+			maxWidth: 1440,
+			aspectRatio: {
+				min: 4 / 5,
+				max: 1.91 / 1,
+			},
 		},
 		video: {
 			maxLength: 90,

--- a/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
@@ -136,7 +136,7 @@ export const RESTRICTIONS = {
 			maxWidth: 1440,
 			aspectRatio: {
 				min: 4 / 5,
-				max: 1.91 / 1,
+				max: 1.91,
 			},
 		},
 		video: {
@@ -145,8 +145,8 @@ export const RESTRICTIONS = {
 			maxSize: 1000,
 			maxWidth: 1920,
 			aspectRatio: {
-				min: 0.01 / 1,
-				max: 10 / 1,
+				min: 0.01,
+				max: 10,
 			},
 		},
 	},

--- a/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/test/index.test.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/test/index.test.js
@@ -32,8 +32,8 @@ const DUMMY_CONNECTIONS = [
 const INVALID_TYPES = [ 'imagejpg', 'image/tgif', 'video/mp5', '', null ];
 
 const VALID_MEDIA_ALL = [
-	{ metaData: { mime: 'image/jpg', fileSize: 40 } },
-	{ metaData: { mime: 'image/jpeg', fileSize: 20 } },
+	{ metaData: { mime: 'image/jpg', fileSize: 40 }, mediaData: { width: 400, height: 500 } },
+	{ metaData: { mime: 'image/jpeg', fileSize: 20 }, mediaData: { width: 400, height: 500 } },
 ];
 const ALLOWED_MEDIA_TYPES_ALL = [
 	'image/jpeg',
@@ -142,9 +142,27 @@ describe( 'useMediaRestrictions hook', () => {
 
 	test( 'Instagram should only accept good sized image', () => {
 		[
-			{ media: { metaData: { mime: 'image/jpg', fileSize: 10000000 } }, error: FILE_SIZE_ERROR }, // Too big image
-			{ media: { metaData: { mime: 'image/png', fileSize: 10000000 } }, error: FILE_TYPE_ERROR }, // Png
-			{ media: { metaData: { mime: 'video/mp5', fileSize: 10 } }, error: FILE_TYPE_ERROR }, // Bad Video
+			{
+				media: {
+					metaData: { mime: 'image/jpg', fileSize: 10000000 },
+					mediaData: { width: 400, height: 500 },
+				},
+				error: FILE_SIZE_ERROR,
+			}, // Too big image
+			{
+				media: {
+					metaData: { mime: 'image/png', fileSize: 10000000 },
+					mediaData: { width: 400, height: 500 },
+				},
+				error: FILE_TYPE_ERROR,
+			}, // Png
+			{
+				media: {
+					metaData: { mime: 'video/mp5', fileSize: 10 },
+					mediaData: { width: 320, height: 500 },
+				},
+				error: FILE_TYPE_ERROR,
+			}, // Bad Video
 		].forEach( testData => {
 			const { result } = renderHook( () =>
 				useMediaRestrictions(
@@ -159,11 +177,17 @@ describe( 'useMediaRestrictions hook', () => {
 	test( 'Can get video length error', () => {
 		[
 			{
-				media: { metaData: { mime: 'video/mp4', fileSize: 1000000, length: 2 } },
+				media: {
+					metaData: { mime: 'video/mp4', fileSize: 1000000, length: 2 },
+					mediaData: { width: 10, height: 10 },
+				},
 				error: VIDEO_LENGTH_TOO_SHORT_ERROR,
 			}, // Too short video
 			{
-				media: { metaData: { mime: 'video/mp4', fileSize: 1000000, length: 20000 } },
+				media: {
+					metaData: { mime: 'video/mp4', fileSize: 1000000, length: 20000 },
+					mediaData: { width: 10, height: 10 },
+				},
 				error: VIDEO_LENGTH_TOO_LONG_ERROR,
 			}, // Too long video
 		].forEach( testData => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

At the moment we only check aspect-ratio for videos. This should be fixed, this change adds the needed logic to correctly check the width and aspect-ratio requirements for Instagram

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On trunk turn off auto-conversion on your site.
* Find an image that [does not meet the requirements](https://developers.facebook.com/docs/instagram-api/reference/ig-user/media/#image-specifications) for the aspect-ratio validation of Instagram
* Uploading that as attached media - if the filesize is correct - should not show errors.
* Check out this PR. Applying the same image should result in a warning.

