### PR TITLE
AI Extension: use registerBlockType to connect components with AI Data and UI Handler

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-propagate-data-via-different-filter
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-propagate-data-via-different-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: use registerBlockType to connect components with AI Data and UI Handler

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -142,6 +142,8 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
  *
  * - Populate the Jetpack Form edit component
  * with the AI Assistant bar and button (jetpackFormEditWithAiComponents).
+ * - Add the UI Handler data provider (withUiHandlerDataProvider).
+ * - Add the AI Assistant data provider (withAiDataProvider).
  *
  * @param {object} settings - The block settings.
  * @param {string} name     - The block name.
@@ -155,7 +157,9 @@ function jetpackFormWithAiSupport( settings, name: string ) {
 
 	return {
 		...settings,
-		edit: jetpackFormEditWithAiComponents( settings.edit ),
+		edit: withAiDataProvider(
+			withUiHandlerDataProvider( jetpackFormEditWithAiComponents( settings.edit ) )
+		),
 	};
 }
 
@@ -230,12 +234,3 @@ addFilter(
 	jetpackFormChildrenEditWithAiSupport
 );
 
-// Provide the UI Handler data context to the block.
-addFilter(
-	'editor.BlockListBlock',
-	'jetpack/ai-assistant-support',
-	withUiHandlerDataProvider,
-	100
-);
-
-addFilter( 'editor.BlockListBlock', 'jetpack/ai-assistant-block-list', withAiDataProvider, 110 );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -233,4 +233,3 @@ addFilter(
 	'jetpack/ai-assistant-support',
 	jetpackFormChildrenEditWithAiSupport
 );
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~Needs https://github.com/Automattic/jetpack/pull/33629 merged~

Continuing with the changes introduced by #33629, this PR connects the Jetpack Form edit component with the AI Data provider and the UI Handler using the same `registerBlockType` filter.
As mentioned in the previous PR, with these changes, the app will extend only the Jetpack Form block.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: use registerBlockType to connect components with AI Data and UI Handler #33638

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm the app works as usual

### Checking the extended blocks

* Go to the block
* Create a few generic blocks
* Create only one Jetpack Form block instance 
* Open the React dev tool
* Filter components by `withAiDataProvider `.
* Confirm you have as many instances of `withAiDataProvider ` as there are Jetpack Form instances in the post content


**Before (trunk)** 
There 18 instances of `withAiDataProvider `. Not good.

<img width="1728" alt="Screenshot 2023-10-17 at 16 13 59" src="https://github.com/Automattic/jetpack/assets/77539/cd61947c-920a-4778-913c-f401e62d5ebf">


**After (This PR)**
There is only one `withAiDataProvider ` instance because there is only Jetpack Form block instance 
<img width="1728" alt="Screenshot 2023-10-17 at 16 11 04" src="https://github.com/Automattic/jetpack/assets/77539/cdf6cc3c-e50c-4fae-bbc0-3b176bf64d68">



