### PR TITLE
Admin Menu: Account for badges that use update-plugins class

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -465,7 +465,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			&& preg_match( '/<span class="(awaiting-mod|update-plugins)">(.+)<\/span>/', $title, $matches )
 		) {
 
-			$text = $matches[1];
+			$text = $matches[2];
 			if ( $text ) {
 				// Keep the text in the item array.
 				$item['badge'] = $text;

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -461,8 +461,8 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		}
 
 		if (
-			false !== strpos( $title, 'awaiting-mod' )
-			&& preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches )
+			( false !== strpos( $title, 'awaiting-mod' ) || false !== strpos( $title, 'update-plugins' ) )
+			&& preg_match( '/<span class="(awaiting-mod|update-plugins)">(.+)<\/span>/', $title, $matches )
 		) {
 
 			$text = $matches[1];

--- a/projects/plugins/jetpack/changelog/update-admin-menu-badges
+++ b/projects/plugins/jetpack/changelog/update-admin-menu-badges
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Admin Menu now correctly picks up badges that use the update-plugins CSS class to be displayed as a badge.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -653,6 +653,13 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 					'title' => 'Comments more title',
 				),
 			),
+			array(
+				'Settings <span class="update-plugins">staging</span>more title',
+				array(
+					'badge' => 'staging',
+					'title' => 'Settings more title',
+				),
+			),
 		);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/65479

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Expand CSS class matcher to include `update-plugins` to catch badges that use that markup.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

