### PR TITLE
Fix Map block not rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-map-block-not-rendering
+++ b/projects/plugins/jetpack/changelog/fix-map-block-not-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix Map block not rendering

--- a/projects/plugins/jetpack/extensions/blocks/map/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/edit.js
@@ -284,7 +284,7 @@ class MapEdit extends Component {
 		);
 
 		const instructions = (
-			<Fragment>
+			<p className="components-placeholder__instructions">
 				{ __( 'To use the map block, you need an Access Token.', 'jetpack' ) }
 				<br />
 				<ExternalLink href="https://www.mapbox.com">
@@ -295,16 +295,12 @@ class MapEdit extends Component {
 					'Locate and copy the default access token. Then, paste it into the field below.',
 					'jetpack'
 				) }
-			</Fragment>
+			</p>
 		);
 		const placeholderAPIStateFailure = (
-			<Placeholder
-				icon={ settings.icon }
-				label={ __( 'Map', 'jetpack' ) }
-				notices={ notices }
-				instructions={ instructions }
-			>
+			<Placeholder icon={ settings.icon } label={ __( 'Map', 'jetpack' ) } notices={ notices }>
 				<Fragment>
+					{ instructions }
 					<form>
 						<input
 							type="text"

--- a/projects/plugins/jetpack/extensions/blocks/map/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/map/editor.scss
@@ -13,9 +13,13 @@
 		}
 	}
 
-	.components-placeholder__instructions .components-external-link {
-		display: inline-block;
-		margin: 1em auto;
+	.components-placeholder__instructions {
+		margin-top: 0;
+
+		.components-external-link {
+			display: inline-block;
+			margin: 1em auto;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Similar issue to #33441

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fixes the Map block not rendering properly in the post editor.
<img width="500" alt="Screenshot 2023-10-13 at 2 48 37 PM" src="https://github.com/Automattic/jetpack/assets/1620183/f9f4d548-da88-4f21-9491-bf287a4638d0">


The Map block consume the `Placeholder` component from the `@wordpress/components` and pass, amongst other props, the `instructions` property. This property is [typed as a string](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/placeholder/types.ts#L27), though we've been passing a React element until now without it being an issue. [A recent update in the package](https://github.com/WordPress/gutenberg/commit/955aef63f9b8a667c543d0ab3ac1952bfda9e85b#diff-2f283f2da01fc903a834bbf20a0a127a272c3d78183306f839a7dc4f959ff049R84) requires us to pass an actual string. Since the instructions contain an external link, they were moved to the `children` property of the `Placeholder` component. This is even more accurate semantically since the instructions seem to be rendered in a `legend` tag, which should act as a title rather than a set of instructions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch (build the Jetpack plugin).
- Visit `Posts > Add New`.
- Add the Map block to the page.
- Notice the block is rendered.

<img width="500" alt="Screenshot 2023-10-13 at 2 42 05 PM" src="https://github.com/Automattic/jetpack/assets/1620183/9d8cfeea-2f0e-4d09-a68b-93a8df06b4ef">


