### PR TITLE
VideoPress: register block type with block metadata

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-register-block-json
+++ b/projects/packages/videopress/changelog/fix-videopress-register-block-json
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use register_block_type and block.json to handle the block's scripts properly and fix assets being loaded when block is not present

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.18.x-dev"
+			"dev-trunk": "0.19.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.18.1-alpha",
+	"version": "0.19.0-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -7,15 +7,11 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
-use Automattic\Jetpack\Assets;
-
 /**
  * Initialized the VideoPress package
  */
 class Initializer {
 
-	const JETPACK_VIDEOPRESS_VIDEO_HANDLER      = 'jetpack-videopress-video-block';
-	const JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER = 'jetpack-videopress-video-block-view';
 	const JETPACK_VIDEOPRESS_IFRAME_API_HANDLER = 'jetpack-videopress-iframe-api';
 
 	/**
@@ -382,43 +378,6 @@ class Initializer {
 
 		// Register and enqueue scripts used by the VideoPress video block.
 		Block_Editor_Extensions::init( $script_handle );
-	}
-
-	/**
-	 * Enqueue scripts used by the VideoPress video block and register block type.
-	 *
-	 * @param string $videopress_video_metadata_file Path to the block metadata file.
-	 */
-	public static function enqueue_block_assets( $videopress_video_metadata_file ) {
-		// Register script used by the VideoPress video block in the editor.
-		Assets::register_script(
-			self::JETPACK_VIDEOPRESS_VIDEO_HANDLER,
-			'../build/block-editor/blocks/video/index.js',
-			__FILE__,
-			array(
-				'in_footer'  => false,
-				'textdomain' => 'jetpack-videopress-pkg',
-			)
-		);
-
-		// Register script used by the VideoPress video block in the front-end.
-		Assets::register_script(
-			self::JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER,
-			'../build/block-editor/blocks/video/view.js',
-			__FILE__,
-			array(
-				'in_footer'  => true,
-				'textdomain' => 'jetpack-videopress-pkg',
-			)
-		);
-
-		// Register VideoPress video block.
-		register_block_type(
-			$videopress_video_metadata_file,
-			array(
-				'render_callback' => array( __CLASS__, 'render_videopress_video_block' ),
-			)
-		);
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -343,10 +343,15 @@ class Initializer {
 		// Is the block already registered?
 		$is_block_registered = \WP_Block_Type_Registry::get_instance()->is_registered( $videopress_video_block_name );
 
+		// Do not register if the block is already registered.
+		if ( $is_block_registered ) {
+			return;
+		}
+
 		// Is this a REST API request?
 		$is_rest = defined( 'REST_API_REQUEST' ) && REST_API_REQUEST;
 
-		if ( $is_rest && ! $is_block_registered ) {
+		if ( $is_rest ) {
 			register_block_type(
 				$videopress_video_metadata_file,
 				array(

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -361,15 +361,27 @@ class Initializer {
 			return;
 		}
 
-		// Register and enqueue scripts used by the VideoPress video block.
-		Block_Editor_Extensions::init( self::JETPACK_VIDEOPRESS_VIDEO_HANDLER );
+		$registration = register_block_type(
+			$videopress_video_metadata_file,
+			array(
+				'render_callback' => array( __CLASS__, 'render_videopress_video_block' ),
+			)
+		);
 
-		// Do not register if the block is already registered.
-		if ( $is_block_registered ) {
+		// Do not enqueue scripts if the block could not be registered.
+		if ( empty( $registration ) || empty( $registration->editor_script_handles ) ) {
 			return;
 		}
 
-		self::enqueue_block_assets( $videopress_video_metadata_file );
+		// Extensions use Connection_Initial_State::render_script with script handle as parameter.
+		if ( is_array( $registration->editor_script_handles ) ) {
+			$script_handle = $registration->editor_script_handles[0];
+		} else {
+			$script_handle = $registration->editor_script_handles;
+		}
+
+		// Register and enqueue scripts used by the VideoPress video block.
+		Block_Editor_Extensions::init( $script_handle );
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.18.1-alpha';
+	const PACKAGE_VERSION = '0.19.0-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -126,8 +126,8 @@
 		}
 	},
 	"textdomain": "jetpack-videopress",
-	"editorScript": "jetpack-videopress-video-block",
-	"editorStyle": "jetpack-videopress-video-block",
-	"style": "jetpack-videopress-video-block-view",
-	"viewScript": "jetpack-videopress-video-block-view"
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style.css",
+	"viewScript": "file:./view.js"
 }

--- a/projects/plugins/jetpack/changelog/fix-videopress-register-block-json
+++ b/projects/plugins/jetpack/changelog/fix-videopress-register-block-json
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2588,7 +2588,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "f510ccfda3f1d6529d5acd206a71cd4c8a2edd75"
+                "reference": "b08bf2e1a72f0d382c4245fe58ca4a8e866c47fe"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2613,7 +2613,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/plugins/videopress/changelog/fix-videopress-register-block-json
+++ b/projects/plugins/videopress/changelog/fix-videopress-register-block-json
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1349,7 +1349,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "f510ccfda3f1d6529d5acd206a71cd4c8a2edd75"
+                "reference": "b08bf2e1a72f0d382c4245fe58ca4a8e866c47fe"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1374,7 +1374,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"


### PR DESCRIPTION
Use `register_block_type` to handle assets loading properly

Fixes #32235

## Proposed changes:
This PR removes old asset enqueueing code and uses the return value from `register_block_type` to get the script handle, which is then provided to `Connection_Initial_State::render_script` for proper initial state rendering.

The PR doesn't change any functional aspect, but tries to solve the mentioned issue after a failed attempt on #33042 (which ended being reverted).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Test on .com:

Use the downloader script to apply on your sandbox. Point to your sandbox:
- [ ] a P2 site (might need to upgrade to P2+ to enable video uploading, ping me for a test-ready site)
- [ ] a simple site with a classic theme
- [ ] a simple site with a block theme

### Test on Jetpack and WoA sites
Use local or rsync, then setup:
- [ ] with classic theme
- [ ] with block theme
- [ ] with infinity scroll if available (search themes that support it)

### On all cases:

- [ ] publish multiple posts with and without videos
- [ ] use Settings -> Reading to list only 2 blog posts (so posts with videos are not on first render/load)
- [ ] see that posts/lists where no videos are published `view.css` is NOT loaded on sources under
  - [ ] wp-content/mu-plugins/jetpack-plugin/**/jetpack_vendor/automattic/jetpack-videopress/build/block-editor/blocks/video
  - [ ] wp-content/plugins/videopress/jetpack_vendor/automattic/jetpack-videopress/build/block-editor/blocks/video
  - [ ] wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-videopress/build/block-editor/blocks/video
- [ ] see that scrolling into or loading a post with a video will show `view.css` loaded from one of those paths
- [ ] see that videos, both on lists and single posts, are loaded properly and can be played


