### PR TITLE
Boost: Fix depreciation notice `wp_print_styles` WP 6.4

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/Admin_Bar_Compatibilty.php
+++ b/projects/plugins/boost/app/lib/critical-css/Admin_Bar_Compatibilty.php
@@ -49,6 +49,20 @@ class Admin_Bar_Compatibility {
 	 * @see     wp_before_admin_bar_render
 	 */
 	public static function force_admin_bar_stylesheet() {
+		/**
+		 * Temporarily remove the deprecated `print_emoji_styles` handler.
+		 * It avoids breaking style generation with a deprecation message.
+   		 * `print_emoji_styles` is deprecated in WP 6.4.
+		 */
+		$has_emoji_styles = has_action( 'wp_print_styles', 'print_emoji_styles' );
+		if ( $has_emoji_styles ) {
+			remove_action( 'wp_print_styles', 'print_emoji_styles' );
+		}
+
 		wp_print_styles( 'admin-bar' );
+
+		if ( $has_emoji_styles ) {
+			add_action( 'wp_print_styles', 'print_emoji_styles' );
+		}
 	}
 }

--- a/projects/plugins/boost/changelog/update-compatibility
+++ b/projects/plugins/boost/changelog/update-compatibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed a potential compatibility issue on WP 6.4
+
+


### PR DESCRIPTION
**⚠️ I am still trying to figure out if we really need this.**

Core seems to have found a weird way to deprecate `print_emoji_styles`. Even though `print_emoji_styles` itself isn't depricated, using it without this hack may still produce deprication notice. 

Related to  #33655

See WordPress/gutenberg#54806 and WordPress/gutenberg#54828

## Proposed changes:
* Temporarily remove action call to `print_emoji_styles` while using `wp_print_styles`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Install WP 6.4 beta
* Generate critical CSS and ensure no deprication notice is present related to `print_emoji_styles`.

