### PR TITLE
VideoPress: fix upgrade flow

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-videopress-upgrade-flow
+++ b/projects/packages/my-jetpack/changelog/fix-videopress-upgrade-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Use Current_Plan to check/return from has_required_plan on VP product class

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
@@ -163,7 +164,7 @@ class Videopress extends Hybrid_Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
-		// TODO: import and perform a proper check with Current_Plan. See #33410.
-		return true;
+		// using second argument `true` to force fetching from wpcom
+		return Current_Plan::supports( 'videopress-1tb-storage', true );
 	}
 }


### PR DESCRIPTION
Follow up to #33410  #33697 and #33706

Fixes #33222 

## Proposed changes:
This PR is just reimplementing #33410 after it had to be reverted for lack of proper dependency definition. Dependencies have now been updated in #33706 and that should be enough for this change to not blow up.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1697748366739339-slack-C02TQF5VAJD

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Instructions are the same as in #33410:

> Start with a site with no VP subscription. Upload a video to exhaust the free quota.
>
> Go to My Jetpack. See the VideoPress card now reads "Purchase" and shows as inactive. Click "Purchase" and follow the flow, purchase with credits.
>
> You should be taken back to My Jetpack screen to now show the VideoPress card active and with a "Manage" button as CTA.

Plus, the issue seen upon Jetpack plugin removal should not happen anymore:

> Install a standalone Jetpack plugin like Jetpack VaultPress Backups
> Make sure you have uninstalled and removed the main Jetpack plugin
> Navigate to My Jetpack
> You will get a fatal error