### PR TITLE
[newsletters] retrieve subscriptions for self hosted

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-login-for-self-hosted
+++ b/projects/plugins/jetpack/changelog/add-newsletter-login-for-self-hosted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Allow users to retrieve subscriptions on self-hosted

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -364,6 +364,15 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	}
 
 	/**
+	 * Check whether the JWT_TOKEN cookie is set
+	 *
+	 * @return bool
+	 */
+	public static function has_token_from_cookie() {
+		return isset( $_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] ) && ! empty( $_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] );
+	}
+
+	/**
 	 * Store the auth cookie.
 	 *
 	 * @param  string $token Auth token.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1079,14 +1079,14 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		$id           = '';
 		$sign_in_link = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
 		$button_text  = esc_html__( 'Log in', 'jetpack' );
-	} elseif ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
+	} elseif ( class_exists( 'Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Jetpack_Token_Subscription_Service' ) &&
 		! $host->is_wpcom_simple() ) {
 		// We are on Jetpack and no cookie is set
 		$id              = 'jp_retrieve_subscriptions_link';
 		$sign_in_link    = '#'; // listening to "click" event in view.js
 		$access_question = __( 'I am already subscribed.', 'jetpack' );
 		if ( ! Jetpack_Token_Subscription_Service::has_token_from_cookie() ) {
-			$button_text = esc_html__( 'Retrieve subscriptions', 'jetpack' );
+			$button_text = esc_html__( 'Log in', 'jetpack' );
 		} else {
 			$button_text = esc_html__( 'Switch accounts', 'jetpack' );
 		}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1076,15 +1076,17 @@ function get_paywall_blocks( $newsletter_access_level ) {
 	$sign_in             = '';
 	$show_button_sign_in = false;
 	$host                = new Host();
-	if ( ! is_user_logged_in() && $host->is_wpcom_simple() ) {
+	if ( false && ( ! is_user_logged_in() && $host->is_wpcom_simple() ) ) {
+		$id                  = '';
 		$show_button_sign_in = true;
 		$sign_in_link        = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
 		$button_text         = esc_html__( 'Log in', 'jetpack' );
-	} elseif ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
-		! $host->is_wpcom_platform() ) {
+	} elseif ( true || ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
+		! $host->is_wpcom_platform() ) ) {
 		// We are on Jetpack and no cookie is set
 		$show_button_sign_in = true;
-		$sign_in_link        = '';
+		$id                  = 'retrieve_subscriptions_link';
+		$sign_in_link        = 'javascript:show_iframe_retrieve_subscriptions_from_email()';
 		$access_question     = __( 'I am already subscribed.', 'jetpack' );
 		if ( ! Jetpack_Token_Subscription_Service::has_token_from_cookie() ) {
 			$button_text = esc_html__( 'Retrieve subscriptions', 'jetpack' );
@@ -1095,7 +1097,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 
 	if ( $show_button_sign_in ) {
 		$sign_in = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->
-<p class="has-text-align-center" style="font-size:14px">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '">' . $button_text . '</a></p>
+<p class="has-text-align-center" style="font-size:14px">' . esc_html( $access_question ) . ' <a id="' . $id . '" href="' . $sign_in_link . '">' . $button_text . '</a></p>
 <!-- /wp:paragraph -->';
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1073,12 +1073,29 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		? __( 'Already a paid subscriber?', 'jetpack' )
 		: __( 'Already a subscriber?', 'jetpack' );
 
-	$sign_in = '';
-	if ( ! is_user_logged_in() && ( new Host() )->is_wpcom_simple() ) {
-		$sign_in_link = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
+	$sign_in             = '';
+	$show_button_sign_in = false;
+	$host                = new Host();
+	if ( ! is_user_logged_in() && $host->is_wpcom_simple() ) {
+		$show_button_sign_in = true;
+		$sign_in_link        = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
+		$button_text         = esc_html__( 'Log in', 'jetpack' );
+	} elseif ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
+		! $host->is_wpcom_platform() ) {
+		// We are on Jetpack and no cookie is set
+		$show_button_sign_in = true;
+		$sign_in_link        = '';
+		$access_question     = __( 'I am already subscribed.', 'jetpack' );
+		if ( ! Jetpack_Token_Subscription_Service::has_token_from_cookie() ) {
+			$button_text = esc_html__( 'Retrieve subscriptions', 'jetpack' );
+		} else {
+			$button_text = esc_html__( 'Change user ', 'jetpack' );
+		}
+	}
 
+	if ( $show_button_sign_in ) {
 		$sign_in = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->
-<p class="has-text-align-center" style="font-size:14px">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '">' . esc_html__( 'Log in', 'jetpack' ) . '</a></p>
+<p class="has-text-align-center" style="font-size:14px">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '">' . $button_text . '</a></p>
 <!-- /wp:paragraph -->';
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1076,12 +1076,12 @@ function get_paywall_blocks( $newsletter_access_level ) {
 	$sign_in             = '';
 	$show_button_sign_in = false;
 	$host                = new Host();
-//	if ( ! is_user_logged_in() && $host->is_wpcom_simple() ) {
-//		$show_button_sign_in = true;
-//		$sign_in_link        = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
-//		$button_text         = esc_html__( 'Log in', 'jetpack' );
-//	} elseif ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
-//		! $host->is_wpcom_platform() ) {
+	if ( ! is_user_logged_in() && $host->is_wpcom_simple() ) {
+		$show_button_sign_in = true;
+		$sign_in_link        = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
+		$button_text         = esc_html__( 'Log in', 'jetpack' );
+	} elseif ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
+		! $host->is_wpcom_platform() ) {
 		// We are on Jetpack and no cookie is set
 		$show_button_sign_in = true;
 		$sign_in_link        = '';
@@ -1091,7 +1091,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		} else {
 			$button_text = esc_html__( 'Change user ', 'jetpack' );
 		}
-//	}
+	}
 
 	if ( $show_button_sign_in ) {
 		$sign_in = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1073,29 +1073,26 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		? __( 'Already a paid subscriber?', 'jetpack' )
 		: __( 'Already a subscriber?', 'jetpack' );
 
-	$sign_in             = '';
-	$show_button_sign_in = false;
-	$host                = new Host();
+	$sign_in = '';
+	$host    = new Host();
 	if ( ! is_user_logged_in() && $host->is_wpcom_simple() ) {
-		$id                  = '';
-		$show_button_sign_in = true;
-		$sign_in_link        = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
-		$button_text         = esc_html__( 'Log in', 'jetpack' );
+		$id           = '';
+		$sign_in_link = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
+		$button_text  = esc_html__( 'Log in', 'jetpack' );
 	} elseif ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
-		! $host->is_wpcom_platform() ) {
+		! $host->is_wpcom_simple() ) {
 		// We are on Jetpack and no cookie is set
-		$show_button_sign_in = true;
-		$id                  = 'retrieve_subscriptions_link';
-		$sign_in_link        = 'javascript:show_iframe_retrieve_subscriptions_from_email()';
-		$access_question     = __( 'I am already subscribed.', 'jetpack' );
+		$id              = 'jp_retrieve_subscriptions_link';
+		$sign_in_link    = '#'; // listening to "click" event in view.js
+		$access_question = __( 'I am already subscribed.', 'jetpack' );
 		if ( ! Jetpack_Token_Subscription_Service::has_token_from_cookie() ) {
 			$button_text = esc_html__( 'Retrieve subscriptions', 'jetpack' );
 		} else {
-			$button_text = esc_html__( 'Change user ', 'jetpack' );
+			$button_text = esc_html__( 'Switch accounts', 'jetpack' );
 		}
 	}
 
-	if ( $show_button_sign_in ) {
+	if ( ! empty( $sign_in_link ) ) {
 		$sign_in = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->
 <p class="has-text-align-center" style="font-size:14px">' . esc_html( $access_question ) . ' <a id="' . $id . '" href="' . $sign_in_link . '">' . $button_text . '</a></p>
 <!-- /wp:paragraph -->';

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1076,12 +1076,12 @@ function get_paywall_blocks( $newsletter_access_level ) {
 	$sign_in             = '';
 	$show_button_sign_in = false;
 	$host                = new Host();
-	if ( ! is_user_logged_in() && $host->is_wpcom_simple() ) {
-		$show_button_sign_in = true;
-		$sign_in_link        = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
-		$button_text         = esc_html__( 'Log in', 'jetpack' );
-	} elseif ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
-		! $host->is_wpcom_platform() ) {
+//	if ( ! is_user_logged_in() && $host->is_wpcom_simple() ) {
+//		$show_button_sign_in = true;
+//		$sign_in_link        = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
+//		$button_text         = esc_html__( 'Log in', 'jetpack' );
+//	} elseif ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
+//		! $host->is_wpcom_platform() ) {
 		// We are on Jetpack and no cookie is set
 		$show_button_sign_in = true;
 		$sign_in_link        = '';
@@ -1091,7 +1091,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		} else {
 			$button_text = esc_html__( 'Change user ', 'jetpack' );
 		}
-	}
+//	}
 
 	if ( $show_button_sign_in ) {
 		$sign_in = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1076,13 +1076,13 @@ function get_paywall_blocks( $newsletter_access_level ) {
 	$sign_in             = '';
 	$show_button_sign_in = false;
 	$host                = new Host();
-	if ( false && ( ! is_user_logged_in() && $host->is_wpcom_simple() ) ) {
+	if ( ! is_user_logged_in() && $host->is_wpcom_simple() ) {
 		$id                  = '';
 		$show_button_sign_in = true;
 		$sign_in_link        = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
 		$button_text         = esc_html__( 'Log in', 'jetpack' );
-	} elseif ( true || ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
-		! $host->is_wpcom_platform() ) ) {
+	} elseif ( class_exists( 'Automattic\Jetpack\Connection\Tokens\Jetpack_Token_Subscription_Service' ) &&
+		! $host->is_wpcom_platform() ) {
 		// We are on Jetpack and no cookie is set
 		$show_button_sign_in = true;
 		$id                  = 'retrieve_subscriptions_link';

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -40,7 +40,7 @@ function show_iframe( data ) {
 }
 
 domReady( function () {
-	const link = document.querySelector( '#retrieve_subscriptions_link' );
+	const link = document.querySelector( '#jp_retrieve_subscriptions_link' );
 	if ( link ) {
 		link.addEventListener( 'click', function ( event ) {
 			event.preventDefault();

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -6,7 +6,48 @@ import '../../shared/memberships.scss';
 import domReady from '@wordpress/dom-ready';
 import { handleIframeResult } from '../../../extensions/shared/memberships';
 
+// @ts-ignore
+function show_iframe_retrieve_subscriptions_from_email() {
+	const form = document.querySelector( '.wp-block-jetpack-subscriptions__container form' );
+	if ( ! form ) {
+		return;
+	}
+	const email = form.querySelector( 'input[type=email]' ).value;
+	show_iframe( {
+		email,
+		blog: form.dataset.blog,
+		plan: 'newsletter',
+		source: 'jetpack_retrieve_subscriptions',
+		post_access_level: form.dataset.post_access_level,
+		display: 'alternate',
+	} );
+}
+
+function show_iframe( data ) {
+	const params = new URLSearchParams( data );
+
+	const url = 'https://subscribe.wordpress.com/memberships/?' + params.toString();
+
+	window.scrollTo( 0, 0 );
+	tb_show( null, url + '&TB_iframe=true', null );
+
+	window.addEventListener( 'message', handleIframeResult, false );
+	const tbWindow = document.querySelector( '#TB_window' );
+	tbWindow.classList.add( 'jetpack-memberships-modal' );
+
+	// This line has to come after the Thickbox has opened otherwise Firefox doesnt scroll to the top.
+	window.scrollTo( 0, 0 );
+}
+
 domReady( function () {
+	const link = document.querySelector( '#retrieve_subscriptions_link' );
+	if ( link ) {
+		link.addEventListener( 'click', function ( event ) {
+			event.preventDefault();
+			show_iframe_retrieve_subscriptions_from_email();
+		} );
+	}
+
 	const form = document.querySelector( '.wp-block-jetpack-subscriptions__container form' );
 	if ( ! form ) {
 		return;
@@ -25,7 +66,7 @@ domReady( function () {
 			const post_id = form.querySelector( 'input[name=post_id]' )?.value ?? '';
 			const tier_id = form.querySelector( 'input[name=tier_id]' )?.value ?? '';
 
-			const params = new URLSearchParams( {
+			show_iframe( {
 				email,
 				post_id,
 				tier_id,
@@ -35,18 +76,6 @@ domReady( function () {
 				post_access_level: form.dataset.post_access_level,
 				display: 'alternate',
 			} );
-
-			const url = 'https://subscribe.wordpress.com/memberships/?' + params.toString();
-
-			window.scrollTo( 0, 0 );
-			tb_show( null, url + '&TB_iframe=true', null );
-
-			window.addEventListener( 'message', handleIframeResult, false );
-			const tbWindow = document.querySelector( '#TB_window' );
-			tbWindow.classList.add( 'jetpack-memberships-modal' );
-
-			// This line has to come after the Thickbox has opened otherwise Firefox doesnt scroll to the top.
-			window.scrollTo( 0, 0 );
 		} );
 	}
 } );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -4,7 +4,7 @@ import './view.scss';
 import '../../shared/memberships.scss';
 
 import domReady from '@wordpress/dom-ready';
-import { handleIframeResult } from '../../../extensions/shared/memberships';
+import { handleIframeResult } from '../../shared/memberships';
 
 // @ts-ignore
 function show_iframe_retrieve_subscriptions_from_email() {
@@ -12,7 +12,14 @@ function show_iframe_retrieve_subscriptions_from_email() {
 	if ( ! form ) {
 		return;
 	}
+
+	if ( ! form.checkValidity() ) {
+		form.reportValidity();
+		return;
+	}
+
 	const email = form.querySelector( 'input[type=email]' ).value;
+
 	show_iframe( {
 		email,
 		blog: form.dataset.blog,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/171
Fixes https://github.com/Automattic/gold/issues/164

Needs D125802-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allow mail-login so subscriptions are retrieved via email code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a JN instance
* Connect JP
* Link JETPACK__SANDBOX_DOMAIN to your sandbox (don't forget `sudo global-http enable`)	
* Enable Earn (Stripe, add a plan)
* Patch D125802-code on your sandbox
* Sandbox subscribe.wordpress.com
* Create a post with paid-subscribers access
* Log using the "login" link
  
<img width="1299" alt="Screenshot 2023-10-19 at 11 57 24" src="https://github.com/Automattic/jetpack/assets/790558/5259a59c-6780-42b2-a08e-b06b405f1fb5">
