### PR TITLE
AI Assistant: Add upgrade button to usage panel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-upgrade-button-to-usage-panel
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-upgrade-button-to-usage-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: add Upgrade button component on the UsagePanel.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -12,6 +13,10 @@ import UsageBar from '../usage-bar';
 export default function UsagePanel() {
 	// fetch usage data
 	const { hasFeature, requestsCount, requestsLimit } = useAIFeature();
+
+	const handleUpgradeClick = () => {
+		alert( 'Work in progress' );
+	};
 
 	// build messages
 	const freeUsageMessage = sprintf(
@@ -46,6 +51,16 @@ export default function UsagePanel() {
 						sprintf( __( 'Requests will reset in %1$d days.', 'jetpack' ), 10 )
 					}
 				</p>
+			) }
+
+			{ ! hasFeature && (
+				<Button
+					variant="primary"
+					label="Upgrade your Jetpack AI plan"
+					onClick={ handleUpgradeClick }
+				>
+					Upgrade
+				</Button>
 			) }
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -7,16 +7,15 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './style.scss';
+import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
 import useAIFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import UsageBar from '../usage-bar';
 
 export default function UsagePanel() {
+	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
+
 	// fetch usage data
 	const { hasFeature, requestsCount, requestsLimit } = useAIFeature();
-
-	const handleUpgradeClick = () => {
-		alert( 'Work in progress' );
-	};
 
 	// build messages
 	const freeUsageMessage = sprintf(
@@ -57,7 +56,9 @@ export default function UsagePanel() {
 				<Button
 					variant="primary"
 					label="Upgrade your Jetpack AI plan"
-					onClick={ handleUpgradeClick }
+					href={ checkoutUrl }
+					onClick={ autosaveAndRedirect }
+					disabled={ isRedirecting }
 				>
 					Upgrade
 				</Button>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -9,10 +9,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import './style.scss';
 import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
 import useAIFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
+import { canUserPurchasePlan } from '../../../../blocks/ai-assistant/lib/connection';
 import UsageBar from '../usage-bar';
 
 export default function UsagePanel() {
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
+	const canUpgrade = canUserPurchasePlan();
 
 	// fetch usage data
 	const { hasFeature, requestsCount, requestsLimit } = useAIFeature();
@@ -52,7 +54,7 @@ export default function UsagePanel() {
 				</p>
 			) }
 
-			{ ! hasFeature && (
+			{ ! hasFeature && canUpgrade && (
 				<Button
 					variant="primary"
 					label="Upgrade your Jetpack AI plan"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #33360.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add an "Upgrade" button on the usage panel when the site does not have a plan
* Point the button to the checkout URL
* Only display the button when the user can purchase upgrades

The logic to show this button is different from the upgrade prompt that we are using on the Assistant itself: it will not wait for the user to reach the limit; it will always be visible while the user does not buy the upgrade.

The button style is the standard WordPress style, as per i6 designs: p1HpG7-oMv-p2.

Note: this is based on the current state of trunk, before merging #33714, so the usage data is not real.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open the Jetpack sidebar; look for the AI Assistant section and open it:

<img width="323" alt="Screenshot 2023-10-19 at 18 05 48" src="https://github.com/Automattic/jetpack/assets/6760046/d4fb3cbf-bb83-47bb-a65c-50001391198b">

---

* If the site already have a plan, you should not see the button
* If the site does not have a plan and the user is an admin or other user with `manage` powers, you should see the "Upgrade" button:

<img width="289" alt="Screenshot 2023-10-20 at 19 07 22" src="https://github.com/Automattic/jetpack/assets/6760046/e573a793-ed56-4862-b534-da64963b57df">

---

* If the site does not have a plan and the user does not have `manage` powers, you should not see the button (test with an author or editor, for example)
* When the button is present, if you click it, it should lead to the right page of the upgrade flow:
   * When the site is a Jetpack site, it should redirect to the Jetpack AI interstitial
   * When the site is a Simple site, it should redirect to the checkout page