### PR TITLE
Repo Gardening: add WooSync to name exceptions

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-repo_gardening_label_tweaks
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo_gardening_label_tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Adds Woo Sync to GH label name exceptions.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -14,79 +14,27 @@ const getFiles = require( '../../utils/get-files' );
  * @returns {string} Cleaned up feature name.
  */
 function cleanName( name ) {
-	// Sharedaddy is a legacy codename.
-	if ( name === 'sharedaddy' ) {
-		name = 'Sharing';
-	}
+	const name_exceptions = {
+		'custom-post-types': 'Custom Content Types', // We name our CPTs "Custom Content Types" to avoid confusion with WordPress's CPT.
+		'instagram-gallery': 'Latest Instagram Posts', // Latest Instagram Posts used to be named "Instagram Gallery".
+		'mu-wpcom-plugin': 'mu-wpcom', // [Plugin] mu wpcom plugin is a bit too long.
+		'premium-content': 'Paid content', // Premium Content was renamed into Paid content.
+		'rating-star': 'Star Rating', // Rating Star was renamed into Star Rating.
+		'recurring-payments': 'Payments', // Payments used to be called Recurring Payments.
+		'render-blocking-js': 'Defer JS', // render-blocking-js is a Boost feature.
+		sharedaddy: 'Sharing', // Sharedaddy is a legacy codename.
+		shortcodes: 'Shortcodes / Embeds', // Our Shortcodes feature includes shortcodes and embeds.
+		'simple-payments': 'Pay With Paypal', // Simple Payments was renamed to "Pay With Paypal".
+		stats: 'Stats Data', // We customize the Stats module's name to differentiate from the Stats UI (Stats dashboard).
+		widgets: 'Extra Sidebar Widgets', // Our widgets are "Extra Sidebar Widgets".
+		'woo-sync': 'WooSync', // The WooSync module does not have a space, despite legacy naming
+		wordads: 'Ad', // WordAds is a codename. We name the feature just "Ad" or "Ads".
+		'wpcom-block-editor': 'WordPress.com Block Editor', // WordPress.com Block Editor lives under 'wpcom-block-editor'.
+	};
 
-	// Our Shortcodes feature includes shortcodes and embeds.
-	if ( name === 'shortcodes' ) {
-		name = 'Shortcodes / Embeds';
-	}
-
-	// We customize the Stats module's name to differentiate from the Stats UI (Stats dashboard).
-	if ( name === 'stats' ) {
-		name = 'Stats Data';
-	}
-
-	// We name our CPTs "Custom Content Types" to avoid confusion with WordPress's CPT.
-	if ( name === 'custom-post-types' ) {
-		name = 'Custom Content Types';
-	}
-
-	// Our widgets are "Extra Sidebar Widgets".
-	if ( name === 'widgets' ) {
-		name = 'Extra Sidebar Widgets';
-	}
-
-	// Simple Payments was renamed into "Pay With Paypal".
-	if ( name === 'simple-payments' ) {
-		name = 'Pay With Paypal';
-	}
-
-	// WordPress.com Block Editor lives under 'wpcom-block-editor'.
-	if ( name === 'wpcom-block-editor' ) {
-		name = 'WordPress.com Block Editor';
-	}
-
-	// WordAds is a codename. We name the feature just "Ad" or "Ads".
-	if ( name === 'wordads' ) {
-		name = 'Ad';
-	}
-
-	// Latest Instagram Posts used to be named Instagram Gallery.
-	if ( name === 'instagram-gallery' ) {
-		name = 'Latest Instagram Posts';
-	}
-
-	// Payments used to be called Recurring Payments.
-	if ( name === 'recurring-payments' ) {
-		name = 'Payments';
-	}
-
-	// Premium Content was renamed into Paid content.
-	if ( name === 'premium-content' ) {
-		name = 'Paid content';
-	}
-
-	// Rating Star was renamed into Star Rating.
-	if ( name === 'rating-star' ) {
-		name = 'Star Rating';
-	}
-
-	// render-blocking-js is a Boost feature.
-	if ( name === 'render-blocking-js' ) {
-		name = 'Defer JS';
-	}
-
-	// [Plugin] mu wpcom plugin is a bit too long.
-	if ( name === 'mu-wpcom-plugin' ) {
-		name = 'mu-wpcom';
-	}
-
-	// The WooSync module does not have a space, despite legacy naming
-	if ( name === 'woo-sync' ) {
-		name = 'WooSync';
+	if ( name_exceptions[ name ] ) {
+		// don't return here, as at least of the above (mu-wpcom) is further changed below
+		name = name_exceptions[ name ];
 	}
 
 	return (

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -84,6 +84,11 @@ function cleanName( name ) {
 		name = 'mu-wpcom';
 	}
 
+	// The WooSync module does not have a space, despite legacy naming
+	if ( name === 'woo-sync' ) {
+		name = 'WooSync';
+	}
+
 	return (
 		name
 			// Break up words


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Currently if a CRM file with `woo-sync` is touched, the PR is labeled with `[CRM] Woo Sync Module`. Despite the legacy file path, the module is really WooSync (no space).

This PR adds said exception to the `cleanName` function, and also modularises and alphabetises the list of exceptions.

Note: once merged, I'll manually reassign issues associated with the old label.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The easiest way to test this is to load the `cleanName` function into a console, and verify any passed strings return the expected value. The only change should be that `woo-sync` will return `WooSync` (`fix/repo_gardening_label_tweaks` branch) instead of `Woo Sync` (`trunk`).
