### PR TITLE
Subscribers: Allow admins to see subscribe modal

### DIFF
--- a/projects/plugins/jetpack/changelog/update-show-subscribe-modal-to-admins
+++ b/projects/plugins/jetpack/changelog/update-show-subscribe-modal-to-admins
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribers: Allow admins to see subscribe modal.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -189,11 +189,6 @@ HTML;
 			return false;
 		}
 
-		// Dont show if user is member of site.
-		if ( is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
-			return false;
-		}
-
 		// Don't show if user is subscribed to blog.
 		require_once __DIR__ . '/../views.php';
 		if ( $this->has_subscription_cookie() || Jetpack_Subscriptions_Widget::is_current_user_subscribed() ) {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Allow site administrators to see the subscriber modal/popup. We had hidden this because admins obviously do not want to subscribe. But based on feedback from Happiness Engineers, it has been confusing for site managers when they can't see/demo the modal on the front end.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Test on Jetpack self hosted:**
* You'll need to test on a jurassic connected site. 
* Go to Jetpack > Settings > Newsletters and enable the subscriber modal. 
* While logged in as an admin, go to a frontend post without a paywall or limited access, scroll, and confirm the modal loads. 

**Test on Simple sites:**
* Run the bin command below to load this branch in your sandbox. Be sure to sandbox public-api and the domain of your test site. 
* Go to Settings > Newsletters and enable the subscriber modal. 
* While logged in as an admin, go to a frontend post without a paywall or limited access, scroll, and confirm the modal loads. 

