### PR TITLE
Sync unit test: Account for new core post type properties

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sync-unit-test
+++ b/projects/plugins/jetpack/changelog/fix-sync-unit-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync unit test: Fixes sync unit test to Aaccount for new post type properties

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -753,11 +753,17 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		global $wp_post_types;
 		$synced = Functions::get_post_types();
 		foreach ( $wp_post_types as $post_type => $post_type_object ) {
-			$post_type_object->rest_controller_class           = false;
-			$post_type_object->rest_controller                 = null;
-			$post_type_object->revisions_rest_controller_class = false;
-			$post_type_object->autosave_rest_controller_class  = false;
-			$post_type_object->late_route_registration         = false;
+			$post_type_object->rest_controller_class = false;
+			$post_type_object->rest_controller       = null;
+			if ( isset( $post_type_object->revisions_rest_controller_class ) ) {
+				$post_type_object->revisions_rest_controller_class = false;
+			}
+			if ( isset( $post_type_object->autosave_rest_controller_class ) ) {
+				$post_type_object->autosave_rest_controller_class = false;
+			}
+			if ( isset( $post_type_object->late_route_registration ) ) {
+				$post_type_object->late_route_registration = false;
+			}
 			if ( ! isset( $post_type_object->supports ) ) {
 				$post_type_object->supports = array();
 			}

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -753,8 +753,11 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		global $wp_post_types;
 		$synced = Functions::get_post_types();
 		foreach ( $wp_post_types as $post_type => $post_type_object ) {
-			$post_type_object->rest_controller_class = false;
-			$post_type_object->rest_controller       = null;
+			$post_type_object->rest_controller_class           = false;
+			$post_type_object->rest_controller                 = null;
+			$post_type_object->revisions_rest_controller_class = false;
+			$post_type_object->autosave_rest_controller_class  = false;
+			$post_type_object->late_route_registration         = false;
 			if ( ! isset( $post_type_object->supports ) ) {
 				$post_type_object->supports = array();
 			}


### PR DESCRIPTION
A [recently introduced core change](https://github.com/WordPress/wordpress-develop/commit/1f51e1f4f6c81238fffed706ff165795ea34d522) resulted in a Sync unit test in the Jetpack plugin to fail.

The aforementioned core change introduces the following new properties in the `WP_Post_Type` class:
- `revisions_rest_controller_class`
- `autosave_rest_controller_class`
- `late_route_registration `

This PR takes these properties under account when running `WP_Test_Jetpack_Sync_Functions::test_get_post_types_method` by overriding their default values, similar to what we've done for `rest_controller` [in the past](https://github.com/Automattic/jetpack/pull/19944)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Updates `WP_Test_Jetpack_Sync_Functions::test_get_post_types_method` by overriding the following properties:
- `revisions_rest_controller_class`
- `autosave_rest_controller_class`
- `late_route_registration `

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdWQjU-zB-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Ensure all tests pass, focusing on **PHP Tests: PHP 8.2 WP trunk**