### PR TITLE
Newsletters: Unify UI/UX for Access Panel and Paywall block 2

### DIFF
--- a/projects/plugins/jetpack/changelog/update-access-panel-merge-2
+++ b/projects/plugins/jetpack/changelog/update-access-panel-merge-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+refactoring

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -131,7 +131,6 @@ function PaywallEdit( { className } ) {
 				>
 					<NewsletterAccessRadioButtons
 						isEditorPanel={ true }
-						onChange={ setAccess }
 						accessLevel={ _accessLevel }
 						stripeConnectUrl={ stripeConnectUrl }
 						hasNewsletterPlans={ hasNewsletterPlans }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -8,7 +8,6 @@ import {
 	useModuleStatus,
 } from '@automattic/jetpack-shared-extension-utils';
 import { Button, ExternalLink, Flex, FlexItem, Notice, PanelRow } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import {
 	PluginPrePublishPanel,
@@ -52,14 +51,14 @@ const SubscriptionsPanelPlaceholder = ( { children } ) => {
 	);
 };
 
-function NewsletterEditorSettingsPanel( { accessLevel, setPostMeta } ) {
+function NewsletterEditorSettingsPanel( { accessLevel } ) {
 	return (
 		<PluginDocumentSettingPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Access', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
-			<NewsletterAccessDocumentSettings accessLevel={ accessLevel } setPostMeta={ setPostMeta } />
+			<NewsletterAccessDocumentSettings accessLevel={ accessLevel } />
 		</PluginDocumentSettingPanel>
 	);
 }
@@ -278,7 +277,6 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 export default function SubscribePanels() {
 	const { isModuleActive } = useModuleStatus( name );
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
-	const [ , setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const { tracks } = useAnalytics();
@@ -303,24 +301,16 @@ export default function SubscribePanels() {
 
 	return (
 		<>
-			{ isModuleActive && (
-				<NewsletterEditorSettingsPanel accessLevel={ accessLevel } setPostMeta={ setPostMeta } />
-			) }
+			{ isModuleActive && <NewsletterEditorSettingsPanel accessLevel={ accessLevel } /> }
 			<NewsletterPrePublishSettingsPanel
 				accessLevel={ accessLevel }
-				setPostMeta={ setPostMeta }
 				isModuleActive={ isModuleActive }
 				showPreviewModal={ () => {
 					tracks.recordEvent( 'jetpack_send_email_preview_prepublish_preview_button' );
 					setIsModalOpen( true );
 				} }
 			/>
-			{ isModuleActive && (
-				<NewsletterPostPublishSettingsPanel
-					accessLevel={ accessLevel }
-					setPostMeta={ setPostMeta }
-				/>
-			) }
+			{ isModuleActive && <NewsletterPostPublishSettingsPanel accessLevel={ accessLevel } /> }
 			<EmailPreview isModalOpen={ isModalOpen } closeModal={ () => setIsModalOpen( false ) } />
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -68,7 +68,7 @@ export function useSetTier() {
 	};
 }
 
-function TierSelector( { onChange } ) {
+function TierSelector() {
 	// TODO: figure out how to handle different currencies
 	const products = useSelect( select => select( membershipProductsStore ).getProducts() )
 		.filter( product => product.subscribe_as_site_subscriber && product.interval === '1 month' )
@@ -107,18 +107,13 @@ function TierSelector( { onChange } ) {
 					const value = Number( product.id );
 					return { label, value };
 				} ) }
-				onChange={ newValue => {
-					const obj = {};
-					obj[ META_NAME_FOR_POST_TIER_ID_SETTINGS ] = newValue;
-					return onChange && onChange( obj );
-				} }
+				onChange={ setTier }
 			/>
 		</div>
 	);
 }
 
 export function NewsletterAccessRadioButtons( {
-	onChange,
 	accessLevel,
 	hasNewsletterPlans,
 	stripeConnectUrl,
@@ -178,7 +173,7 @@ export function NewsletterAccessRadioButtons( {
 			/>
 			{ accessLevel === accessOptions.paid_subscribers.key &&
 				isStripeConnected &&
-				hasNewsletterPlans && <TierSelector onChange={ onChange }></TierSelector> }
+				hasNewsletterPlans && <TierSelector></TierSelector> }
 
 			{ isEditorPanel && (
 				<PlansSetupDialog closeDialog={ closeDialog } showDialog={ showDialog } />
@@ -187,7 +182,7 @@ export function NewsletterAccessRadioButtons( {
 	);
 }
 
-export function NewsletterAccessDocumentSettings( { accessLevel, setPostMeta } ) {
+export function NewsletterAccessDocumentSettings( { accessLevel } ) {
 	const { hasNewsletterPlans, stripeConnectUrl, isLoading, foundPaywallBlock } = useSelect(
 		select => {
 			const { getNewsletterProducts, getConnectUrl, isApiStateLoading } = select(
@@ -265,7 +260,6 @@ export function NewsletterAccessDocumentSettings( { accessLevel, setPostMeta } )
 									<div className="editor-post-visibility">
 										<NewsletterAccessRadioButtons
 											isEditorPanel={ true }
-											onChange={ setPostMeta }
 											accessLevel={ _accessLevel }
 											stripeConnectUrl={ stripeConnectUrl }
 											hasNewsletterPlans={ hasNewsletterPlans }

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
@@ -45,35 +45,6 @@
 			margin-top: 10px;
 		}
 	}
-
-	fieldset.editor-post-visibility__fieldset .editor-post-visibility {
-		&__choice {
-			margin-bottom: 15px;
-
-			.editor-post-visibility__label {
-				font-size: $default-font-size;
-			}
-
-			input[disabled] {
-				cursor: no-drop;
-
-				& + label {
-					cursor: no-drop;
-					text-decoration: line-through;
-				}
-			}
-		}
-
-		&__notice {
-			margin-top: 5px;
-			margin-left: 33px;
-		}
-
-		&__info {
-			margin-top: -10px;
-		}
-	}
-
 }
 
 .jetpack-editor-post-tiers {


### PR DESCRIPTION
Follow up to https://github.com/Automattic/jetpack/pull/33570

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* More refactoring and unification of Paywall and Access settings
* Fixes an error when selecting a tier from the paywall block settings

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1697123156303389/1697053350.571519-slack-C05RV8BUF7V

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Subscribers and Tiers selection should work on Paywall block settings and Document settings