### PR TITLE
Project Board automations: do not process closed issues

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-update-board-closed-issue
+++ b/projects/github-actions/repo-gardening/changelog/update-update-board-closed-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Project Board automations: do not run any automation on closed issues.

--- a/projects/github-actions/repo-gardening/src/tasks/update-board/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/update-board/index.js
@@ -376,9 +376,17 @@ async function setStatusField( octokit, projectInfo, projectItemId, statusText )
  */
 async function updateBoard( payload, octokit ) {
 	const { action, issue, label = {}, repository } = payload;
-	const { number, node_id } = issue;
+	const { number, node_id, state } = issue;
 	const { owner, name } = repository;
 	const ownerLogin = owner.login;
+
+	// Do not run this task if the issue is not open.
+	if ( 'open' !== state ) {
+		debug(
+			`update-board: Issue #${ number } is not open. No need to update its status on the board.`
+		);
+		return;
+	}
 
 	const projectToken = getInput( 'triage_projects_token' );
 	if ( ! projectToken ) {


### PR DESCRIPTION
## Proposed changes:

See https://github.com/Automattic/wp-calypso/issues/82818

We do not need to be making any project board changes for issues that are already closed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This cannot be tested in this repo, but we can test it in a fork:
https://github.com/jeherve/jetpack/issues/105
https://github.com/jeherve/jetpack/actions/runs/6472204347/job/17572351910

<img width="709" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/e8a7b81b-a4bd-44c5-8b9f-5e7027001307">
