### PR TITLE
Paywall: Cross platforms login link

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-login-link-2
+++ b/projects/plugins/jetpack/changelog/update-paywall-login-link-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+add login link to paywall

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -13,7 +13,6 @@ use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Jetpack_T
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\WPCOM_Token_Subscription_Service;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 use Jetpack;
 use Jetpack_Gutenberg;
 use Jetpack_Memberships;
@@ -1073,14 +1072,11 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		? __( 'Already a paid subscriber?', 'jetpack' )
 		: __( 'Already a subscriber?', 'jetpack' );
 
-	$sign_in = '';
-	if ( ! is_user_logged_in() && ( new Host() )->is_wpcom_simple() ) {
-		$sign_in_link = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link' );
+	$sign_in_link = 'https://subscribe.wordpress.com/memberships/jwt?site_id=' . \Jetpack_Options::get_option( 'id' ) . '&redirect_url=' . get_current_url();
 
-		$sign_in = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->
+	$sign_in = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->
 <p class="has-text-align-center" style="font-size:14px">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '">' . esc_html__( 'Log in', 'jetpack' ) . '</a></p>
 <!-- /wp:paragraph -->';
-	}
 
 	$lock_svg = plugins_url( 'images/lock-paywall.svg', JETPACK__PLUGIN_FILE );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Alternative to #33627 and #33656

## Proposed changes:
* Similar to #33627 but uses an existing endpoint.
* Display the "log in" link in Jetpack sites
* See more details in D125480-code
* Test alongside with D126041-code to get the magic link flow instead of the user name login flow.

<img width="690" alt="Screenshot 2023-10-19 at 17 41 55" src="https://github.com/Automattic/jetpack/assets/104869/96cc899d-a425-4fe3-b60a-662ac3a26dab">

Asks the user to log in 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See D125480-code