### PR TITLE
Social: Fix console warning with conditional className

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-console-warnings-quick-share
+++ b/projects/js-packages/publicize-components/changelog/fix-console-warnings-quick-share
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue with conditional className property

--- a/projects/js-packages/publicize-components/src/components/panel/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.jsx
@@ -54,12 +54,14 @@ const PublicizePanel = ( { prePublish, enableTweetStorm, children } ) => {
 
 	// Panel wrapper.
 	const PanelWrapper = prePublish ? Fragment : PanelBody;
-	const wrapperProps = prePublish ? {} : { title: __( 'Share this post', 'jetpack' ) };
+	const wrapperProps = prePublish
+		? {}
+		: { title: __( 'Share this post', 'jetpack' ), className: styles.panel };
 
 	const [ isModalOpen, toggleModal ] = useReducer( isOpen => ! isOpen, false );
 
 	return (
-		<PanelWrapper className={ styles.panel } { ...wrapperProps }>
+		<PanelWrapper { ...wrapperProps }>
 			{ isPostPublished && (
 				<OneClickSharingDropdown
 					onClickLearnMore={ toggleModal }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

There is an issue where we see a console warning on trunk when the pre-publish panel opens in the editor. It snuck in there with the Quick-share changes, when a className could get onto a Fragment if it's not the main panel. This fixes that.

<img width="1458" alt="CleanShot 2023-10-13 at 12 41 54 png" src="https://github.com/Automattic/jetpack/assets/36671565/717f4784-b27c-46cb-a000-0e39d06bc21a">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On trunk create a new post, select some connection and click Publish once, so the pre-publish panel opens. You should see the warning in the console.
* Check out this PR; The same action should not result in a warning in the console



