### PR TITLE
Backport mu-wpcom-plugin 1.7.0, jetpack 12.7-beta Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.11] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.1.10] - 2023-09-28
 ### Added
 - AI Client: Add keyboard shortcut text next to Stop action [#33271]
@@ -136,6 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.1.11]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.7...v0.1.8

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.1.11-alpha",
+	"version": "0.1.11",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.16.3] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.16.2] - 2023-09-04
 ### Changed
 - Updated package dependencies. [#32803]
@@ -267,5 +271,6 @@
 - Add the API methods left behind by the previous PR.
 - Initial release of jetpack-api package
 
+[0.16.3]: https://github.com/Automattic/jetpack-api/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/Automattic/jetpack-api/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/Automattic/jetpack-api/compare/v0.16.0...v0.16.1

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.16.3-alpha",
+	"version": "0.16.3",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.10] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.6.9] - 2023-09-11
 ### Changed
 - Bump pkgs version [#32825]
@@ -220,6 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.10]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.9...0.6.10
 [0.6.9]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.8...0.6.9
 [0.6.8]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.7...0.6.8
 [0.6.7]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.6...0.6.7

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.10-alpha",
+	"version": "0.6.10",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.1.11] - 2023-09-19
 ### Changed
 - Updated package dependencies. [#32957]
@@ -63,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.12]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.8...v0.1.9

--- a/projects/js-packages/boost-score-api/changelog/renovate-npm-zod-vulnerability
+++ b/projects/js-packages/boost-score-api/changelog/renovate-npm-zod-vulnerability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.12-alpha",
+	"version": "0.1.12",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.43.1] - 2023-10-10
+### Changed
+- Boost Score Graph: Show a straight line before the first data point. [#33133]
+- Updated package dependencies. [#33428]
+
 ## [0.43.0] - 2023-10-03
 ### Added
 - Added new sharing icon [#33244]
@@ -830,6 +835,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.43.1]: https://github.com/Automattic/jetpack-components/compare/0.43.0...0.43.1
 [0.43.0]: https://github.com/Automattic/jetpack-components/compare/0.42.5...0.43.0
 [0.42.5]: https://github.com/Automattic/jetpack-components/compare/0.42.4...0.42.5
 [0.42.4]: https://github.com/Automattic/jetpack-components/compare/0.42.3...0.42.4

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/update-boost-score-graph-start
+++ b/projects/js-packages/components/changelog/update-boost-score-graph-start
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Boost Score Graph: Show a straight line before the first data point.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.43.1-alpha",
+	"version": "0.43.1",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.30.1] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.30.0] - 2023-09-25
 ### Added
 - Handle connection error codes and display proper error messages. Enabled for the "private network" error only at the moment. [#32898]
@@ -632,6 +636,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.30.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.29.10...v0.30.0
 [0.29.10]: https://github.com/Automattic/jetpack-connection-js/compare/v0.29.9...v0.29.10
 [0.29.9]: https://github.com/Automattic/jetpack-connection-js/compare/v0.29.8...v0.29.9

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.30.1-alpha",
+	"version": "0.30.1",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.38] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [2.0.37] - 2023-09-04
 ### Changed
 - Updated package dependencies. [#32803]
@@ -179,6 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.38]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.37...v2.0.38
 [2.0.37]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.36...v2.0.37
 [2.0.36]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.35...v2.0.36
 [2.0.35]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.34...v2.0.35

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.38-alpha",
+	"version": "2.0.38",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.47 - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## 0.10.46 - 2023-09-19
 ### Changed
 - Updated package dependencies. [#33001]

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.47-alpha",
+	"version": "0.10.47",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.7 - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## 0.11.6 - 2023-09-13
 ### Changed
 - Updated package dependencies. [#33001]

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.11.7-alpha",
+	"version": "0.11.7",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.56 - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## 0.2.55 - 2023-09-19
 ### Changed
 - Updated package dependencies. [#33001]

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.56-alpha",
+	"version": "0.2.56",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.1] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.40.0] - 2023-10-03
 ### Added
 - Added a new post-publish panel for quick sharing [#33244]
@@ -447,6 +451,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.40.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.40.0...v0.40.1
 [0.40.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.39.1...v0.40.0
 [0.39.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.39.0...v0.39.1
 [0.39.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.38.0...v0.39.0

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.40.1-alpha",
+	"version": "0.40.1",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.12.0] - 2023-09-19
 ### Added
 - Helpers functions for block icons [#32698]
@@ -256,6 +260,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.12.1]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.12.0...0.12.1
 [0.12.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.11.5...0.12.0
 [0.11.5]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.11.4...0.11.5
 [0.11.4]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.11.3...0.11.4

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.12.1-alpha",
+	"version": "0.12.1",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.1 - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## 2.0.0 - 2023-10-03
 ### Added
 - Document PnpmDeterministicModuleIdsPlugin that was added way back in 1.2.0. [#33392]

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "2.0.1-alpha",
+	"version": "2.0.1",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/action-bar/CHANGELOG.md
+++ b/projects/packages/action-bar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.28] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.1.27] - 2023-09-19
 ### Changed
 - Updated package dependencies. [#33001]
@@ -118,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds the Action Bar package and Jetpack plugin module for follows, likes, and comments. Just a scaffold to build on, for now. [#25447]
 
+[0.1.28]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.24...v0.1.25

--- a/projects/packages/action-bar/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/action-bar/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/action-bar/package.json
+++ b/projects/packages/action-bar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-action-bar",
-	"version": "0.1.28-alpha",
+	"version": "0.1.28",
 	"description": "An easy way for visitors to follow, like, and comment on your WordPress site.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/action-bar/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.12] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
+### Fixed
+- Pass `false`, not `null`, to `WP_Scripts->add()`. [#33513]
+
 ## [1.18.11] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.18.10] - 2023-09-04
@@ -360,6 +368,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[1.18.12]: https://github.com/Automattic/jetpack-assets/compare/v1.18.11...v1.18.12
 [1.18.11]: https://github.com/Automattic/jetpack-assets/compare/v1.18.10...v1.18.11
 [1.18.10]: https://github.com/Automattic/jetpack-assets/compare/v1.18.9...v1.18.10
 [1.18.9]: https://github.com/Automattic/jetpack-assets/compare/v1.18.8...v1.18.9

--- a/projects/packages/assets/changelog/fix-assets-add-null
+++ b/projects/packages/assets/changelog/fix-assets-add-null
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Pass `false`, not `null`, to `WP_Scripts->add()`.

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.7] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [1.17.6] - 2023-09-19
 ### Changed
 - Updated Jetpack submenu sort order so individual features are alpha-sorted. [#32958]
@@ -487,6 +491,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[1.17.7]: https://github.com/Automattic/jetpack-backup/compare/v1.17.6...v1.17.7
 [1.17.6]: https://github.com/Automattic/jetpack-backup/compare/v1.17.5...v1.17.6
 [1.17.5]: https://github.com/Automattic/jetpack-backup/compare/v1.17.4...v1.17.5
 [1.17.4]: https://github.com/Automattic/jetpack-backup/compare/v1.17.3...v1.17.4

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.17.7-alpha';
+	const PACKAGE_VERSION = '1.17.7';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.10.2] - 2023-09-19
 ### Changed
 - Updated package dependencies. [#33001]
@@ -207,6 +211,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.10.3]: https://github.com/automattic/jetpack-blaze/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/automattic/jetpack-blaze/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/automattic/jetpack-blaze/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/automattic/jetpack-blaze/compare/v0.9.3...v0.10.0

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.10.3-alpha",
+	"version": "0.10.3",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.10.3-alpha';
+	const PACKAGE_VERSION = '0.10.3';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.1] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [1.58.0] - 2023-09-25
 ### Added
 - Disallow private IP addresses for site connection. [#32898]
@@ -888,6 +892,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[1.58.1]: https://github.com/Automattic/jetpack-connection/compare/v1.58.0...v1.58.1
 [1.58.0]: https://github.com/Automattic/jetpack-connection/compare/v1.57.5...v1.58.0
 [1.57.5]: https://github.com/Automattic/jetpack-connection/compare/v1.57.4...v1.57.5
 [1.57.4]: https://github.com/Automattic/jetpack-connection/compare/v1.57.3...v1.57.4

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.58.1-alpha';
+	const PACKAGE_VERSION = '1.58.1';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.2] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.22.1] - 2023-09-28
 ### Changed
 - Minor internal updates.
@@ -336,6 +340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.22.2]: https://github.com/automattic/jetpack-forms/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/automattic/jetpack-forms/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/automattic/jetpack-forms/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/automattic/jetpack-forms/compare/v0.20.1...v0.21.0

--- a/projects/packages/forms/changelog/renovate-npm-postcss-vulnerability
+++ b/projects/packages/forms/changelog/renovate-npm-postcss-vulnerability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.22.2-alpha",
+	"version": "0.22.2",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.22.2-alpha';
+	const PACKAGE_VERSION = '0.22.2';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.6] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.10.5] - 2023-09-19
 ### Changed
 - Updated package dependencies. [#33001]
@@ -413,6 +417,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.10.6]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.5...v0.10.6
 [0.10.5]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.4...v0.10.5
 [0.10.4]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.2...v0.10.3

--- a/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.10.6-alpha",
+	"version": "0.10.6",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.10.6-alpha';
+	const PACKAGE_VERSION = '0.10.6';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.14.0] - 2023-10-10
+### Added
+- Expose newsletter_categories_location to JavaScript [#33374]
+
+### Changed
+- Changed domain launchpad task visibility [#33456]
+- Changed email verification visibility [#33457]
+
 ## [4.13.0] - 2023-10-03
 ### Added
 - Add new task for user to confirm email when purchasing a domain. [#33373]
@@ -384,6 +392,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[4.14.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.13.0...v4.14.0
 [4.13.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.12.0...v4.13.0
 [4.12.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.11.0...v4.12.0
 [4.11.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.10.0...v4.11.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-newsletter-categories-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-newsletter-categories-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Expose newsletter_categories_location to JavaScript

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-domain-task-visibility
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-domain-task-visibility
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Changed domain launchpad task visibility

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-email-task-visibility
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-email-task-visibility
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Changed email verification visibility

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.14.0-alpha",
+	"version": "4.14.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.14.0-alpha';
+	const PACKAGE_VERSION = '4.14.0';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2023-10-10
+### Added
+- JITMs can now redirect to a specific Jetpack settings page. [#32826]
+
+### Changed
+- Update color of WooCommerce logo. [#33491]
+- Updated package dependencies. [#33428]
+
 ## [2.4.0] - 2023-09-28
 ### Changed
 - Moved tracking for JITM buttons into JITM script, added message_path property [#33252]
@@ -629,6 +637,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[2.5.0]: https://github.com/Automattic/jetpack-jitm/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.19...v2.4.0
 [2.3.19]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.18...v2.3.19
 [2.3.18]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.17...v2.3.18

--- a/projects/packages/jitm/changelog/fix-jitms-not-clickable
+++ b/projects/packages/jitm/changelog/fix-jitms-not-clickable
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: minor fix
-
-

--- a/projects/packages/jitm/changelog/jitm-redirection-after-activate-click
+++ b/projects/packages/jitm/changelog/jitm-redirection-after-activate-click
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-JITMs can now redirect to a specific Jetpack settings page

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jitm/changelog/update-jitm-woo-color
+++ b/projects/packages/jitm/changelog/update-jitm-woo-color
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update color of WooCommerce logo

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.5.0-alpha';
+	const PACKAGE_VERSION = '2.5.0';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/lazy-images/CHANGELOG.md
+++ b/projects/packages/lazy-images/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [2.3.0] - 2023-09-28
 ### Added
 - Add logic to disable the Lazy Images module in the Jetpack plugin. [#33208]
@@ -360,6 +364,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lazy Images: Move into a package
 
+[2.3.1]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.45...v2.2.0
 [2.1.45]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.44...v2.1.45

--- a/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.1] - 2023-10-10
+### Changed
+- Changes title of the my-jetpack page to "My Jetpack" [#33486]
+- Updated package dependencies. [#33428]
+
+### Fixed
+- My Jetpack: fix fatal error [#33523]
+- My Jetpack: fix Stats card status when not connected [#33521]
+
 ## [3.8.0] - 2023-10-03
 ### Added
 - Display a new section on My Jetpack to display the stats of the site. [#33283]
@@ -1044,6 +1053,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[3.8.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.8.0...3.8.1
 [3.8.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.7.0...3.8.0
 [3.7.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.6.0...3.7.0
 [3.6.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.5.0...3.6.0

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-use-jetpack-modules
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-use-jetpack-modules
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Fix fatal error

--- a/projects/packages/my-jetpack/changelog/fix-stats-status-when-not-connected
+++ b/projects/packages/my-jetpack/changelog/fix-stats-status-when-not-connected
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: fix Stats card status when not connected

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-title
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-title
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Changed title of the my-jetpack page to "My Jetpack"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.8.1-alpha",
+	"version": "3.8.1",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.8.1-alpha';
+	const PACKAGE_VERSION = '3.8.1';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.2] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.36.1] - 2023-09-19
 ### Fixed
 - Classic Editor Notices: do not display Twitter in post-publish message. [#33063]
@@ -389,6 +393,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.36.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.1...v0.36.2
 [0.36.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.0...v0.36.1
 [0.36.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.34.0...v0.35.0

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.36.2-alpha",
+	"version": "0.36.2",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.1] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.39.0] - 2023-10-03
 ### Added
 - Add a setting for Jetpack AI Search [#33432]
@@ -808,6 +812,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.39.1]: https://github.com/Automattic/jetpack-search/compare/v0.39.0...v0.39.1
 [0.39.0]: https://github.com/Automattic/jetpack-search/compare/v0.38.8...v0.39.0
 [0.38.8]: https://github.com/Automattic/jetpack-search/compare/v0.38.7...v0.38.8
 [0.38.7]: https://github.com/Automattic/jetpack-search/compare/v0.38.6...v0.38.7

--- a/projects/packages/search/changelog/renovate-npm-postcss-vulnerability
+++ b/projects/packages/search/changelog/renovate-npm-postcss-vulnerability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.39.1-alpha",
+	"version": "0.39.1",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.39.1-alpha';
+	const VERSION = '0.39.1';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.57.4] - 2023-10-10
+- Minor internal updates.
+
 ## [1.57.3] - 2023-09-28
 ### Removed
 - Remove compatibility code for PHP <5.5. [#33288]
@@ -934,6 +937,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.57.4]: https://github.com/Automattic/jetpack-sync/compare/v1.57.3...v1.57.4
 [1.57.3]: https://github.com/Automattic/jetpack-sync/compare/v1.57.2...v1.57.3
 [1.57.2]: https://github.com/Automattic/jetpack-sync/compare/v1.57.1...v1.57.2
 [1.57.1]: https://github.com/Automattic/jetpack-sync/compare/v1.57.0...v1.57.1

--- a/projects/packages/sync/changelog/fix-sync-bucket_size-cast
+++ b/projects/packages/sync/changelog/fix-sync-bucket_size-cast
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Cast `$bucket_size` to an int when embedding in SQL. Should already have been validated by the caller, but doesn't hurt to enforce it.
-
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.57.4-alpha';
+	const PACKAGE_VERSION = '1.57.4';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.4] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.17.3] - 2023-10-03
 ### Fixed
 - Use a try/catch when calling get_the_content to avoid fatals. See: https://github.com/Automattic/jetpack/issues/33284 [#33394]
@@ -1130,6 +1134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.17.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.3...v0.17.4
 [0.17.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.0...v0.17.1

--- a/projects/packages/videopress/changelog/renovate-npm-postcss-vulnerability
+++ b/projects/packages/videopress/changelog/renovate-npm-postcss-vulnerability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.17.4-alpha",
+	"version": "0.17.4",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.17.4-alpha';
+	const PACKAGE_VERSION = '0.17.4';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.13] - 2023-10-10
+### Fixed
+- Escape email address when output in HTML. [#33536]
+
 ## [0.11.12] - 2023-09-28
 ### Changed
 - Minor internal updates.
@@ -231,6 +235,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.11.13]: https://github.com/Automattic/jetpack-waf/compare/v0.11.12...v0.11.13
 [0.11.12]: https://github.com/Automattic/jetpack-waf/compare/v0.11.11...v0.11.12
 [0.11.11]: https://github.com/Automattic/jetpack-waf/compare/v0.11.10...v0.11.11
 [0.11.10]: https://github.com/Automattic/jetpack-waf/compare/v0.11.9...v0.11.10

--- a/projects/packages/waf/changelog/fix-waf-email-in-html
+++ b/projects/packages/waf/changelog/fix-waf-email-in-html
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Escape email address when output in HTML.

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.53] - 2023-10-10
+### Changed
+- Updated package dependencies. [#33428]
+
 ## [0.2.52] - 2023-09-19
 ### Changed
 - Updated Jetpack submenu sort order so individual features are alpha-sorted. [#32958]
@@ -249,6 +253,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.2.53]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.52...v0.2.53
 [0.2.52]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.51...v0.2.52
 [0.2.51]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.50...v0.2.51
 [0.2.50]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.49...v0.2.50

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.53-alpha",
+	"version": "0.2.53",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.53-alpha';
+	const VERSION = '0.2.53';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.7-beta - 2023-10-10
+### Enhancements
+- Newsletter: launch the ability to create tiered newsletter plans. [#32710]
+- Blogroll: move blogroll and blogroll-items blocks from beta to production, along with various improvements. [#33475] [#33483]
+
+### Improved compatibility
+- AI Chat block: fix icon color in block selector. [#33478]
+
+### Bug fixes
+- AI Assistant: do not register the editor plugin if the site is not connected to WordPress.com. [#33408]
+- AI Chat block: fix text wrapping in button for Firefox. [#33519]
+- Block Editor: update the Likes and Sharing copy in the Jetpack menu to address grammatical mistake. [#33509] 
+- Subscriptions module: fix fatal error caused by undefined constant. [#33473]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add jetpack_memberships_product_id to the list of post meta to sync. [#33323]
+- AI Excerpt: set support document link depending on site type [#33499]
+- Sites API: add was_hosting_trial flag to data returned for site details. [#33487]
+- Incorrect typing for a meta field [#33515]
+- Add conditional rendering for newsletter categories based on the wpcom_newsletter_categories_location filter [#33376]
+- Paywall block: remove "beta" from the name in block.json [#33527]
+- Removed WPCOM-specific references from site settings endpoint. [#33466]
+- Sharing: improve the display of the official X button. [#33474]
+- Paywall: login paragraph to use theme text colour [#33532]
+- Updated package dependencies. [#33455]
+
 ## 12.7-a.7 - 2023-10-04
 ### Improved compatibility
 - Notifications: temporarily disable the notifications admin bar menu on any block editor page to allow for Gutenberg 16.7 compatability. [#33458]

--- a/projects/plugins/jetpack/changelog/add-blogroll-block-move-to-production
+++ b/projects/plugins/jetpack/changelog/add-blogroll-block-move-to-production
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Blogroll: Move blogroll and blogroll-items blocks from beta to production

--- a/projects/plugins/jetpack/changelog/add-detect-tier-upgrade
+++ b/projects/plugins/jetpack/changelog/add-detect-tier-upgrade
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Adds newsletter tier upgrade detection

--- a/projects/plugins/jetpack/changelog/add-gate-access-for-newsletter-tiers
+++ b/projects/plugins/jetpack/changelog/add-gate-access-for-newsletter-tiers
@@ -1,4 +1,0 @@
-Significance: minor
-Type: major
-
-New feature: gate access depending on Newsletter tier

--- a/projects/plugins/jetpack/changelog/add-keep-deleted-plans
+++ b/projects/plugins/jetpack/changelog/add-keep-deleted-plans
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-

--- a/projects/plugins/jetpack/changelog/add-membership_tier_endpoints
+++ b/projects/plugins/jetpack/changelog/add-membership_tier_endpoints
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add tier parameter for Membership product endpoints

--- a/projects/plugins/jetpack/changelog/add-newsletter-categories-settings-check
+++ b/projects/plugins/jetpack/changelog/add-newsletter-categories-settings-check
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add conditional rendering for newsletter categories based on the wpcom_newsletter_categories_location filter

--- a/projects/plugins/jetpack/changelog/add-newsletter-tiers-feature
+++ b/projects/plugins/jetpack/changelog/add-newsletter-tiers-feature
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Newsletter tiers are added

--- a/projects/plugins/jetpack/changelog/add-tier-logic-for-premium-content
+++ b/projects/plugins/jetpack/changelog/add-tier-logic-for-premium-content
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Use tier logic to get premium content block

--- a/projects/plugins/jetpack/changelog/earn-fix-memberships-meta-product_id
+++ b/projects/plugins/jetpack/changelog/earn-fix-memberships-meta-product_id
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Add jetpack_memberships_product_id to the list of post meta to sync.

--- a/projects/plugins/jetpack/changelog/earn-tier-selector
+++ b/projects/plugins/jetpack/changelog/earn-tier-selector
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Create a TierSelector component and add to post paid newsletter access selector

--- a/projects/plugins/jetpack/changelog/fht-add_was_hosting_trial_flag
+++ b/projects/plugins/jetpack/changelog/fht-add_was_hosting_trial_flag
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-527 - Sites API: add was_hosting_trial flag to data returned for site details.

--- a/projects/plugins/jetpack/changelog/fix-33465
+++ b/projects/plugins/jetpack/changelog/fix-33465
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix error on Subscribe Modal

--- a/projects/plugins/jetpack/changelog/fix-ai-chat-button-wrapping
+++ b/projects/plugins/jetpack/changelog/fix-ai-chat-button-wrapping
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Chat block: Fix text wrapping in botton for Firefox.

--- a/projects/plugins/jetpack/changelog/fix-ai-chat-icon-color
+++ b/projects/plugins/jetpack/changelog/fix-ai-chat-icon-color
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-AI Chat block: Fix icon color

--- a/projects/plugins/jetpack/changelog/fix-ai-plugins-connection
+++ b/projects/plugins/jetpack/changelog/fix-ai-plugins-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Assistant: do not register the editor plugin if the site is not connected to WordPress.com.

--- a/projects/plugins/jetpack/changelog/fix-blogroll-fe-styles
+++ b/projects/plugins/jetpack/changelog/fix-blogroll-fe-styles
@@ -1,5 +1,0 @@
-Significance: patch
-Type: enhancement
-Comment: Blogroll: small front-end styling fixes
-
-

--- a/projects/plugins/jetpack/changelog/fix-class-jetpack-esc_url
+++ b/projects/plugins/jetpack/changelog/fix-class-jetpack-esc_url
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Escape various URLs in class.jetpack.php. These all should have been ok before (no user-controlled data), but technically should still be escaped just in case.
-
-

--- a/projects/plugins/jetpack/changelog/fix-paywall-login-text-colour
+++ b/projects/plugins/jetpack/changelog/fix-paywall-login-text-colour
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Paywall: login paragraph to use theme text colour

--- a/projects/plugins/jetpack/changelog/fix-sharing-and-like-copy
+++ b/projects/plugins/jetpack/changelog/fix-sharing-and-like-copy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Block Editor: Update the Likes and Sharing copy in the Jetpack menu to address grammatical mistake.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 12.7-a.8
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 12.8-a.0
+
+

--- a/projects/plugins/jetpack/changelog/jitm-redirection-after-activate-click
+++ b/projects/plugins/jetpack/changelog/jitm-redirection-after-activate-click
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/jitm-redirection-after-activate-click#2
+++ b/projects/plugins/jetpack/changelog/jitm-redirection-after-activate-click#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/remove-wpcom-amp-enabled
+++ b/projects/plugins/jetpack/changelog/remove-wpcom-amp-enabled
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Removed WPCOM-specific references from site settings endpoint.

--- a/projects/plugins/jetpack/changelog/renovate-npm-postcss-vulnerability
+++ b/projects/plugins/jetpack/changelog/renovate-npm-postcss-vulnerability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/tier-id-meta-integer
+++ b/projects/plugins/jetpack/changelog/tier-id-meta-integer
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Incorrect typing for a meta field

--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-update-doc-link
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-update-doc-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Excerpt: set docs link depending on site type

--- a/projects/plugins/jetpack/changelog/update-blogroll-improvements
+++ b/projects/plugins/jetpack/changelog/update-blogroll-improvements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Blogroll improvements

--- a/projects/plugins/jetpack/changelog/update-blogroll-non-frontend-rendering
+++ b/projects/plugins/jetpack/changelog/update-blogroll-non-frontend-rendering
@@ -1,5 +1,0 @@
-Significance: patch
-Type: bugfix
-Comment: Beta block improvements
-
-

--- a/projects/plugins/jetpack/changelog/update-harden-upload-file-handling
+++ b/projects/plugins/jetpack/changelog/update-harden-upload-file-handling
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Harden code paths accessing uploaded files.
-
-

--- a/projects/plugins/jetpack/changelog/update-paywall-block-dialog-component
+++ b/projects/plugins/jetpack/changelog/update-paywall-block-dialog-component
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-refactor

--- a/projects/plugins/jetpack/changelog/update-paywall-title-beta
+++ b/projects/plugins/jetpack/changelog/update-paywall-title-beta
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Paywall block: remove "beta" from the name in block.json

--- a/projects/plugins/jetpack/changelog/update-twitter-x-sharing-official
+++ b/projects/plugins/jetpack/changelog/update-twitter-x-sharing-official
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Shairng: improve the display of the official X button.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -104,7 +104,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_beta",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -104,7 +104,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_a_8",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_7_beta",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.7-a.8
+ * Version: 12.7-beta
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.7-a.8' );
+define( 'JETPACK__VERSION', '12.7-beta' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.7-beta
+ * Version: 12.8-a.0
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.7-beta' );
+define( 'JETPACK__VERSION', '12.8-a.0' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.7.0-beta",
+	"version": "12.8.0-a.0",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.7.0-a.8",
+	"version": "12.7.0-beta",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,10 +293,71 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 12.6.2 - 2023-09-27
+### 12.7-beta - 2023-10-10
+#### Enhancements
+- Added a new post publish panel for quick sharing.
+- AI Assistant: Modify language reminder for toolbar options.
+- AI Assistant: Start using backend to generate the prompts.
+- AI Assistant: Update block description.
+- AI Chat: Enhanced error presentation and UX improvements. [#33387]
+- AI Chat: Fix feedback section styles and include svg for icons.
+- AI Chat: Show guideline message.
+- AI Excerpt: Add `Beta` label to sidebar panel.
+- AI Excerpt: disable `Generate` button when there's no post content.
+- AI Extension: Add keyboard shortcut to stop action on forms.
+- AI Extension: Show AI Form extension with connection nudge for disconnected users.
+- AI Search Block: release the Jetpack AI Search Block.
+- Block Editor: add a new post publish panel for quick sharing.
+- Block Editor: display the SEO and Sharing editor panels in the block editor under the Jetpack side menu. [#33258]
+- Blogroll: Add blog appender site searching.
+- Blogroll: Disable blogroll appender sites that have been added to blogroll block.
+- Blogroll: Fix blogroll block typography editor styling.
+- Blogroll: move blogroll and blogroll-items blocks from beta to production, along with various improvements. [#33475]
+- Blogroll: Update blogroll appender height, max lines of text, and container scrolling.
+- Blogroll: Update CSS styling to allow blogroll block color styling customizations.
+- Blogroll Block: Add the ability to subscribe to recommended blogs.
+- Blogroll Block: Update blogroll appender styling and functionality.
+- Fix styling of multiple elements in the ai-chat block.
+- Improves the blogroll subscribe form alignment.
+- Jetpack Likes: display the Likes editor panel with an invitation to activate the feature when it is disabled.
+- Newsletter: launch the ability to create tiered newsletter plans.
+- Paywall: add a filter to define a custom paywall.
+- Paywall Block: Update description.
+- Sharing: add X sharing button.
+- Sidebar: Rename the "Inbox" menu to "My Mailboxes" for domain-only sites.
+- Social Menu & Social Media Icons: Add support for the X icon.
+- SSO: offer ability to force a site to use Jetpack SSO with Two-Factor Authentication for certain roles.
+- Subscription block: drop unnecessary .0 from big subscriber counts.
+- Update Blogroll appender accessibility.
+
+#### Improved compatibility
+- Admin menu: Update view capabilities for Home & Stats to be independant from edit_posts.
+- AI Chat block: fix icon color in block selector.
+- Improve color handling for the newsletter categories.
+- Lazy Images: prepare feature for its deprecation, coming in November. You will be able to rely on Lazy loading features provided by WordPress itself.
+- Notifications: temporarily disable the notifications admin bar menu on any block editor page to allow for Gutenberg 16.7 compatability.
+
 #### Bug fixes
-- Fix erroneous path check in Jetpack_Gutenberg class
-- Fix warning about Dashboard being unset in WooCommerce analytics class
+- AI Assistant: do not register the editor plugin if the site is not connected to WordPress.com.
+- AI Chat: Remove extra request in $search->is_active() and only load initial state in editor.
+- AI Chat block: fix text wrapping in button for Firefox.
+- AI Excerpts: avoid errors on Custom Post Types that do not support excerpts.
+- AI Extension: Revert PR causing stream rendering issue on Firefox.
+- Block Editor: update the Likes and Sharing copy in the Jetpack menu to address grammatical mistake.
+- Carousel: avoid invalid markup notices in Google Pagespeed insights.
+- Dashboard: Avoid errors when dashboard is accessed by WordPress users with a custom non-admin role.
+- Dashboard: avoid errors when dashboard is accessed by WordPress users with a custom non-admin role.
+- Dashboard: do not display Apps and Support cards to users who do not need that information.
+- External Media: do not surface the endpoint to contributors, are unable to upload media anyway.
+- Fix menu focus state without My Jetpack.
+- Fix subscribe block button not showing on newline.
+- Google Doc block: fix Google Doc blocks not rendering in the editor.
+- Hide launchpad modal on first post for bloggers.
+- Shortcodes: improve validation of attributes dislayed with the Crowdsignal shortcode.
+- Site Editor: Fix block exception error in Site Editor.
+- Skip video file addition to upload queue if it fails the space/allowance check.
+- Subscriptions: Fix conditions for showing modal.
+- Subscriptions module: fix fatal error caused by undefined constant.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.0 - 2023-10-10
+### Changed
+- Updated lock files [#33456]
+- Updated lock file [#33457]
+
 ## 1.6.24 - 2023-10-04
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-domain-task-visibility
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-domain-task-visibility
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated lock files

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-email-task-visibility
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-email-task-visibility
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated lock file

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_0_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_0"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.7.0-alpha
+ * Version: 1.7.0
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.7.0-alpha",
+	"version": "1.7.0",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 1.7.0, jetpack 12.7-beta

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.