### PR TITLE
CRM: Resolves #3365 - catch PHP fatal if openssl unavailable

### DIFF
--- a/projects/plugins/crm/admin/settings/mail-delivery.page.php
+++ b/projects/plugins/crm/admin/settings/mail-delivery.page.php
@@ -541,7 +541,7 @@ if ( count( $zbsSMTPAccs ) <= 0 ) {
 if ( $runningLocally ) {
 
 	?>
-	<div class="ui message"><div class="header"><div class="ui yellow label"><?php esc_html_e( 'Local Machine?', 'zero-bs-crm' ); ?></div></div><p><?php esc_html_e( 'It appears you are running Jetpack CRM locally, this may cause SMTP delivery methods to behave unexpectedly.<br />(e.g. your computer may block outgoing SMTP traffic via firewall or anti-virus software).<br />Jetpack CRM may require external web hosting to properly send via SMTP.', 'zero-bs-crm' ); ?></p></div>
+	<div class="ui message"><div class="header"><div class="ui yellow label"><?php esc_html_e( 'Local Machine?', 'zero-bs-crm' ); ?></div></div><p><?php esc_html_e( 'It appears you are running Jetpack CRM locally. This may cause SMTP delivery methods to behave unexpectedly (e.g. your computer may block outgoing SMTP traffic via firewall or antivirus software). Jetpack CRM may require external web hosting to properly send via SMTP.', 'zero-bs-crm' ); ?></p></div>
 	<?php
 
 }

--- a/projects/plugins/crm/changelog/fix-crm-3365-catch_fatal_if_openssl_unavailable
+++ b/projects/plugins/crm/changelog/fix-crm-3365-catch_fatal_if_openssl_unavailable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent error if OpenSSL functions aren't available in PHP.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -570,22 +570,6 @@ final class ZeroBSCRM {
 			// we need urls
 			$this->setupUrlsSlugsEtc();
 
-			// build message
-			$message_html = '<p>' . sprintf( __( 'This version of CRM (%1$s) requires an upgraded database (3.0). Your database is using an older version than this (%2$s). To use CRM you will need to install version 4 of CRM and run the database upgrade.', 'zero-bs-crm' ), $this->version, $this->dal_version ) . '</p>';
-
-			##WLREMOVE
-			$message_html  = '<p>' . sprintf( __( 'This version of Jetpack CRM (%1$s) requires an upgraded database (3.0). Your database is using an older version than this (%2$s). To use Jetpack CRM you will need to install version 4 of Jetpack CRM and run the database upgrade.', 'zero-bs-crm' ), $this->version, $this->dal_version ) . '</p>';
-			$message_html .= '<p><a href="' . esc_url( $this->urls['kb-pre-v5-migration-todo'] ) . '" target="_blank" class="button">' . __( 'Read the guide on migrating', 'zero-bs-crm' ) . '<a></p>';
-			##/WLREMOVE
-
-			$this->add_wp_admin_notice(
-				'',
-				array(
-					'class' => 'warning',
-					'html'  => $message_html,
-				)
-			);
-
 		}
 
 		// display any wp admin notices in the stack
@@ -613,8 +597,38 @@ final class ZeroBSCRM {
 		// v5.0+ JPCRM requires DAL3+
 		if ( ! $this->isDAL3() ) {
 
+			// build message
+			$message_html = '<p>' . sprintf( esc_html__( 'This version of CRM (%1$s) requires an upgraded database (3.0). Your database is using an older version than this (%2$s). To use CRM you will need to install version 4 of CRM and run the database upgrade.', 'zero-bs-crm' ), $this->version, $this->dal_version ) . '</p>'; // phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment
+
+			##WLREMOVE
+			$message_html  = '<p>' . sprintf( esc_html__( 'This version of Jetpack CRM (%1$s) requires an upgraded database (3.0). Your database is using an older version than this (%2$s). To use Jetpack CRM you will need to install version 4 of Jetpack CRM and run the database upgrade.', 'zero-bs-crm' ), $this->version, $this->dal_version ) . '</p>'; // phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment
+			$message_html .= '<p><a href="' . esc_url( $this->urls['kb-pre-v5-migration-todo'] ) . '" target="_blank" class="button">' . __( 'Read the guide on migrating', 'zero-bs-crm' ) . '<a></p>';
+			##/WLREMOVE
+
+			$this->add_wp_admin_notice(
+				'',
+				array(
+					'class' => 'warning',
+					'html'  => $message_html,
+				)
+			);
+
 			return false;
 
+		} elseif ( ! function_exists( 'openssl_get_cipher_methods' ) ) {
+
+			// build message
+			$message_html  = '<p>' . sprintf( __( 'Jetpack CRM uses the OpenSSL extension for PHP to properly protect sensitive data. Most PHP environments have this installed by default, but it seems yours does not; we recommend contacting your host for further help.', 'zero-bs-crm' ), $this->version, $this->dal_version ) . '</p>';
+			$message_html .= '<p><a href="' . esc_url( 'https://www.php.net/manual/en/book.openssl.php' ) . '" target="_blank" class="button">' . __( 'PHP docs on OpenSSL', 'zero-bs-crm' ) . '<a></p>';
+
+			$this->add_wp_admin_notice(
+				'',
+				array(
+					'class' => 'warning',
+					'html'  => $message_html,
+				)
+			);
+			return false;
 		}
 
 		return true;

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -563,6 +563,13 @@ final class ZeroBSCRM {
 			// } Post Init hook
 			do_action( 'zerobscrm_loaded' );
 
+		} else {
+			// used by some extensions to determine if current page is an admin page
+			require_once ZEROBSCRM_INCLUDE_PATH . 'ZeroBSCRM.AdminPages.Checks.php';
+
+			// extensions use the dependency checker functions
+			require_once ZEROBSCRM_INCLUDE_PATH . 'jpcrm-dependency-checker.php';
+			$this->dependency_checker = new JPCRM_DependencyChecker();
 		}
 
 		// display any wp admin notices in the stack

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -563,13 +563,6 @@ final class ZeroBSCRM {
 			// } Post Init hook
 			do_action( 'zerobscrm_loaded' );
 
-		} else {
-
-			// fails minimum requirements, show warnings
-
-			// we need urls
-			$this->setupUrlsSlugsEtc();
-
 		}
 
 		// display any wp admin notices in the stack
@@ -596,6 +589,9 @@ final class ZeroBSCRM {
 
 		// v5.0+ JPCRM requires DAL3+
 		if ( ! $this->isDAL3() ) {
+
+			// we need urls
+			$this->setupUrlsSlugsEtc();
 
 			// build message
 			$message_html = '<p>' . sprintf( esc_html__( 'This version of CRM (%1$s) requires an upgraded database (3.0). Your database is using an older version than this (%2$s). To use CRM you will need to install version 4 of CRM and run the database upgrade.', 'zero-bs-crm' ), $this->version, $this->dal_version ) . '</p>'; // phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -598,7 +598,7 @@ final class ZeroBSCRM {
 
 			##WLREMOVE
 			$message_html  = '<p>' . sprintf( esc_html__( 'This version of Jetpack CRM (%1$s) requires an upgraded database (3.0). Your database is using an older version than this (%2$s). To use Jetpack CRM you will need to install version 4 of Jetpack CRM and run the database upgrade.', 'zero-bs-crm' ), $this->version, $this->dal_version ) . '</p>'; // phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment
-			$message_html .= '<p><a href="' . esc_url( $this->urls['kb-pre-v5-migration-todo'] ) . '" target="_blank" class="button">' . __( 'Read the guide on migrating', 'zero-bs-crm' ) . '<a></p>';
+			$message_html .= '<p><a href="' . esc_url( $this->urls['kb-pre-v5-migration-todo'] ) . '" target="_blank" class="button">' . __( 'Read the guide on migrating', 'zero-bs-crm' ) . '</a></p>';
 			##/WLREMOVE
 
 			$this->add_wp_admin_notice(
@@ -615,7 +615,7 @@ final class ZeroBSCRM {
 
 			// build message
 			$message_html  = '<p>' . sprintf( __( 'Jetpack CRM uses the OpenSSL extension for PHP to properly protect sensitive data. Most PHP environments have this installed by default, but it seems yours does not; we recommend contacting your host for further help.', 'zero-bs-crm' ), $this->version, $this->dal_version ) . '</p>';
-			$message_html .= '<p><a href="' . esc_url( 'https://www.php.net/manual/en/book.openssl.php' ) . '" target="_blank" class="button">' . __( 'PHP docs on OpenSSL', 'zero-bs-crm' ) . '<a></p>';
+			$message_html .= '<p><a href="' . esc_url( 'https://www.php.net/manual/en/book.openssl.php' ) . '" target="_blank" class="button">' . __( 'PHP docs on OpenSSL', 'zero-bs-crm' ) . '</a></p>';
 
 			$this->add_wp_admin_notice(
 				'',

--- a/projects/plugins/crm/includes/jpcrm-dependency-checker.php
+++ b/projects/plugins/crm/includes/jpcrm-dependency-checker.php
@@ -31,15 +31,18 @@ class JPCRM_DependencyChecker {
 	 */
 	protected $dal_ver;
 
-  public function __construct( ) {
-    if ( ! function_exists( 'get_plugins' ) ) {
-      require_once ABSPATH . 'wp-admin/includes/plugin.php';
-    }
-    global $zbs;
-    $this->all_plugins = get_plugins();
-    $this->core_ver = $zbs->version;
-    $this->dal_ver = $zbs->dal_version;
-  }
+	/**
+	 * Build DependencyChecker class
+	 */
+	public function __construct() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		global $zbs;
+		$this->all_plugins = get_plugins();
+		$this->core_ver    = $zbs->version ?? '';
+		$this->dal_ver     = $zbs->dal_version ?? '';
+	}
 
   /**
    * 

--- a/projects/plugins/crm/includes/jpcrm-dependency-checker.php
+++ b/projects/plugins/crm/includes/jpcrm-dependency-checker.php
@@ -98,7 +98,12 @@ class JPCRM_DependencyChecker {
     // otherwise, proceed to trigger an admin notice
     $feature_name = !empty( $feature_name ) ? $feature_name : __( 'CRM feature', 'zero-bs-crm' );
 
-    if ( !$is_good_core_ver ) {
+		if ( empty( $this->core_ver ) || empty( $this->dal_ver ) ) {
+			$error_msg = __( 'Your CRM install appears to have issues. Please verify the CRM is fully installed and any notices are properly handled before trying again.', 'zero-bs-crm' );
+			##WLREMOVE
+			$error_msg = __( 'Your Jetpack CRM install appears to have issues. Please verify the CRM is fully installed and any notices are properly handled before trying again.', 'zero-bs-crm' );
+			##/WLREMOVE
+		} elseif ( ! $is_good_core_ver ) {
       $error_msg = sprintf( __( '%s requires CRM version %s or greater, but version %s is currently installed. Please update your CRM to use this feature.', 'zero-bs-crm' ), $feature_name, $req_core_ver, $this->core_ver );
       ##WLREMOVE
       $error_msg = sprintf( __( '%s requires Jetpack CRM version %s or greater, but version %s is currently installed. Please update Jetpack CRM to use this feature.', 'zero-bs-crm' ), $feature_name, $req_core_ver, $this->core_ver );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: Resolves Automattic/zero-bs-crm#3365 - catch PHP fatal if openssl unavailable

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
While the OpenSSL extension for PHP is quite common, it's possible for some environments to not have it installed. This came up when testing in the WordPress Playground (https://playground.wordpress.net/?plugin=zero-bs-crm), which doesn't provide said extension.

There are more elegant solutions, but they would all require some significant (and careful) refactoring to ensure we don't corrupt data due to errant encryption/decryption.

I was originally going to throw warnings in a few places, but our reliance on this extension is fairly embedded (API, mail delivery, file uploads, avatar filenames, migrations, etc.). As such, I moved some logic into `verify_minimum_requirements()` and added a new condition to check for the `openssl_get_cipher_methods()` function. I avoided `! extension_loaded( 'openssl' )`, as technically the extension might be loaded but the function still could be unavailable.

Going forward, if they don't have the function, it'll short circuit and not load the CRM.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Update your site's `php.ini` (or if using Local, disable the site first and then update its `php.ini.hbs`) with the following:
```
disable_functions = openssl_x509_export_to_file,openssl_x509_export,openssl_x509_fingerprint,openssl_x509_check_private_key,openssl_x509_verify,openssl_x509_parse,openssl_x509_checkpurpose,openssl_x509_read,openssl_x509_free,openssl_pkcs12_export_to_file,openssl_pkcs12_export,openssl_pkcs12_read,openssl_csr_export_to_file,openssl_csr_export,openssl_csr_sign,openssl_csr_new,openssl_csr_get_subject,openssl_csr_get_public_key,openssl_pkey_new,openssl_pkey_export_to_file,openssl_pkey_export,openssl_pkey_get_public,openssl_get_publickey,openssl_pkey_free,openssl_free_key,openssl_pkey_get_private,openssl_get_privatekey,openssl_pkey_get_details,openssl_pbkdf2,openssl_pkcs7_verify,openssl_pkcs7_encrypt,openssl_pkcs7_sign,openssl_pkcs7_decrypt,openssl_pkcs7_read,openssl_cms_verify,openssl_cms_encrypt,openssl_cms_sign,openssl_cms_decrypt,openssl_cms_read,openssl_private_encrypt,openssl_private_decrypt,openssl_public_encrypt,openssl_public_decrypt,openssl_error_string,openssl_sign,openssl_verify,openssl_seal,openssl_open,openssl_get_md_methods,openssl_get_cipher_methods,openssl_get_curve_names,openssl_digest,openssl_encrypt,openssl_decrypt,openssl_cipher_iv_length,openssl_cipher_key_length,openssl_dh_compute_key,openssl_pkey_derive,openssl_random_pseudo_bytes,openssl_spki_new,openssl_spki_verify,openssl_spki_export,openssl_spki_export_challenge,openssl_get_cert_locations
```

Note: the above list was determined with the following:
```
$all_internal_functions = get_defined_functions()['internal'];
$open_ssl_functions = array_filter($all_internal_functions, function($fn) {
	return str_starts_with($fn, 'openssl_');
});
error_log(var_export(implode(',', $open_ssl_functions), true));
```

2. Activate Jetpack CRM if not already active.

In `trunk` with a new install you'll get a PHP fatal right off. If instead migrations had already run on the site, you'll see PHP fatals when generating an API key or saving a contact or performing various other tasks.

In the `fix/crm/3365-catch_fatal_if_openssl_unavailable` branch, you'll see this message and cannot use the CRM:
![image](https://github.com/Automattic/jetpack/assets/32492176/428f0e8f-bd3e-4a41-96db-253c98c06582)