### PR TITLE
Super cache: cancel the full preload scheduled job instead of the mini one

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache_cancel_full_preload
+++ b/projects/plugins/super-cache/changelog/fix-super-cache_cancel_full_preload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Super Cache: cancel the full preload job correctly.

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3838,7 +3838,7 @@ function wpsc_cancel_preload() {
 	}
 	if ( $next_full_preload ) {
 		wp_cache_debug( 'wpsc_cancel_preload: unscheduling wp_cache_full_preload_hook' );
-		wp_unschedule_event( $next_preload, 'wp_cache_full_preload_hook' );
+		wp_unschedule_event( $next_full_preload, 'wp_cache_full_preload_hook' );
 	}
 	wp_cache_debug( 'wpsc_cancel_preload: creating stop_preload.txt' );
 


### PR DESCRIPTION
When the preload is cancelled it wasn't cancelling the job that started the next round of preloading. This small change fixes that.

Fixes #33479

## Proposed changes:
* Fixed a typo calling wp_unschedule_event() so it unschedules $next_full_preload rather than $next_preload

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Install Super Cache and start a preload.
* Clicking on "Cancel Cache Preload" and the preload won't be cancelled. The button will still show as a cancel button.
* Apply this patch and click the Cancel button and preloading will be cancelled.
