### PR TITLE
VideoPress: handle block registration in the REST API request context

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-video-block-register-when-rest-request
+++ b/projects/packages/videopress/changelog/update-videopress-video-block-register-when-rest-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: handle block registration in the REST API request context

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.17.4",
+	"version": "0.17.5-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -340,11 +340,27 @@ class Initializer {
 		// Pick the block name straight from the block metadata .json file.
 		$videopress_video_block_name = $videopress_video_metadata->name;
 
+		// Is the block already registered?
+		$is_block_registered = \WP_Block_Type_Registry::get_instance()->is_registered( $videopress_video_block_name );
+
+		// Is this a REST API request?
+		$is_rest = defined( 'REST_API_REQUEST' ) && REST_API_REQUEST;
+
+		if ( $is_rest && ! $is_block_registered ) {
+			register_block_type(
+				$videopress_video_metadata_file,
+				array(
+					'render_callback' => array( __CLASS__, 'render_videopress_video_block' ),
+				)
+			);
+			return;
+		}
+
 		// Register and enqueue scripts used by the VideoPress video block.
 		Block_Editor_Extensions::init( self::JETPACK_VIDEOPRESS_VIDEO_HANDLER );
 
 		// Do not register if the block is already registered.
-		if ( \WP_Block_Type_Registry::get_instance()->is_registered( $videopress_video_block_name ) ) {
+		if ( $is_block_registered ) {
 			return;
 		}
 

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.17.4';
+	const PACKAGE_VERSION = '0.17.5-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR registers the VideoPress video block in the REST API request context.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: handle block registration in the REST API request context

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes in your sandbox 
* Ensure to have a post with a VideoPress video block instance in its content
* hit the `sites/$site/posts/$post` endpoint
* Confirm the endpoint body contains the block markup 

In the screenshots below, I created https://retrosimplepremium02.wordpress.com/2023/04/27/poh-3/.

before (prod) | After (this branch)
-------|--------
<img width="710" alt="Screenshot 2023-10-11 at 17 59 42" src="https://github.com/Automattic/jetpack/assets/77539/20e80199-3081-4a5d-b87b-70fdd5fd20f5"> | <img width="710" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/285aff41-1a44-4f8a-820b-a273e58cdfe0">