### PR TITLE
Fix quick share buttons' tracking

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-quick-share-tracking
+++ b/projects/js-packages/publicize-components/changelog/fix-quick-share-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed tracking for quick share buttons

--- a/projects/js-packages/publicize-components/src/components/share-buttons/share-buttons.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-buttons/share-buttons.tsx
@@ -81,8 +81,7 @@ export function ShareButtons( { buttonStyle = 'icon', buttonVariant }: ShareButt
 							href={ href }
 							target="_blank"
 							rel="noopener noreferrer"
-							onClick={ getOnClick( href ) }
-							data-network={ networkName }
+							onClick={ getOnClick( href, { network: networkName } ) }
 							className={ 'icon' === buttonStyle ? styles[ networkName ] : 'has-text' }
 						>
 							{ 'icon' === buttonStyle ? null : (


### PR DESCRIPTION
The tracking for quick share buttons stopped working after this change - https://github.com/Automattic/jetpack/pull/33244#discussion_r1357815757

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix quick share tracking by adding the network name to the tracking data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Please follow the instructions given in #33229

