### PR TITLE
Subscribers: Update subscriber modal option text

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -165,14 +165,14 @@ function SubscriptionsSettings( props ) {
 								/>
 								<p className="jp-form-setting-explanation">
 									{ __(
-										'Grow subscribers by enabling a popup subscribe form that will show as readers scroll.',
+										'Automatically add a subscribe form pop-up to every post and turn visitors into subscribers. It will appear as readers scroll through your posts.',
 										'jetpack'
 									) }
 									{ isBlockTheme && subscribeModalEditorUrl && (
 										<>
 											{ ' ' }
 											<ExternalLink href={ subscribeModalEditorUrl }>
-												{ __( 'Preview and edit.', 'jetpack' ) }
+												{ __( 'Preview and edit the pop-up', 'jetpack' ) }
 											</ExternalLink>
 										</>
 									) }

--- a/projects/plugins/jetpack/changelog/update-subscriber-modal-option-text
+++ b/projects/plugins/jetpack/changelog/update-subscriber-modal-option-text
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Minor text change.
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Updates the option description for the subscribe modal to match calypso PR here: https://github.com/Automattic/wp-calypso/pull/83059

<img width="1364" alt="subscribe-modal-option" src="https://github.com/Automattic/jetpack/assets/21228350/f44c2e80-78bd-481e-bb48-3a38d0eb3f85">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Settings > Newsletters and confirm that the new text for the option description shows. 

