### PR TITLE
VideoPress: Improve attribute escaping

### DIFF
--- a/projects/packages/videopress/changelog/improve-vp-attribute-escaping
+++ b/projects/packages/videopress/changelog/improve-vp-attribute-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Escape VideoPress attributes

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.17.5",
+	"version": "0.17.6-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -237,7 +237,7 @@ class Initializer {
 
 		// Try to get the custom anchor from the block attributes.
 		if ( isset( $block_attributes['anchor'] ) && $block_attributes['anchor'] ) {
-			$id_attribute = sprintf( 'id="%s"', $block_attributes['anchor'] );
+			$id_attribute = sprintf( 'id="%s"', esc_attr( $block_attributes['anchor'] ) );
 		} elseif ( preg_match( '/<figure[^>]*id="([^"]+)"/', $content, $matches ) ) {
 			// Othwerwise, try to get the custom anchor from the <figure /> element.
 			$id_attribute = sprintf( 'id="%s"', $matches[1] );
@@ -266,9 +266,8 @@ class Initializer {
 			$inline_style = '';
 			if ( $poster ) {
 				$inline_style = sprintf(
-					'style="background-image: url(%s); background-size: cover;
-				background-position: center center;"',
-					$poster
+					'style="background-image: url(%s); background-size: cover; background-position: center center;"',
+					esc_attr( $poster )
 				);
 			}
 
@@ -309,6 +308,7 @@ class Initializer {
 			);
 		}
 
+		// $id_attribute, $video_wrapper, $figcaption properly escaped earlier on the code
 		return sprintf(
 			$figure_template,
 			esc_attr( $classes ),

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.17.5';
+	const PACKAGE_VERSION = '0.17.6-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 


### PR DESCRIPTION
Add escaping to attributes

## Proposed changes:
This PR addresses a couple of unescaped attributes. 

## Jetpack product discussion
p3btAN-2sq-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- On a site with the VideoPress block, go to the editor.
- Set the different attributes of the block, mainly an anchor and a poster.
- Verify that the VideoPress block still works as expected
- Verify no injection is possible