### PR TITLE
Require that new projects have an initial change entry

### DIFF
--- a/tools/check-changelogger-use.php
+++ b/tools/check-changelogger-use.php
@@ -158,7 +158,7 @@ foreach ( glob( 'projects/*/*/composer.json' ) as $file ) {
 debug( 'Checking diff from %s...%s.', $base, $head );
 $pipes = null;
 $p     = proc_open(
-	sprintf( 'git -c core.quotepath=off diff --no-renames --name-only %s...%s', escapeshellarg( $base ), escapeshellarg( $head ) ),
+	sprintf( 'git -c core.quotepath=off diff --no-renames --name-status %s...%s', escapeshellarg( $base ), escapeshellarg( $head ) ),
 	array( array( 'pipe', 'r' ), array( 'pipe', 'w' ), STDERR ),
 	$pipes
 );
@@ -171,35 +171,40 @@ $ok_projects      = array();
 $touched_projects = array();
 // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 while ( ( $line = fgets( $pipes[1] ) ) ) {
-	$line  = trim( $line );
-	$parts = explode( '/', $line, 5 );
+	$line                  = trim( $line );
+	list( $status, $file ) = explode( "\t", $line, 2 );
+	$parts                 = explode( '/', $file, 5 );
 	if ( count( $parts ) < 4 || 'projects' !== $parts[0] ) {
-		debug( 'Ignoring non-project file %s.', $line );
+		debug( 'Ignoring non-project file %s.', $file );
 		continue;
 	}
 	$slug = "{$parts[1]}/{$parts[2]}";
 	if ( ! isset( $changelogger_projects[ $slug ] ) ) {
-		debug( 'Ignoring file %s, project %s does not use changelogger.', $line, $slug );
+		debug( 'Ignoring file %s, project %s does not use changelogger.', $file, $slug );
 		continue;
 	}
 	if ( $parts[3] === $changelogger_projects[ $slug ]['changelog'] ) {
-		debug( 'PR touches changelog file %s, marking %s as having a change file.', $line, $slug );
-		$ok_projects[ $slug ] = true;
-		continue;
+		if ( $status === 'A' ) {
+			debug( 'PR adds changelog file %s, this does not count as having a change file.', $file );
+		} else {
+			debug( 'PR touches changelog file %s, marking %s as having a change file.', $file, $slug );
+			$ok_projects[ $slug ] = true;
+			continue;
+		}
 	}
 	if ( $parts[3] === $changelogger_projects[ $slug ]['changes-dir'] ) {
 		if ( '.' === $parts[4][0] ) {
-			debug( 'Ignoring changes dir dotfile %s.', $line );
+			debug( 'Ignoring changes dir dotfile %s.', $file );
 		} else {
-			debug( 'PR touches file %s, marking %s as having a change file.', $line, $slug );
+			debug( 'PR touches file %s, marking %s as having a change file.', $file, $slug );
 			$ok_projects[ $slug ] = true;
 		}
 		continue;
 	}
 
-	debug( 'PR touches file %s, marking %s as touched.', $line, $slug );
+	debug( 'PR touches file %s, marking %s as touched.', $file, $slug );
 	if ( ! isset( $touched_projects[ $slug ] ) ) {
-		$touched_projects[ $slug ][] = $line;
+		$touched_projects[ $slug ][] = $file;
 	}
 }
 
@@ -231,8 +236,7 @@ fclose( $pipes[0] );
 $unmerged_projects = array();
 // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 while ( ( $line = fgets( $pipes[1] ) ) ) {
-	$line  = trim( $line );
-	$file  = substr( $line, 3 );
+	$file  = trim( substr( $line, 3 ) );
 	$parts = explode( '/', $file, 5 );
 	if ( count( $parts ) < 4 || 'projects' !== $parts[0] ) {
 		debug( 'Ignoring non-project file %s.', $file );

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -994,7 +994,13 @@ async function buildProject( t ) {
 	await once( rl, 'close' );
 
 	if ( ! projectVersionNumber ) {
-		throw new Error( `\nError fetching latest version number from ${ changelogFileName }\n` );
+		const dir = npath.relative(
+			process.cwd(),
+			npath.resolve( t.cwd, composerJson.extra?.changelogger?.[ 'changes-dir' ] || 'changelog' )
+		);
+		throw new Error(
+			`\nFailed to fetch latest version number from ${ changelogFileName }\n\nIf this is the initial commit of a new project, be sure there's a change entry in ${ dir }/\n`
+		);
 	}
 
 	if ( t.project.startsWith( 'packages/' ) && projectVersionNumber.endsWith( 'alpha' ) ) {

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -595,7 +595,7 @@ async function checkChangelogFiles() {
 
 	// Check for any existing changelog files.
 	for ( const file of touchedFiles ) {
-		const match = file.match( /^projects\/([^/]+\/[^/]+)\/changelog\// );
+		const match = file.match( /^projects\/([^/]+\/[^/]+)\/changelog\/[^.]/ );
 		if ( match ) {
 			changelogsAdded.add( match[ 1 ] );
 		}

--- a/tools/cli/skeletons/common/changelog/initial-version
+++ b/tools/cli/skeletons/common/changelog/initial-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Initial version.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`jetpack build` chokes if there is no changelog entry at all, which can happen on creation of a new project if that project doesn't contain an initial change entry file.

The fix for this is threefold:

* Have `jetpack generate` include an initial change entry.
* Have `tools/check-changelogger-use.php` not count the addition of CHANGELOG.md as having a change entry.
* Improve the error produced by `jetpack build` to indicate that an initial change entry file may be needed.

This also fixes two small bugs in related code:

* `tools/check-changelogger-use.php` was trimming the first path character of uncommitted files in some cases.
* `jetpack changelog add` was counting `.gitkeep` as a change entry file.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1697549556880869/1697547904.858059-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack generate` and follow the prompts. Verify that the new project's `changelog/` dir contains a change entry.
* `git add` and `git commit` the new project, then run `tools/check-changelogger-use.php trunk HEAD`. It should complete successfully with no error output.
* Remove the change entry from the `changelog/` dir in your new project and commit. Run `tools/check-changelogger-use.php trunk HEAD` again. It should fail with an error about the lack of a change entry in your new project.
* Run `jetpack changelog add`. It should prompt to add a change entry to your new project.