### PR TITLE
AI Extension: improve info message when selected blocks don't have content to modify

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-disable-when-no-content
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-disable-when-no-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: improve info message when selected blocks don't have content to modify

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -255,12 +255,14 @@ function AiAssistantDropdownContent( {
 					onChange={ tone => {
 						requestSuggestion( PROMPT_TYPE_CHANGE_TONE, { tone } );
 					} }
+					disabled={ noContent }
 				/>
 
 				<I18nMenuDropdown
 					onChange={ language => {
 						requestSuggestion( PROMPT_TYPE_CHANGE_LANGUAGE, { language } );
 					} }
+					disabled={ noContent }
 				/>
 			</MenuGroup>
 		</>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -220,7 +220,7 @@ function AiAssistantDropdownContent( {
 		<>
 			{ noContent && (
 				<Notice status="warning" isDismissible={ false } className="jetpack-ai-assistant__info">
-					{ __( 'Add content to use these tools', 'jetpack' ) }
+					{ __( 'Add content to activate the tools below', 'jetpack' ) }
 				</Notice>
 			) }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -6,7 +6,7 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { getBlockContent } from '@wordpress/blocks';
 import { MenuItem, MenuGroup, ToolbarButton, Dropdown, Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { post, postContent, postExcerpt, termDescription } from '@wordpress/icons';
 import React from 'react';
@@ -126,6 +126,18 @@ function AiAssistantDropdownContent( {
 	const { getSelectedBlockClientIds, getBlocksByClientId } = useSelect( 'core/block-editor' );
 	const { removeBlocks, replaceBlock } = useDispatch( 'core/block-editor' );
 
+	// Store the current content in a local state
+	useEffect( () => {
+		const clientIds = getSelectedBlockClientIds();
+		const blocks = getBlocksByClientId( clientIds );
+		const content = getBlocksContent( blocks );
+
+		const rawContent = getRawTextFromHTML( content );
+
+		// Set no content condition to show the Notice info message.
+		return setNoContent( ! rawContent.length );
+	}, [ getBlocksByClientId, getSelectedBlockClientIds ] );
+
 	const { tracks } = useAnalytics();
 
 	const requestSuggestion = (
@@ -135,13 +147,6 @@ function AiAssistantDropdownContent( {
 		const clientIds = getSelectedBlockClientIds();
 		const blocks = getBlocksByClientId( clientIds );
 		const content = getBlocksContent( blocks );
-
-		const rawContent = getRawTextFromHTML( content );
-
-		if ( ! rawContent.length ) {
-			// Set no content condition to show the Notice info message.
-			return setNoContent( true );
-		}
 
 		onClose();
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -230,6 +230,7 @@ function AiAssistantDropdownContent( {
 					iconPosition="left"
 					key="key-ai-assistant"
 					onClick={ replaceWithAiAssistantBlock }
+					disabled={ noContent }
 				>
 					<div className="jetpack-ai-assistant__menu-item">
 						{ __( 'Ask AI Assistant', 'jetpack' ) }
@@ -244,6 +245,7 @@ function AiAssistantDropdownContent( {
 						onClick={ () => {
 							requestSuggestion( quickAction.aiSuggestion, {} );
 						} }
+						disabled={ noContent }
 					>
 						<div className="jetpack-ai-assistant__menu-item">{ quickAction.name }</div>
 					</MenuItem>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -220,7 +220,7 @@ function AiAssistantDropdownContent( {
 		<>
 			{ noContent && (
 				<Notice status="warning" isDismissible={ false } className="jetpack-ai-assistant__info">
-					{ __( 'No content to modify.', 'jetpack' ) }
+					{ __( 'Add content to use these tools', 'jetpack' ) }
 				</Notice>
 			) }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/style.scss
@@ -16,6 +16,10 @@
 	}
 }
 
+.jetpack-ai-assistant__info {
+	margin-bottom: 8px;
+}
+
 @keyframes fadingSpark {
 	to {
 		opacity: 0.3;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/style.scss
@@ -17,7 +17,7 @@
 }
 
 .jetpack-ai-assistant__info {
-	margin-bottom: 8px;
+	margin: 0 0 8px 0;
 }
 
 @keyframes fadingSpark {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
@@ -33,6 +33,7 @@ type LanguageDropdownControlProps = {
 	value?: LanguageProp;
 	onChange: ( value: string ) => void;
 	label?: string;
+	disabled?: boolean;
 };
 
 const defaultLanguageLocale =
@@ -152,7 +153,6 @@ export function I18nMenuDropdown( {
 			className="ai-assistant__i18n-dropdown"
 			icon={ globe }
 			label={ label }
-			disabled={ disabled }
 			toggleProps={ {
 				children: (
 					<>
@@ -160,6 +160,7 @@ export function I18nMenuDropdown( {
 						<Icon icon={ chevronRight } />
 					</>
 				),
+				disabled,
 			} }
 		>
 			{ ( { onClose } ) => (

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -131,6 +131,7 @@ type ToneToolbarDropdownMenuProps = {
 	value?: ToneProp;
 	onChange: ( value: ToneProp ) => void;
 	label?: string;
+	disabled?: boolean;
 };
 
 const ToneMenuGroup = ( { value, onChange }: ToneToolbarDropdownMenuProps ) => (
@@ -153,6 +154,7 @@ export function ToneDropdownMenu( {
 	label = __( 'Change tone', 'jetpack' ),
 	value = DEFAULT_PROMPT_TONE,
 	onChange,
+	disabled = false,
 }: ToneToolbarDropdownMenuProps ) {
 	return (
 		<DropdownMenu
@@ -169,6 +171,7 @@ export function ToneDropdownMenu( {
 						<Icon icon={ chevronRight } />
 					</>
 				),
+				disabled,
 			} }
 		>
 			{ ( { onClose } ) => (
@@ -187,6 +190,7 @@ export function ToneDropdownMenu( {
 export default function ToneToolbarDropdownMenu( {
 	value = DEFAULT_PROMPT_TONE,
 	onChange,
+	disabled = false,
 }: ToneToolbarDropdownMenuProps ) {
 	return (
 		<ToolbarDropdownMenu
@@ -195,6 +199,7 @@ export default function ToneToolbarDropdownMenu( {
 			popoverProps={ {
 				variant: 'toolbar',
 			} }
+			disabled={ disabled }
 		>
 			{ () => <ToneMenuGroup value={ value } onChange={ onChange } /> }
 		</ToolbarDropdownMenu>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR:

* React the AI Assistant dropdown component: Create a new `<AiAssistantDropdownContent />` reducing the its functionality scope 
* Edit no-content message info: Change the text and slightly tweak the notice component layout.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: improve info message when selected blocks don't have content to modify

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Confirm the AI extensions work as usual when the selected blocks have content:

Single selection | Multiple selections
-----------|----------
<img width="661" alt="Screenshot 2023-10-23 at 09 09 59" src="https://github.com/Automattic/jetpack/assets/77539/f4d97fa6-f17e-4cc4-b1f1-4c5b847a78e2"> | <img width="625" alt="Screenshot 2023-10-23 at 09 10 39" src="https://github.com/Automattic/jetpack/assets/77539/f29c78dc-12d6-46fa-923f-75b30ef167bc">

* Confirm the AI extension items get disabled when there isn't content in the blocks' selection (tip: use spaces to be able to see the block toolbar)

Single selection | Multiple selections
-----------|----------
<img width="431" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/817ddab8-0ee3-4ce7-be59-df1b83eb2bac"> | <img width="584" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/78b71905-b175-414d-9481-d464bd6121c7">

