### PR TITLE
REST API settings endpoint: Fix google analytics option handling for Jetpack sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-settings-endpoint-wga
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-settings-endpoint-wga
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+REST API settings endpoint: Fix google analytics option handling for Jetpack sites.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -572,8 +572,20 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * Get GA tracking code.
 	 */
 	protected function get_google_analytics() {
-		$option_name = defined( 'IS_WPCOM' ) && IS_WPCOM ? 'wga' : 'jetpack_wga';
+		$option_name = $this->get_google_analytics_option_name();
+
 		return get_option( $option_name );
+	}
+
+	/**
+	 * Get GA tracking code option name.
+	 */
+	protected function get_google_analytics_option_name() {
+		/** This filter is documented in class.json-api-endpoints.php */
+		$is_jetpack  = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
+		$option_name = $is_jetpack ? 'jetpack_wga' : 'wga';
+
+		return $option_name;
 	}
 
 	/**
@@ -690,8 +702,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						return new WP_Error( 'invalid_code', 'Invalid UA ID' );
 					}
 
-					$is_wpcom    = defined( 'IS_WPCOM' ) && IS_WPCOM;
-					$option_name = $is_wpcom ? 'wga' : 'jetpack_wga';
+					$option_name = $this->get_google_analytics_option_name();
 
 					$wga         = get_option( $option_name, array() );
 					$wga['code'] = $value['code']; // maintain compatibility with wp-google-analytics.
@@ -715,6 +726,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					/** This action is documented in modules/widgets/social-media-icons.php */
 					do_action( 'jetpack_bump_stats_extras', 'google-analytics', $enabled_or_disabled );
 
+					$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
 					if ( $is_wpcom ) {
 						$business_plugins = WPCOM_Business_Plugins::instance();
 						$business_plugins->activate_plugin( 'wp-google-analytics' );

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -89,11 +89,12 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 	 *
 	 * @dataProvider setting_value_pairs_get_request
 	 *
+	 * @param string $option_name The option lookup key.
 	 * @param string $setting_name The setting lookup key.
 	 * @param string $setting_value The setting value to test.
 	 */
-	public function test_get_settings_contains_keys_values( $setting_name, $setting_value ) {
-		update_option( $setting_name, $setting_value );
+	public function test_get_settings_contains_keys_values( $option_name, $setting_name, $setting_value ) {
+		update_option( $option_name, $setting_value );
 
 		$response = $this->make_get_request();
 		$settings = $response['settings'];
@@ -295,6 +296,22 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 			'woocommerce_default_country'    => array( 'woocommerce_default_country', '' ),
 			'woocommerce_store_postcode'     => array( 'woocommerce_store_postcode', '' ),
 			'woocommerce_onboarding_profile' => array( 'woocommerce_onboarding_profile', array() ),
+			'wga'                            => array(
+				'wga',
+				array(
+					'code'                          => '',
+					'anonymize_ip'                  => false,
+					'honor_dnt'                     => false,
+					'ec_track_purchases'            => false,
+					'ec_track_add_to_cart'          => false,
+					'enh_ec_tracking'               => false,
+					'enh_ec_track_remove_from_cart' => false,
+					'enh_ec_track_prod_impression'  => false,
+					'enh_ec_track_prod_click'       => false,
+					'enh_ec_track_prod_detail_view' => false,
+					'enh_ec_track_checkout_started' => false,
+				),
+			),
 		);
 	}
 
@@ -305,12 +322,29 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 	 */
 	public function setting_value_pairs_get_request() {
 		return array(
-			'woocommerce_store_address'      => array( 'woocommerce_store_address', 'Street 34th 1/2' ),
-			'woocommerce_store_address_2'    => array( 'woocommerce_store_address_2', 'Apt #1' ),
-			'woocommerce_store_city'         => array( 'woocommerce_store_city', 'City' ),
-			'woocommerce_default_country'    => array( 'woocommerce_default_country', 'US:NY' ),
-			'woocommerce_store_postcode'     => array( 'woocommerce_store_postcode', '98738' ),
-			'woocommerce_onboarding_profile' => array( 'woocommerce_onboarding_profile', array( 'test' => 'test value' ) ),
+			'woocommerce_store_address'      => array( 'woocommerce_store_address', 'woocommerce_store_address', 'Street 34th 1/2' ),
+			'woocommerce_store_address_2'    => array( 'woocommerce_store_address_2', 'woocommerce_store_address_2', 'Apt #1' ),
+			'woocommerce_store_city'         => array( 'woocommerce_store_city', 'woocommerce_store_city', 'City' ),
+			'woocommerce_default_country'    => array( 'woocommerce_default_country', 'woocommerce_default_country', 'US:NY' ),
+			'woocommerce_store_postcode'     => array( 'woocommerce_store_postcode', 'woocommerce_store_postcode', '98738' ),
+			'woocommerce_onboarding_profile' => array( 'woocommerce_onboarding_profile', 'woocommerce_onboarding_profile', array( 'test' => 'test value' ) ),
+			'wga'                            => array(
+				'jetpack_wga',
+				'wga',
+				array(
+					'code'                          => 'G-TESTING',
+					'anonymize_ip'                  => false,
+					'honor_dnt'                     => false,
+					'ec_track_purchases'            => false,
+					'ec_track_add_to_cart'          => false,
+					'enh_ec_tracking'               => false,
+					'enh_ec_track_remove_from_cart' => false,
+					'enh_ec_track_prod_impression'  => false,
+					'enh_ec_track_prod_click'       => false,
+					'enh_ec_track_prod_detail_view' => false,
+					'enh_ec_track_checkout_started' => false,
+				),
+			),
 		);
 	}
 
@@ -342,6 +376,15 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 				array(
 					'invitation'     => 'Test string <a href="#">link</a>',
 					'comment_follow' => "Test string 2\n\n Other line",
+				),
+			),
+			'wga'                                       => array(
+				'wga',
+				array(
+					'code' => 'G-TESTING',
+				),
+				array(
+					'code' => 'G-TESTING',
 				),
 			),
 		);


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `WPCOM_JSON_API_Site_Settings_Endpoint`: Rely on whether this is a Jetpack site instead of the environment (WPCOM vs remote site) in order to determine whether the `wga` or `jetpack_wga` option should be used for fetching/storing Google Analytics tracking data.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf5801-5l-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
- Using the [Developer console](https://developer.wordpress.com/docs/api/console/) check the `sites/[SITE_ID]/settings` endpoint for both fetching and updating the `wga` setting
- Make sure to test on a Simple site too
- Bonus points for testing on a Jetpack site, forcing the endpoint to fetch the results from WPCOM (`?force=wpcom`)