### PR TITLE
Newsletters: Unify UI/UX for Access Panel and Paywall block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-access-panel-merge
+++ b/projects/plugins/jetpack/changelog/update-access-panel-merge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+refactor

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -1,32 +1,20 @@
 import './editor.scss';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import {
-	MenuGroup,
-	MenuItem,
-	PanelBody,
-	RadioControl,
-	ToolbarDropdownMenu,
-} from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
+import { MenuGroup, MenuItem, PanelBody, ToolbarDropdownMenu } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { arrowDown, Icon, people, check } from '@wordpress/icons';
 import PlansSetupDialog from '../../shared/components/plans-setup-dialog';
-import {
-	accessOptions,
-	META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
-} from '../../shared/memberships/constants';
+import { accessOptions } from '../../shared/memberships/constants';
 import { useAccessLevel } from '../../shared/memberships/edit';
-import { getReachForAccessLevelKey } from '../../shared/memberships/settings';
-import { store as membershipProductsStore } from '../../store/membership-products';
+import { NewsletterAccessRadioButtons, useSetAccess } from '../../shared/memberships/settings';
 
 function PaywallEdit( { className } ) {
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const accessLevel = useAccessLevel( postType );
-	const [ , setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
 
 	const { stripeConnectUrl, hasNewsletterPlans } = useSelect( select => {
 		const { getNewsletterProducts, getConnectUrl } = select( 'jetpack/membership-products' );
@@ -38,14 +26,13 @@ function PaywallEdit( { className } ) {
 
 	const [ showDialog, setShowDialog ] = useState( false );
 	const closeDialog = () => setShowDialog( false );
+	const setAccess = useSetAccess();
 
 	useEffect( () => {
 		if ( ! accessLevel || accessLevel === accessOptions.everybody.key ) {
-			setPostMeta( {
-				[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ]: accessOptions.subscribers.key,
-			} );
+			setAccess( accessOptions.subscribers.key );
 		}
-	}, [ accessLevel, setPostMeta ] );
+	}, [ accessLevel, setAccess ] );
 
 	function selectAccess( value ) {
 		if (
@@ -55,9 +42,7 @@ function PaywallEdit( { className } ) {
 			setShowDialog( true );
 			return;
 		}
-		setPostMeta( {
-			[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ]: value,
-		} );
+		setAccess( value );
 	}
 
 	const getText = key => {
@@ -87,9 +72,6 @@ function PaywallEdit( { className } ) {
 		userSelect: 'none',
 	};
 
-	const { emailSubscribers, paidSubscribers } = useSelect( select =>
-		select( membershipProductsStore ).getSubscriberCounts()
-	);
 	let _accessLevel = accessLevel ?? accessOptions.subscribers.key;
 	if ( _accessLevel === accessOptions.everybody.key ) {
 		_accessLevel = accessOptions.subscribers.key;
@@ -147,31 +129,13 @@ function PaywallEdit( { className } ) {
 					icon={ <JetpackEditorPanelLogo /> }
 					initialOpen={ true }
 				>
-					<RadioControl
-						onChange={ selectAccess }
-						options={ [
-							{
-								label: `${ accessOptions.subscribers.label } (${ getReachForAccessLevelKey(
-									accessOptions.subscribers.key,
-									emailSubscribers,
-									paidSubscribers
-								) })`,
-								value: accessOptions.subscribers.key,
-							},
-							{
-								label: `${ accessOptions.paid_subscribers.label } (${ getReachForAccessLevelKey(
-									accessOptions.paid_subscribers.key,
-									emailSubscribers,
-									paidSubscribers
-								) })`,
-								value: accessOptions.paid_subscribers.key,
-							},
-						] }
-						selected={ _accessLevel }
-						help={ __(
-							'Choose who will be able to read the content below the paywall block.',
-							'jetpack'
-						) }
+					<NewsletterAccessRadioButtons
+						isEditorPanel={ true }
+						onChange={ setAccess }
+						accessLevel={ _accessLevel }
+						stripeConnectUrl={ stripeConnectUrl }
+						hasNewsletterPlans={ hasNewsletterPlans }
+						postHasPaywallBlock={ true }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -11,7 +11,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PostVisibilityCheck, store as editorStore } from '@wordpress/editor';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { useState } from 'react';
 import { icon as paywallIcon, blockName as paywallBlockName } from '../../blocks/paywall';
@@ -103,11 +103,7 @@ function TierSelector( { onChange } ) {
 				hideLabelFromVision={ true }
 				selected={ Number( tierId ) }
 				options={ products.map( product => {
-					const label = sprintf(
-						/* Translators: %s is the tier label created by site user */
-						__( '%s subscribers', 'jetpack' ),
-						product.title
-					);
+					const label = product.title;
 					const value = Number( product.id );
 					return { label, value };
 				} ) }

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -50,13 +50,22 @@ export function useSetAccess() {
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const [ , setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
 
-	const setAccess = value => {
+	return value => {
 		setPostMeta( {
 			[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ]: value,
 		} );
 	};
+}
 
-	return setAccess;
+export function useSetTier() {
+	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
+	const [ , setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
+
+	return value => {
+		setPostMeta( {
+			[ META_NAME_FOR_POST_TIER_ID_SETTINGS ]: value,
+		} );
+	};
 }
 
 function TierSelector( { onChange } ) {
@@ -73,6 +82,7 @@ function TierSelector( { onChange } ) {
 		postType,
 		'meta'
 	);
+	const setTier = useSetTier();
 
 	// Tiers don't apply if less than 2 products (this is called here because
 	// the hooks have to run before any early returns)
@@ -83,10 +93,7 @@ function TierSelector( { onChange } ) {
 	// if no tier are selected, we select the lowest one
 	if ( ! tierId ) {
 		tierId = products[ products.length - 1 ].id;
-		const obj = {};
-		obj[ META_NAME_FOR_POST_TIER_ID_SETTINGS ] = tierId;
-		// Call the callback
-		onChange && setTimeout( () => onChange( obj ) );
+		setTimeout( () => setTier( tierId ) );
 	}
 
 	return (

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
@@ -79,8 +79,4 @@
 .jetpack-editor-post-tiers {
 	padding-left: 35px;
 	padding-top: 5px;
-
-	div {
-		margin-top: 10px;
-	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use RadioControl for Radio buttons
* Use Dialog instead of Setup badge in the panel
* Use Same component in Paywall block panels and Access panels

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

