### PR TITLE
Fix paywall login text colour

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-paywall-login-text-colour
+++ b/projects/plugins/jetpack/changelog/fix-paywall-login-text-colour
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Paywall: login paragraph to use theme text colour

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1191,8 +1191,9 @@ function get_paywall_blocks( $newsletter_access_level ) {
 	$sign_in = '';
 	if ( ! is_user_logged_in() && ( new Host() )->is_wpcom_simple() ) {
 		$sign_in_link = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
-		$sign_in      = '<!-- wp:paragraph {"align":"center", "typography":{"fontSize":"14px","fontWeight":"400";"color":"#646970"}} -->
-<p class="has-text-align-center" style="font-size:14px;font-weight:400;color:#646970">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '" class="jetpack-subscriber-paywall-login" style="font-size:14px;font-weight:400;color:#646970">' . esc_html__( 'Log in', 'jetpack' ) . '</a></p>
+
+		$sign_in = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->
+<p class="has-text-align-center" style="font-size:14px">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '">' . esc_html__( 'Log in', 'jetpack' ) . '</a></p>
 <!-- /wp:paragraph -->';
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes issues with paywall login text in different dark themes. The login link is shown only at WP.com so this doesn't apply to Jetpack sites (yet).

Previously the "login" link's text was fixed colour, which caused issues on non-light backgrounds:

![image](https://github.com/Automattic/jetpack/assets/87168/368ad222-175e-4fbf-b716-fc8f5ffca37e)


## Proposed changes:
* Rely on body text and link colour for the login link:

Lettre
![image](https://github.com/Automattic/jetpack/assets/87168/f9672aa1-e755-4536-b66c-da360e60f3ea)

Muscat
![image](https://github.com/Automattic/jetpack/assets/87168/cee5f2a6-7b3c-4d11-884a-56ffbc85804e)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync changes to WP.com
* Create paywalled post with simple site, and open it on incognito
* Test Muscat, Lettre and any other themes. Ensure you can always read the login text.

Note that "lock" icon has colour issues, which this PR doesn't address.
