### PR TITLE
CRM: Resolves #3369 - allow WooSync contact to be assigned to existing company

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3369-assign_customer_to_existing_company
+++ b/projects/plugins/crm/changelog/fix-crm-3369-assign_customer_to_existing_company
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WooSync: contacts can now be assigned to existing companies

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
@@ -415,6 +415,8 @@ class zbsDAL_companies extends zbsDAL_ObjectLayer {
             (!empty($id) && $id > 0)
             ||
             (!empty($email))
+					||
+					( ! empty( $name ) )
             ||
             (!empty($externalSource) && !empty($externalSourceUID))
             ){

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1555,7 +1555,12 @@ class Woo_Sync_Background_Sync_Job {
 
 		if ( isset( $order_data['billing'] ) && isset( $order_data['billing']['company'] ) ) {
 
-			// Build fields for company
+			/**
+			 * Build fields for company in case it doesn't exist
+			 *
+			 * WooCommerce only gives us one company field (company name), and we can't infer other fields
+			 * from customer info since multiple customers might put the same company
+			 */
 			$data['company'] = array(
 				'status'          => __( 'Customer', 'zero-bs-crm' ),
 				'name'            => $order_data['billing']['company'],
@@ -1569,38 +1574,6 @@ class Woo_Sync_Background_Sync_Job {
 					),
 				),
 			);
-
-			if ( isset( $order_data['billing']['address_1'] ) && !empty( $order_data['billing']['address_1'] ) ) {
-				$data['company']['addr1'] = $order_data['billing']['address_1'];
-			}
-
-			if ( isset( $order_data['billing']['address_2'] ) && !empty( $order_data['billing']['address_2'] ) ) {
-				$data['company']['addr2'] = $order_data['billing']['address_2'];
-			}
-
-			if ( isset( $order_data['billing']['city'] ) && !empty( $order_data['billing']['city'] ) ) {
-				$data['company']['city'] = $order_data['billing']['city'];
-			}
-
-			if ( isset( $order_data['billing']['state'] ) && !empty( $order_data['billing']['state'] ) ) {
-				$data['company']['county'] = $order_data['billing']['state'];
-			}
-
-			if ( isset( $order_data['billing']['country'] ) && !empty( $order_data['billing']['country'] ) ) {
-				$data['company']['country'] = $order_data['billing']['country'];
-			}
-
-			if ( isset( $order_data['billing']['postcode'] ) && !empty( $order_data['billing']['postcode'] ) ) {
-				$data['company']['postcode'] = $order_data['billing']['postcode'];
-			}
-
-			if ( isset( $order_data['billing']['phone'] ) && !empty( $order_data['billing']['phone'] ) ) {
-				$data['company']['maintel'] = $order_data['billing']['phone'];
-			}
-
-			if ( isset( $order_data['billing']['email'] ) && !empty( $order_data['billing']['email'] ) ) {
-				$data['company']['email'] = $order_data['billing']['email'];
-			}
 
 		}
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -898,10 +898,24 @@ class Woo_Sync_Background_Sync_Job {
 			$b2b_mode = zeroBSCRM_getSetting( 'companylevelcustomers' );
 			if ( $b2b_mode && isset( $crm_object_data['company']['name'] ) && !empty( $crm_object_data['company']['name'] ) ) {
 
-				// Add the company
-				$company_id = $zbs->DAL->companies->addUpdateCompany( array(
-					'data' => $crm_object_data['company'],
-				) );
+				/**
+				 * Note: we use existing company ID if we can find it by name; otherwise we create it
+				 *
+				 * WooCommerce orders only has one company field that we can use (company name). As such,
+				 * we can't rely on more accurate searches (e.g. by email)
+				 */
+				$potential_company = $zbs->DAL->companies->getCompany( -1, array( 'name' => $crm_object_data['company']['name'] ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+				if ( $potential_company ) {
+					$company_id = $potential_company['id'];
+				} else {
+					// Add the company
+					$company_id = $zbs->DAL->companies->addUpdateCompany( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						array(
+							'data' => $crm_object_data['company'],
+						)
+					);
+				}
 
 				if ( $company_id > 0 ) {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3369 - allow WooSync contact to be assigned to existing company

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If a Woo order was created with a company name that already existed in the CRM, the CRM contact would not be associated with the company. This is because the companies were created with the Woo customer info (e.g. email + address). A new customer using the same company name would have a different email and thus would not be able to find the existing company.

Given that this happens behind the scenes (via hooks and `cron`), there isn't a way to have the user decide on the fly.

If the company existed, we could handle this in three ways:
1. Continue to fail, as the email won't match and company name is a unique field. This is what we currently do, and it's not very intuitive, though the failure does show in WooSync logs.
2. Search for a company by name and use that ID. In edge cases, two customers might list the same company name for two distinct companies.
3. Add a setting to let the user decide between the two behaviours. This still requires option 2 to be implemented and adds a fair amount of complexity for a situation that hasn't previously been reported.

I opted for option 2 at this stage. With this PR I introduce the following changes:

* Companies can be searched by name via DAL (this actually existed, but there was a missing condition preventing this).
* Woo orders that have a company names field that matches an existing CRM company name will associate the CRM contact with the existing CRM company.
* Woo orders that have a company name that doesn't exist in the CRM will create a new CRM company without contact-specific fields.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a new Woo order with the following:
    - surname: `鈴木`
    - company: `東京産業`
    - email: `suzuki@dev.null`
    - address: 123 Shady Ln
2. Verify CRM contact and CRM company are created and associated.

In `trunk`, the new company is created with the contact email address (as well as any contact address fields if provided).

In the `fix/crm/3369-assign_customer_to_existing_company` branch, the new company will only have the name field. All other fields will be blank.

3. Add a new Woo order with the following:
    - surname: `田中`
    - company: `東京産業`
    - email: `tanaka@dev.null`

In `trunk`, the CRM contact will not be associated with the existing CRM company.

In the `fix/crm/3369-assign_customer_to_existing_company` branch, the CRM contact is properly associated with the existing company.