### PR TITLE
Only add WooCommerce tracking to core order actions

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-limit-tracking-to-core-buttons
+++ b/projects/plugins/jetpack/changelog/fix-limit-tracking-to-core-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed a bug that prevent customers from downloading invoices from the my account page in WooCommerce

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
@@ -232,6 +232,12 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 			if ( ! isset( $action['url'] ) ) {
 				continue;
 			}
+
+			// Check if the action key is view, pay, or cancel.
+			if ( ! in_array( $key, array( 'view', 'pay', 'cancel' ), true ) ) {
+				continue;
+			}
+
 			$url                    = add_query_arg( array( '_wca_initiator' => 'action' ), $action['url'] );
 			$actions[ $key ]['url'] = $url;
 		}


### PR DESCRIPTION
This PR limits add the tracking initiator query var from being added to non woo-core actions, so it's only limited to view, pay, and cancel.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
Testing this PR might require some code to be used, or a longer route of installing a plugin.

Using code:
- In a live, Jetpack website, add this code:
```php
add_filter('woocommerce_my_account_my_orders_actions', function( $actions ) {
	$actions['test'] = [
			'url'  => $_REQUEST['_wp_http_referer'],
			'name' => __( 'Test', 'woocommerce' ),
	];
	return $actions;
});
```
- You will need WooCommerce installed, logged in, add a product to your Cart and Checkout.
- Got to the /my-account/orders page, you should see a couple of buttons, View, and Test, on each order.
- Make sure the view button link has a `?_wca_initiator=action` on it, and that the test button has nothing but the current page url.

Using a plugin
- Install [PDF invoices plugin.](https://wordpress.org/plugins/woocommerce-pdf-invoices-packing-slips/)
- You will need WooCommerce installed, add a product to your Cart and Checkout.
- Go to wp-admin > WooCommerce > Orders > The order you just created.
- Hit "PDF Invoice" on the Create PDF box.
- Got to the /my-account/orders page, you should see a couple of buttons, View, and Invoice, on each order.
- The View button link should have `?_wca_initiator=action` on it, the invoice link should work.
