### PR TITLE
AI Extension: use registerBlockType filter to extend Jetpack Form / children block instances

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-change-filter-to-extened-children
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-change-filter-to-extened-children
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: use registerBlockType filter to extend Jetpack Form / children block instances

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -145,10 +145,12 @@ addFilter(
 );
 
 /**
- * Add the AI Assistant button to the toolbar.
- * This HOC should be used only for children blocks of the Jetpack Form block.
+ * HOC to populate the Jetpack Form children blocks edit components:
+ * - AI Assistant toolbar button.
+ *
+ * This HOC must be used only for children blocks of the Jetpack Form block.
  */
-const withAiToolbarButton = createHigherOrderComponent( BlockEdit => {
+const jetpackFormChildrenEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 	return props => {
 		// Get clientId of the parent block.
 		const parentClientId = useSelect(
@@ -182,9 +184,29 @@ const withAiToolbarButton = createHigherOrderComponent( BlockEdit => {
 			</>
 		);
 	};
-}, 'withAiToolbarButton' );
+}, 'jetpackFormChildrenEditWithAiComponents' );
 
-addFilter( 'editor.BlockEdit', 'jetpack/jetpack-form-block-edit', withAiToolbarButton );
+/*
+ * Extend children blocks of Jetpack Form block
+ * with the AI Assistant components.
+ */
+function jetpackFormChildrenEditWithAiSupport( settings, name ) {
+	// Only extend allowed blocks (Jetpack form and its children)
+	if ( ! JETPACK_FORM_CHILDREN_BLOCKS.includes( name ) ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		edit: jetpackFormChildrenEditWithAiComponents( settings.edit ),
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'jetpack/ai-assistant-support',
+	jetpackFormChildrenEditWithAiSupport
+);
 
 // Provide the UI Handler data context to the block.
 addFilter(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Aligned with the changes introduced by https://github.com/Automattic/jetpack/pull/33629, let's use the `registerBlockType` to extend the children block instances of the Jetpack block.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: use registerBlockType filter to extend Jetpack Form / children block instances

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

These changes should not change the feature:

* Create a Jetpack Form instance
* Ensure the form has children's blocks
* Confirm you see the AI Assistant button in the block toolbar

<img width="828" alt="Screenshot 2023-10-17 at 15 23 32" src="https://github.com/Automattic/jetpack/assets/77539/a18a3733-22d3-487a-87da-17e1ec9b5473">

* Confirm the primary Jetpack Form block instance is selected

<img width="827" alt="Screenshot 2023-10-17 at 15 24 11" src="https://github.com/Automattic/jetpack/assets/77539/f9146def-444b-43cb-b759-2622816ae35a">


* Confirm you can request changes using the AI Assistant bar, as usual.


