### PR TITLE
Hotfix/revert 33410

### DIFF
--- a/projects/packages/my-jetpack/changelog/hotfix-revert-33410
+++ b/projects/packages/my-jetpack/changelog/hotfix-revert-33410
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make has_required_plan return true (as it was before #33410) as a way to revert the change.

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
-use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
@@ -164,7 +163,6 @@ class Videopress extends Hybrid_Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
-		// using second argument `true` to force fetching from wpcom
-		return Current_Plan::supports( 'videopress-1tb-storage', true );
+		return true;
 	}
 }

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -163,6 +163,7 @@ class Videopress extends Hybrid_Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
+		// TODO: import and perform a proper check with Current_Plan. See #33410.
 		return true;
 	}
 }


### PR DESCRIPTION
Revert #33410 as it can cause fatals

## Proposed changes:
Using Current_Plan falls into a use case where Jetpack is required to be installed (as it provides the lib for Current_Plan), causing fatals otherwise.

This _revert_ makes `has_required_plan` return `true`, as it is the default parent's class behavior (as it was before the change).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1697748366739339-slack-C02TQF5VAJD

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Without this patch:
- Install a standalone Jetpack plugin like Jetpack VaultPress Backups
- Make sure you have uninstalled and removed the main Jetpack plugin
- Navigate to My Jetpack
- You will get a fatal error

Apply patch and navigate to My Jetpack, fatal should be gone