### PR TITLE
Harden code paths accessing uploaded files

### DIFF
--- a/projects/plugins/jetpack/changelog/update-harden-upload-file-handling
+++ b/projects/plugins/jetpack/changelog/update-harden-upload-file-handling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Harden code paths accessing uploaded files.
+
+

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -2160,6 +2160,11 @@ abstract class WPCOM_JSON_API_Endpoint {
 			return false;
 		}
 
+		// We don't know if this is an upload or a sideload, but in either case the tmp_name should be a path, not a URL.
+		if ( wp_parse_url( $media_item['tmp_name'], PHP_URL_SCHEME ) !== null ) {
+			return false;
+		}
+
 		// Check if video is longer than 5 minutes.
 		$video_meta = wp_read_video_metadata( $media_item['tmp_name'] );
 		if (

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -212,12 +212,14 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 	 *
 	 * @param  {Array}  $file_array - array containing file data.
 	 * @param  {Number} $media_id - the media id.
+	 * @param  {bool}   $is_upload - True if `$file_array` derives from an upload in `$_FILES`, false if this is a sideload.
 	 * @return {Array|WP_Error} An array with information about the new file saved or a WP_Error is something went wrong.
 	 */
-	private function save_temporary_file( $file_array, $media_id ) {
+	private function save_temporary_file( $file_array, $media_id, $is_upload ) {
 		$tmp_filename = $file_array['tmp_name'];
 
-		if ( ! file_exists( $tmp_filename ) ) {
+		$is_ok = $is_upload ? is_uploaded_file( $tmp_filename ) : file_exists( $tmp_filename );
+		if ( ! $is_ok ) {
 			return new WP_Error( 'invalid_input', 'No media provided in input.' );
 		}
 
@@ -232,7 +234,9 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 			! $this->is_file_supported_for_sideloading( $tmp_filename ) &&
 			! file_is_displayable_image( $tmp_filename )
 		) {
-			wp_delete_file( $tmp_filename );
+			if ( ! $is_upload ) {
+				wp_delete_file( $tmp_filename );
+			}
 			return new WP_Error( 'invalid_input', 'Invalid file type.', 403 );
 		}
 		remove_filter( 'jetpack_supported_media_sideload_types', $mime_type_static_filter );
@@ -246,9 +250,12 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 		$time = $this->get_time_string_from_guid( $media_id );
 
 		$file_array['name'] = $tmp_new_filename;
-		$file               = wp_handle_sideload( $file_array, $overrides, $time );
-
-		$this->remove_tmp_file( $file_array );
+		if ( $is_upload ) {
+			$file = wp_handle_upload( $file_array, $overrides, $time );
+		} else {
+			$file = wp_handle_sideload( $file_array, $overrides, $time );
+			$this->remove_tmp_file( $file_array );
+		}
 
 		if ( isset( $file['error'] ) ) {
 			return new WP_Error( 'upload_error', $file['error'] );
@@ -422,6 +429,7 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 			}
 
 			// save the temporal file locally.
+			$is_upload     = (bool) $media_file;
 			$temporal_file = $media_file ? $media_file : $this->build_file_array_from_url( $media_id, $media_url );
 
 			if ( is_wp_error( $temporal_file ) ) {
@@ -433,7 +441,7 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 
 			$uploaded_file = $should_restore
 				? $this->restore_original( $media_id, $has_original_media )
-				: $this->save_temporary_file( $temporal_file, $media_id );
+				: $this->save_temporary_file( $temporal_file, $media_id, $is_upload );
 
 			if ( is_wp_error( $uploaded_file ) ) {
 				return $uploaded_file;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
@@ -218,6 +218,12 @@ class WPCOM_JSON_API_Upload_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			return $file;
 		}
 
+		// We don't know if this is an upload or a sideload, but in either case the tmp_name should be a path, not a URL.
+		if ( wp_parse_url( $file['tmp_name'], PHP_URL_SCHEME ) !== null ) {
+			$file['error'] = 'rest_upload_invalid|' . __( 'Specified file failed upload test.', 'default' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+			return $file;
+		}
+
 		if ( defined( 'WP_IMPORTING' ) ) {
 			return $file;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* WPCOM_JSON_API_Edit_Media_v1_2_Endpoint can handle both uploads and sideloads. Adjust the code to handle the upload as an upload instead of pretending it's a sideload.
* Jetpack_Media handles only uploads. Adjust code to handle it as such, and reject sideloads.
* WPCOM_JSON_API_Endpoint::media_item_is_free_video_mobile_upload_and_too_long might handle uploads or sideloads, and we can't easily determine which. But we can at least guard against the "path" being a URL.
* WPCOM_JSON_API_Upload_Media_v1_1_Endpoint can handle both uploads and sideloads. While we could jump through some hoops to detect which, it's more straightforward to just do the no-URL check as later code will actually validate uploads vs sideloads.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p3btAN-2b9-p2#comment-18382
p1696334164011099/1696321784.982469-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure uploads and/or sideloads via these code paths still work.