### PR TITLE
AI Extension: do not skip React hook instances

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-improve-extending
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-improve-extending
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: do not skip React hook instances

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -105,6 +105,7 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
 			 * and close the event source.
 			 */
 			return () => {
+				// Only stop when the parent block is unmouted.
 				if ( props?.name !== 'jetpack/contact-form' ) {
 					return;
 				}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -84,11 +84,12 @@ export function isPossibleToExtendJetpackFormBlock(
 	return true;
 }
 
-const withAiAssistantComponents = createHigherOrderComponent( BlockEdit => {
+/**
+ * HOC to populate the Jetpack Form edit component
+ * with the AI Assistant bar and button.
+ */
+const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 	return props => {
-		if ( ! isPossibleToExtendJetpackFormBlock( props?.name, { clientId: props.clientId } ) ) {
-			return <BlockEdit { ...props } />;
-		}
 		const { eventSource } = useAiContext();
 
 		const stopSuggestion = useCallback( () => {
@@ -104,9 +105,18 @@ const withAiAssistantComponents = createHigherOrderComponent( BlockEdit => {
 			 * and close the event source.
 			 */
 			return () => {
+				if ( props?.name !== 'jetpack/contact-form' ) {
+					return;
+				}
+
 				stopSuggestion();
 			};
-		}, [ stopSuggestion ] );
+		}, [ stopSuggestion, props?.name ] );
+
+		// Only extend Jetpack Form block (children not included).
+		if ( ! isPossibleToExtendJetpackFormBlock( props?.name, { clientId: props.clientId } ) ) {
+			return <BlockEdit { ...props } />;
+		}
 
 		const blockControlsProps = {
 			group: 'block',
@@ -124,9 +134,14 @@ const withAiAssistantComponents = createHigherOrderComponent( BlockEdit => {
 			</>
 		);
 	};
-}, 'withAiAssistantComponents' );
+}, 'jetpackFormEditWithAiComponents' );
 
-addFilter( 'editor.BlockEdit', 'jetpack/jetpack-form-block-edit', withAiAssistantComponents, 100 );
+addFilter(
+	'editor.BlockEdit',
+	'jetpack/jetpack-form-block-edit',
+	jetpackFormEditWithAiComponents,
+	100
+);
 
 /**
  * Add the AI Assistant button to the toolbar.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR addresses a bad practice when using React hooks, calling hooks only at [the top level of the React function](https://legacy.reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level).

> Don’t call Hooks inside loops, conditions, or nested functions

The code involves the HOC used to populate the Jetpack Form edit function (block canvas representation) with the AI Assistant bar and the AI toolbar button.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: do not skip React hook instances

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This change shouldn't change anything in the app.
Since the PR changes how the Jetpack Form block instance is extended, you should ensure that:

* The AI Assistant bar works as usual
  * Ask to generate a new form
  * Ask to edit the form content
  * Remove the block instance and ensure the ai request stops
  * Test on mobile
* The AI toolbar button works as usual
  * Confirm you see the button
  * Confirm it shows/hides the assistant bar
  * Test on mobile 

<img width="685" alt="Screenshot 2023-10-17 at 12 55 18" src="https://github.com/Automattic/jetpack/assets/77539/5ffb5603-bb99-4402-b71f-10211a44bd50">


