### PR TITLE
AI Extension: change the filter to populate the Jetpack Form block with AI components

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-change-filter-to-extend-components
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-change-filter-to-extend-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: change the filter to populate the Jetpack Form block with AI components

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -138,7 +138,7 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
 }, 'jetpackFormEditWithAiComponents' );
 
 /**
- * Function used to extened the registerBlockType settings.
+ * Function used to extend the registerBlockType settings.
  *
  * - Populate the Jetpack Form edit component
  * with the AI Assistant bar and button (jetpackFormEditWithAiComponents).

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -105,6 +105,7 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
 			 * and close the event source.
 			 */
 			return () => {
+				// Only stop when the parent block is unmouted.
 				if ( props?.name !== 'jetpack/contact-form' ) {
 					return;
 				}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -105,7 +105,6 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
 			 * and close the event source.
 			 */
 			return () => {
-				// Only stop when the parent block is unmouted.
 				if ( props?.name !== 'jetpack/contact-form' ) {
 					return;
 				}
@@ -137,10 +136,32 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
 	};
 }, 'jetpackFormEditWithAiComponents' );
 
+/**
+ * Function used to extened the registerBlockType settings.
+ *
+ * - Populate the Jetpack Form edit component
+ * with the AI Assistant bar and button (jetpackFormEditWithAiComponents).
+ *
+ * @param {object} settings - The block settings.
+ * @param {string} name     - The block name.
+ * @returns {object}          The block settings.
+ */
+function jetpackFormWithAiSupport( settings, name: string ) {
+	// Only extend Jetpack Form block type.
+	if ( name !== 'jetpack/contact-form' ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		edit: jetpackFormEditWithAiComponents( settings.edit ),
+	};
+}
+
 addFilter(
-	'editor.BlockEdit',
-	'jetpack/jetpack-form-block-edit',
-	jetpackFormEditWithAiComponents,
+	'blocks.registerBlockType',
+	'jetpack/ai-assistant-support',
+	jetpackFormWithAiSupport,
 	100
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR replaces the filter used to extend the Jetpack Form edit component. Currently (trunk) it uses the `editor.BlockEdit` filter which is replaced with `blocks.registerBlockType`.

With these changes, the block is extended at a different runtime level; specifically when the app registers the block. It avoids, for instance, the situation of creating hook instances for other block types.

Also and which isn't less important, it avoids extending other block types (see testing instructions)

The code involves the part that extends the Jetpack Form block with the AI Assistant toolbar button and the AI Assistant bar.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: change the filter to populate the Jetpack Form block with AI components

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

####  Testing how the app extends the blocks

* Go to the block editor
* Test with a post without content 
* Create a Jetpack Form block instance
* Create another block, for instance, an image block
* Open the dev tool of your browser
* Ensure you have installed the React Dev Tool: [chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) - [Firefox](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/)
* Filter the blocks by the `jetpackFormEditWithAiComponents` string

**Before (trunk)**, confirm you see two instances of `jetpackFormEditWithAiComponents`.

<img width="1248" alt="Screenshot 2023-10-17 at 14 37 04" src="https://github.com/Automattic/jetpack/assets/77539/9c5ade9e-32b7-4a77-91a7-7d0b768c5c9e">

☝️ is not good. It means that we are extending all blocks with the `jetpackFormEditWithAiComponents` HOC. We can increase its visibility by creating more block instances. You should see how the number of jetpackFormEditWithAiComponents increases, one per each new block.

**After (this PR)**, confirm you see only one instance, which belongs to the Jetpack Form block instance

<img width="1246" alt="Screenshot 2023-10-17 at 14 34 04" src="https://github.com/Automattic/jetpack/assets/77539/20a6fcee-c36b-4bd7-b2d5-45f76879c8dd">

Also and similarly to https://github.com/Automattic/jetpack/pull/33628, you should check that the AI Assistant bar and the AI Assistant toolbar button work as expected (pasting the same instructions):

* The AI Assistant bar works as usual
  * Ask to generate a new form
  * Ask to edit the form content
  * Remove the block instance and ensure the ai request stops
  * Test on mobile
* The AI toolbar button works as usual
  * Confirm you see the button
  * Confirm it shows/hides the assistant bar
  * Test on mobile 

<img width="685" alt="Screenshot 2023-10-17 at 12 55 18" src="https://github.com/Automattic/jetpack/assets/77539/5ffb5603-bb99-4402-b71f-10211a44bd50">


