### PR TITLE
Prerelease

### DIFF
--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.30] - 2023-10-17
+### Changed
+- Updated package dependencies. [#33646]
+
 ## [1.0.29] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]
@@ -139,6 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 - Replace missing domains too.
 
+[1.0.30]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.29...v1.0.30
 [1.0.29]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.28...v1.0.29
 [1.0.28]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.27...v1.0.28
 [1.0.27]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.26...v1.0.27

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.0.30-alpha",
+	"version": "1.0.30",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/babel-plugin-replace-textdomain/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.43.4] - 2023-10-17
+### Changed
+- Updated package dependencies. [#33646]
+
 ## [0.43.3] - 2023-10-16
 ### Changed
 - Replaced inline social icons with social-logos package. [#33613]
@@ -844,6 +848,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.43.4]: https://github.com/Automattic/jetpack-components/compare/0.43.3...0.43.4
 [0.43.3]: https://github.com/Automattic/jetpack-components/compare/0.43.2...0.43.3
 [0.43.2]: https://github.com/Automattic/jetpack-components/compare/0.43.1...0.43.2
 [0.43.1]: https://github.com/Automattic/jetpack-components/compare/0.43.0...0.43.1

--- a/projects/js-packages/components/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/components/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.43.4-alpha",
+	"version": "0.43.4",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.30.3] - 2023-10-17
+### Changed
+- Updated package dependencies. [#33646]
+
 ## [0.30.2] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429, #33584]
@@ -640,6 +644,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.30.3]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.2...v0.30.3
 [0.30.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.1...v0.30.2
 [0.30.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.29.10...v0.30.0

--- a/projects/js-packages/connection/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.30.3-alpha",
+	"version": "0.30.3",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2023-10-17
+### Changed
+- Updated package dependencies. [#33646]
+
 ## [1.1.1] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]
@@ -180,6 +184,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.1.2]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.36...v1.1.0
 [1.0.36]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.35...v1.0.36

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.1.2-alpha",
+	"version": "1.1.2",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-check-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.49 - 2023-10-17
+### Changed
+- Updated package dependencies. [#33646]
+
 ## 0.10.48 - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]

--- a/projects/js-packages/idc/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.49-alpha",
+	"version": "0.10.49",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.9 - 2023-10-17
+### Changed
+- Updated package dependencies. [#33646]
+
 ## 0.11.8 - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]

--- a/projects/js-packages/licensing/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.11.9-alpha",
+	"version": "0.11.9",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.3] - 2023-10-17
+### Changed
+- Updated package dependencies. [#33646]
+
 ## [0.12.2] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]
@@ -264,6 +268,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.12.3]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.12.2...0.12.3
 [0.12.2]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.12.1...0.12.2
 [0.12.1]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.12.0...0.12.1
 [0.12.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.11.5...0.12.0

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.12.3-alpha",
+	"version": "0.12.3",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.3 - 2023-10-17
+### Changed
+- Updated package dependencies. [#33646]
+
 ## 2.0.2 - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429, #33600]

--- a/projects/js-packages/webpack-config/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "2.0.3-alpha",
+	"version": "2.0.3",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2023-10-17
+### Changed
+- Updated package dependencies. [#33646]
+
+### Fixed
+- Added search and replace protection for wpcom urls stored in the database. [#33412]
+
 ## [0.10.7] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]
@@ -421,6 +428,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.11.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.7...v0.11.0
 [0.10.7]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.6...v0.10.7
 [0.10.6]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.5...v0.10.6
 [0.10.5]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.4...v0.10.5

--- a/projects/packages/identity-crisis/changelog/fix-idc-search-replace-protection
+++ b/projects/packages/identity-crisis/changelog/fix-idc-search-replace-protection
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Added search and replace protection for wpcom urls stored in the database.

--- a/projects/packages/identity-crisis/changelog/renovate-babel-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.11.0-alpha",
+	"version": "0.11.0",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.11.0-alpha';
+	const PACKAGE_VERSION = '0.11.0';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.0] - 2023-10-17
+### Added
+- Add has_required_plan method for VideoPress product class, check plan purchase exists for site [#33410]
+
+### Changed
+- Updated package dependencies. [#33646]
+
 ## [3.8.2] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429, #33584]
@@ -1057,6 +1064,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[3.9.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.8.2...3.9.0
 [3.8.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.8.1...3.8.2
 [3.8.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.8.0...3.8.1
 [3.8.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.7.0...3.8.0

--- a/projects/packages/my-jetpack/changelog/fix-videopress-upgrade-path
+++ b/projects/packages/my-jetpack/changelog/fix-videopress-upgrade-path
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add has_required_plan method for VideoPress product class, check plan purchase exists for site

--- a/projects/packages/my-jetpack/changelog/renovate-babel-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.9.0-alpha",
+	"version": "3.9.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.9.0-alpha';
+	const PACKAGE_VERSION = '3.9.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.1] - 2023-10-18
+### Fixed
+- Update dependencies.
+
 ## [1.58.0] - 2023-10-16
 ### Changed
 - Migrated 'jetpack_sync_before_send*' actions for Sync queue to 'jetpack_sync_before_enqueue' instead. [#33384]
@@ -942,6 +946,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.58.1]: https://github.com/Automattic/jetpack-sync/compare/v1.58.0...v1.58.1
 [1.58.0]: https://github.com/Automattic/jetpack-sync/compare/v1.57.4...v1.58.0
 [1.57.4]: https://github.com/Automattic/jetpack-sync/compare/v1.57.3...v1.57.4
 [1.57.3]: https://github.com/Automattic/jetpack-sync/compare/v1.57.2...v1.57.3

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.58.0';
+	const PACKAGE_VERSION = '1.58.1';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.6] - 2023-10-17
+### Security
+- Escape VideoPress attributes [#33637]
+
+### Changed
+- Updated package dependencies. [#33646]
+
 ## [0.17.5] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429, #33584]
@@ -1141,6 +1148,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.17.6]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.5...v0.17.6
 [0.17.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.4...v0.17.5
 [0.17.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.3...v0.17.4
 [0.17.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.2...v0.17.3

--- a/projects/packages/videopress/changelog/improve-vp-attribute-escaping
+++ b/projects/packages/videopress/changelog/improve-vp-attribute-escaping
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Escape VideoPress attributes

--- a/projects/packages/videopress/changelog/renovate-babel-monorepo
+++ b/projects/packages/videopress/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.17.6-alpha",
+	"version": "0.17.6",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.17.6-alpha';
+	const PACKAGE_VERSION = '0.17.6';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/videopress/CHANGELOG.md
+++ b/projects/plugins/videopress/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Indicate full compatibility with WordPress 6.3
 - Updated WordPress version requirement to WordPress 6.2
 - Made the Jetpack menu item default to point to My Jetpack.
-- Hide core Video and embed VideOpress variations, when video block is available.
+- Hide core Video and embed VideoPress variations, when video block is available.
 - Improved the connection prompt when the Jetpack VideoPress module is not active.
 - Changed max duration of the Preview On Hover effect to ten seconds.
 - Support autoplay playback option when Preview On Hover is enabled.

--- a/projects/plugins/videopress/CHANGELOG.md
+++ b/projects/plugins/videopress/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 1.6-beta - 2023-10-17
+### Added
+
+- Added Divi Builder Compatibility.
+- Added play button when the video block Show controls and Preview On Hover are enabled.
+- Pick video block attributes from URL when pasting/inserting.
+- Integrated video poster with Preview On Hover effect.
+
+
+### Changed
+- Indicate full compatibility with WordPress 6.3
+- Updated WordPress version requirement to WordPress 6.2
+- Made the Jetpack menu item default to point to My Jetpack.
+- Hide core Video and embed VideOpress variations, when video block is available.
+- Improved the connection prompt when the Jetpack VideoPress module is not active.
+- Changed max duration of the Preview On Hover effect to ten seconds.
+- Support autoplay playback option when Preview On Hover is enabled.
+- Render VideoPress video block 100% dynamically instead of saving html representation.
+- Video block: Create VideoPress video block when pasting URLs.
+- Video block: Stopped saving HTML markup representation.
+- Video block: Added Privacy and Rating panel to native block's settings.
+- Video block: Added replace functionality for the native version of the block.
+- Video block: Handle uploading video files when dropping in the editor canvas.
+
+### Security
+
+- Escape VideoPress attributes poster, and anchor when rendering block.
+
+### Fixed
+
+- Added a Notice when trying to edit a video that doesn't belong to the site.
+- Added error handling for track files upload process.
+- Handle block registration in the REST API request context.
+- Defer assets enqueuing for non block themes so they don't load on every page.
+- Enqueue token bridge file in the front-end only when required.
+- Ensure the appropriate scripts are enqueued to support private VideoPress videos rendered by the VideoPress Divi module.
+- Set video player position according to "starting point" and "duration".
+- Avoid conflicts with Better Click To Tweet plugin.
+- Fixed compatibility with Timber theme.
+- Fixed false values not working on shortcodes.
+- Fixed issue with disabled Privacy and rating panel.
+- Fixed JITM layout on video edit page.
+- Fixed playing state of poster mini-player.
+- Fixed playback of private videos on private sites.
+- Video block: Fixed blocking state when stopping an upload.
+
 ## 1.5 - 2023-03-22
 ### Added
 - Added request and update video poster functionality

--- a/projects/plugins/videopress/changelog/Update readme.txt and assets
+++ b/projects/plugins/videopress/changelog/Update readme.txt and assets
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated changes to reflect updates that are already live on the dotorg plugin repo
-
-

--- a/projects/plugins/videopress/changelog/add-golden-token-experience
+++ b/projects/plugins/videopress/changelog/add-golden-token-experience
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-idc-generate-secret-endpoint
+++ b/projects/plugins/videopress/changelog/add-idc-generate-secret-endpoint
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-idc-generate-secret-endpoint#2
+++ b/projects/plugins/videopress/changelog/add-idc-generate-secret-endpoint#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-include-stats-module-on-videopress-plugin
+++ b/projects/plugins/videopress/changelog/add-include-stats-module-on-videopress-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: Added Stats module as a requirement for the plugin and enabled it on plugin activation.

--- a/projects/plugins/videopress/changelog/add-integrate-ip-package
+++ b/projects/plugins/videopress/changelog/add-integrate-ip-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-jetpack-ai-yearly
+++ b/projects/plugins/videopress/changelog/add-jetpack-ai-yearly
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/videopress/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-

--- a/projects/plugins/videopress/changelog/add-jetpack-sync-custom-table-initialization-and-migration
+++ b/projects/plugins/videopress/changelog/add-jetpack-sync-custom-table-initialization-and-migration
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-jetpack-sync-custom-table-switching-logic-and-error-handling
+++ b/projects/plugins/videopress/changelog/add-jetpack-sync-custom-table-switching-logic-and-error-handling
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-license-key-activation-link
+++ b/projects/plugins/videopress/changelog/add-license-key-activation-link
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-loaded-extensions-sync-callable
+++ b/projects/plugins/videopress/changelog/add-loaded-extensions-sync-callable
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-make-earn-products-free-for-all
+++ b/projects/plugins/videopress/changelog/add-make-earn-products-free-for-all
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-my-jetpack-idc
+++ b/projects/plugins/videopress/changelog/add-my-jetpack-idc
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-my-jetpack-product-detail-table
+++ b/projects/plugins/videopress/changelog/add-my-jetpack-product-detail-table
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-my-jetpack-stats-section
+++ b/projects/plugins/videopress/changelog/add-my-jetpack-stats-section
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-offline-mode-standalone-plugins
+++ b/projects/plugins/videopress/changelog/add-offline-mode-standalone-plugins
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-package-suggestions
+++ b/projects/plugins/videopress/changelog/add-package-suggestions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-package-suggestions#2
+++ b/projects/plugins/videopress/changelog/add-package-suggestions#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-private-network-connection
+++ b/projects/plugins/videopress/changelog/add-private-network-connection
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-restore-connection-owner
+++ b/projects/plugins/videopress/changelog/add-restore-connection-owner
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-stats-product-my-jetpack
+++ b/projects/plugins/videopress/changelog/add-stats-product-my-jetpack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-subscriber-modal
+++ b/projects/plugins/videopress/changelog/add-subscriber-modal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-sync-auto-conversion
+++ b/projects/plugins/videopress/changelog/add-sync-auto-conversion
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-sync-custom-queua-table-flag
+++ b/projects/plugins/videopress/changelog/add-sync-custom-queua-table-flag
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-sync-custom-queua-table-flag#2
+++ b/projects/plugins/videopress/changelog/add-sync-custom-queua-table-flag#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-token-lock-aiowpm
+++ b/projects/plugins/videopress/changelog/add-token-lock-aiowpm
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-videopress-divi
+++ b/projects/plugins/videopress/changelog/add-videopress-divi
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-videopress-divi#2
+++ b/projects/plugins/videopress/changelog/add-videopress-divi#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-w.org-assets
+++ b/projects/plugins/videopress/changelog/add-w.org-assets
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Only adding w.org assets that already exist.
-
-

--- a/projects/plugins/videopress/changelog/add-yoast-promo-prepublish-panel
+++ b/projects/plugins/videopress/changelog/add-yoast-promo-prepublish-panel
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-zendesk-chat-authentication
+++ b/projects/plugins/videopress/changelog/add-zendesk-chat-authentication
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Updated composer.lock

--- a/projects/plugins/videopress/changelog/backport-cherry-pick-12.1-beta
+++ b/projects/plugins/videopress/changelog/backport-cherry-pick-12.1-beta
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/change-videopress-block-registration-check
+++ b/projects/plugins/videopress/changelog/change-videopress-block-registration-check
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/videopress/changelog/earn-remove-connected-account-id-option
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/feat-rest-api-jetpack-block
+++ b/projects/plugins/videopress/changelog/feat-rest-api-jetpack-block
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/videopress/changelog/fix-akismet-upgrade-screen
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/fix-autoloader-self-version
+++ b/projects/plugins/videopress/changelog/fix-autoloader-self-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/videopress/changelog/fix-connection-initial-state-render-repeat
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/fix-disconnect-wpcom-offline-mode
+++ b/projects/plugins/videopress/changelog/fix-disconnect-wpcom-offline-mode
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/fix-do-not-force-enable-stats-on-videopress
+++ b/projects/plugins/videopress/changelog/fix-do-not-force-enable-stats-on-videopress
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: Do not force-enable the Stats module inside the VideoPress plugin.

--- a/projects/plugins/videopress/changelog/fix-idc-search-replace-protection
+++ b/projects/plugins/videopress/changelog/fix-idc-search-replace-protection
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/fix-jetpack-icon-menu-bar
+++ b/projects/plugins/videopress/changelog/fix-jetpack-icon-menu-bar
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/plugins/videopress/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/fix-non-semver-plugins-changelog-claiming-semver
+++ b/projects/plugins/videopress/changelog/fix-non-semver-plugins-changelog-claiming-semver
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Remove mention of semver from changelog header, this plugin does not use semver.
-
-

--- a/projects/plugins/videopress/changelog/fix-staging-calypso-domains-js
+++ b/projects/plugins/videopress/changelog/fix-staging-calypso-domains-js
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/videopress/changelog/fix-videopress-upgrade-path
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/jitm-redirection-after-activate-click
+++ b/projects/plugins/videopress/changelog/jitm-redirection-after-activate-click
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/jitm-redirection-after-activate-click#2
+++ b/projects/plugins/videopress/changelog/jitm-redirection-after-activate-click#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/monthly-branch-2023-04-25
+++ b/projects/plugins/videopress/changelog/monthly-branch-2023-04-25
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/prerelease
+++ b/projects/plugins/videopress/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/prerelease#2
+++ b/projects/plugins/videopress/changelog/prerelease#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/remove-pm2
+++ b/projects/plugins/videopress/changelog/remove-pm2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unused e2e `pnpm tunnel:write-logs` command.
-
-

--- a/projects/plugins/videopress/changelog/remove-unused-js-deps
+++ b/projects/plugins/videopress/changelog/remove-unused-js-deps
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unused JS deps. No change to the project itself.
-
-

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo#2
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo#3
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo#4
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo#5
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo#6
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo#7
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-eslint-packages
+++ b/projects/plugins/videopress/changelog/renovate-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Fix/ignore new playwright lints. No change to the plugin itself.
-
-

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#4
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#5
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#6
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#7
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#8
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#9
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#9
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/renovate-sass-1.x
+++ b/projects/plugins/videopress/changelog/renovate-sass-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-storybook-monorepo
+++ b/projects/plugins/videopress/changelog/renovate-storybook-monorepo
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unnecessary `.npmrc`.
-
-

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#4
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#5
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#6
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#7
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#8
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#9
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/plugins/videopress/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/revert-d5ca47d8de
+++ b/projects/plugins/videopress/changelog/revert-d5ca47d8de
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-blocks-metadata-icon
+++ b/projects/plugins/videopress/changelog/update-blocks-metadata-icon
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/videopress/changelog/update-jetpack-module-tags-i18n
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-jitm-tracking-props
+++ b/projects/plugins/videopress/changelog/update-jitm-tracking-props
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-my-jetpack-zendesk-chat-show-conditionally-with-api
+++ b/projects/plugins/videopress/changelog/update-my-jetpack-zendesk-chat-show-conditionally-with-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Remove conditional rendering from zendesk chat widget component due to it being handled by an api endpoint now

--- a/projects/plugins/videopress/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/plugins/videopress/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-pnpm-8
+++ b/projects/plugins/videopress/changelog/update-pnpm-8
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unneeded "engines" in e2e package.json files.
-
-

--- a/projects/plugins/videopress/changelog/update-sync-drop-table-on-disconnection
+++ b/projects/plugins/videopress/changelog/update-sync-drop-table-on-disconnection
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-sync-migrate-before-send-to-before-enqueue
+++ b/projects/plugins/videopress/changelog/update-sync-migrate-before-send-to-before-enqueue
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-tested-up-to-63
+++ b/projects/plugins/videopress/changelog/update-tested-up-to-63
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: indicate full compatibility with the latest version of WordPress, 6.3.

--- a/projects/plugins/videopress/changelog/update-use-assets-enqueue-stats
+++ b/projects/plugins/videopress/changelog/update-use-assets-enqueue-stats
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-videopress-stable-tag
+++ b/projects/plugins/videopress/changelog/update-videopress-stable-tag
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated stable tag
-
-

--- a/projects/plugins/videopress/changelog/update-wp-requirements
+++ b/projects/plugins/videopress/changelog/update-wp-requirements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update WordPress version requirements. Now requires version 6.1.

--- a/projects/plugins/videopress/changelog/update-wp-requirements-62
+++ b/projects/plugins/videopress/changelog/update-wp-requirements-62
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: update WordPress version requirements to WordPress 6.2.

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -59,6 +59,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_6_beta"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_7_alpha"
 	}
 }

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -59,6 +59,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_6_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_6_beta"
 	}
 }

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VideoPress
  * Plugin URI: https://wordpress.org/plugins/jetpack-videopress
  * Description: High quality, ad-free video.
- * Version: 1.6-beta
+ * Version: 1.7-alpha
  * Author: Automattic - Jetpack Video team
  * Author URI: https://jetpack.com/videopress/
  * License: GPLv2 or later

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VideoPress
  * Plugin URI: https://wordpress.org/plugins/jetpack-videopress
  * Description: High quality, ad-free video.
- * Version: 1.6-alpha
+ * Version: 1.6-beta
  * Author: Automattic - Jetpack Video team
  * Author URI: https://jetpack.com/videopress/
  * License: GPLv2 or later


### PR DESCRIPTION
Merge `prerelease` branch back into trunk

Fixes https://github.com/Automattic/videopress/issues/1001


## Proposed changes:
This is the last step on the standalone plugin release process

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1697564420947809-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD