### PR TITLE
AI Assistant: Only register AI Assistant extension if not explicitly disabled via jetpack_ai_enabled filter

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack_ai_enabled_assistant
+++ b/projects/plugins/jetpack/changelog/update-jetpack_ai_enabled_assistant
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Make the jetpack_ai_enabled filter decide whether to register AI editor extensions

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -24,8 +24,9 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  */
 function register_block() {
 	if (
-		( new Host() )->is_wpcom_simple()
+	( ( new Host() )->is_wpcom_simple()
 		|| ! ( new Status() )->is_offline_mode()
+	) && apply_filters( 'jetpack_ai_enabled', true )
 	) {
 		Blocks::jetpack_register_block(
 			BLOCK_NAME,
@@ -62,7 +63,9 @@ function load_assets( $attr, $content ) {
 add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
-		\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-support' );
+		if ( apply_filters( 'jetpack_ai_enabled', true ) ) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-support' );
+		}
 	}
 );
 
@@ -72,7 +75,9 @@ add_action(
 add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
-		\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-form-support' );
+		if ( apply_filters( 'jetpack_ai_enabled', true ) ) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-form-support' );
+		}
 	}
 );
 
@@ -82,7 +87,9 @@ add_action(
 add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
-		\Jetpack_Gutenberg::set_extension_available( 'ai-content-lens' );
+		if ( apply_filters( 'jetpack_ai_enabled', true ) ) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-content-lens' );
+		}
 	}
 );
 
@@ -92,6 +99,8 @@ add_action(
 add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
-		\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-backend-prompts' );
+		if ( apply_filters( 'jetpack_ai_enabled', true ) ) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-backend-prompts' );
+		}
 	}
 );


### PR DESCRIPTION
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Makes the registering of AI editor extensions respect the `jetpack_ai_enabled` filter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Launch a site with this branch and connect Jetpack (Or checkout this branch)
* Apply a code snippet to set `jetpack_ai_enabled` to false. e.g.: `add_filter( 'jetpack_ai_enabled', '__return_false' );`
* Visit the editor. Confirm you don't see any of the Jetpack AI extension (block is not avaliable, excerpt, feedback tool in pre-publish, etc)

