### PR TITLE
Sitemaps: update colors to match updated Jetpack branding

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-colors-sitemap
+++ b/projects/plugins/jetpack/changelog/update-jetpack-colors-sitemap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Sitemaps: update the colors used on the sitemap page to match updated Jetpack branding colors.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-stylist.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-stylist.php
@@ -725,13 +725,13 @@ XSL;
 		}
 
 		#description {
-			background-color: #81a844;
-			color: #FFF;
+			background-color: #f0f2eb;
+			color: #000;
 			padding: 30px 30px 20px;
 		}
 
 		#description a {
-			color: #fff;
+			color: #008710;
 		}
 
 		#content {
@@ -757,7 +757,7 @@ XSL;
 		}
 
 		.odd {
-			background-color: #E7F1D4;
+			background: linear-gradient( 159.87deg, #f6f6f4 7.24%, #f7f4ea 64.73%, #ddedd5 116.53% );
 		}
 
 		#footer {


### PR DESCRIPTION
## Proposed changes:

The Jetpack sitemap styles haven't been updated to match the most recent color changes in the Jetpack design. This little PR should take care of that.

**Before**

<img width="882" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/83ebe011-49fa-4518-bfc9-b9407ee54428">

**After**

<img width="947" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/c92d4309-6802-4afa-a53d-971784bd1a99">

> **Note**
> I didn't just replace the green to the new Jetpack green, as we do not use the Jetpack green for plain backgrounds like this today. This matches the colors we use on jetpack.com for the footer, for example.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings
* Enable the Sitemaps feature
* Go to yoursite.com/sitemap.xml
   * See the updated color
