### PR TITLE
JSPackages: make ContextualUpgradeTrigger icon click work

### DIFF
--- a/projects/js-packages/components/changelog/change-contextual-upgrade-arrow-behavior
+++ b/projects/js-packages/components/changelog/change-contextual-upgrade-arrow-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use pointer-events: none on arrow icon so its click behavior falls back to the container/underlying component

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/style.module.scss
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/style.module.scss
@@ -57,6 +57,7 @@
 .icon {
 	fill: var( --jp-green-40 );
 	transition: transform 0.1s ease-out;
+	pointer-events: none;
 }
 
 .iconContainer {

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.44.0",
+	"version": "0.44.1-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
ContextualUpgradeTrigger holds an arrow icon, but the icon doesn't have an `onClick` and blocks the click behavior of the component


https://github.com/Automattic/jetpack/assets/157240/829ee7cc-fb22-401a-8063-d2395e5224e4


## Proposed changes:
Set the icon to `pointer-events: none` so the click behavior falls back to the underlying component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The component is used on some Jetpack products, like VideoPress, Search, Scan, Protect, Firewall.
The easiest way to see it is installing VideoPress plugin and upload a video. Then navigate to the dashboard `/wp-admin/admin.php?page=jetpack-videopress#/` and the upgrade banner (ContextualUpgradeTrigger) should show:
<img width="587" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/46f4cec7-236c-499a-83ca-350ce38fdbe9">

- [ ] Hover the arrow to see it behave as the rest of the component (since it doesn't receive the events)
- [ ] See that hovering still triggers the animation
- [ ] See that clicking on the arrow triggers the same action as the rest of the component
