### PR TITLE
Publicize: fix tweet storm performance issue

### DIFF
--- a/projects/js-packages/publicize-components/src/components/twitter/index.js
+++ b/projects/js-packages/publicize-components/src/components/twitter/index.js
@@ -1,5 +1,5 @@
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { useSelect, withSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import TweetDivider from './tweet-divider';
 import './editor.scss';
@@ -53,11 +53,23 @@ export const SUPPORTED_CONTAINER_BLOCKS = [ 'core/column', 'core/columns', 'core
  * @returns {object} The blockSettings, with our extra functionality inserted.
  */
 const addTweetDivider = blockSettings => {
-	const { edit } = blockSettings;
+	const { edit: Edit } = blockSettings;
 
 	return {
 		...blockSettings,
-		edit: props => <TweetDivider ChildEdit={ edit } childProps={ props } />,
+		edit: props => {
+			const isTweetStorm = useSelect( select => select( 'jetpack/publicize' ).isTweetStorm() );
+
+			// CAUTION: code added before this line will be executed for all
+			// extended blocks, not just tweet storms. TweetDivider runs
+			// additional selectors that should be avoided if a post is not a
+			// tweet storm.
+			if ( ! isTweetStorm ) {
+				return <Edit { ...props } />;
+			}
+
+			return <TweetDivider ChildEdit={ Edit } childProps={ props } />;
+		},
 	};
 };
 

--- a/projects/js-packages/publicize-components/src/components/twitter/tweet-divider.js
+++ b/projects/js-packages/publicize-components/src/components/twitter/tweet-divider.js
@@ -17,10 +17,7 @@ import './editor.scss';
  */
 class TweetDivider extends Component {
 	componentDidMount() {
-		const { isTweetStorm, updateTweets } = this.props;
-		if ( isTweetStorm ) {
-			updateTweets();
-		}
+		this.props.updateTweets();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -28,16 +25,11 @@ class TweetDivider extends Component {
 			boundaries,
 			childProps,
 			currentAnnotations,
-			isTweetStorm,
 			updateAnnotations,
 			updateTweets,
 			supportedBlockType,
 			contentAttributesChanged,
 		} = this.props;
-
-		if ( ! isTweetStorm ) {
-			return;
-		}
 
 		if ( ! supportedBlockType ) {
 			return;
@@ -61,15 +53,10 @@ class TweetDivider extends Component {
 		const {
 			ChildEdit,
 			childProps,
-			isTweetStorm,
 			isSelectedTweetBoundary,
 			boundaryStylesSelectors,
 			popoverWarnings,
 		} = this.props;
-
-		if ( ! isTweetStorm ) {
-			return <ChildEdit { ...childProps } />;
-		}
 
 		return (
 			<>
@@ -123,7 +110,6 @@ class TweetDivider extends Component {
 export default compose( [
 	withSelect( ( select, { childProps } ) => {
 		const {
-			isTweetStorm,
 			getPopoverWarnings,
 			getBoundariesForBlock,
 			getBoundaryStyleSelectors,
@@ -137,7 +123,6 @@ export default compose( [
 		);
 
 		return {
-			isTweetStorm: isTweetStorm(),
 			isSelectedTweetBoundary: isSelectedTweetBoundary( childProps ),
 			boundaries: getBoundariesForBlock( childProps.clientId ),
 			boundaryStylesSelectors: getBoundaryStyleSelectors( childProps.clientId ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `TweetDivider` and its selectors through `withSelect` are currently being called for all blocks in a post on every keystroke, even if that post is not a tweet storm. We should avoid rendering the component entirely if a post is not a tweet storm.

This could be having a significant performance impact. All the green squares you see in the red box below are `withSelect` call form `TweetDivider`

<img width="798" alt="Screenshot 2023-10-21 at 01 10 53" src="https://github.com/Automattic/jetpack/assets/4710635/a96bcb33-8a8c-46d5-a966-60fcc91e013d">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

