### PR TITLE
Welcome message: Add support for the welcome email setting in wp-admin

### DIFF
--- a/projects/plugins/jetpack/changelog/add-welcome-email-field
+++ b/projects/plugins/jetpack/changelog/add-welcome-email-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add support for welcome message inside wp-admin

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -430,6 +430,14 @@ class Jetpack_Subscriptions {
 			'reading',
 			'email_settings'
 		);
+
+		add_settings_field(
+			'welcome',
+			__( 'Welcome email text', 'jetpack' ),
+			array( $this, 'setting_welcome' ),
+			'reading',
+			'email_settings'
+		);
 	}
 
 	/**
@@ -621,16 +629,43 @@ class Jetpack_Subscriptions {
 	}
 
 	/**
+	 * HTML output helper for Welcome section.
+	 */
+	public function setting_welcome() {
+		$settings = $this->get_settings();
+		echo '<textarea name="subscription_options[welcome]" class="large-text" cols="50" rows="5">' . esc_textarea( $settings['welcome'] ) . '</textarea>';
+		echo '<p><span class="description">' . esc_html__( 'Welcome text sent when someone follows your blog.', 'jetpack' ) . '</span></p>';
+	}
+
+	/**
 	 * Get default settings for the Subscriptions module.
 	 */
 	public function get_default_settings() {
 		$site_url    = get_home_url();
 		$display_url = preg_replace( '(^https?://)', '', untrailingslashit( $site_url ) );
 
+		// TODO: Remove the locale check once the translation is ready.
+		$is_english_locale = str_starts_with( get_locale(), 'en' );
+		if ( $is_english_locale ) {
+			/* translators: %1$s is the site address */
+			$welcome = sprintf( __( 'Cool, you are now subscribed to %1$s and will receive an email notification when a new post is published.', 'jetpack' ), $display_url );
+		} else {
+			$welcome = sprintf(
+				str_replace(
+					'<a href="%1$s" data-tracks-link-desc="site-url">%2$s</a>',
+					'%1$s',
+					/* translators: Both %1$s and %2$s is site address */
+					__( 'Cool, you are now subscribed to <a href="%1$s" data-tracks-link-desc="site-url">%2$s</a> and will receive an email notification when a new post is published.', 'jetpack' )
+				),
+				$display_url
+			);
+		}
+
 		return array(
 			/* translators: Both %1$s and %2$s is site address */
 			'invitation'     => sprintf( __( "Howdy,\nYou recently subscribed to <a href='%1\$s'>%2\$s</a> and we need to verify the email you provided. Once you confirm below, you'll be able to receive and read new posts.\n\nIf you believe this is an error, ignore this message and nothing more will happen.", 'jetpack' ), $site_url, $display_url ),
 			'comment_follow' => __( "Howdy.\n\nYou recently followed one of my posts. This means you will receive an email when new comments are posted.\n\nTo activate, click confirm below. If you believe this is an error, ignore this message and we'll never bother you again.", 'jetpack' ),
+			'welcome'        => $welcome,
 		);
 	}
 

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -644,28 +644,12 @@ class Jetpack_Subscriptions {
 		$site_url    = get_home_url();
 		$display_url = preg_replace( '(^https?://)', '', untrailingslashit( $site_url ) );
 
-		// TODO: Remove the locale check once the translation is ready.
-		$is_english_locale = str_starts_with( get_locale(), 'en' );
-		if ( $is_english_locale ) {
-			/* translators: %1$s is the site address */
-			$welcome = sprintf( __( 'Cool, you are now subscribed to %1$s and will receive an email notification when a new post is published.', 'jetpack' ), $display_url );
-		} else {
-			$welcome = sprintf(
-				str_replace(
-					'<a href="%1$s" data-tracks-link-desc="site-url">%2$s</a>',
-					'%1$s',
-					/* translators: Both %1$s and %2$s is site address */
-					__( 'Cool, you are now subscribed to <a href="%1$s" data-tracks-link-desc="site-url">%2$s</a> and will receive an email notification when a new post is published.', 'jetpack' )
-				),
-				$display_url
-			);
-		}
-
 		return array(
 			/* translators: Both %1$s and %2$s is site address */
 			'invitation'     => sprintf( __( "Howdy,\nYou recently subscribed to <a href='%1\$s'>%2\$s</a> and we need to verify the email you provided. Once you confirm below, you'll be able to receive and read new posts.\n\nIf you believe this is an error, ignore this message and nothing more will happen.", 'jetpack' ), $site_url, $display_url ),
 			'comment_follow' => __( "Howdy.\n\nYou recently followed one of my posts. This means you will receive an email when new comments are posted.\n\nTo activate, click confirm below. If you believe this is an error, ignore this message and we'll never bother you again.", 'jetpack' ),
-			'welcome'        => $welcome,
+			/* translators: %1$s is the site address */
+			'welcome'        => sprintf( __( 'Cool, you are now subscribed to %1$s and will receive an email notification when a new post is published.', 'jetpack' ), $display_url ),
 		);
 	}
 

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -1031,6 +1031,8 @@ function subscription_options_fallback( $default, $option, $passed_default ) {
 		/* translators: Both %1$s and %2$s is site address */
 		'invitation'     => sprintf( __( "Howdy,\nYou recently subscribed to <a href='%1\$s'>%2\$s</a> and we need to verify the email you provided. Once you confirm below, you'll be able to receive and read new posts.\n\nIf you believe this is an error, ignore this message and nothing more will happen.", 'jetpack' ), $site_url, $display_url ),
 		'comment_follow' => __( "Howdy.\n\nYou recently followed one of my posts. This means you will receive an email when new comments are posted.\n\nTo activate, click confirm below. If you believe this is an error, ignore this message and we'll never bother you again.", 'jetpack' ),
+		/* translators: %1$s is the site address */
+		'welcome'        => sprintf( __( 'Cool, you are now subscribed to %1$s and will receive an email notification when a new post is published.', 'jetpack' ), $display_url ),
 	);
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83081

## Proposed changes:
- Adds the field for the welcome message inside `wp-admin`
- Sets the default value for the default value we're using right now when sending the welcome email
- 
![Reading Settings _ HelloWord _ WordPress](https://github.com/Automattic/jetpack/assets/528287/2a323c9b-628a-4d72-990a-360c58d713ee)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this PR to your JT site
2. Go to Settings > Reading and verify that the field is there and works.

If you need to reset the fields back to their default setting you can use this command:

```
docker exec -it jetpack_dev-wordpress-1 wp option delete subscription_options  --allow-root
```