### PR TITLE
Jetpack: add @wordpress/wordcount dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2992,6 +2992,9 @@ importers:
       '@wordpress/widgets':
         specifier: 3.21.0
         version: 3.21.0(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
+      '@wordpress/wordcount':
+        specifier: 3.44.0
+        version: 3.44.0
       bounding-client-rect:
         specifier: 1.0.5
         version: 1.0.5
@@ -24087,6 +24090,7 @@ packages:
   /ws@7.5.9:
     resolution: {integrity: sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==}
     engines: {node: '>=8.3.0'}
+    requiresBuild: true
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2

--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-add-missing-pgk-dep
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-add-missing-pgk-dep
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: add @wordpress/wordcount dependency

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -45,8 +45,8 @@
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "3.1.1",
 		"@automattic/format-currency": "1.0.1",
-		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-ai-client": "workspace:*",
+		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-api": "workspace:*",
 		"@automattic/jetpack-boost-score-api": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
@@ -76,6 +76,7 @@
 		"@wordpress/url": "3.45.0",
 		"@wordpress/viewport": "5.21.0",
 		"@wordpress/widgets": "3.21.0",
+		"@wordpress/wordcount": "3.44.0",
 		"bounding-client-rect": "1.0.5",
 		"classnames": "2.3.2",
 		"clipboard": "2.0.6",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR explicitly sets the `@wordpress/wordcount` dependency on the Jetpack plugin package.json file.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: add @wordpress/wordcount dependency

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm the build process of the Jetpack plugin works as expected

```
jetpack build plugins/jetpack -deps
```

