### PR TITLE
Backport changes for Jetpack 12.8-a.3 and mu-wpcom-plugin 1.7.2

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.13] - 2023-10-23
+### Changed
+- Updated package dependencies. [#33687]
+
+### Removed
+- AI Client: Remove obsolete blockListBlockWithAiDataProvider() HOC component. [#33726]
+
 ## [0.1.12] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33584]
@@ -144,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.1.13]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.9...v0.1.10

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/changelog/update-ai-client-clean-obsolte-hoc
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-clean-obsolte-hoc
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-AI Client: remove obsolete blockListBlockWithAiDataProvider() HOC component

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.1.13-alpha",
+	"version": "0.1.13",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.44.1] - 2023-10-23
+### Changed
+- Use pointer-events: None on arrow icon so its click behavior falls back to the container/underlying component. [#33733]
+
 ## [0.44.0] - 2023-10-19
 ### Added
 - Add a `ProgressBar` component. [#33054]
@@ -856,6 +860,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.44.1]: https://github.com/Automattic/jetpack-components/compare/0.44.0...0.44.1
 [0.44.0]: https://github.com/Automattic/jetpack-components/compare/0.43.4...0.44.0
 [0.43.4]: https://github.com/Automattic/jetpack-components/compare/0.43.3...0.43.4
 [0.43.3]: https://github.com/Automattic/jetpack-components/compare/0.43.2...0.43.3

--- a/projects/js-packages/components/changelog/change-contextual-upgrade-arrow-behavior
+++ b/projects/js-packages/components/changelog/change-contextual-upgrade-arrow-behavior
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use pointer-events: none on arrow icon so its click behavior falls back to the container/underlying component

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.44.1-alpha",
+	"version": "0.44.1",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.30.5] - 2023-10-23
+### Added
+- Added getCalypsoOrigin() helper function. [#33257]
+
 ## [0.30.4] - 2023-10-19
 ### Changed
 - Updated package dependencies. [#33687]
@@ -648,6 +652,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.30.5]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.4...v0.30.5
 [0.30.4]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.3...v0.30.4
 [0.30.3]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.2...v0.30.3
 [0.30.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.1...v0.30.2

--- a/projects/js-packages/connection/changelog/add-get-calypso-origin-helper
+++ b/projects/js-packages/connection/changelog/add-get-calypso-origin-helper
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added getCalypsoOrigin() helper function.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.30.5-alpha",
+	"version": "0.30.5",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.58 - 2023-10-23
+### Changed
+- Updated package dependencies. [#33646] [#33687]
+
 ## 0.2.57 - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]

--- a/projects/js-packages/partner-coupon/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.58-alpha",
+	"version": "0.2.58",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.0] - 2023-10-23
+### Added
+- Added media restrictions for nextdoor media. [#33630]
+
+### Changed
+- Updated package dependencies. [#33646] [#33687]
+
+### Removed
+- Social: Remove tweetstorm editor components. [#33723]
+
+### Fixed
+- Connection Toggle: Prevented the change handler for firing when the component is disabled. [#33602]
+
 ## [0.40.2] - 2023-10-16
 ### Added
 - Added aspect-ratio validation for Instagram images. [#33522]
@@ -466,6 +479,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.41.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.40.2...v0.41.0
 [0.40.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.40.1...v0.40.2
 [0.40.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.40.0...v0.40.1
 [0.40.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.39.1...v0.40.0

--- a/projects/js-packages/publicize-components/changelog/add-nextdoor-frontend-media-validation
+++ b/projects/js-packages/publicize-components/changelog/add-nextdoor-frontend-media-validation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added media restrictions for nextdoor media

--- a/projects/js-packages/publicize-components/changelog/fix-social-connection-toggle
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connection-toggle
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Connection Toggle: Prevented the change handler for firing when the component is disabled

--- a/projects/js-packages/publicize-components/changelog/remove-twitter
+++ b/projects/js-packages/publicize-components/changelog/remove-twitter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Social: Remove tweetstorm editor components

--- a/projects/js-packages/publicize-components/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.41.0-alpha",
+	"version": "0.41.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/action-bar/CHANGELOG.md
+++ b/projects/packages/action-bar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.30] - 2023-10-23
+### Changed
+- Updated package dependencies. [#33646] [#33687]
+
 ## [0.1.29] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]
@@ -126,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds the Action Bar package and Jetpack plugin module for follows, likes, and comments. Just a scaffold to build on, for now. [#25447]
 
+[0.1.30]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.29...v0.1.30
 [0.1.29]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.28...v0.1.29
 [0.1.28]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.26...v0.1.27

--- a/projects/packages/action-bar/changelog/renovate-babel-monorepo
+++ b/projects/packages/action-bar/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/action-bar/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/action-bar/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/action-bar/package.json
+++ b/projects/packages/action-bar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-action-bar",
-	"version": "0.1.30-alpha",
+	"version": "0.1.30",
 	"description": "An easy way for visitors to follow, like, and comment on your WordPress site.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/action-bar/#readme",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.9] - 2023-10-23
+### Changed
+- Replace Calypso progress bar with one from VideoPress. [#33054]
+- Updated package dependencies. [#33646] [#33687]
+
 ## [1.17.8] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]
@@ -495,6 +500,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[1.17.9]: https://github.com/Automattic/jetpack-backup/compare/v1.17.8...v1.17.9
 [1.17.8]: https://github.com/Automattic/jetpack-backup/compare/v1.17.7...v1.17.8
 [1.17.7]: https://github.com/Automattic/jetpack-backup/compare/v1.17.6...v1.17.7
 [1.17.6]: https://github.com/Automattic/jetpack-backup/compare/v1.17.5...v1.17.6

--- a/projects/packages/backup/changelog/renovate-babel-monorepo
+++ b/projects/packages/backup/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/changelog/try-remove-calypso-progress-bar
+++ b/projects/packages/backup/changelog/try-remove-calypso-progress-bar
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Replace Calypso progress bar with one from VideoPress.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.17.9-alpha';
+	const PACKAGE_VERSION = '1.17.9';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2023-10-23
+### Added
+- DSP media endpoints allowlisting. [#33598]
+
+### Changed
+- Updated package dependencies. [#33646] [#33687]
+
+### Fixed
+- Fix unsetting `sub_path` in `Dashboard_REST_Controller`. [#33668]
+
 ## [0.10.4] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]
@@ -215,6 +225,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.11.0]: https://github.com/automattic/jetpack-blaze/compare/v0.10.4...v0.11.0
 [0.10.4]: https://github.com/automattic/jetpack-blaze/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/automattic/jetpack-blaze/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/automattic/jetpack-blaze/compare/v0.10.1...v0.10.2

--- a/projects/packages/blaze/changelog/fix-wpcom-rector-complaints
+++ b/projects/packages/blaze/changelog/fix-wpcom-rector-complaints
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix unsetting `'sub_path'` in `Dashboard_REST_Controller`.

--- a/projects/packages/blaze/changelog/media-endpoints-whitelisting
+++ b/projects/packages/blaze/changelog/media-endpoints-whitelisting
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-DSP media endpoints whitelisting

--- a/projects/packages/blaze/changelog/renovate-babel-monorepo
+++ b/projects/packages/blaze/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.11.0-alpha",
+	"version": "0.11.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.11.0-alpha';
+	const PACKAGE_VERSION = '0.11.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/blocks/CHANGELOG.md
+++ b/projects/packages/blocks/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2023-10-23
+### Fixed
+- Fix missing block translations. [#33546]
+
 ## [1.6.1] - 2023-09-26
 ### Fixed
 - Fix erroneous path check in Blocks class [#33318]
@@ -161,6 +165,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Blocks: introduce new package for block management
 
+[1.6.2]: https://github.com/Automattic/jetpack-blocks/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/Automattic/jetpack-blocks/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/Automattic/jetpack-blocks/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/Automattic/jetpack-blocks/compare/v1.4.23...v1.5.0

--- a/projects/packages/blocks/changelog/fix-block-translations-2
+++ b/projects/packages/blocks/changelog/fix-block-translations-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix missing block translations

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.4] - 2023-10-23
+### Changed
+- Updated package dependencies. [#33646] [#33687]
+
 ## [0.22.3] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429]
@@ -344,6 +348,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.22.4]: https://github.com/automattic/jetpack-forms/compare/v0.22.3...v0.22.4
 [0.22.3]: https://github.com/automattic/jetpack-forms/compare/v0.22.2...v0.22.3
 [0.22.2]: https://github.com/automattic/jetpack-forms/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/automattic/jetpack-forms/compare/v0.22.0...v0.22.1

--- a/projects/packages/forms/changelog/renovate-babel-monorepo
+++ b/projects/packages/forms/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.22.4-alpha",
+	"version": "0.22.4",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.22.4-alpha';
+	const PACKAGE_VERSION = '0.22.4';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/google-fonts-provider/CHANGELOG.md
+++ b/projects/packages/google-fonts-provider/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2023-10-23
+### Added
+- Google Fonts: Integrate the google fonts with the new font library. [#33203]
+
 ## [0.5.4] - 2023-09-11
 ### Changed
 - General: remove backwards-compatible functions now that package relies on WordPress 6.2. [#32772]
@@ -86,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds a provider for Google Fonts using the new Webfonts API in Gutenberg
 
+[0.6.0]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.5.4...v0.6.0
 [0.5.4]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.5.1...v0.5.2

--- a/projects/packages/google-fonts-provider/changelog/feat-google-fonts-with-new-font-library
+++ b/projects/packages/google-fonts-provider/changelog/feat-google-fonts-with-new-font-library
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Google Fonts: Integrate the google fonts with the new font library

--- a/projects/packages/google-fonts-provider/package.json
+++ b/projects/packages/google-fonts-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-google-fonts-provider",
-	"version": "0.6.0-alpha",
+	"version": "0.6.0",
 	"description": "WordPress Webfonts provider for Google Fonts",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/google-fonts-provider/#readme",
 	"bugs": {

--- a/projects/packages/lazy-images/CHANGELOG.md
+++ b/projects/packages/lazy-images/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2023-10-23
+### Changed
+- Updated package dependencies. [#33687]
+
 ## [2.3.1] - 2023-10-10
 ### Changed
 - Updated package dependencies. [#33428]
@@ -364,6 +368,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lazy Images: Move into a package
 
+[2.3.2]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.45...v2.2.0

--- a/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0] - 2023-10-23
+### Added
+- Add jetpack-plans dependency. It will be use to restore the reverted change on #33410. [#33706]
+
+### Changed
+- Update checkout flow to connect "After" checkout vs before (if not connected). [#33257]
+
+### Fixed
+- Use Current_Plan to check/return from has_required_plan on VP product class. [#33708]
+
 ## [3.9.1] - 2023-10-19
 ### Changed
 - Make has_required_plan return true (as it was before #33410) as a way to revert the change. [#33697]
@@ -1069,6 +1079,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[3.10.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.9.1...3.10.0
 [3.9.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.9.0...3.9.1
 [3.9.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.8.2...3.9.0
 [3.8.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.8.1...3.8.2

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-plans-dependency
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-plans-dependency
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add jetpack-plans dependency. It will be use to restore the reverted change on #33410

--- a/projects/packages/my-jetpack/changelog/fix-videopress-upgrade-flow
+++ b/projects/packages/my-jetpack/changelog/fix-videopress-upgrade-flow
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Use Current_Plan to check/return from has_required_plan on VP product class

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-after-checkout
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-after-checkout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update checkout flow to connect "After" checkout vs before (if not connected).

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.10.0-alpha",
+	"version": "3.10.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.10.0-alpha';
+	const PACKAGE_VERSION = '3.10.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.4] - 2023-10-23
+### Added
+- Social: Add the Nextdoor connection toggle. [#33663]
+
+### Changed
+- Updated package dependencies. [#33687]
+
 ## [0.36.3] - 2023-10-16
 ### Changed
 - Added type prop to custom media for social posts. [#33504]
@@ -397,6 +404,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.36.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.3...v0.36.4
 [0.36.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.2...v0.36.3
 [0.36.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.1...v0.36.2
 [0.36.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.0...v0.36.1

--- a/projects/packages/publicize/changelog/add-nextdoor-social-toggle
+++ b/projects/packages/publicize/changelog/add-nextdoor-social-toggle
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Social: Add the Nextdoor connection toggle

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.36.4-alpha",
+	"version": "0.36.4",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.3] - 2023-10-23
+### Changed
+- Updated package dependencies. [#33646] [#33687]
+
 ## [0.39.2] - 2023-10-16
 ### Added
 - Added HEIC (`*.heic`) to list of images types allowed to be passed through Photon during instant search. [#33494]
@@ -822,6 +826,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.39.3]: https://github.com/Automattic/jetpack-search/compare/v0.39.2...v0.39.3
 [0.39.2]: https://github.com/Automattic/jetpack-search/compare/v0.39.1...v0.39.2
 [0.39.1]: https://github.com/Automattic/jetpack-search/compare/v0.39.0...v0.39.1
 [0.39.0]: https://github.com/Automattic/jetpack-search/compare/v0.38.8...v0.39.0

--- a/projects/packages/search/changelog/renovate-babel-monorepo
+++ b/projects/packages/search/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.39.3-alpha",
+	"version": "0.39.3",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.39.3-alpha';
+	const VERSION = '0.39.3';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.6] - 2023-10-23
+### Fixed
+- Stats: Increase timeout to 20s. [#33549]
+
 ## [0.6.5] - 2023-08-28
 ### Changed
 - Updated package dependencies. [#32605]
@@ -96,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.6.6]: https://github.com/Automattic/jetpack-stats/compare/v0.6.5...v0.6.6
 [0.6.5]: https://github.com/Automattic/jetpack-stats/compare/v0.6.4...v0.6.5
 [0.6.4]: https://github.com/Automattic/jetpack-stats/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/Automattic/jetpack-stats/compare/v0.6.2...v0.6.3

--- a/projects/packages/stats/changelog/fix-increase-timeout-20s
+++ b/projects/packages/stats/changelog/fix-increase-timeout-20s
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Stats: increase timeout to 20s

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.59.0] - 2023-10-23
+### Changed
+- Dedicated Sync: Update 'init' hook priority on Dedicated Sync requests to 0, in order to start sending Sync actions to WPCOM and exit as early as possible. [#33594]
+
 ## [1.58.1] - 2023-10-18
 ### Fixed
 - Update dependencies.
@@ -946,6 +950,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.59.0]: https://github.com/Automattic/jetpack-sync/compare/v1.58.1...v1.59.0
 [1.58.1]: https://github.com/Automattic/jetpack-sync/compare/v1.58.0...v1.58.1
 [1.58.0]: https://github.com/Automattic/jetpack-sync/compare/v1.57.4...v1.58.0
 [1.57.4]: https://github.com/Automattic/jetpack-sync/compare/v1.57.3...v1.57.4

--- a/projects/packages/sync/changelog/update-dedicated-sync-init-hook-priority
+++ b/projects/packages/sync/changelog/update-dedicated-sync-init-hook-priority
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Dedicated Sync: Update 'init' hook priority on Dedicated Sync requests to 0, in order to start sending Sync actions to WPCOM and exit as early as possible.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.59.0-alpha';
+	const PACKAGE_VERSION = '1.59.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2023-10-23
+### Changed
+- Use register_block_type and block.json to handle the block's scripts properly and fix assets being loaded when block is not present. [#33701]
+
 ## [0.18.0] - 2023-10-19
 ### Changed
 - Move ProgressBar component to the shared `@automattic/jetpack-components` package. [#33054]
@@ -1154,6 +1158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.19.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.6...v0.18.0
 [0.17.6]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.5...v0.17.6
 [0.17.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.4...v0.17.5

--- a/projects/packages/videopress/changelog/fix-videopress-register-block-json
+++ b/projects/packages/videopress/changelog/fix-videopress-register-block-json
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Use register_block_type and block.json to handle the block's scripts properly and fix assets being loaded when block is not present

--- a/projects/packages/videopress/changelog/videopress-transform-missing-return-early
+++ b/projects/packages/videopress/changelog/videopress-transform-missing-return-early
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.19.0-alpha",
+	"version": "0.19.0",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.19.0-alpha';
+	const PACKAGE_VERSION = '0.19.0';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.55] - 2023-10-23
+### Changed
+- Updated package dependencies. [#33646] [#33687]
+
 ## [0.2.54] - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33429, #33569]
@@ -257,6 +261,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.2.55]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.54...v0.2.55
 [0.2.54]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.53...v0.2.54
 [0.2.53]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.52...v0.2.53
 [0.2.52]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.51...v0.2.52

--- a/projects/packages/wordads/changelog/renovate-babel-monorepo
+++ b/projects/packages/wordads/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.55-alpha",
+	"version": "0.2.55",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.55-alpha';
+	const VERSION = '0.2.55';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.8-a.3 - 2023-10-23
+### Enhancements
+- Adds new modifications for the admin menu on Atomic sites that ensures that all links go to wp-admin except those that are only available in Calypso. [#33631]
+- Add support for welcome message inside WP Admin. [#33677]
+- AI Assistant: Add scaffolding for the Usage Panel. [#33671]
+- AI Assistant: Add strikethrough Markdown syntax to Markdown generator. [#33647]
+- AI Assistant: Add UsageBar component and add a sample of it to the Usage Panel. [#33696]
+- AI Assistant: Enable backend prompts for 100% of production sites. [#33632]
+- AI Assistant: Enhance toolbar UX. [#33717]
+- AI Assistant: Register ai-assistant-usage-panel beta extension. [#33666]
+- AI Extension: Change the filter to populate the Jetpack Form block with AI components. [#33629]
+- AI Extension: Do not skip React hook instances. [#33628]
+- AI Extension: Enable Form extension inside query loops. [#33670]
+- AI Extension: Improve info message when selected blocks don't have content to modify. [#33731]
+- AI Extension: Show "no content" notice when the extended block content is empty. [#33693]
+- AI Extension: Use registerBlockType filter to extend Jetpack Form / children block instances. [#33636]
+- AI Extension: Use registerBlockType to connect components with AI Data and UI Handler. [#33638]
+- Allow users to retrieve subscriptions on self-hosted. [#33705]
+- Jetpack: Handle Proofread feature availability via jetpack_ai_enabled filter. [#33676]
+- SEO Title & Description - Display the current nucount of characters, even when over the suggested limit. [#33609]
+- Subscribers: Allow admins to see subscribe modal. [#33622]
+
+### Improved compatibility
+- Connection: added protection for wpcom urls stored in the database during identity crisis. [#33412]
+- Make the jetpack_ai_enabled filter decide whether to register AI editor extensions. [#33618]
+- Social: Remove the tweetstorm editor components. [#33723]
+- Memberships: Prevent data to be retrieved from cache sites on WP.com. [#33502]
+
+### Bug fixes
+- AI Assistant: Fix issue when getting AI assistant block instance. [#33690]
+- AI Extension: Fix undefined 'disabled' I18nMenuDropdown prop bug. [#33742]
+- AI Extension: Improve performance bug when extending blocks with AI Assistant. [#33681]
+- Block Editor: Disable some of Twitter's Thread publishing tools since the feature is no longer accessible. [#33641]
+- Fixed a bug that prevent customers from downloading invoices from the my account page in WooCommerce. [#33686]
+- Fix issue when email was double encoded. [#33664]
+- Fix Map block not rendering. [#33606]
+- Fix missing block translations. [#33546]
+- Jetpack: Fix performance issues by not calling useAnalytics hook for all paragraphs. [#33725]
+- REST API settings endpoint: Fix google analytics option handling for Jetpack sites. [#33730]
+- Subscribe modal: Match block markup with params. [#33634]
+- The Google Photos media inserter only checks for the connection status when needed. [#33674]
+- VideoPress: Avoid performance issues by calling useEffect for every block on typing. [#33724]
+- YouTube embeds: Avoid errors when opening YouTube in a new window from a YouTube embed. [#33601]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add additional properties to WooCommerce analytics events. [#33544]
+- Add parameter to method. [#33659]
+- Add support for welcome message in subscription_options. [#33639]
+- Add WooCommerce to env setup for CI tests. [#32208]
+- Check for post access first then do tracking action. [#33620]
+- CSS fix. [#33691]
+- Fix some possible undefined variable warnings. [#33668]
+- General: Update Facebook color code to match newer brand colors. [#33633]
+- General: Update mentions of the old Jetpack color code. [#33583]
+- Google Fonts: Integrate the google fonts with the new font library. [#33203]
+- Replace Calypso progress bar with one from VideoPress. [#33054]
+- Social Logos: Update logos with the most recent version of the package, including bug fixes for the Threads and X logos, as well as an updated X logo to match updated X branding guidelines. [#33591]
+- Subscribe modal: Simplify URL construction. [#33653]
+- Updated package dependencies. [#33646] [#33687]
+- WordPress.com Navigation: Ensure that the stats menu is properly registered. [#33702]
+
 ## 12.8-a.1 - 2023-10-16
 ### Enhancements
 - AI Assistant: Enable backend prompts for 50% of production sites. [#33514]

--- a/projects/plugins/jetpack/changelog/Create a new site option for WPCOM admin interface
+++ b/projects/plugins/jetpack/changelog/Create a new site option for WPCOM admin interface
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Create a new site option for WPCOM admin interface
-
-

--- a/projects/plugins/jetpack/changelog/add-atomic-wpadmin-menu
+++ b/projects/plugins/jetpack/changelog/add-atomic-wpadmin-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Adds new modifications for the admin menu on Atomic sites that ensures that all links go to wp-admin except those that are only available in Calypso.

--- a/projects/plugins/jetpack/changelog/add-memberships-prevent-use-of-cached-site-data
+++ b/projects/plugins/jetpack/changelog/add-memberships-prevent-use-of-cached-site-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-[Memberships] Prevent data to be retrieved from cache sites on WPCOM

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-plans-dependency
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-plans-dependency
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-new-purchase-checkout-properties-oct
+++ b/projects/plugins/jetpack/changelog/add-new-purchase-checkout-properties-oct
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add additional properties to WooCommerce analytics events

--- a/projects/plugins/jetpack/changelog/add-newsletter-login-for-self-hosted
+++ b/projects/plugins/jetpack/changelog/add-newsletter-login-for-self-hosted
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Allow users to retrieve subscriptions on self-hosted

--- a/projects/plugins/jetpack/changelog/add-subscription-settings-sync
+++ b/projects/plugins/jetpack/changelog/add-subscription-settings-sync
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add support for welcome message in subscription_options

--- a/projects/plugins/jetpack/changelog/add-welcome-email-field
+++ b/projects/plugins/jetpack/changelog/add-welcome-email-field
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add support for welcome message inside wp-admin

--- a/projects/plugins/jetpack/changelog/add-woo-sync-tests-to-ci
+++ b/projects/plugins/jetpack/changelog/add-woo-sync-tests-to-ci
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add WooCommerce to env setup for CI tests.

--- a/projects/plugins/jetpack/changelog/feat-google-fonts-with-new-font-library
+++ b/projects/plugins/jetpack/changelog/feat-google-fonts-with-new-font-library
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Google Fonts: Integrate the google fonts with the new font library

--- a/projects/plugins/jetpack/changelog/feat-google-fonts-with-new-font-library#2
+++ b/projects/plugins/jetpack/changelog/feat-google-fonts-with-new-font-library#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-block-translations-2
+++ b/projects/plugins/jetpack/changelog/fix-block-translations-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix missing block translations

--- a/projects/plugins/jetpack/changelog/fix-check-for-paywall-access-prior-to-tracking
+++ b/projects/plugins/jetpack/changelog/fix-check-for-paywall-access-prior-to-tracking
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Check for post access first then do tracking action.

--- a/projects/plugins/jetpack/changelog/fix-double-email-encoding
+++ b/projects/plugins/jetpack/changelog/fix-double-email-encoding
@@ -1,4 +1,0 @@
-Significance: minor
-Type: bugfix
-
-Fix issue when email was double encoded

--- a/projects/plugins/jetpack/changelog/fix-idc-search-replace-protection
+++ b/projects/plugins/jetpack/changelog/fix-idc-search-replace-protection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Connection: added protection for wpcom urls stored in the database during identity crisis.

--- a/projects/plugins/jetpack/changelog/fix-idc-search-replace-protection#2
+++ b/projects/plugins/jetpack/changelog/fix-idc-search-replace-protection#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-jetpack-settings-endpoint-wga
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-settings-endpoint-wga
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-REST API settings endpoint: Fix google analytics option handling for Jetpack sites.

--- a/projects/plugins/jetpack/changelog/fix-limit-tracking-to-core-buttons
+++ b/projects/plugins/jetpack/changelog/fix-limit-tracking-to-core-buttons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fixed a bug that prevent customers from downloading invoices from the my account page in WooCommerce

--- a/projects/plugins/jetpack/changelog/fix-map-block-not-rendering
+++ b/projects/plugins/jetpack/changelog/fix-map-block-not-rendering
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix Map block not rendering

--- a/projects/plugins/jetpack/changelog/fix-media-sidebar-checks-google-photos-connection-before-needed
+++ b/projects/plugins/jetpack/changelog/fix-media-sidebar-checks-google-photos-connection-before-needed
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-The Google Photos media inserter only checks for the connection status when needed.

--- a/projects/plugins/jetpack/changelog/fix-missing-stats-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-missing-stats-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WordPress.com Navigation: ensure that the stats menu is properly registered.

--- a/projects/plugins/jetpack/changelog/fix-subscribe-modal-block-markup
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-modal-block-markup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscribe modal: match block markup with params

--- a/projects/plugins/jetpack/changelog/fix-upgrade-banner-hoc-perf
+++ b/projects/plugins/jetpack/changelog/fix-upgrade-banner-hoc-perf
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Jetpack: fix performance issues by not calling useAnalytics hook for all paragraphs

--- a/projects/plugins/jetpack/changelog/fix-videopress-register-block-json
+++ b/projects/plugins/jetpack/changelog/fix-videopress-register-block-json
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-videopress-upgrade-path
+++ b/projects/plugins/jetpack/changelog/fix-videopress-upgrade-path
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-wpcom-rector-complaints
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-rector-complaints
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix some possible undefined variable warnings.

--- a/projects/plugins/jetpack/changelog/hotfix-revert-vp-conditional-asset-enqueueing
+++ b/projects/plugins/jetpack/changelog/hotfix-revert-vp-conditional-asset-enqueueing
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 12.8-a.2
-
-

--- a/projects/plugins/jetpack/changelog/parikshit-adhikari-patch1
+++ b/projects/plugins/jetpack/changelog/parikshit-adhikari-patch1
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix typos in code comments and docs.
-
-

--- a/projects/plugins/jetpack/changelog/remove-twitter
+++ b/projects/plugins/jetpack/changelog/remove-twitter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-Social: Remove the tweetstorm editor components

--- a/projects/plugins/jetpack/changelog/renovate-babel-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/rm-twitter-tweetstorm-thread-listener
+++ b/projects/plugins/jetpack/changelog/rm-twitter-tweetstorm-thread-listener
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Block Editor: disable some of Twitter's Thread publishing tools since the feature is no longer accessible.

--- a/projects/plugins/jetpack/changelog/try-remove-calypso-progress-bar
+++ b/projects/plugins/jetpack/changelog/try-remove-calypso-progress-bar
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Replace Calypso progress bar with one from VideoPress.

--- a/projects/plugins/jetpack/changelog/update-access-token-permalink
+++ b/projects/plugins/jetpack/changelog/update-access-token-permalink
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-add parameter to method

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-usage-bar-component
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-usage-bar-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: add UsageBar component and add a sample of it to the Usage Panel.

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-usage-panel-beta-feature
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-usage-panel-beta-feature
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: register ai-assistant-usage-panel beta extension.

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-usage-panel-scaffolding
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-usage-panel-scaffolding
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Add scaffolding for the Usage Panel.

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-block-get-block
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-block-get-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Assistant: fix issue when getting AI assistant block instance

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-disable-when-no-content
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-disable-when-no-content
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: improve info message when selected blocks don't have content to modify

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-enable-backend-prompts-for-all-sites
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-enable-backend-prompts-for-all-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Enable backend prompts for 100% of production sites.

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-style
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-style
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Add strikethrough Markdown syntax to Markdown generator

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-toolbar-ux
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-toolbar-ux
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Enhance toolbar UX

--- a/projects/plugins/jetpack/changelog/update-ai-extension-fix-disable-prop-bug
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-fix-disable-prop-bug
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Extension: fix undefined 'disabled' I18nMenuDropdown prop bug

--- a/projects/plugins/jetpack/changelog/update-ai-extension-form-query-loop
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-form-query-loop
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: Enable Form extension inside query loops

--- a/projects/plugins/jetpack/changelog/update-ai-extension-show-empty-info
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-show-empty-info
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: show "no content" notice when the extended block content is empty

--- a/projects/plugins/jetpack/changelog/update-composer-2.6
+++ b/projects/plugins/jetpack/changelog/update-composer-2.6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-counted-textarea-show-overcount
+++ b/projects/plugins/jetpack/changelog/update-counted-textarea-show-overcount
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-SEO Title & Description - Display the current nucount of characters, even when over the suggested limit..

--- a/projects/plugins/jetpack/changelog/update-dedicated-sync-init-hook-priority
+++ b/projects/plugins/jetpack/changelog/update-dedicated-sync-init-hook-priority
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-facebook-color-code
+++ b/projects/plugins/jetpack/changelog/update-facebook-color-code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-General: update Facebook color code to match newer brand colors.

--- a/projects/plugins/jetpack/changelog/update-fix-perfomance-issue-extending-blocks-with-ai
+++ b/projects/plugins/jetpack/changelog/update-fix-perfomance-issue-extending-blocks-with-ai
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Extension: improve performance bug when extending blocks with AI Assistant

--- a/projects/plugins/jetpack/changelog/update-jetpack-colors-misc
+++ b/projects/plugins/jetpack/changelog/update-jetpack-colors-misc
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-General: update mentions of the old Jetpack color code.

--- a/projects/plugins/jetpack/changelog/update-jetpack-form-change-filter-to-extend-components
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-change-filter-to-extend-components
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: change the filter to populate the Jetpack Form block with AI components

--- a/projects/plugins/jetpack/changelog/update-jetpack-form-change-filter-to-extened-children
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-change-filter-to-extened-children
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: use registerBlockType filter to extend Jetpack Form / children block instances

--- a/projects/plugins/jetpack/changelog/update-jetpack-form-improve-extending
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-improve-extending
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: do not skip React hook instances

--- a/projects/plugins/jetpack/changelog/update-jetpack-form-propagate-data-via-different-filter
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-propagate-data-via-different-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: use registerBlockType to connect components with AI Data and UI Handler

--- a/projects/plugins/jetpack/changelog/update-jetpack_ai_enabled_assistant
+++ b/projects/plugins/jetpack/changelog/update-jetpack_ai_enabled_assistant
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-Make the jetpack_ai_enabled filter decide whether to register AI editor extensions

--- a/projects/plugins/jetpack/changelog/update-paywall-block-styles-2
+++ b/projects/plugins/jetpack/changelog/update-paywall-block-styles-2
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-css fix

--- a/projects/plugins/jetpack/changelog/update-register-proofread-via-filter
+++ b/projects/plugins/jetpack/changelog/update-register-proofread-via-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Jetpack: handle Proofread feature availability via jetpack_ai_enabled filter

--- a/projects/plugins/jetpack/changelog/update-show-subscribe-modal-to-admins
+++ b/projects/plugins/jetpack/changelog/update-show-subscribe-modal-to-admins
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscribers: Allow admins to see subscribe modal.

--- a/projects/plugins/jetpack/changelog/update-social-logos-256
+++ b/projects/plugins/jetpack/changelog/update-social-logos-256
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Social Logos: update logos with the most recent version of the package, including bug fixes for the Threads and X logos, as well as an updated X logo to match updated X branding guidelines.

--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-simplify-url
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-simplify-url
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscribe modal: simplify URL construction

--- a/projects/plugins/jetpack/changelog/update-subscriber-modal-option-text
+++ b/projects/plugins/jetpack/changelog/update-subscriber-modal-option-text
@@ -1,5 +1,0 @@
-Significance: patch
-Type: bugfix
-Comment: Minor text change.
-
-

--- a/projects/plugins/jetpack/changelog/update-youtube-embeds-popup-sandbox
+++ b/projects/plugins/jetpack/changelog/update-youtube-embeds-popup-sandbox
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-YouTube embeds: avoid errors when opening YouTube in a new window from a YouTube embed.

--- a/projects/plugins/jetpack/changelog/vdimitrakis-SELFSERVE-781-media-endpoints-whitelisting
+++ b/projects/plugins/jetpack/changelog/vdimitrakis-SELFSERVE-781-media-endpoints-whitelisting
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/videopress-transform-missing-return-early
+++ b/projects/plugins/jetpack/changelog/videopress-transform-missing-return-early
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-VideoPress: avoid performance issues by calling useEffect for every block on typing

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_2",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_3",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.8-a.2
+ * Version: 12.8-a.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.8-a.2' );
+define( 'JETPACK__VERSION', '12.8-a.3' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.8.0-a.2",
+	"version": "12.8.0-a.3",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.2 - 2023-10-23
+
 ## 1.7.1 - 2023-10-16
 ### Changed
 - Updated package dependencies. [#33498]

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-composer-2.6
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-composer-2.6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_2_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_2"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.7.2-alpha
+ * Version: 1.7.2
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.7.2-alpha",
+	"version": "1.7.2",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
Backports changes for mu-wpcom-plugin 1.7.2 and jetpack 12.8-a.3.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread the changelogs.