### PR TITLE
Backport chaanges for mu-wpcom-plugin 1.7.1 and jejtpack 12.8-a.1

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33584]
+
 ## [0.1.11] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -140,6 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.1.12]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.8...v0.1.9

--- a/projects/js-packages/ai-client/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.1.12-alpha",
+	"version": "0.1.12",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.29] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## [1.0.28] - 2023-09-13
 ### Changed
 - Updated package dependencies. [#33001]
@@ -135,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 - Replace missing domains too.
 
+[1.0.29]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.28...v1.0.29
 [1.0.28]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.27...v1.0.28
 [1.0.27]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.26...v1.0.27
 [1.0.26]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.25...v1.0.26

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.0.29-alpha",
+	"version": "1.0.29",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/babel-plugin-replace-textdomain/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.13] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33567, #33569]
+
 ## [0.1.12] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -67,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.13]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.9...v0.1.10

--- a/projects/js-packages/boost-score-api/changelog/renovate-eslint-packages
+++ b/projects/js-packages/boost-score-api/changelog/renovate-eslint-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/changelog/renovate-major-eslint-packages
+++ b/projects/js-packages/boost-score-api/changelog/renovate-major-eslint-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.13-alpha",
+	"version": "0.1.13",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.43.3] - 2023-10-16
+### Changed
+- Replaced inline social icons with social-logos package. [#33613]
+- Updated package dependencies. [#33584, #33429]
+
 ## [0.43.2] - 2023-10-11
 ### Changed
 - Changed Twitter icon and label to X [#33445]
@@ -839,6 +844,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.43.3]: https://github.com/Automattic/jetpack-components/compare/0.43.2...0.43.3
 [0.43.2]: https://github.com/Automattic/jetpack-components/compare/0.43.1...0.43.2
 [0.43.1]: https://github.com/Automattic/jetpack-components/compare/0.43.0...0.43.1
 [0.43.0]: https://github.com/Automattic/jetpack-components/compare/0.42.5...0.43.0

--- a/projects/js-packages/components/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/components/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/renovate-major-eslint-packages
+++ b/projects/js-packages/components/changelog/renovate-major-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Make new version of prettier happy. No functional change.
-
-

--- a/projects/js-packages/components/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/components/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/update-replace-social-icons-with-social-logos
+++ b/projects/js-packages/components/changelog/update-replace-social-icons-with-social-logos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Replaced inline social icons with social-logos package

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.43.3-alpha",
+	"version": "0.43.3",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.30.2] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429, #33584]
+
 ## [0.30.1] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -636,6 +640,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.30.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.1...v0.30.2
 [0.30.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.29.10...v0.30.0
 [0.29.10]: https://github.com/Automattic/jetpack-connection-js/compare/v0.29.9...v0.29.10

--- a/projects/js-packages/connection/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.30.2-alpha",
+	"version": "0.30.2",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## [1.1.0] - 2023-10-03
 ### Added
 - Add a sub-plugin, `I18nSafeMangleExportsPlugin`, to allow for avoiding problems with Webpack's `optimization.mangleExports` option occasionally mangling an export to one of the i18n function names. [#33392]
@@ -176,6 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.1.1]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.36...v1.1.0
 [1.0.36]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.35...v1.0.36
 [1.0.35]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.34...v1.0.35

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-major-eslint-packages
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-major-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Make new version of prettier happy. No functional change.
-
-

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.1.1-alpha",
+	"version": "1.1.1",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-check-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.48 - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## 0.10.47 - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]

--- a/projects/js-packages/idc/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.48-alpha",
+	"version": "0.10.48",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.8 - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## 0.11.7 - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]

--- a/projects/js-packages/licensing/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.11.8-alpha",
+	"version": "0.11.8",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.57 - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## 0.2.56 - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]

--- a/projects/js-packages/partner-coupon/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.57-alpha",
+	"version": "0.2.57",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.2] - 2023-10-16
+### Added
+- Added aspect-ratio validation for Instagram images. [#33522]
+
+### Changed
+- Added type prop to custom media for social posts. [#33504]
+- Changed Twitter icon and label to X. [#33445]
+- Convert Twitter to X. [#33574]
+- Replaced inline social icons with social-logos package. [#33613]
+- Updated package dependencies. [#33429]
+
+### Fixed
+- Fixed an issue with conditional className property [#33592]
+- Fixed tracking for quick share buttons [#33589]
+
 ## [0.40.1] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -451,6 +466,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.40.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.40.1...v0.40.2
 [0.40.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.40.0...v0.40.1
 [0.40.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.39.1...v0.40.0
 [0.39.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.39.0...v0.39.1

--- a/projects/js-packages/publicize-components/changelog/fix-add-instagram-image-dimension-validation
+++ b/projects/js-packages/publicize-components/changelog/fix-add-instagram-image-dimension-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added aspect-ratio validation for Instagram images

--- a/projects/js-packages/publicize-components/changelog/fix-console-warnings-quick-share
+++ b/projects/js-packages/publicize-components/changelog/fix-console-warnings-quick-share
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed an issue with conditional className property

--- a/projects/js-packages/publicize-components/changelog/fix-quick-share-tracking
+++ b/projects/js-packages/publicize-components/changelog/fix-quick-share-tracking
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed tracking for quick share buttons

--- a/projects/js-packages/publicize-components/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/update-add-type-prop-to-custom-media
+++ b/projects/js-packages/publicize-components/changelog/update-add-type-prop-to-custom-media
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Added type prop to custom media for social posts

--- a/projects/js-packages/publicize-components/changelog/update-convert-twitter-icons-to-X
+++ b/projects/js-packages/publicize-components/changelog/update-convert-twitter-icons-to-X
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Changed Twitter icon and label to X

--- a/projects/js-packages/publicize-components/changelog/update-replace-social-icons-with-social-logos
+++ b/projects/js-packages/publicize-components/changelog/update-replace-social-icons-with-social-logos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Replaced inline social icons with social-logos package

--- a/projects/js-packages/publicize-components/changelog/update-social-previews-convert-twitter-to-x
+++ b/projects/js-packages/publicize-components/changelog/update-social-previews-convert-twitter-to-x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Convert Twitter to X

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.40.2-alpha",
+	"version": "0.40.2",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## [0.12.1] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -260,6 +264,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.12.2]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.12.1...0.12.2
 [0.12.1]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.12.0...0.12.1
 [0.12.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.11.5...0.12.0
 [0.11.5]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.11.4...0.11.5

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-major-eslint-packages
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-major-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Make new version of prettier happy. No functional change.
-
-

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.12.2-alpha",
+	"version": "0.12.2",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.2 - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429, #33600]
+
 ## 2.0.1 - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]

--- a/projects/js-packages/webpack-config/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/changelog/renovate-browserslist-4.x
+++ b/projects/js-packages/webpack-config/changelog/renovate-browserslist-4.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "2.0.2-alpha",
+	"version": "2.0.2",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/action-bar/CHANGELOG.md
+++ b/projects/packages/action-bar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.29] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## [0.1.28] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -122,6 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds the Action Bar package and Jetpack plugin module for follows, likes, and comments. Just a scaffold to build on, for now. [#25447]
 
+[0.1.29]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.28...v0.1.29
 [0.1.28]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.25...v0.1.26

--- a/projects/packages/action-bar/changelog/renovate-babel-monorepo
+++ b/projects/packages/action-bar/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/action-bar/package.json
+++ b/projects/packages/action-bar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-action-bar",
-	"version": "0.1.29-alpha",
+	"version": "0.1.29",
 	"description": "An easy way for visitors to follow, like, and comment on your WordPress site.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/action-bar/#readme",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.8] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## [1.17.7] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -491,6 +495,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[1.17.8]: https://github.com/Automattic/jetpack-backup/compare/v1.17.7...v1.17.8
 [1.17.7]: https://github.com/Automattic/jetpack-backup/compare/v1.17.6...v1.17.7
 [1.17.6]: https://github.com/Automattic/jetpack-backup/compare/v1.17.5...v1.17.6
 [1.17.5]: https://github.com/Automattic/jetpack-backup/compare/v1.17.4...v1.17.5

--- a/projects/packages/backup/changelog/renovate-babel-monorepo
+++ b/projects/packages/backup/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.17.8-alpha';
+	const PACKAGE_VERSION = '1.17.8';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.4] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## [0.10.3] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -211,6 +215,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.10.4]: https://github.com/automattic/jetpack-blaze/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/automattic/jetpack-blaze/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/automattic/jetpack-blaze/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/automattic/jetpack-blaze/compare/v0.10.0...v0.10.1

--- a/projects/packages/blaze/changelog/renovate-babel-monorepo
+++ b/projects/packages/blaze/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.10.4-alpha",
+	"version": "0.10.4",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.10.4-alpha';
+	const PACKAGE_VERSION = '0.10.4';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.3] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## [0.22.2] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -340,6 +344,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.22.3]: https://github.com/automattic/jetpack-forms/compare/v0.22.2...v0.22.3
 [0.22.2]: https://github.com/automattic/jetpack-forms/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/automattic/jetpack-forms/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/automattic/jetpack-forms/compare/v0.21.0...v0.22.0

--- a/projects/packages/forms/changelog/renovate-babel-monorepo
+++ b/projects/packages/forms/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/changelog/renovate-major-eslint-packages
+++ b/projects/packages/forms/changelog/renovate-major-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Make new version of prettier happy. No functional change.
-
-

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.22.3-alpha",
+	"version": "0.22.3",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.22.3-alpha';
+	const PACKAGE_VERSION = '0.22.3';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.7] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429]
+
 ## [0.10.6] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -417,6 +421,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.10.7]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.6...v0.10.7
 [0.10.6]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.5...v0.10.6
 [0.10.5]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.4...v0.10.5
 [0.10.4]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.3...v0.10.4

--- a/projects/packages/identity-crisis/changelog/renovate-babel-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.10.7-alpha",
+	"version": "0.10.7",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.10.7-alpha';
+	const PACKAGE_VERSION = '0.10.7';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2023-10-16
+### Added
+- Added HEIC (`*.heic`) to list of images types allowed to be passed through Photon. [#33494]
+
 ## [0.2.6] - 2023-09-28
 ### Fixed
 - Use WordPress `str_ends_with` polyfill. [#33288]
@@ -43,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add image CDN package. [#29561]
 
+[0.2.7]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.3...v0.2.4

--- a/projects/packages/image-cdn/changelog/xyu-patch-1
+++ b/projects/packages/image-cdn/changelog/xyu-patch-1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added HEIC (`*.heic`) to list of images types allowed to be passed through Photon.

--- a/projects/packages/image-cdn/package.json
+++ b/projects/packages/image-cdn/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-image-cdn",
-	"version": "0.2.7-alpha",
+	"version": "0.2.7",
 	"description": "Serve images through Jetpack's powerful CDN",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/image-cdn/#readme",
 	"bugs": {

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Assets;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.2.7-alpha';
+	const PACKAGE_VERSION = '0.2.7';
 
 	/**
 	 * Singleton.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.15.0] - 2023-10-16
+### Added
+- Launchpad: Add earn-newsletter checklist. [#33200]
+
+### Changed
+- Launchpad: Update copy for global styles in plan_selected task. [#33462]
+
 ## [4.14.0] - 2023-10-10
 ### Added
 - Expose newsletter_categories_location to JavaScript [#33374]
@@ -392,6 +399,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[4.15.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.14.0...v4.15.0
 [4.14.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.13.0...v4.14.0
 [4.13.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.12.0...v4.13.0
 [4.12.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.11.0...v4.12.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-earn-newsletter-launchpad-checklist
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-earn-newsletter-launchpad-checklist
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Launchpad: Add earn-newsletter checklist.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-launchpad-global-styles-copy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-launchpad-global-styles-copy
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Launchpad: Update copy for global styles in plan_selected task

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.15.0-alpha",
+	"version": "4.15.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.15.0-alpha';
+	const PACKAGE_VERSION = '4.15.0';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.2] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429, #33584]
+
 ## [3.8.1] - 2023-10-10
 ### Changed
 - Changes title of the my-jetpack page to "My Jetpack" [#33486]
@@ -1053,6 +1057,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[3.8.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.8.1...3.8.2
 [3.8.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.8.0...3.8.1
 [3.8.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.7.0...3.8.0
 [3.7.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.6.0...3.7.0

--- a/projects/packages/my-jetpack/changelog/renovate-babel-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/renovate-storybook-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.8.2-alpha",
+	"version": "3.8.2",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.8.2-alpha';
+	const PACKAGE_VERSION = '3.8.2';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.3] - 2023-10-16
+### Changed
+- Added type prop to custom media for social posts. [#33504]
+
 ## [0.36.2] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -393,6 +397,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.36.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.2...v0.36.3
 [0.36.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.1...v0.36.2
 [0.36.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.0...v0.36.1
 [0.36.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.35.0...v0.36.0

--- a/projects/packages/publicize/changelog/update-add-type-prop-to-custom-media
+++ b/projects/packages/publicize/changelog/update-add-type-prop-to-custom-media
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Added type prop to custom media for social posts

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.36.3-alpha",
+	"version": "0.36.3",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.2] - 2023-10-16
+### Added
+- Added HEIC (`*.heic`) to list of images types allowed to be passed through Photon during instant search. [#33494]
+
+### Changed
+- Updated package dependencies. [#33429, #33569]
+
+### Fixed
+- Search: Fixed excluded types option is not available under certain circumstances. [#33548]
+
 ## [0.39.1] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -812,6 +822,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.39.2]: https://github.com/Automattic/jetpack-search/compare/v0.39.1...v0.39.2
 [0.39.1]: https://github.com/Automattic/jetpack-search/compare/v0.39.0...v0.39.1
 [0.39.0]: https://github.com/Automattic/jetpack-search/compare/v0.38.8...v0.39.0
 [0.38.8]: https://github.com/Automattic/jetpack-search/compare/v0.38.7...v0.38.8

--- a/projects/packages/search/changelog/fix-allow-only-valid-post-types
+++ b/projects/packages/search/changelog/fix-allow-only-valid-post-types
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Search: fixed excluded types option is not available under certain circumstances

--- a/projects/packages/search/changelog/renovate-babel-monorepo
+++ b/projects/packages/search/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/renovate-major-eslint-packages
+++ b/projects/packages/search/changelog/renovate-major-eslint-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/xyu-patch-1
+++ b/projects/packages/search/changelog/xyu-patch-1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added HEIC (`*.heic`) to list of images types allowed to be passed through Photon during instant search

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.39.2-alpha",
+	"version": "0.39.2",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.39.2-alpha';
+	const VERSION = '0.39.2';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.0] - 2023-10-16
+### Changed
+- Migrated 'jetpack_sync_before_send*' actions for Sync queue to 'jetpack_sync_before_enqueue' instead. [#33384]
+
 ## [1.57.4] - 2023-10-10
+
 - Minor internal updates.
 
 ## [1.57.3] - 2023-09-28
@@ -937,6 +942,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.58.0]: https://github.com/Automattic/jetpack-sync/compare/v1.57.4...v1.58.0
 [1.57.4]: https://github.com/Automattic/jetpack-sync/compare/v1.57.3...v1.57.4
 [1.57.3]: https://github.com/Automattic/jetpack-sync/compare/v1.57.2...v1.57.3
 [1.57.2]: https://github.com/Automattic/jetpack-sync/compare/v1.57.1...v1.57.2

--- a/projects/packages/sync/changelog/update-sync-migrate-before-send-to-before-enqueue
+++ b/projects/packages/sync/changelog/update-sync-migrate-before-send-to-before-enqueue
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Migrated 'jetpack_sync_before_send*' actions for Sync queue to 'jetpack_sync_before_enqueue' instead

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.58.0-alpha';
+	const PACKAGE_VERSION = '1.58.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.5] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429, #33584]
+
+### Fixed
+- VideoPress: Handle block registration in the REST API request context. [#33565]
+
 ## [0.17.4] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -1134,6 +1141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.17.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.4...v0.17.5
 [0.17.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.3...v0.17.4
 [0.17.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.1...v0.17.2

--- a/projects/packages/videopress/changelog/renovate-babel-monorepo
+++ b/projects/packages/videopress/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-major-eslint-packages
+++ b/projects/packages/videopress/changelog/renovate-major-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Make new version of prettier happy. No functional change.
-
-

--- a/projects/packages/videopress/changelog/renovate-storybook-monorepo
+++ b/projects/packages/videopress/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/update-videopress-video-block-register-when-rest-request
+++ b/projects/packages/videopress/changelog/update-videopress-video-block-register-when-rest-request
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: handle block registration in the REST API request context

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.17.5-alpha",
+	"version": "0.17.5",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.17.5-alpha';
+	const PACKAGE_VERSION = '0.17.5';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.54] - 2023-10-16
+### Changed
+- Updated package dependencies. [#33429, #33569]
+
 ## [0.2.53] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -253,6 +257,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.2.54]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.53...v0.2.54
 [0.2.53]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.52...v0.2.53
 [0.2.52]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.51...v0.2.52
 [0.2.51]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.50...v0.2.51

--- a/projects/packages/wordads/changelog/renovate-babel-monorepo
+++ b/projects/packages/wordads/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/changelog/renovate-major-eslint-packages
+++ b/projects/packages/wordads/changelog/renovate-major-eslint-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.54-alpha",
+	"version": "0.2.54",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.54-alpha';
+	const VERSION = '0.2.54';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.8-a.1 - 2023-10-16
+### Enhancements
+- AI Assistant: Enable backend prompts for 50% of production sites. [#33514]
+- Sitemaps: Update the colors used on the sitemap page to match updated Jetpack branding colors. [#33582]
+- Subscriptions: Do not display token in URL. [#33561]
+
+### Bug fixes
+- Blogging prompts block: Add default gravatar attribute to prevent js error. [#33572]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Convert Twitter to X. [#33574]
+- Remove newsletter categories from the subscriber block. [#33579]
+- Sync unit test: Fixes sync unit test to Aaccount for new post type properties. [#33553]
+- Unit tests: Updated Sync related unit tests. [#33384]
+- Update "social-logos" to the latest version. [#33613]
+- Updated package dependencies. [#33429, #33498]
+
 ## [12.7] - 2023-10-12
 ### Enhancements
 - Blogroll: move blogroll and blogroll-items blocks from beta to production, along with various improvements. [#33475] [#33483]

--- a/projects/plugins/jetpack/changelog/add-memberships-remove-token-from-url
+++ b/projects/plugins/jetpack/changelog/add-memberships-remove-token-from-url
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscriptions: Do not display token in URL

--- a/projects/plugins/jetpack/changelog/add-remove-newsletter-categories
+++ b/projects/plugins/jetpack/changelog/add-remove-newsletter-categories
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Remove newsletter categories from the subscriber block.

--- a/projects/plugins/jetpack/changelog/fix-blogging-prompts-save-js-error
+++ b/projects/plugins/jetpack/changelog/fix-blogging-prompts-save-js-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Blogging prompts block: add default gravatar attribute to prevent js error

--- a/projects/plugins/jetpack/changelog/fix-jetpack-test-deprecation-notices
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-test-deprecation-notices
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix PHP 8.2 deprecation notices in tests. No changes to the plugin itself.
-
-

--- a/projects/plugins/jetpack/changelog/fix-sync-unit-test
+++ b/projects/plugins/jetpack/changelog/fix-sync-unit-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Sync unit test: Fixes sync unit test to Aaccount for new post type properties

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 12.8-a.2
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 12.8-a.0
-
-

--- a/projects/plugins/jetpack/changelog/renovate-babel-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-access-panel-merge
+++ b/projects/plugins/jetpack/changelog/update-access-panel-merge
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-refactor

--- a/projects/plugins/jetpack/changelog/update-access-panel-merge-2
+++ b/projects/plugins/jetpack/changelog/update-access-panel-merge-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-refactoring

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-enable-backend-prompts-for-half-site-base
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-enable-backend-prompts-for-half-site-base
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Enable backend prompts for 50% of production sites.

--- a/projects/plugins/jetpack/changelog/update-jetpack-colors-sitemap
+++ b/projects/plugins/jetpack/changelog/update-jetpack-colors-sitemap
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Sitemaps: update the colors used on the sitemap page to match updated Jetpack branding colors.

--- a/projects/plugins/jetpack/changelog/update-replace-social-icons-with-social-logos
+++ b/projects/plugins/jetpack/changelog/update-replace-social-icons-with-social-logos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update "social-logos" to the latest version

--- a/projects/plugins/jetpack/changelog/update-social-previews-convert-twitter-to-x
+++ b/projects/plugins/jetpack/changelog/update-social-previews-convert-twitter-to-x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Convert Twitter to X

--- a/projects/plugins/jetpack/changelog/update-sync-migrate-before-send-to-before-enqueue
+++ b/projects/plugins/jetpack/changelog/update-sync-migrate-before-send-to-before-enqueue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Unit tests: Updated Sync related unit tests

--- a/projects/plugins/jetpack/changelog/update-sync-migrate-before-send-to-before-enqueue#2
+++ b/projects/plugins/jetpack/changelog/update-sync-migrate-before-send-to-before-enqueue#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_0",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.8-a.0
+ * Version: 12.8-a.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.8-a.0' );
+define( 'JETPACK__VERSION', '12.8-a.1' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.8-a.1
+ * Version: 12.8-a.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.8-a.1' );
+define( 'JETPACK__VERSION', '12.8-a.2' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.8.0-a.0",
+	"version": "12.8.0-a.1",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.8.0-a.1",
+	"version": "12.8.0-a.2",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.1 - 2023-10-16
+### Changed
+- Updated package dependencies. [#33498]
+
 ## 1.7.0 - 2023-10-10
 ### Changed
 - Updated lock files [#33456]

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-launchpad-global-styles-copy
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-launchpad-global-styles-copy
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_1_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_1"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.7.1-alpha
+ * Version: 1.7.1
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.7.1-alpha",
+	"version": "1.7.1",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Backports changes for mu-wpcom-plugin 1.7.1 and jetpack 12.8-a.1.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread the changelogs.

