### PR TITLE
Earn: Rename earn to monetize

### DIFF
--- a/projects/plugins/jetpack/_inc/client/admin.js
+++ b/projects/plugins/jetpack/_inc/client/admin.js
@@ -127,7 +127,7 @@ export function getRouteName( path ) {
 		case '/discussion':
 			return _x( 'Discussion', 'Navigation item.', 'jetpack' );
 		case '/earn':
-			return _x( 'Earn', 'Navigation item.', 'jetpack' );
+			return _x( 'Monetize', 'Navigation item.', 'jetpack' );
 		case '/newsletter':
 			return _x( 'Newsletter', 'Navigation item.', 'jetpack' );
 		case '/security':

--- a/projects/plugins/jetpack/_inc/client/components/navigation-settings/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/navigation-settings/index.jsx
@@ -211,7 +211,7 @@ export class NavigationSettings extends React.Component {
 							onClick={ this.handleClickForTracking( 'earn' ) }
 							selected={ this.props.location.pathname === '/earn' }
 						>
-							{ _x( 'Earn', 'Navigation item.', 'jetpack' ) }
+							{ _x( 'Monetize', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
 				</NavTabs>

--- a/projects/plugins/jetpack/_inc/client/components/navigation-settings/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/navigation-settings/test/component.js
@@ -168,7 +168,7 @@ describe( 'NavigationSettings', () => {
 			expect( screen.getByRole( 'menuitem', { name: 'Discussion' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'option', { name: 'Discussion' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'menuitem', { name: 'Monetize' } ) ).toBeInTheDocument();
-			expect( screen.getByRole( 'option', { name: 'Earn' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'option', { name: 'Monetize' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'menuitem', { name: 'Newsletter' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'option', { name: 'Newsletter' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'menuitem', { name: 'Security' } ) ).toBeInTheDocument();
@@ -263,7 +263,7 @@ describe( 'NavigationSettings', () => {
 				routeName: 'Earn',
 			};
 			render( <NavigationSettings { ...currentTestProps2 } /> );
-			const option = screen.getByRole( 'option', { name: 'Earn' } );
+			const option = screen.getByRole( 'option', { name: 'Monetize' } );
 			expect( option ).toHaveAttribute( 'aria-selected', 'true' );
 		} );
 

--- a/projects/plugins/jetpack/_inc/client/components/navigation-settings/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/navigation-settings/test/component.js
@@ -168,7 +168,7 @@ describe( 'NavigationSettings', () => {
 			expect( screen.getByRole( 'menuitem', { name: 'Discussion' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'option', { name: 'Discussion' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'menuitem', { name: 'Monetize' } ) ).toBeInTheDocument();
-			expect( screen.getByRole( 'option', { name: 'Monetize' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'option', { name: 'Earn' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'menuitem', { name: 'Newsletter' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'option', { name: 'Newsletter' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'menuitem', { name: 'Security' } ) ).toBeInTheDocument();

--- a/projects/plugins/jetpack/_inc/client/components/navigation-settings/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/navigation-settings/test/component.js
@@ -167,8 +167,8 @@ describe( 'NavigationSettings', () => {
 			expect( screen.getAllByRole( 'option' ) ).toHaveLength( 8 );
 			expect( screen.getByRole( 'menuitem', { name: 'Discussion' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'option', { name: 'Discussion' } ) ).toBeInTheDocument();
-			expect( screen.getByRole( 'menuitem', { name: 'Earn' } ) ).toBeInTheDocument();
-			expect( screen.getByRole( 'option', { name: 'Earn' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'menuitem', { name: 'Monetize' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'option', { name: 'Monetize' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'menuitem', { name: 'Newsletter' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'option', { name: 'Newsletter' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'menuitem', { name: 'Security' } ) ).toBeInTheDocument();

--- a/projects/plugins/jetpack/changelog/update-rename-earn-to-monetize
+++ b/projects/plugins/jetpack/changelog/update-rename-earn-to-monetize
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Earn: Rename Earn to Monetize

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -348,7 +348,7 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->hide_submenu_page( 'tools.php', 'delete-blog' );
 
 		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 0 );
-		add_submenu_page( 'tools.php', esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
+		add_submenu_page( 'tools.php', esc_attr__( 'Monetize', 'jetpack' ), __( 'Monetize', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Renames Earn page and main nav links from 'Earn' to 'Monetize'. This will be visible on the Jetpack settings page, but also on the main WordPress dashboard menu on simple sites. 
* Updates associated tests

**Jetpack self-hosted sites**
<img width="1418" alt="monetize 1" src="https://github.com/Automattic/jetpack/assets/21228350/28210608-3717-4e9f-ac65-8dbbff63aac3">

**WordPress.com simple sites*
![monetize2](https://github.com/Automattic/jetpack/assets/21228350/18b378dc-6564-47a0-b739-75896c45ccb8)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Test on a Jetpack self hosted site.
   - On a jurassic tube site, go to `http://YOURJURASSICTUBEURL/wp-admin/admin.php?page=jetpack#/settings`
   - Confirm the Monetize tab shows at the top right like the first screenshot above
   - Confirm the tab loads as expected when clicked
   
 2) Test on a simple site
    - Run `bin/jetpack-downloader test jetpack update/rename-earn-to-monetize` in your sandbox
    - Sandbox public-api and the domain of your test site
    - Go to the WordPress admin area and confirm that you see the Tools > Monetize like the second screenshot above
    - Click the nav link and confirm it loads the Earn/Monetize screen as expected

3) Bonus: confirm tests pass as expected
    - In your local jetpack working directly navigate to projects/plugins/jetpack, run `pnpm run test-gui`, and confirm all tests pass. 