### PR TITLE
CRM: Fix PHP Notice - Trying to get property 'ID' of non-object in /wp-includes/link-template.php on line 445

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3357-remove-php-notice-id-of-non-object
+++ b/projects/plugins/crm/changelog/fix-crm-3357-remove-php-notice-id-of-non-object
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Remove PHP notice "Trying to get property 'ID' of non-object in /wp-includes/link-template.php on line 445" for PHP version >= 8.x

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1348,7 +1348,7 @@ function zeroBSCRM_portal_linkObj( $obj_id = -1, $type_int = ZBS_TYPE_INVOICE ) 
 function jpcrm_get_portal_slug() {
 	$portal_page_id   = zeroBSCRM_getSetting( 'portalpage' );
 	$portal_post      = get_post( $portal_page_id );
-	$portal_permalink = rtrim( _get_page_link( $portal_post ), '/' );
+	$portal_permalink = $portal_post ? rtrim( _get_page_link( $portal_post ), '/' ) : '';
 	$portal_slug      = str_replace( home_url(), "", $portal_permalink);
 	
 	if ( empty( $portal_slug ) ) {


### PR DESCRIPTION
This PR removes the PHP Notice - Trying to get property 'ID' of non-object in /wp-includes/link-template.php on line 445

## Proposed changes:
* Stop calling `_get_page_link` with a null object.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3357

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use PHP Version >= 8.x
* Remove the Client Portal page in /wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=clients (set to `No Portal Page Found!`)
* Send an e-mail to a contact

In `trunk` you will get a notice in your error_logs
In this branch the notice is gone.