### PR TITLE
Jetpack Dashboard: improve Akismet tooltip text and link to features page

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -91,11 +91,11 @@ class DashAkismet extends Component {
 
 		const support = {
 			text: __(
-				'Jetpack Anti-spam powered by Akismet. Comments and contact form submissions are checked against our global database of spam.',
+				'Comments and contact form submissions are checked against our global database of spam.',
 				'jetpack'
 			),
 			// Hide the action link from Atomic sites because it promotes purchase of Jetpack product
-			link: this.props.isAtomicSite ? null : 'https://akismet.com/',
+			link: this.props.isAtomicSite ? null : 'https://akismet.com/features',
 			privacyLink: 'https://automattic.com/privacy/',
 		};
 

--- a/projects/plugins/jetpack/_inc/client/components/support-info/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-info/index.jsx
@@ -73,7 +73,7 @@ export default class SupportInfo extends Component {
 				>
 					{ text + ' ' }
 					{ link && (
-						<span className="jp-support-info__learn-more">
+						<div className="jp-support-info__learn-more">
 							<ExternalLink
 								href={ link }
 								onClick={ this.trackLearnMoreClick }
@@ -81,7 +81,7 @@ export default class SupportInfo extends Component {
 							>
 								{ __( 'Learn more', 'jetpack' ) }
 							</ExternalLink>
-						</span>
+						</div>
 					) }
 					<span className="jp-support-info__privacy">
 						<ExternalLink

--- a/projects/plugins/jetpack/changelog/fix-jetpack-dashboard-akismet-tooltip
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-dashboard-akismet-tooltip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack Dashboard: improve Akismet tooltip


### PR DESCRIPTION
This came up at the Jetpack DM during @grbicsanja's "[assumption dumption](https://universaldesignguide.com/method/assumption-dumption/)" session.

On the Jetpack Dashboard, the Akismet tooltip starts with "Jetpack Anti-spam powered by Akismet". This seems to be a leftover from when the product was named "Jetpack Anti-spam", so we needed to include a reference to Akismet somewhere. Now that we refer to the product as "Akismet Anti-spam" here, this part of the tooltip seems redundant and the mismatched product names are confusing.

## Proposed changes:
* Remove the text 'Jetpack Anti-spam powered by Akismet' from the tooltip
* Change the 'Learn more' link to point to akismet.com/features rather than the Akismet homepage.

Before:

<img width="557" alt="Screenshot 2023-10-11 at 11 28 45" src="https://github.com/Automattic/jetpack/assets/17325/f37ae9f7-1319-4c7e-be57-ac866dfc872e">

After:

<img width="538" alt="Screenshot 2023-10-11 at 11 28 58" src="https://github.com/Automattic/jetpack/assets/17325/a02c84cd-abc7-4073-ad13-2cc73872502c">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Check out the branch fix/jetpack-dashboard-akismet-tooltip and build the Jetpack plugin locally. For me this looks like:
```
pnpm install
pnpm jetpack build plugins/jetpack
pnpm jetpack watch plugins/jetpack
pnpm jetpack docker up -d
ngrok start jetpack
```
2. Navigate to /wp-admin/admin.php?page=jetpack#/dashboard on your test site.
3. Hover over the 'info' icon in the Akismet Anti-spam section. 
4. Verify that the text matches the 'After' screenshot above. 
5. Verify that the 'Learn more' link takes you to https://akismet.com/features.