### PR TITLE
Instant Search: don't send images to Photon if they have a relative URL

### DIFF
--- a/projects/packages/search/changelog/fix-search-photon-relative-urls
+++ b/projects/packages/search/changelog/fix-search-photon-relative-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: don't send images to Photon if they have a relative URL

--- a/projects/packages/search/src/instant-search/lib/hooks/use-photon.js
+++ b/projects/packages/search/src/instant-search/lib/hooks/use-photon.js
@@ -23,22 +23,23 @@ function stripQueryString( url ) {
  * @param {boolean} isPhotonEnabled - Toggle photon on/off
  * @returns {string} - Photonized image URL if service is available; initialSrc otherwise.
  */
-export function usePhoton( initialSrc, width, height, isPhotonEnabled = true ) {
+export function usePhoton( initialSrc = '', width, height, isPhotonEnabled = true ) {
 	const [ src, setSrc ] = useState( null );
 	const initialSrcWithoutQueryString = stripQueryString( initialSrc );
 
 	// Photon only supports GIF, JPG, PNG and WebP images
 	// Photon also has partial support for HEIC which currently always
-	// reencodes as JPG regardless of advertised support from the browser
+	// re-encodes as JPG regardless of advertised support from the browser
 	// @see https://developer.wordpress.com/docs/photon/
 	const supportedImageTypes = [ 'gif', 'jpg', 'jpeg', 'png', 'webp', 'heic' ];
 	const fileExtension = initialSrcWithoutQueryString
 		?.substring( initialSrcWithoutQueryString.lastIndexOf( '.' ) + 1 )
 		.toLowerCase();
 	const isSupportedImageType = supportedImageTypes.includes( fileExtension );
+	const isRelativeUrl = initialSrc.charAt( 0 ) === '/';
 
 	useEffect( () => {
-		if ( isPhotonEnabled && isSupportedImageType ) {
+		if ( isPhotonEnabled && isSupportedImageType && ! isRelativeUrl ) {
 			const photonSrc = photon( initialSrcWithoutQueryString, {
 				resize: `${ width },${ height }`,
 			} );
@@ -52,6 +53,7 @@ export function usePhoton( initialSrc, width, height, isPhotonEnabled = true ) {
 		height,
 		isPhotonEnabled,
 		initialSrcWithoutQueryString,
+		isRelativeUrl,
 		isSupportedImageType,
 	] );
 

--- a/projects/packages/search/src/instant-search/lib/query-string.js
+++ b/projects/packages/search/src/instant-search/lib/query-string.js
@@ -57,7 +57,7 @@ export function getResultFormatQuery() {
 }
 
 /**
- * Navigates the window to a specified location with all search-related query values stirpped out.
+ * Navigates the window to a specified location with all search-related query values stripped out.
  *
  * @param {string} initialHref - Target location to navigate to via push/replaceState.
  * @param {Function} callback - Callback to be invoked if initialHref didn't include any search queries.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/33481.

## Proposed changes:
* Don't send images to Photon if they appear to be relative.
* Add support for rendering of images with a relative path.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

