### PR TITLE
sync: Explicitly cast an int variable when building SQL

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-bucket_size-cast
+++ b/projects/packages/sync/changelog/fix-sync-bucket_size-cast
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cast `$bucket_size` to an int when embedding in SQL. Should already have been validated by the caller, but doesn't hurt to enforce it.
+
+

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.57.3';
+	const PACKAGE_VERSION = '1.57.4-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/class-replicastore.php
+++ b/projects/packages/sync/src/class-replicastore.php
@@ -1280,7 +1280,7 @@ class Replicastore implements Replicastore_Interface {
 		// With a limit present, we'll look at a dataset consisting of object_ids that meet the constructs of the $where clause.
 		// Without a limit, we can use the actual table as a dataset.
 		$from = $bucket_size ?
-			"( SELECT $distinct_sql $id_field FROM $object_table $where_sql ORDER BY $id_field ASC LIMIT $bucket_size ) as ids" :
+			"( SELECT $distinct_sql $id_field FROM $object_table $where_sql ORDER BY $id_field ASC LIMIT " . ( (int) $bucket_size ) . ' ) as ids' :
 			"$object_table $where_sql ORDER BY $id_field ASC";
 
 		return $wpdb->get_row(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

# Proposed changes:
<!--- Explain what functional changes your PR includes -->
Explicitly cast an int variable when building SQL. Should already have been verified by the caller, but doesn't hurt to add an explicit cast.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1696334164011099/1696321784.982469-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check things still work.