### PR TITLE
AI Extension: show "no content" notice when the extended block content is empty

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-show-empty-info
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-show-empty-info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: show "no content" notice when the extended block content is empty

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -4,8 +4,9 @@
 import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { getBlockContent } from '@wordpress/blocks';
-import { MenuItem, MenuGroup, ToolbarButton, Dropdown } from '@wordpress/components';
+import { MenuItem, MenuGroup, ToolbarButton, Dropdown, Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { post, postContent, postExcerpt, termDescription } from '@wordpress/icons';
 import React from 'react';
@@ -21,6 +22,7 @@ import {
 	PROMPT_TYPE_SUMMARIZE,
 	PROMPT_TYPE_CHANGE_LANGUAGE,
 } from '../../lib/prompt';
+import { getRawTextFromHTML } from '../../lib/utils/block-content';
 import { transformToAIAssistantBlock } from '../../transforms';
 import { I18nMenuDropdown } from '../i18n-dropdown-control';
 import { ToneDropdownMenu } from '../tone-dropdown-control';
@@ -99,7 +101,7 @@ export function getBlocksContent( blocks ) {
 }
 
 export default function AiAssistantDropdown( { blockType }: AiAssistantControlComponentProps ) {
-	const toolbarLabel = __( 'AI Assistant', 'jetpack' );
+	const [ noContentInfo, setNoContentInfo ] = useState( false );
 
 	/*
 	 * Let's disable the eslint rule for this line.
@@ -114,16 +116,26 @@ export default function AiAssistantDropdown( { blockType }: AiAssistantControlCo
 
 	const requestSuggestion = (
 		promptType: PromptTypeProp,
-		options: AiAssistantDropdownOnChangeOptionsArgProps = {}
+		options: AiAssistantDropdownOnChangeOptionsArgProps = {},
+		closeDropdown: () => void
 	) => {
+		const clientIds = getSelectedBlockClientIds();
+		const blocks = getBlocksByClientId( clientIds );
+		const content = getBlocksContent( blocks );
+
+		const rawContent = getRawTextFromHTML( content );
+
+		if ( ! rawContent.length ) {
+			// Set a message info about block no content.
+			return setNoContentInfo( true );
+		}
+
+		closeDropdown();
+
 		tracks.recordEvent( 'jetpack_editor_ai_assistant_extension_toolbar_button_click', {
 			suggestion: promptType,
 			block_type: blockType,
 		} );
-
-		const clientIds = getSelectedBlockClientIds();
-		const blocks = getBlocksByClientId( clientIds );
-		const content = getBlocksContent( blocks );
 
 		const [ firstBlock ] = blocks;
 		const [ firstClientId, ...otherBlocksIds ] = clientIds;
@@ -199,53 +211,57 @@ export default function AiAssistantDropdown( { blockType }: AiAssistantControlCo
 						onClick={ onToggle }
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
-						label={ toolbarLabel }
+						label={ __( 'AI Assistant', 'jetpack' ) }
 						icon={ aiAssistantIcon }
-						disabled={ false }
 					/>
 				);
 			} }
 			renderContent={ ( { onClose: closeDropdown } ) => (
-				<MenuGroup>
-					<MenuItem
-						icon={ aiAssistantIcon }
-						iconPosition="left"
-						key="key-ai-assistant"
-						onClick={ replaceWithAiAssistantBlock }
-					>
-						<div className="jetpack-ai-assistant__menu-item">
-							{ __( 'Ask AI Assistant', 'jetpack' ) }
-						</div>
-					</MenuItem>
+				<>
+					{ noContentInfo && (
+						<Notice status="warning" isDismissible={ false } className="jetpack-ai-assistant__info">
+							{ __( 'No content to modify.', 'jetpack' ) }
+						</Notice>
+					) }
 
-					{ quickActionsList.map( quickAction => (
+					<MenuGroup>
 						<MenuItem
-							icon={ quickAction?.icon }
+							icon={ aiAssistantIcon }
 							iconPosition="left"
-							key={ `key-${ quickAction.key }` }
-							onClick={ () => {
-								requestSuggestion( quickAction.aiSuggestion );
-								closeDropdown();
-							} }
+							key="key-ai-assistant"
+							onClick={ replaceWithAiAssistantBlock }
 						>
-							<div className="jetpack-ai-assistant__menu-item">{ quickAction.name }</div>
+							<div className="jetpack-ai-assistant__menu-item">
+								{ __( 'Ask AI Assistant', 'jetpack' ) }
+							</div>
 						</MenuItem>
-					) ) }
 
-					<ToneDropdownMenu
-						onChange={ tone => {
-							requestSuggestion( PROMPT_TYPE_CHANGE_TONE, { tone } );
-							closeDropdown();
-						} }
-					/>
+						{ quickActionsList.map( quickAction => (
+							<MenuItem
+								icon={ quickAction?.icon }
+								iconPosition="left"
+								key={ `key-${ quickAction.key }` }
+								onClick={ () => {
+									requestSuggestion( quickAction.aiSuggestion, {}, closeDropdown );
+								} }
+							>
+								<div className="jetpack-ai-assistant__menu-item">{ quickAction.name }</div>
+							</MenuItem>
+						) ) }
 
-					<I18nMenuDropdown
-						onChange={ language => {
-							requestSuggestion( PROMPT_TYPE_CHANGE_LANGUAGE, { language } );
-							closeDropdown();
-						} }
-					/>
-				</MenuGroup>
+						<ToneDropdownMenu
+							onChange={ tone => {
+								requestSuggestion( PROMPT_TYPE_CHANGE_TONE, { tone }, closeDropdown );
+							} }
+						/>
+
+						<I18nMenuDropdown
+							onChange={ language => {
+								requestSuggestion( PROMPT_TYPE_CHANGE_LANGUAGE, { language }, closeDropdown );
+							} }
+						/>
+					</MenuGroup>
+				</>
 			) }
 		/>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -160,7 +160,7 @@ export default function AiAssistantDropdown( { blockType }: AiAssistantControlCo
 		removeBlocks( otherBlocksIds );
 	};
 
-	const onChange = (
+	const requestAiSuggestion = (
 		promptType: PromptTypeProp,
 		options: AiAssistantDropdownOnChangeOptionsArgProps = {}
 	) => {
@@ -231,7 +231,7 @@ export default function AiAssistantDropdown( { blockType }: AiAssistantControlCo
 							iconPosition="left"
 							key={ `key-${ quickAction.key }` }
 							onClick={ () => {
-								onChange( quickAction.aiSuggestion );
+								requestAiSuggestion( quickAction.aiSuggestion );
 								closeDropdown();
 							} }
 						>
@@ -241,14 +241,14 @@ export default function AiAssistantDropdown( { blockType }: AiAssistantControlCo
 
 					<ToneDropdownMenu
 						onChange={ tone => {
-							onChange( PROMPT_TYPE_CHANGE_TONE, { tone } );
+							requestAiSuggestion( PROMPT_TYPE_CHANGE_TONE, { tone } );
 							closeDropdown();
 						} }
 					/>
 
 					<I18nMenuDropdown
 						onChange={ language => {
-							onChange( PROMPT_TYPE_CHANGE_LANGUAGE, { language } );
+							requestAiSuggestion( PROMPT_TYPE_CHANGE_LANGUAGE, { language } );
 							closeDropdown();
 						} }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -114,8 +114,13 @@ export default function AiAssistantDropdown( { blockType }: AiAssistantControlCo
 
 	const requestSuggestion = (
 		promptType: PromptTypeProp,
-		options: AiAssistantDropdownOnChangeOptionsArgProps
+		options: AiAssistantDropdownOnChangeOptionsArgProps = {}
 	) => {
+		tracks.recordEvent( 'jetpack_editor_ai_assistant_extension_toolbar_button_click', {
+			suggestion: promptType,
+			block_type: blockType,
+		} );
+
 		const clientIds = getSelectedBlockClientIds();
 		const blocks = getBlocksByClientId( clientIds );
 		const content = getBlocksContent( blocks );
@@ -158,18 +163,6 @@ export default function AiAssistantDropdown( { blockType }: AiAssistantControlCo
 
 		// It removes the rest of the blocks in case there are more than one.
 		removeBlocks( otherBlocksIds );
-	};
-
-	const requestAiSuggestion = (
-		promptType: PromptTypeProp,
-		options: AiAssistantDropdownOnChangeOptionsArgProps = {}
-	) => {
-		tracks.recordEvent( 'jetpack_editor_ai_assistant_extension_toolbar_button_click', {
-			suggestion: promptType,
-			block_type: blockType,
-		} );
-
-		requestSuggestion( promptType, options );
 	};
 
 	const replaceWithAiAssistantBlock = () => {
@@ -231,7 +224,7 @@ export default function AiAssistantDropdown( { blockType }: AiAssistantControlCo
 							iconPosition="left"
 							key={ `key-${ quickAction.key }` }
 							onClick={ () => {
-								requestAiSuggestion( quickAction.aiSuggestion );
+								requestSuggestion( quickAction.aiSuggestion );
 								closeDropdown();
 							} }
 						>
@@ -241,14 +234,14 @@ export default function AiAssistantDropdown( { blockType }: AiAssistantControlCo
 
 					<ToneDropdownMenu
 						onChange={ tone => {
-							requestAiSuggestion( PROMPT_TYPE_CHANGE_TONE, { tone } );
+							requestSuggestion( PROMPT_TYPE_CHANGE_TONE, { tone } );
 							closeDropdown();
 						} }
 					/>
 
 					<I18nMenuDropdown
 						onChange={ language => {
-							requestAiSuggestion( PROMPT_TYPE_CHANGE_LANGUAGE, { language } );
+							requestSuggestion( PROMPT_TYPE_CHANGE_LANGUAGE, { language } );
 							closeDropdown();
 						} }
 					/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR avoids requesting an AI suggestion from the AI extension when the block doesn't have content, showing a notice instead.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: show "no content" notice when the extended block content is empty

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add some spaces to a paragraph block instance
* Click on the AI Extension button of the block toolbar
* Click on one of the dropdown menu items
* Confirm that, since the block doesn't have content, the app shows a notice instead of performing a request

<img width="422" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/efe12d4b-5106-4711-a31a-fa2b9139ad10">

* Confirm that when the block has content, it works as expected

