### PR TITLE
CRM: Resolves #3371 - remove buggy unused code

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3371-remove_buggy_unused_code
+++ b/projects/plugins/crm/changelog/fix-crm-3371-remove_buggy_unused_code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Listview: remove legacy code

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -493,15 +493,6 @@ class zeroBSCRM_list{
             // Vars for zbs list view drawer
             var zbsListViewParams = <?php echo wp_json_encode( $list_view_parameters ) ?>;
 
-            var zbsUnsortables = [<?php $c = 0; if (count($this->unsortables) > 0) foreach ($this->unsortables as $sortableStr) {
-
-                        if ($c > 0) echo ',';
-
-                        echo "'". esc_html( zeroBSCRM_slashOut($sortableStr,true) )."'";
-
-                        $c++;
-                        
-            } ?>]; // this is columns that are "unsortable" e.g. edit link
             var zbsSortables = [<?php 
 
                 $c = 0; if (count($this->sortables) > 0) foreach ($this->sortables as $sortableStr) {
@@ -594,48 +585,6 @@ class zeroBSCRM_list{
 
                     default:
                         zeroBSCRM_slashOut(__('Item',"zero-bs-crm"));
-                        break;
-
-
-
-                } 
-
-            ?>';
-            var zbsListViewObjNamePlural = '<?php
-
-                switch ($this->postType){
-
-
-                    case 'zerobs_customer':
-                        zeroBSCRM_slashOut(__('Contacts',"zero-bs-crm"));
-                        break;
-
-                    case 'zerobs_company':
-                        zeroBSCRM_slashOut(jpcrm_label_company(true));
-                        break;
-
-                    case 'zerobs_quote':
-                        zeroBSCRM_slashOut(__('Quotes',"zero-bs-crm"));
-                        break;
-
-                    case 'zerobs_invoice':
-                        zeroBSCRM_slashOut(__('Invoices',"zero-bs-crm"));
-                        break;
-
-                    case 'zerobs_transaction':
-                        zeroBSCRM_slashOut(__('Transactions',"zero-bs-crm"));
-                        break;
-
-                    case 'zerobs_form':
-                        zeroBSCRM_slashOut(__('Forms',"zero-bs-crm"));
-                        break;
-
-                    case 'zerobs_quotetemplate':
-                        zeroBSCRM_slashOut(__('Quote Templates',"zero-bs-crm"));
-                        break;
-
-                    default:
-                        zeroBSCRM_slashOut(__('Items',"zero-bs-crm"));
                         break;
 
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -493,30 +493,6 @@ class zeroBSCRM_list{
             // Vars for zbs list view drawer
             var zbsListViewParams = <?php echo wp_json_encode( $list_view_parameters ) ?>;
 
-            var zbsFilterButtons = [
-                    // e.g. {namestr:'Status',fieldstr:'_status'}
-                    <?php  $buttonCount = 0;
-
-                        #} Current cols
-                        if (is_array($currentFilterButtons)) foreach ($currentFilterButtons as $buttonKey => $button){
-
-                            if ($buttonCount > 0) echo ',';
-                            
-							// Hard coded, lazy
-							printf(
-								"{namestr:'%s',fieldstr:'%s'}",
-								wp_kses( $button[0], array( 'i' => array( 'class' => array() ) ) ),
-								// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- to be refactored.
-								esc_html( $buttonKey )
-								// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-							);
-
-                            $buttonCount++;
-
-                        }
-
-                    ?>
-                ];
             var zbsUnsortables = [<?php $c = 0; if (count($this->unsortables) > 0) foreach ($this->unsortables as $sortableStr) {
 
                         if ($c > 0) echo ',';

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -182,19 +182,6 @@ class zeroBSCRM_list{
         $currentColumns = false; if (isset($customViews) && isset($customViews[$this->objType])) $currentColumns = $customViews[$this->objType];
         if ($currentColumns == false) $currentColumns = $defaultColumns;
 
-
-        #} Filter buttons
-        // load defaults (List.columns.php)
-        $filterVar = 'zeroBSCRM_filterbuttons_'.$this->objType; //$zeroBSCRM_filterbuttons_transaction;
-        if ( !isset( $GLOBALS[ $filterVar ] ) ) {
-            $GLOBALS[ $filterVar ] = array( 'default'=>array(), 'all'=>array() );
-        }
-        $defaultFilterButtons = $GLOBALS[ $filterVar ]['default'];
-        // retrieve from customViews (as retrieved above)
-        $currentFilterButtons = false; if (isset($customViews) && isset($customViews[$this->objType.'_filters'])) $currentFilterButtons = $customViews[$this->objType.'_filters'];
-        if ($currentFilterButtons == false) $currentFilterButtons = $defaultFilterButtons;
-        $allFilterButtons = $GLOBALS[ $filterVar ]['all'];
-
 		// add all columns to sortables :)
 		if ( is_array( $currentColumns ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			foreach ( $currentColumns as $col => $var ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3371 - remove buggy unused code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If a user has some manually-translated statuses (e.g. via Loco Translate), it can cause issues. The root cause is that we have some legacy listview filter code that isn't used but that is also not properly escaped. This PR removes said code (the `zbsFilterButtons` JS var) and some additional unused code surrounding it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a bit hard to reproduce. In `trunk`, the easiest way is to edit `includes/ZeroBSCRM.List.php` and modify these lines:

https://github.com/Automattic/jetpack/blob/5cd649f44de4fe9bdcf7dc89d1e1d088d352e062/projects/plugins/crm/includes/ZeroBSCRM.List.php#L498-L500

To add the following:

```
                    <?php  $buttonCount = 0;

                        $currentFilterButtons['bad_filter'] = array( "'קצת אוהד 'לקוח'" );

                        #} Current cols
```

Then go to the contact listview and you'll see the JS error due to improper output escaping. Given this JS isn't even used, the `fix/crm/3371-remove_buggy_unused_code` branch simply removes it altogether.