### PR TITLE
Fix stuff wpcom's rector is complaining about

### DIFF
--- a/projects/packages/blaze/changelog/fix-wpcom-rector-complaints
+++ b/projects/packages/blaze/changelog/fix-wpcom-rector-complaints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix unsetting `'sub_path'` in `Dashboard_REST_Controller`.

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -296,8 +296,8 @@ class Dashboard_REST_Controller {
 		}
 
 		// We don't use sub_path in the blaze posts, only query strings
-		if ( isset( $params['sub_path'] ) ) {
-			unset( $req->get_params()['sub_path'] );
+		if ( isset( $req['sub_path'] ) ) {
+			unset( $req['sub_path'] );
 		}
 
 		return $this->request_as_user(
@@ -344,8 +344,8 @@ class Dashboard_REST_Controller {
 		}
 
 		// We don't use sub_path in the blaze posts, only query strings
-		if ( isset( $params['sub_path'] ) ) {
-			unset( $req->get_params()['sub_path'] );
+		if ( isset( $req['sub_path'] ) ) {
+			unset( $req['sub_path'] );
 		}
 
 		return $this->get_dsp_generic( sprintf( 'v1/wpcom/sites/%d/blaze/posts', $site_id ), $req );

--- a/projects/packages/identity-crisis/changelog/fix-wpcom-rector-complaints
+++ b/projects/packages/identity-crisis/changelog/fix-wpcom-rector-complaints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix possible use of an undefined variable.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.11.0",
+	"version": "0.11.1-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.11.0';
+	const PACKAGE_VERSION = '0.11.1-alpha';
 
 	/**
 	 * Instance of the object.
@@ -1327,12 +1327,12 @@ class Identity_Crisis {
 			$secret = new URL_Secret();
 
 			$secret->create();
+
+			if ( $secret->exists() ) {
+				$response['url_secret'] = $secret->get_secret();
+			}
 		} catch ( Exception $e ) {
 			$response['url_secret_error'] = new WP_Error( 'unable_to_create_url_secret', $e->getMessage() );
-		}
-
-		if ( $secret->exists() ) {
-			$response['url_secret'] = $secret->get_secret();
 		}
 
 		return $response;

--- a/projects/plugins/jetpack/changelog/fix-wpcom-rector-complaints
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-rector-complaints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix some possible undefined variable warnings.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -842,7 +842,7 @@ class Jetpack {
 		add_filter( 'jetpack_static_url', array( 'Automattic\\Jetpack\\Assets', 'staticize_subdomain' ) );
 
 		// Validate the domain names in Jetpack development versions.
-		add_action( 'jetpack_pre_register', array( get_called_class(), 'registration_check_domains' ) );
+		add_action( 'jetpack_pre_register', array( static::class, 'registration_check_domains' ) );
 
 		// Register product descriptions for partner coupon usage.
 		add_filter( 'jetpack_partner_coupon_products', array( $this, 'get_partner_coupon_product_descriptions' ) );
@@ -1562,6 +1562,7 @@ class Jetpack {
 	 * @return array
 	 */
 	public static function get_updates() {
+		$updates     = array();
 		$update_data = wp_get_update_data();
 
 		// Stores the individual update counts as well as the total count.
@@ -1576,7 +1577,7 @@ class Jetpack {
 				$updates['wp_update_version'] = $cur->current;
 			}
 		}
-		return isset( $updates ) ? $updates : array();
+		return $updates;
 	}
 	// phpcs:enable WordPress.WP.CapitalPDangit.MisspelledInComment
 
@@ -4128,7 +4129,8 @@ p {
 			self::activate_new_modules( true );
 		}
 
-		$message_code = self::state( 'message' );
+		$activated_manage = false;
+		$message_code     = self::state( 'message' );
 		if ( self::state( 'optin-manage' ) ) {
 			$activated_manage = $message_code;
 			$message_code     = 'jetpack-manage';
@@ -4487,7 +4489,7 @@ endif;
 				}
 			}
 
-			$url = $this->build_authorize_url( $redirect );
+			$url = static::build_authorize_url( $redirect );
 		}
 
 		if ( $from ) {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -102,7 +102,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 				true
 			);
 			$subscriptions      = (array) $payload['subscriptions'];
-			$is_paid_subscriber = $this->validate_subscriptions( $valid_plan_ids, $subscriptions );
+			$is_paid_subscriber = static::validate_subscriptions( $valid_plan_ids, $subscriptions );
 		}
 
 		$has_access = $this->user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, get_the_ID(), $subscriptions );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
<details>
<summary>See D125834-code.</summary>

```
4 files with changes
====================

1) wp-content/mu-plugins/jetpack-plugin/sun/jetpack_vendor/automattic/jetpack-identity-crisis/src/class-identity-crisis.php:658

    ---------- begin diff ----------
@@ @@
 				</p>
 			</div>
 		</div>
-		<?php
+<?php
 	}

 	/**
@@ @@
 		</div>

 		<div class="jp-idc-notice__separator"></div>
-		<?php
+<?php
 	}

 	/**
@@ @@
 				</div>
 			</div>
 		</div>
-		<?php
+<?php
 	}

 	/**
@@ @@
 				<?php echo $this->get_unsure_prompt(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</p>
 		</div>
-		<?php
+<?php
 	}

 	/**
@@ @@
 	 * phpcs:ignore Squiz.Commenting.FunctionCommentThrowTag -- The exception is being caught, false positive.
 	 */
 	public static function add_secret_to_url_validation_response( array $response ) {
+		$secret = null;
 		try {
 			$secret = new URL_Secret();
    ----------- end diff -----------

Applied rules:
 * AddDefaultValueForUndefinedVariableRector (https://github.com/vimeo/psalm/blob/29b70442b11e3e66113935a2ee22e165a70c74a4/docs/fixing_code.md#possiblyundefinedvariable)


2) wp-content/mu-plugins/jetpack-plugin/sun/jetpack_vendor/automattic/jetpack-blaze/src/class-dashboard-rest-controller.php:289

    ---------- begin diff ----------
@@ @@
 	 * @return array|WP_Error
 	 */
 	public function get_blaze_posts( $req ) {
+		$params = [];
 		$site_id = $this->get_site_id();
 		if ( is_wp_error( $site_id ) ) {
 			return array();
@@ @@
 	 * @return array|WP_Error
 	 */
 	public function get_dsp_blaze_posts( $req ) {
+		$params = [];
 		$site_id = $this->get_site_id();
 		if ( is_wp_error( $site_id ) ) {
 			return array();
    ----------- end diff -----------

Applied rules:
 * AddDefaultValueForUndefinedVariableRector (https://github.com/vimeo/psalm/blob/29b70442b11e3e66113935a2ee22e165a70c74a4/docs/fixing_code.md#possiblyundefinedvariable)


3) wp-content/mu-plugins/jetpack-plugin/sun/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php:101

    ---------- begin diff ----------
@@ @@
 				true
 			);
 			$subscriptions      = (array) $payload['subscriptions'];
-			$is_paid_subscriber = $this->validate_subscriptions( $valid_plan_ids, $subscriptions );
+			$is_paid_subscriber = static::validate_subscriptions($valid_plan_ids, $subscriptions);
 		}

 		$has_access = $this->user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, get_the_ID(), $subscriptions );
    ----------- end diff -----------

Applied rules:
 * ThisCallOnStaticMethodToStaticCallRector (https://3v4l.org/rkiSC)


4) wp-content/mu-plugins/jetpack-plugin/sun/class.jetpack.php:841

    ---------- begin diff ----------
@@ @@
 		add_filter( 'jetpack_static_url', array( 'Automattic\\Jetpack\\Assets', 'staticize_subdomain' ) );

 		// Validate the domain names in Jetpack development versions.
-		add_action( 'jetpack_pre_register', array( get_called_class(), 'registration_check_domains' ) );
+		add_action( 'jetpack_pre_register', array( static::class, 'registration_check_domains' ) );

 		// Register product descriptions for partner coupon usage.
 		add_filter( 'jetpack_partner_coupon_products', array( $this, 'get_partner_coupon_product_descriptions' ) );
@@ @@
 	 * @return array
 	 */
 	public static function get_updates() {
+		$updates = [];
 		$update_data = wp_get_update_data();

 		// Stores the individual update counts as well as the total count.
@@ @@
 	 * Handles the page load events for the Jetpack admin page
 	 */
 	public function admin_page_load() {
+		$activated_manage = null;
 		$error = false;

 		// Make sure we have the right body class to hook stylings for subpages off of.
@@ @@
 				}
 			}

-			$url = $this->build_authorize_url( $redirect );
+			$url = static::build_authorize_url($redirect);
 		}

 		if ( $from ) {
    ----------- end diff -----------

Applied rules:
 * GetCalledClassToStaticClassRector (https://www.php.net/ChangeLog-5.php#5.5.0)
 * AddDefaultValueForUndefinedVariableRector (https://github.com/vimeo/psalm/blob/29b70442b11e3e66113935a2ee22e165a70c74a4/docs/fixing_code.md#possiblyundefinedvariable)
 * ThisCallOnStaticMethodToStaticCallRector (https://3v4l.org/rkiSC)


 [OK] 4 files would have changed (dry-run) by Rector
```

</details>

* Some calls of static functions as `$this->` instead of `static::`.
* A `get_called_class()` instead of `static::class`.
* Uninitialized var in `Identity_Crisis::add_secret_to_url_validation_response`, fixed by moving the use inside the try-catch.
* Uninitialized `$params` in `jetpack-blaze/src/class-dashboard-rest-controller.php`, fixed by making use of `WP_REST_Request`'s `ArrayAccess` methods to do what seems to have been intended.
* Some uninitialized vars in `class.jetpack.php`, fixed by initializing them.

I ignored where a broken rector "fix" wants to unindent `<?php`. That makes for less readable code, not better code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure stuff still works.