### PR TITLE
API - Fix Creating Event Endpoint

### DIFF
--- a/projects/plugins/crm/changelog/patch-1
+++ b/projects/plugins/crm/changelog/patch-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Creating Event API Endpoint

--- a/projects/plugins/crm/includes/ZeroBSCRM.IntegrationFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.IntegrationFuncs.php
@@ -885,8 +885,8 @@ function zeroBS_integrations_addOrUpdateTask(
 		is_array( $data_array )
 		&& count( $data_array ) > 0
 		&& ! empty( $data_array['title'] )
-		&& ! empty( $data_array['start'] )
-		&& ! empty( $data_array['end'] )
+		&& ! empty( $data_array['from'] )
+		&& ! empty( $data_array['to'] )
 	) {
 			return zeroBS_addUpdateEvent( $task_id, $data_array, $task_reminders );
 	} else { // no source/id/fields

--- a/projects/plugins/crm/includes/ZeroBSCRM.IntegrationFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.IntegrationFuncs.php
@@ -885,8 +885,13 @@ function zeroBS_integrations_addOrUpdateTask(
 		is_array( $data_array )
 		&& count( $data_array ) > 0
 		&& ! empty( $data_array['title'] )
-		&& ! empty( $data_array['from'] )
-		&& ! empty( $data_array['to'] )
+		&& (
+			// old params
+			( ! empty( $data_array['to'] ) && ! empty( $data_array['from'] ) )
+			||
+			// new params
+			( ! empty( $data_array['start'] ) && ! empty( $data_array['end'] ) )
+		)
 	) {
 			return zeroBS_addUpdateEvent( $task_id, $data_array, $task_reminders );
 	} else { // no source/id/fields


### PR DESCRIPTION
passed data has **"from"** and **"to"** keys not **"start"** and **"end"**, and hence without this update the Create Event API Endpoint keeps returning Error 100

## Testing instructions:

* POST /create_event
* Example POST data: 
```
'{"title":"My Event From the API","notify": 0,"customer":1,"to":"10/23/2023 00:00:00","from":"10/18/2023 00:00:00","complete":0}
```
* without proposed change,  it keeps returning  {"error":100}
* with proposed change, it creates the event as expected and returns expected data:
```
{"title":"My Event From the API","customer":1,"notes":"","to":"10\/23\/2023 00:00:00","from":"10\/18\/2023 00:00:00","notify":-1,"complete":-1,"owner":-1,"id":1}
```

## Does this pull request change what data or activity we track or use?

NO.

