### PR TITLE
AI Assistant: fix issue when getting AI assistant block instance

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-block-get-block
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-block-get-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: fix issue when getting AI assistant block instance

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -58,10 +58,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	const { tracks } = useAnalytics();
 	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId() );
 
-	const getBlock = useSelect(
-		select => () => select( 'core/block-editor' ).getBlock( clientId ),
-		[ clientId ]
-	);
+	const { getBlock } = useSelect( 'core/block-editor' );
 
 	const aiControlRef = useRef( null );
 	const blockRef = useRef( null );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -171,7 +171,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		}
 
 		// Bail out if the block already has children blocks
-		const block = getBlock();
+		const block = getBlock( clientId );
 		if ( block?.innerBlocks?.length ) {
 			return;
 		}
@@ -336,7 +336,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			 * - Blocks are already created
 			 * - blocks are children of the current block
 			 */
-			newGeneratedBlocks = getBlock();
+			newGeneratedBlocks = getBlock( clientId );
 			newGeneratedBlocks = newGeneratedBlocks?.innerBlocks || [];
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an issue reported by the React library when selecting the getBlock function:

```
index.js:143 The 'useSelect' hook returns different values when called with the same state and parameters. This can lead to unnecessary rerenders.
```

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: fix the issue when getting the AI assistant block instance

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a paragraph block with some content
* Change the content by using the AI Assistant tool

**Before (trunk)**
The dev console shows a warning about it:

<img width="784" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/5f985c3e-af3c-49de-bd75-05011f7a091f">

**After (This PR)**
The warning is not reported.

* Confirm the AI block works as expected
  * Ask for some content
  * Use the Translate, Tone, etc shorthands


