### PR TITLE
AI Extension: fix undefined 'disabled' I18nMenuDropdown prop bug

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-fix-disable-prop-bug
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-fix-disable-prop-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Extension: fix undefined 'disabled' I18nMenuDropdown prop bug

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
@@ -157,7 +157,8 @@ export function I18nMenuDropdown( {
 	value = defaultLanguage,
 	label = defaultLabel,
 	onChange,
-}: Pick< LanguageDropdownControlProps, 'label' | 'onChange' | 'value' > & {
+	disabled = false,
+}: Pick< LanguageDropdownControlProps, 'label' | 'onChange' | 'value' | 'disabled' > & {
 	toggleProps?: Record< string, unknown >;
 } ) {
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes a bug that happens because the `disabled` property of the `<I18nMenuDropdown />` is not defined.

<img src="https://github.com/Automattic/jetpack/assets/77539/6a7c9800-bec5-4b12-bdc8-052dd0768eba" width="500px" />

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: fix undefined 'disabled' I18nMenuDropdown prop bug

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Use a paragraph block to test
* Add content
* Open the block toolbar
* Click on the AI button

Before | After
----|-----
<img width="674" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/3438dea2-dcda-4e53-9fce-1b0b5b81cf87"> |  <img width="378" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/27439e60-3afe-4855-9389-335fe6bb13cc">


