### PR TITLE
CRM: Fixing escaping in quote titles when rendered using template placeholders

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-quote-template-title-escaping
+++ b/projects/plugins/crm/changelog/fix-crm-quote-template-title-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Quote templates: Make sure quote titles with apostrophes do not have backslashes added when rendered.

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -749,7 +749,7 @@ function ZeroBSCRM_get_quote_template() {
 
 			// retrieve basics over above
 			if ( isset( $_POST['quote_fields']['zbscq_title'] ) && ! empty( $_POST['quote_fields']['zbscq_title'] ) ) {
-				$quote_title = sanitize_text_field( $_POST['quote_fields']['zbscq_title'] );
+				$quote_title = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_title'] ) );
 			}
 			if ( isset( $_POST['quote_fields']['zbscq_value'] ) && ! empty( $_POST['quote_fields']['zbscq_value'] ) ) {
 				$quote_val = sanitize_text_field( $_POST['quote_fields']['zbscq_value'] );


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3151

## Proposed changes:

* This PR changes the quote sanitization / escaping from `	sanitize_text_field( $_POST['quote_fields']['zbscq_title'] );` to `sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_title'] ) );` in `ZeroBSCRM.AJAX.php`, in line with the sanitization and escaping that happens further down for `$quote_notes`.
* This prevents apostrophes added to new quote titles from being escaped and then the backslash being rendered in the editor, as well as preventing backslashes from being duplicated in the editor as well, when the quote title is rendered via a placeholder in a quote template.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3151

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* On trunk, within a quote template - `wp-admin/admin.php?page=manage-quote-templates` - add a quote title placeholder( `##QUOTE-TITLE##`
* Then, create a new quote - `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=quote` - making sure to enter a quote title that includes an apostrophe
* Select the template from the dropdown, and the title should display with a backslash added (`Karen's Quote` becomes `Karen\'s Quote`)
* Try adding additional backslashes to the original title on a new quote, and when saving these should be duplicated as well.
* Check this branch out locally or using a Jurassic Ninja site, and repeat the same steps. The title should show as inputted (in terms of backslashes and apostrophes).

