### PR TITLE
Jetpack: handle Proofread feature availability via jetpack_ai_enabled filter

### DIFF
--- a/projects/plugins/jetpack/changelog/update-register-proofread-via-filter
+++ b/projects/plugins/jetpack/changelog/update-register-proofread-via-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: handle Proofread feature availability via jetpack_ai_enabled filter

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php
@@ -22,10 +22,13 @@ const FEATURE_NAME = 'ai-assistant-plugin';
  * @return void
  */
 function register_plugin() {
-	// Connection check.
+	// Check Jetpack AI feature availability.
 	if (
-		( new Host() )->is_wpcom_simple()
-		|| ( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() && ! ( new Status() )->is_offline_mode() )
+		(
+			new Host() )->is_wpcom_simple()
+			|| ( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() && ! ( new Status() )->is_offline_mode()
+		)
+		&& apply_filters( 'jetpack_ai_enabled', true )
 	) {
 		// Register AI assistant plugin.
 		\Jetpack_Gutenberg::set_extension_available( FEATURE_NAME );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The changes introduced in this PR allow to unregister the Proofread feature via the `jetpack_ai_enabled` filter.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: handle Proofread feature availability via jetpack_ai_enabled filter

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Unregister the AI Jetpack feature by using a filter:

```php
add_filter( 'jetpack_ai_enabled', '__return_false' );
```

* Confirm the feature is not available when the feature is disabled 

Proofread disabled | Proofread enabled
------|-------
<img width="396" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/5543a56c-eaf3-4102-aa7f-96767a7aac8d"> | <img width="354" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/b1626b2e-66cc-4aa3-b16c-b8be201ea73f">

