### PR TITLE
AI Chat: Register AI Chat extension if not explicitly disabled via jetpack_ai_enabled filter

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -110,7 +110,7 @@ class Jetpack_AI_Helper {
 		 *
 		 * @param bool $default Is AI chat enabled? Defaults to false.
 		 */
-		return apply_filters( 'jetpack_ai_chat_enabled', $default );
+		return apply_filters( 'jetpack_ai_enabled', true ) && apply_filters( 'jetpack_ai_chat_enabled', $default );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-jetpack_ai_enabled_ai_chat
+++ b/projects/plugins/jetpack/changelog/update-jetpack_ai_enabled_ai_chat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Make the jetpack_ai_enabled filter decide whether to register AI Chat extension

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
@@ -24,8 +24,9 @@ use Jetpack_Gutenberg;
  */
 function register_block() {
 	if (
-		( new Host() )->is_wpcom_simple()
+		( ( new Host() )->is_wpcom_simple()
 		|| ( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() && ! ( new Status() )->is_offline_mode() )
+	) && Jetpack_AI_Helper::is_ai_chat_enabled()
 	) {
 		Blocks::jetpack_register_block(
 			__DIR__,

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
@@ -26,7 +26,7 @@ function register_block() {
 	if (
 		( ( new Host() )->is_wpcom_simple()
 		|| ( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() && ! ( new Status() )->is_offline_mode() )
-	) && Jetpack_AI_Helper::is_ai_chat_enabled()
+	) && \Jetpack_AI_Helper::is_ai_chat_enabled()
 	) {
 		Blocks::jetpack_register_block(
 			__DIR__,


### PR DESCRIPTION
Makes the AI Search blocknot be available if `jetpack_ai_enabled` is false.
<img width="362" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/5e74032c-858a-4626-9118-e25c7d845ab7">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Makes the registering of the AI Chat extension respect the `jetpack_ai_enabled` filter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a site with this branch and connect Jetpack (Or checkout this branch)
* Apply a code snippet to set `jetpack_ai_enabled` to false. e.g.: `add_filter( 'jetpack_ai_enabled', '__return_false' );`
* Visit the editor. Confirm you don't see any of the Jetpack AI Chat extension (block is not avaliable)


