### PR TITLE
JITM: Fix jitms not being clickable

### DIFF
--- a/projects/packages/jitm/changelog/fix-jitms-not-clickable
+++ b/projects/packages/jitm/changelog/fix-jitms-not-clickable
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: minor fix
+
+

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -259,7 +259,6 @@ jQuery( document ).ready( function ( $ ) {
 
 		// Handle tracking for JITM CTA buttons
 		$template.find( '.jitm-button' ).on( 'click', function ( e ) {
-			e.preventDefault();
 
 			var button = $( this );
 			var eventName = button.attr( 'data-jptracks-name' );
@@ -275,9 +274,7 @@ jQuery( document ).ready( function ( $ ) {
 			};
 
 			if ( window.jpTracksAJAX ) {
-				window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp).always( function() {
-					window.location.href = button.attr('href');
-				} );
+				window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp);
 			}
 		});
 	};

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -276,7 +276,7 @@ jQuery( document ).ready( function ( $ ) {
 			if ( window.jpTracksAJAX ) {
 				window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp);
 			}
-		});
+		} );
 	};
 
 	var reFetch = function () {

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -275,10 +275,14 @@ jQuery( document ).ready( function ( $ ) {
 			};
 
 			if ( window.jpTracksAJAX ) {
-				window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp);
+				window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp).always( function() {
+					button.trigger('click');  // trigger the original click event after the function has tracked
+				} );
+			}else{
+				button.trigger('click');  // trigger the original click event if jpTracksAJAX is not available
 			}
 
-			button.trigger('click');  // Trigger the actual click event
+			
 
 		} );
 	};

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -277,6 +277,9 @@ jQuery( document ).ready( function ( $ ) {
 			if ( window.jpTracksAJAX ) {
 				window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp);
 			}
+
+			button.trigger('click');  // Trigger the actual click event
+
 		} );
 	};
 

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -259,26 +259,26 @@ jQuery( document ).ready( function ( $ ) {
 
 		// Handle tracking for JITM CTA buttons
 		$template.find( '.jitm-button' ).on( 'click', function ( e ) {
-				e.preventDefault();
+			e.preventDefault();
 
-				var button = $( this );
-				var eventName = button.attr( 'data-jptracks-name' );
-				if ( undefined === eventName ) {
-					return;
-				}
+			var button = $( this );
+			var eventName = button.attr( 'data-jptracks-name' );
+			if ( undefined === eventName ) {
+				return;
+			}
 
-				var jitmName = button.attr( 'data-jptracks-prop' ) || false;
-				var messagePath = button.attr( 'data-jitm-path' ) || false;
-				var eventProp = {
-					clicked: jitmName,
-					jitm_message_path: messagePath,
-				};
+			var jitmName = button.attr( 'data-jptracks-prop' ) || false;
+			var messagePath = button.attr( 'data-jitm-path' ) || false;
+			var eventProp = {
+				clicked: jitmName,
+				jitm_message_path: messagePath,
+			};
 
-				if ( window.jpTracksAJAX ) {
-					window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp).always( function() {
-						window.location.href = button.attr('href');
-					} );
-				}
+			if ( window.jpTracksAJAX ) {
+				window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp).always( function() {
+					window.location.href = button.attr('href');
+				} );
+			}
 		});
 	};
 

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -281,7 +281,6 @@ jQuery( document ).ready( function ( $ ) {
 			}else{
 				button.trigger('click');  // trigger the original click event if jpTracksAJAX is not available
 			}
-			
 		} );
 	};
 

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -259,29 +259,27 @@ jQuery( document ).ready( function ( $ ) {
 
 		// Handle tracking for JITM CTA buttons
 		$template.find( '.jitm-button' ).on( 'click', function ( e ) {
-			e.preventDefault();
+				e.preventDefault();
 
-			var button = $( this );
-			var eventName = button.attr( 'data-jptracks-name' );
-			if ( undefined === eventName ) {
-				return;
-			}
+				var button = $( this );
+				var eventName = button.attr( 'data-jptracks-name' );
+				if ( undefined === eventName ) {
+					return;
+				}
 
-			var jitmName = button.attr( 'data-jptracks-prop' ) || false;
-			var messagePath = button.attr( 'data-jitm-path' ) || false;
-			var eventProp = {
-				clicked: jitmName,
-				jitm_message_path: messagePath,
-			};
+				var jitmName = button.attr( 'data-jptracks-prop' ) || false;
+				var messagePath = button.attr( 'data-jitm-path' ) || false;
+				var eventProp = {
+					clicked: jitmName,
+					jitm_message_path: messagePath,
+				};
 
-			if ( window.jpTracksAJAX ) {
-				window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp).always( function() {
-					button.click();  // trigger the original click event after the function has tracked
-				} );
-			}else{
-				button.click();  // trigger the original click event if jpTracksAJAX is not available
-			}
-		} );
+				if ( window.jpTracksAJAX ) {
+					window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp).always( function() {
+						window.location.href = button.attr('href');
+					} );
+				}
+		});
 	};
 
 	var reFetch = function () {

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -281,9 +281,7 @@ jQuery( document ).ready( function ( $ ) {
 			}else{
 				button.trigger('click');  // trigger the original click event if jpTracksAJAX is not available
 			}
-
 			
-
 		} );
 	};
 

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -276,10 +276,10 @@ jQuery( document ).ready( function ( $ ) {
 
 			if ( window.jpTracksAJAX ) {
 				window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp).always( function() {
-					button.trigger('click');  // trigger the original click event after the function has tracked
+					button.click();  // trigger the original click event after the function has tracked
 				} );
 			}else{
-				button.trigger('click');  // trigger the original click event if jpTracksAJAX is not available
+				button.click();  // trigger the original click event if jpTracksAJAX is not available
 			}
 		} );
 	};


### PR DESCRIPTION
Fixes the bug encountered in testing that JITMs were not clickable due to tracking being moved and the default behaviour was prevented and buttons with external links didn't work. See video:-


https://github.com/Automattic/jetpack/assets/4077604/c80e8735-613a-47f2-bb15-6d4f27050a76



## Proposed changes:
* Trigger the button click event at the end of the tracking function.

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
You need a JITM to be visible, before the buttons were reacting to a click because the default click event was prevented so the JITM could be tracked. 

* Got to any page with a JITM
* A good example is the edit posts page (for Blaze)
* Notice the JITM buttons are not clickable to take you where they want you to go

Apply this patch
* JITMs should be clickable again



