### PR TITLE
CRM: Fixing HTML rendering issue in quote templates notes field 

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-quote-template-notes-escaping
+++ b/projects/plugins/crm/changelog/fix-crm-quote-template-notes-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Quote Templates: Fix issue with notes field rendering HTML entities in some cases

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.QuoteTemplates.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.QuoteTemplates.php
@@ -1056,7 +1056,7 @@ class zbsDAL_quotetemplates extends zbsDAL_ObjectLayer {
      * @return array quotetemplate (clean obj)
      */
     private function tidy_quotetemplate($obj=false,$withCustomFields=false){
-
+			global $zbs;
             $res = false;
 
             if (isset($obj->ID)){
@@ -1076,7 +1076,7 @@ class zbsDAL_quotetemplates extends zbsDAL_ObjectLayer {
             $res['date'] = (int)$obj->zbsqt_date;
             $res['date_date'] = (isset($obj->zbsqt_date) && $obj->zbsqt_date > 0) ? zeroBSCRM_locale_utsToDatetime($obj->zbsqt_date) : false;
             $res['content'] = $this->stripSlashes($obj->zbsqt_content);
-            $res['notes'] = $this->stripSlashes($obj->zbsqt_notes);
+			$res['notes']            = wp_kses( html_entity_decode( $obj->zbsqt_notes, ENT_QUOTES, 'UTF-8' ), $zbs->acceptable_restricted_html );
             $res['currency'] = $this->stripSlashes($obj->zbsqt_currency);
             $res['created'] = (int)$obj->zbsqt_created;
             $res['created_date'] = (isset($obj->zbsqt_created) && $obj->zbsqt_created > 0) ? zeroBSCRM_locale_utsToDatetime($obj->zbsqt_created) : false;


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3366

## Proposed changes:

* This PR adds HTML encoding to the `zbsqt_notes` field when it is being 'tidied' (in the `tidy_quotetemplate` function) when retrived from the database, before being rendered. 
* Previously `strip_slashes` was being used, now a combination of `html_entity_decode` and `wp_kses` is used for more flexibility.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3366
https://github.com/Automattic/jetpack/pull/33596#pullrequestreview-1677168769


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* On trunk, within a quote template - `wp-admin/admin.php?page=manage-quote-templates` - add a few words with an apostrophe, and other characters including forward slashes (for example `Karen's notes \\`).
* Click on 'Update Template', notice this becomes `Karen&#039;s notes \`. Update again, and it's now `Karen&amp;#039;s notes` .
* With this PR applied, the note field with those characters does not change.

