### PR TITLE
Fix/check for paywall access prior to tracking

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-check-for-paywall-access-prior-to-tracking
+++ b/projects/plugins/jetpack/changelog/fix-check-for-paywall-access-prior-to-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Check for post access first then do tracking action.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -916,17 +916,19 @@ function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
 function add_paywall( $the_content ) {
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 
+	$post_access_level = Jetpack_Memberships::get_post_access_level();
+
 	if ( Jetpack_Memberships::user_can_view_post() ) {
-		do_action(
-			'earn_track_paywalled_post_view',
-			array(
-				'post_id' => get_the_ID(),
-			)
-		);
+		if ( $post_access_level !== Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY ) {
+			do_action(
+				'earn_track_paywalled_post_view',
+				array(
+					'post_id' => get_the_ID(),
+				)
+			);
+		}
 		return $the_content;
 	}
-
-	$post_access_level = Jetpack_Memberships::get_post_access_level();
 
 	require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 	$token_service              = is_wpcom() ? new WPCOM_Token_Subscription_Service() : new Jetpack_Token_Subscription_Service();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 180-gh-automattic/gold
Mirrored in D125467-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks for paywall access level first, then do tracking action if post access is protected.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Download this patch to your sandbox and sandbox a memberships test site. Tail the php logs on your sandbox.
* View a site without protected posts and observe there are no messages paywalled post viewed.
* View a site with protected posts and observe the log messages that the paywalled post was viewed.

