### PR TITLE
AI Assistant: Enable backend prompts for 100% of production sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-enable-backend-prompts-for-all-sites
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-enable-backend-prompts-for-all-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Enable backend prompts for 100% of production sites.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -43,11 +43,8 @@ export const PROMPT_TYPE_LIST = [
 
 export type PromptTypeProp = ( typeof PROMPT_TYPE_LIST )[ number ];
 
-// Enable backend prompts for beta sites + 10% of production sites.
-const blogId = parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId );
-export const areBackendPromptsEnabled: boolean =
-	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'ai-assistant-backend-prompts' ]
-		?.available || blogId % 2 === 0;
+// Enable backend prompts for all sites
+export const areBackendPromptsEnabled: boolean = true;
 
 export type PromptItemProps = {
 	role: 'system' | 'user' | 'assistant' | 'jetpack-ai';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a followup to #33356 and #33514.

This will be followed up by a clean up change, removing things that will not be necessary anymore like the feature flag and old code.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Expand backend prompts to 100% of production sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on a site with beta extensions enabled and confirm that it uses the backend prompts:
   * To check if it's using backend prompt, notice the `jetpack-ai-client:ask-question Asking question:` log message
   * Backend prompts will have messages where `role = jetpack-ai`:

<img width="600" alt="Screenshot 2023-10-17 at 09 35 38" src="https://github.com/Automattic/jetpack/assets/6760046/b92bea7f-b2c9-4101-b548-20b3171f5599">

* Now test on a site with production extensions enabled. You will see no difference, the backend prompts (`role = jetpack-ai`) will be there, not matter the ID of the site:

<img width="600" alt="Screenshot 2023-10-17 at 10 04 05" src="https://github.com/Automattic/jetpack/assets/6760046/33e8c9dd-5016-4d5a-83e8-134aab69383e">

<img width="500" alt="Screenshot 2023-10-17 at 10 03 35" src="https://github.com/Automattic/jetpack/assets/6760046/bf7ea040-dffa-4858-932f-67d0da398164">