### PR TITLE
Update WordPress tested version

### DIFF
--- a/projects/plugins/videopress/changelog/update-wp-tested-verions
+++ b/projects/plugins/videopress/changelog/update-wp-tested-verions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Bump WordPress tested version

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, retrofox, oskosk, thehenridev, renatoagds, lhkowalski,
 Tags: video, video-hosting, video-player, cdn, vimeo, youtube, video-streaming, mobile-video, jetpack
 
 Requires at least: 6.2
-Tested up to: 6.3
+Tested up to: 6.4
 Stable tag: 1.5
 Requires PHP: 5.6
 License: GPLv2 or later


### PR DESCRIPTION
Update VideoPress plugin readme.txt

## Proposed changes:
Set WordPress tested version to 6.4

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
No testing required, update is for .org release