### PR TITLE
Welcome message: sync welcome message between Jetpack & WPCOM

### DIFF
--- a/projects/plugins/jetpack/changelog/add-subscription-settings-sync
+++ b/projects/plugins/jetpack/changelog/add-subscription-settings-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add support for welcome message in subscription_options

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -813,7 +813,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						break;
 					}
 
-					$allowed_keys   = array( 'invitation', 'comment_follow' );
+					$allowed_keys   = array( 'invitation', 'comment_follow', 'welcome' );
 					$filtered_value = array_filter(
 						$value,
 						function ( $key ) use ( $allowed_keys ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -126,7 +126,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'show_on_front'                           => '(string) Whether homepage should display related posts or a static page. The expected value is \'posts\' or \'page\'.',
 			'page_on_front'                           => '(string) The page ID of the page to use as the site\'s homepage. It will apply only if \'show_on_front\' is set to \'page\'.',
 			'page_for_posts'                          => '(string) The page ID of the page to use as the site\'s posts page. It will apply only if \'show_on_front\' is set to \'page\'.',
-			'subscription_options'                    => '(array) Array of two options used in subscription email templates: \'invitation\' and \'comment_follow\' strings.',
+			'subscription_options'                    => '(array) Array of three options used in subscription email templates: \'invitation\', \'welcome\' and \'comment_follow\' strings.',
 		),
 
 		'response_format' => array(


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83080

## Proposed changes:
- This adds support for a new key called welcome to the subscription_options

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this PR to your JT site
2. Make sure you're sandboxed, and these two constants are defined in `wp-config.php` of your Docker container:

```
define( 'JETPACK__SANDBOX_DOMAIN', 'yoursandboxdomain' );
define( 'TESTING_IN_JETPACK', true );
```

3. Ensure `global-http` is enabled on your sandbox

### WordPress.com API to JT-site

When calling the API with a new welcome message, this should also be updated on the local Jetpack connected site, because we'll also display this message inside `wp-admin`.

- Use Paw or Postman to craft a POST request to `/rest/v1.4/sites/<yoursite>/settings` (the WP.com console doesn't take array/object values)
- Put the welcome key in the body:

```
{
  "subscription_options": {
    "welcome": "Updating the welcome message, right!"
  }
}
```
- Make sure to copy the Authorization & Cookie headers from the WordPress.com console
- Send the request, it should update the value
- Check the value on your JT-site using the method below (comment out line 9 of the plugin - so it doesn't overwrite the message 😄)

### JT-site to WPCOM
When updating the welcome message on the Jetpack connected site, the changes should also sync to WPCOM. This PR doesn't change anything regarding to that, since the `subscription_options` is already synced (see the replicastore on WPCOM). However, testing this once more doesn't hurt.

To test this, I created a small plugin that I placed inside `wp-content/plugins` of my docker container (`tools/docker/wordpress`) called `subscription-option-tester.php`:

```php
<?php
/*
Plugin Name: Subscription Option Tester
Description: Updates the 'welcome' key in the 'subscription_options' blog option on every request and outputs it as an HTML comment.
Version: 1.0
Author: Tim Broddin
*/

add_action('init', 'update_subscription_options');
// Hook into the 'wp_footer' action to output the value as an HTML comment
add_action('wp_footer', 'output_subscription_options');

function update_subscription_options() {
	// Retrieve the current 'subscription_options' option
	$subscription_options = get_option('subscription_options', array());

	// Update the 'welcome' key
	$formatted_time = date('F j, Y H:i:s');  // Format as "Month Day, Year Hour:Minute:Second"
	$subscription_options['welcome'] = 'This is the welcome message, the time is ' . $formatted_time;

	// Update the 'subscription_options' option with the modified array
	update_option('subscription_options', $subscription_options);
}

function output_subscription_options() {
	// Retrieve the current 'subscription_options' option
	$subscription_options = get_option('subscription_options', array());

	// Output the value
	echo "subscription options value = " . esc_html(json_encode($subscription_options));
}

```

- Enable this plugin through `wp-admin > Plugins`
- When visiting your site (frontend), this will update the setting and print the setting value in the bottom
- Visit your site
- On your sandbox use `wpsh` to retrieve the value saved on the replica: ` var_dump ( get_blog_option('<your JT site id>', 'subscription_options') );`
- This value should match the value outputted in the footer of your site

| WPCOM | Jurassic Tube |
|-|-|
| ![CleanShot 2023-10-17 at 17 13 06@2x](https://github.com/Automattic/jetpack/assets/528287/77058c04-6a30-4b4f-9f97-064d030356df) | ![CleanShot 2023-10-17 at 17 13 37@2x](https://github.com/Automattic/jetpack/assets/528287/b832aee0-5c1c-443c-90c0-2a7137126e2a) |

Note: there's a rate limit on how often this syncing is allowed by WPCOM.

Feel free to test this using any other method, ofcourse.
