### PR TITLE
Blogging prompt block: add default gravatars attribute to fix js error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blogging-prompts-save-js-error
+++ b/projects/plugins/jetpack/changelog/fix-blogging-prompts-save-js-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Blogging prompts block: add default gravatar attribute to prevent js error

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/attributes.js
@@ -21,6 +21,7 @@ export default {
 				attribute: 'src',
 			},
 		},
+		default: [],
 	},
 	promptLabel: {
 		type: 'string',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82874#top

## Proposed changes:

Adds a default gravatar attribute value of an empty array. This prevents js errors when the save function maps the gravatars value and it's empty.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1697052711823979-slack-C02FMH4G8

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* With a connected Jetpack site, use the `answer_prompt` query param when creating a new post to automatically insert a blogging prompt block (e.g. /wp-admin/post-new.php?answer_prompt=2085)
* Without this patch, you'll see a JS console error similar to "Uncaught (in promise) TypeError: can't access property "map", i is undefined"
* With this patch, you should not see the error