### PR TITLE
WIP Media Inserter: Fix checking Google Photos connection when not needed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-media-sidebar-checks-google-photos-connection-before-needed
+++ b/projects/plugins/jetpack/changelog/fix-media-sidebar-checks-google-photos-connection-before-needed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+The Google Photos media inserter only checks for the connection status when needed.

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -242,8 +242,8 @@ export const addGooglePhotosToMediaInserter = async () => {
 		waitFor( () => isAuthenticatedByWithMediaComponent( MediaSource.GooglePhotos ) ).then( () =>
 			registerInInserter( googlePhotosProvider )
 		);
-	});
-}
+	} );
+};
 
 /**
  * Adds Pexels to the media inserter. There is no need to check if it's connected because it's always connected.

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -230,7 +230,7 @@ const isAuthenticatedByWithMediaComponent = ( source: MediaSource ) =>
  * Adds Google Photos to the media inserter if/when it's connected.
  * We will not remove Google Photos from the inserter if the user disconnects Google Photos during runtime.
  */
-export const addGooglePhotosToMediaInserter = async () =>
+export const addGooglePhotosToMediaInserter = async () => {
 	waitFor( isInserterOpened ).then( () => {
 		const isConnected = await isMediaSourceConnected( MediaSource.GooglePhotos );
 
@@ -242,7 +242,8 @@ export const addGooglePhotosToMediaInserter = async () =>
 		waitFor( () => isAuthenticatedByWithMediaComponent( MediaSource.GooglePhotos ) ).then( () =>
 			registerInInserter( googlePhotosProvider )
 		);
-	} );
+	});
+}
 
 /**
  * Adds Pexels to the media inserter. There is no need to check if it's connected because it's always connected.

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -230,10 +230,10 @@ const isAuthenticatedByWithMediaComponent = ( source: MediaSource ) =>
  * Adds Google Photos to the media inserter if/when it's connected.
  * We will not remove Google Photos from the inserter if the user disconnects Google Photos during runtime.
  */
-export const addGooglePhotosToMediaInserter = async () => {
-	const isConnected = await isMediaSourceConnected( MediaSource.GooglePhotos );
-
+export const addGooglePhotosToMediaInserter = async () =>
 	waitFor( isInserterOpened ).then( () => {
+		const isConnected = await isMediaSourceConnected( MediaSource.GooglePhotos );
+
 		if ( isConnected ) {
 			registerInInserter( googlePhotosProvider );
 			return;
@@ -243,7 +243,6 @@ export const addGooglePhotosToMediaInserter = async () => {
 			registerInInserter( googlePhotosProvider )
 		);
 	} );
-};
 
 /**
  * Adds Pexels to the media inserter. There is no need to check if it's connected because it's always connected.

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -231,7 +231,7 @@ const isAuthenticatedByWithMediaComponent = ( source: MediaSource ) =>
  * We will not remove Google Photos from the inserter if the user disconnects Google Photos during runtime.
  */
 export const addGooglePhotosToMediaInserter = async () => {
-	waitFor( isInserterOpened ).then( () => {
+	waitFor( isInserterOpened ).then( async () => {
 		const isConnected = await isMediaSourceConnected( MediaSource.GooglePhotos );
 
 		if ( isConnected ) {

--- a/projects/plugins/jetpack/extensions/shared/external-media/test/external-media-service-test.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/test/external-media-service-test.js
@@ -84,8 +84,6 @@ describe( 'Media API Tests', () => {
 		// Then.
 		// We should not be polling the connection status.
 		expect( select.mock.calls ).toHaveLength( 0 );
-		// Dispatched action to register the source.
-		expect( dispatch.mock.calls ).toHaveLength( 1 );
 		// Connection has been checked.
 		expect( apiFetch.mock.calls ).toHaveLength( 1 );
 	} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1697662881647649-slack-C04DZ8M0GHW

We have an issue with an excessive number of calls being made to the Google Photos endpoint which needs to be solved in order to bring back the number of calls made.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed the order in which we check the Google Photos connection so that we only check the connection when the media inserter is open.

## Does this pull request change what data or activity we track or use?
No

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this branch on an Atomic site.
* Edit or Create a new Post
* Open Chrome's Network tab or equivalent in your browser of choice.
* Filter by `media/list/google` 
* You should not see any requests until you open the media sidebar.