### PR TITLE
Paywall block: remove "beta" from the name in block.json

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-title-beta
+++ b/projects/plugins/jetpack/changelog/update-paywall-title-beta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Paywall block: remove "beta" from the name in block.json

--- a/projects/plugins/jetpack/extensions/blocks/paywall/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "jetpack/paywall",
-	"title": "Paywall (Beta)",
+	"title": "Paywall",
 	"description": "Limit access to the content below this block to chosen subscribers.",
 	"keywords": [
 		"more",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I don't think the block.json is used anywhere yet, but Crew can confirm.

Anyway, the block was released a while back and isn't "beta" anymore. We just missed the block.json

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove "beta" from the name in block.json


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing to test.

