### PR TITLE
phpcs-filter: Support old PHPCS 2.x method of specifying stdin path

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -124,7 +124,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/phpcs-filter",
-                "reference": "dc4372c160cf9609fc3b7077a6fed2bd8d51ae0c"
+                "reference": "4df0aebbb617a0d04f29f3d79bf66a3d227656f7"
             },
             "require": {
                 "automattic/ignorefile": "@dev",
@@ -137,7 +137,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-trunk": "1.0.x-dev"
+                    "dev-trunk": "1.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/packages/phpcs-filter/changelog/add-phpcs-filter-old-phpcs_input_file-syntax
+++ b/projects/packages/phpcs-filter/changelog/add-phpcs-filter-old-phpcs_input_file-syntax
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support the old PHPCS 2.x "phpcs_input_file:path" method for specifying the stdin filename.

--- a/projects/packages/phpcs-filter/composer.json
+++ b/projects/packages/phpcs-filter/composer.json
@@ -50,7 +50,7 @@
 	"prefer-stable": true,
 	"extra": {
 		"branch-alias": {
-			"dev-trunk": "1.0.x-dev"
+			"dev-trunk": "1.1.x-dev"
 		}
 	}
 }

--- a/projects/packages/phpcs-filter/tests/php/.phpcs.dir.xml
+++ b/projects/packages/phpcs-filter/tests/php/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/phpcs-filter/tests/php/StdinBootstrapTest.php
+++ b/projects/packages/phpcs-filter/tests/php/StdinBootstrapTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Tests for stdin-bootstrap.php.
+ *
+ * @package automattic/jetpack-phpcs-filter
+ */
+
+namespace Automattic\Jetpack\PhpcsFilter\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Tests for stdin-bootstrap.php.
+ */
+class StdinBootstrapTest extends TestCase {
+	use \Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
+
+	private function runPhpcs( $args, $content ) {
+		$args = array_merge(
+			array(
+				'--report=json',
+				'--bootstrap=' . __DIR__ . '/../../stdin-bootstrap.php',
+				'--filter=' . __DIR__ . '/../../src/PhpcsFilter.php',
+			),
+			$args
+		);
+
+		$phpcs = __DIR__ . '/../../vendor/bin/phpcs';
+		if ( PHP_VERSION_ID >= 70400 ) {
+			$cmd = array_merge( array( $phpcs ), $args );
+		} else {
+			$cmd = $phpcs;
+			foreach ( $args as $arg ) {
+				$cmd .= ' ' . escapeshellarg( $arg );
+			}
+		}
+		$p = proc_open(
+			$cmd,
+			array(
+				array( 'pipe', 'r' ),
+				array( 'pipe', 'w' ),
+				STDERR,
+			),
+			$pipes,
+			__DIR__ . '/../fixtures/perdir'
+		);
+		if ( ! is_resource( $p ) ) {
+			throw new RuntimeException( 'proc_open failed' );
+		}
+		fwrite( $pipes[0], $content );
+		fclose( $pipes[0] );
+		$ret = stream_get_contents( $pipes[1] );
+		fclose( $pipes[1] );
+		proc_close( $p );
+
+		$data = json_decode( $ret, true );
+		$this->assertIsArray( $data, 'phpcs output contains a JSON object' );
+
+		$fileData = array_values( $data['files'] );
+		$messages = isset( $fileData[0]['messages'] ) ? $fileData[0]['messages'] : array();
+
+		$actual = array();
+		foreach ( $messages as $m ) {
+			$actual[] = "Line {$m['line']}: {$m['source']}";
+		}
+		return $actual;
+	}
+
+	/**
+	 * @dataProvider provideFiles
+	 */
+	public function testStdinPath( $file, $contents, $expect ) {
+		$ret = $this->runPhpcs(
+			array(
+				"--stdin-path=$file",
+			),
+			$contents
+		);
+
+		$this->assertSame( $expect, $ret );
+	}
+
+	/**
+	 * @dataProvider provideFiles
+	 */
+	public function testOldMethod( $file, $contents, $expect ) {
+		$ret = $this->runPhpcs(
+			array(),
+			"phpcs_input_file:$file\n$contents"
+		);
+
+		$this->assertSame( $expect, $ret );
+	}
+
+	public function provideFiles() {
+		$dir = __DIR__ . '/../fixtures/perdir';
+
+		$expect = json_decode( file_get_contents( "$dir/expect.json" ), true );
+		$this->assertIsArray( $expect, 'expect.json contains a JSON object' );
+
+		$l    = strlen( $dir ) + 1;
+		$iter = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::CURRENT_AS_PATHNAME ) );
+		foreach ( $iter as $path ) {
+			$file = substr( $path, $l );
+			if ( $file === 'excludedfile.php' || $file === 'exclude-pattern/excluded1.php' || substr( $file, -4 ) !== '.php' ) {
+				continue;
+			}
+			$contents = file_get_contents( $path );
+			yield array( $file, $contents, isset( $expect[ $file ] ) ? $expect[ $file ] : array() );
+		}
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PHPCS didn't have the `--stdin-path` option until version 2.6. In earlier 2.x versions you could specify the path by prepending the stdin input with "phpcs_input_file:path", and some tools still do this instead of using the command line option.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf4qpu-3P-p2#comment-42

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Try with the stuff being discussed in pf4qpu-3P-p2 too.