### PR TITLE
WordPress.com navigation: ensure that stats are always registered

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-missing-stats-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-missing-stats-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordPress.com Navigation: ensure that the stats menu is properly registered.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -365,6 +365,13 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Adds My Home menu.
+	 */
+	public function add_my_home_menu() {
+		$this->update_menu( 'index.php', 'https://wordpress.com/home/' . $this->domain, __( 'My Home', 'jetpack' ), 'read', 'dashicons-admin-home' );
+	}
+
+	/**
 	 * Also remove the Gutenberg plugin menu.
 	 */
 	public function remove_gutenberg_menu() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83268

## Proposed changes:

This is a follow-up to #33631, where we short-circuited access to 	`add_my_home_menu()` for everyone, including WordPress.com simple sites. This causes issues on wpcom simple sites where some folks still want to access the old stats view in wp-admin (`index.php?page=stats`).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

**On WordPress.com Simple**

* Go to Posts > All Posts while having classic view set as your preferred view.
* Click on the Stats icon in one of your published posts row.
* You should be able to access stats for that post.

**On WoA**

> **Note**
> This is essentially testing that the changes in #33631 still work.

* Via `/_cli` run `wp option update wpcom_admin_interface wp-admin` This will set the option that enables the default menu.
* Check that the menu has changed and that the most menu items now point to wp-admin instead of Calypso.

