### PR TITLE
Publicize: do not continuously watch over block changes

### DIFF
--- a/projects/plugins/jetpack/changelog/rm-twitter-tweetstorm-thread-listener
+++ b/projects/plugins/jetpack/changelog/rm-twitter-tweetstorm-thread-listener
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Block Editor: disable some of Twitter's Thread publishing tools since the feature is no longer accessible.

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -8,7 +8,6 @@
  * displays the Publicize UI there.
  */
 import {
-	TwitterThreadListener,
 	PublicizePanel,
 	useSocialMediaConnections,
 	usePublicizeConfig,
@@ -64,8 +63,6 @@ const PublicizeSettings = () => {
 
 	return (
 		<PostTypeSupportCheck supportKeys="publicize">
-			<TwitterThreadListener />
-
 			<JetpackPluginSidebar>
 				<PublicizePanel enableTweetStorm={ true }>
 					<UpsellNotice />


### PR DESCRIPTION
## Proposed changes:

Publicize to Twitter is no longer available, so we no longer need this feature loaded in the block editor. This should improve the block editor's performance.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related discussion: 8586-gh-jpop-issues

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test since the feature was removed from the interface a while ago.
* You should not see any JS errors in your browser console.
