### PR TITLE
Newsletter categories: Add newsletter categories location filter

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-categories-filter
+++ b/projects/plugins/jetpack/changelog/add-newsletter-categories-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add newsletter categories location filter

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -130,6 +130,10 @@ function register_block() {
 	// Add a 'Newsletter access' column to the Edit posts page
 	add_action( 'manage_post_posts_columns', __NAMESPACE__ . '\register_newsletter_access_column' );
 	add_action( 'manage_post_posts_custom_column', __NAMESPACE__ . '\render_newsletter_access_rows', 10, 2 );
+
+	// This has a lower priority than the filter on WPCOM, so it won't override it.
+	// TODO: remove this & all newsletter category references once the switch is made to the modal
+	add_filter( 'wpcom_newsletter_categories_location', __NAMESPACE__ . '\jetpack_newsletter_categories_location', 5 );
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
 
@@ -1028,6 +1032,15 @@ function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
 		);
 	}
 	return $excerpt;
+}
+
+/**
+ * Retrieve location for the newletter categories.
+ *
+ * @return string Returns the location of the newsletter categories.
+ */
+function jetpack_newsletter_categories_location() {
+	return 'modal';
 }
 
 /**


### PR DESCRIPTION
## Proposed changes:
This patch adds a filter to hide the newsletter categories above the block on Jetpack self-hosted sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this PR
2. On your JT-site, create a post with a subscribe block & some newsletter categories
3. Confirm they aren't rendered above the block