### PR TITLE
CRM: Resolves #3373 and #3376 - address PHP 8.2 deprecation notices in the Client Portal

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3373-deprecation_notices_in_Client_Portal
+++ b/projects/plugins/crm/changelog/fix-crm-3373-deprecation_notices_in_Client_Portal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Client Portal: Better PHP 8.2 support.

--- a/projects/plugins/crm/modules/portal/class-client-portal-endpoint.php
+++ b/projects/plugins/crm/modules/portal/class-client-portal-endpoint.php
@@ -15,6 +15,7 @@ defined( 'ZEROBSCRM_PATH' ) || exit;
  * This class represents a single Client Portal endpoint (e.g. Quotes)
  * 
  */
+#[\AllowDynamicProperties]
 abstract class Client_Portal_Endpoint {
 	public $portal                       = null;
 	public $template_name                = null;

--- a/projects/plugins/crm/modules/portal/class-client-portal-endpoint.php
+++ b/projects/plugins/crm/modules/portal/class-client-portal-endpoint.php
@@ -29,6 +29,11 @@ abstract class Client_Portal_Endpoint {
 	public $template_args                = array();
 	public $template_path                = '';
 	public $default_template_path        = '';
+	/**
+	 * Option param value used by some endpoints
+	 * @var string
+	 */
+	public $param_value;
 
 	abstract public static function register_endpoint( $endpoints, $client_portal );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3373 and Automattic/zero-bs-crm#3376 - address PHP 8.2 deprecation notices in the Client Portal

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Dynamic class properties are not allowed by default in the Client Portal. Since all endpoints use the `param_value` property, I added that as part of the `Client_Portal_Endpoint` class declaration.

After testing Client Portal Pro, I realised there are some other dynamic properties the extension selectively adds. There were three choices:

1. Declare those dynamic properties in the main class. I didn't like this option, because that introduces code only used by the extension.
2. Have an alternate class the endpoints use when the extension is enabled. I didn't like this option, as it relies on load order, adds extra complexity, and would likely duplicate code.
3. Allow dynamic properties with `#[\AllowDynamicProperties]`.

I went with the latter choice. That means the first commit wasn't needed in the end, but I still kept it so as to uphold best practices when possible.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Go to each of the subpages in the Client Portal.

In `trunk`, most of the pages (i.e. `/details`, `/invoices`, `/invoices/1`, `/quotes`, `/quote/1`, `/transactions`) will generate a PHP deprecation notice that looks like this:
```
PHP Deprecated:  Creation of dynamic property Automattic\JetpackCRM\Some_Endpoint::$param_value is deprecated in /modules/portal/class-client-portal.php on line 503
```

In the `fix/crm/3373-deprecation_notices_in_Client_Portal` branch, the deprecation notice is no more.