### PR TITLE
Facebook: update brand color

### DIFF
--- a/projects/plugins/jetpack/_inc/client/scss/variables/_colors.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/variables/_colors.scss
@@ -75,7 +75,7 @@ $sidebar-selected-color: $gray;
 $dashboard-number-border: #cbd7e1;
 
 //Social media colors
-$color-facebook: #1877f2;
+$color-facebook: #0866ff;
 $color-twitter: #55acee;
 $color-gplus: #df4a32;
 $color-tumblr: #35465c;

--- a/projects/plugins/jetpack/changelog/update-facebook-color-code
+++ b/projects/plugins/jetpack/changelog/update-facebook-color-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+General: update Facebook color code to match newer brand colors.

--- a/projects/plugins/jetpack/modules/sharedaddy/amp-sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/amp-sharing.css
@@ -55,7 +55,7 @@ amp-social-share[type='tumblr']::before {
 }
 
 amp-social-share[type='facebook'] {
-	background: #1877F2;
+	background: #0866ff;
 }
 
 amp-social-share[type='facebook']::before {

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -637,7 +637,7 @@ body .sd-social-icon .sd-content li.share-custom a span {
 }
 
 .sd-social-icon .sd-content ul li[class*='share-'].share-facebook a.sd-button {
-	background: #1877F2;
+	background: #0866ff;
 	color: #fff !important;
 }
 


### PR DESCRIPTION
## Proposed changes:

Update color to match newer brand guidelines:
https://about.meta.com/brand/resources/facebookapp/logo/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test here, you can compare the color code with the one used in the Facebook logo.
