### PR TITLE
Gardening, docs: Remove references to "Required review" check

### DIFF
--- a/docs/pull-request.md
+++ b/docs/pull-request.md
@@ -19,7 +19,7 @@ Once you know what the first small piece of your feature will be, follow this ge
 1. If you end up needing more than a few commits, consider splitting the pull request into separate components. Discuss in the new pull request and in the comments why the branch was broken apart and any changes that may have taken place that necessitated the split. Our goal is to catch early in the review process those pull requests that attempt to do too much.
 1. When you feel that you are ready for a formal review or for merging into `trunk` make sure you check this list.
     - Make sure your Pull Request [includes a changelog entry](writing-a-good-changelog-entry.md) for each project touched.
-    - Make sure all required checks (other than "Required review") listed at the bottom of the Pull Request are passing.
+    - Make sure all required checks listed at the bottom of the Pull Request are passing.
     - Make sure your branch merges cleanly and consider rebasing against `trunk` to keep the branch history short and clean.
     - If there are visual changes, add before and after screenshots in the pull request comments.
     - Add unit tests, or at a minimum, provide helpful instructions for the reviewer so they can test your changes. This will help speed up the review process.

--- a/projects/github-actions/repo-gardening/changelog/remove-doc-refs-to-required-review
+++ b/projects/github-actions/repo-gardening/changelog/remove-doc-refs-to-required-review
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Description task: remove reference to "Required review" check that was removed a while back.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -481,7 +481,7 @@ The e2e test report can be found [here](https://automattic.github.io/jetpack-e2e
 	if ( statusChecks.isFromContributor ) {
 		comment += `
 
-Once your PR is ready for review, check one last time that all required checks (other than "Required review") appearing at the bottom of this PR are passing or skipped.
+Once your PR is ready for review, check one last time that all required checks appearing at the bottom of this PR are passing or skipped.
 Then, add the "[Status] Needs Team Review" label and ask someone from your team review the code. Once reviewed, it can then be merged.
 If you need an extra review from someone familiar with the codebase, you can update the labels from "[Status] Needs Team Review" to "[Status] Needs Review", and in that case Jetpack Approvers will do a final review of your PR.`;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We removed the check in May 2023 (#31118) as it had been non-required for months before that. Some docs and a comment left by the Gardening action were still making reference to it. Those are now removed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the doc.
* Create a PR based on this one and check the comment.

