### PR TITLE
Boost: Add deprecation notice for lazy-loading

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/elements/Notice.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/Notice.svelte
@@ -15,7 +15,7 @@
 	};
 
 	export let level: 'info' | 'warning' | 'success' | 'error' = 'info';
-	export let title: string | null = null;
+	export let title: string;
 	export let message: string;
 	export let actions: ActionButton[] = [];
 	export let hideCloseButton = true;
@@ -31,7 +31,7 @@
 				key: index,
 				isLoading: !! action.isLoading,
 				disabled: !! action.disabled,
-				isExternalLink: !! action.isExternalLink || false,
+				isExternalLink: !! action.isExternalLink,
 				variant: action.variant || 'primary',
 			},
 			action.label

--- a/projects/plugins/boost/app/assets/src/js/elements/Notice.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/Notice.svelte
@@ -10,12 +10,14 @@
 		onClick?: () => void;
 		isLoading?: boolean;
 		disabled?: boolean;
+		isExternalLink?: boolean;
+		variant?: 'primary' | 'secondary' | 'link' | 'tertiary';
 	};
 
 	export let level: 'info' | 'warning' | 'success' | 'error' = 'info';
-	export let title: string;
+	export let title: string | null = null;
 	export let message: string;
-	export let actions: ActionButton[] | undefined;
+	export let actions: ActionButton[] = [];
 	export let hideCloseButton = true;
 
 	const dispatch = createEventDispatcher();
@@ -29,6 +31,8 @@
 				key: index,
 				isLoading: !! action.isLoading,
 				disabled: !! action.disabled,
+				isExternalLink: !! action.isExternalLink || false,
+				variant: action.variant || 'primary',
 			},
 			action.label
 		)

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -5,7 +5,6 @@
 
 	export let toggle = true;
 	export let slug: string;
-	export let hideIfUnavailable = true;
 
 	const dispatch = createEventDispatcher();
 
@@ -37,7 +36,7 @@
 	} );
 </script>
 
-{#if isModuleAvailable || ! hideIfUnavailable}
+{#if isModuleAvailable || slug === 'lazy_images'}
 	<div class="jb-feature-toggle">
 		<div class="jb-feature-toggle__toggle">
 			{#if toggle}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -5,6 +5,7 @@
 
 	export let toggle = true;
 	export let slug: string;
+	export let hideIfUnavailable = true;
 
 	const dispatch = createEventDispatcher();
 
@@ -36,13 +37,14 @@
 	} );
 </script>
 
-{#if isModuleAvailable}
+{#if isModuleAvailable || ! hideIfUnavailable}
 	<div class="jb-feature-toggle">
 		<div class="jb-feature-toggle__toggle">
 			{#if toggle}
 				<Toggle
 					id={`jb-feature-toggle-${ slug }`}
 					checked={isModuleActive}
+					disabled={! isModuleAvailable}
 					on:click={handleToggle}
 				/>
 			{/if}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -216,7 +216,7 @@
 		</p>
 	</Module>
 
-	<Module slug="lazy_images" hideIfUnavailable={false}>
+	<Module slug="lazy_images">
 		<h3 slot="title">{__( 'Lazy Image Loading', 'jetpack-boost' )}</h3>
 		<p slot="description">
 			<TemplatedString

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -6,6 +6,7 @@
 	import { getRedirectUrl } from '@automattic/jetpack-components';
 	import { onMount } from 'svelte';
 	import { __ } from '@wordpress/i18n';
+	import Notice from '../../../elements/Notice.svelte';
 	import ReactComponent from '../../../elements/ReactComponent.svelte';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
 	import RecommendationsMeta from '../../../modules/image-size-analysis/RecommendationsMeta.svelte';
@@ -43,6 +44,19 @@
 	const criticalCssLink = getRedirectUrl( 'jetpack-boost-critical-css' );
 	const deferJsLink = getRedirectUrl( 'jetpack-boost-defer-js' );
 	const lazyLoadLink = getRedirectUrl( 'jetpack-boost-lazy-load' );
+	const learnLazyLoadDeprecation = () => {
+		window.open( getRedirectUrl( 'jetpack-boost-lazy-load-deprecation' ), '_blank' );
+	};
+
+	$: lazyLoadDeprecationMessage = $modulesState.lazy_images?.available
+		? __(
+				'Modern browsers now support lazy loading, and WordPress itself bundles lazy loading for images. This feature will consequently be removed from Jetpack Boost.',
+				'jetpack-boost'
+		  )
+		: __(
+				'Modern browsers now support lazy loading, and WordPress itself bundles lazy loading for images. This feature has been disabled to avoid potential conflicts with Gutenberg 16.6.0+ or WordPress 6.4+. This feature will consequently be removed from Jetpack Boost.',
+				'jetpack-boost'
+		  );
 
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
@@ -213,6 +227,18 @@
 				vars={externalLinkTemplateVar( lazyLoadLink )}
 			/>
 		</p>
+		<Notice
+			title={__( 'Lazy image loading is going away', 'jetpack-boost' )}
+			message={lazyLoadDeprecationMessage}
+			actions={[
+				{
+					label: __( 'Learn more', 'jetpack-boost' ),
+					onClick: learnLazyLoadDeprecation,
+					isExternalLink: true,
+					variant: 'link',
+				},
+			]}
+		/>
 	</Module>
 
 	<Module slug="minify_js">

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -202,7 +202,7 @@
 		</p>
 	</Module>
 
-	<Module slug="lazy_images">
+	<Module slug="lazy_images" hideIfUnavailable={false}>
 		<h3 slot="title">{__( 'Lazy Image Loading', 'jetpack-boost' )}</h3>
 		<p slot="description">
 			<TemplatedString

--- a/projects/plugins/boost/changelog/update-depricate-lazy
+++ b/projects/plugins/boost/changelog/update-depricate-lazy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Lazy Loading: Added a notice mentioning that the feature is being deprecated

--- a/projects/plugins/boost/changelog/update-depricate-lazy#2
+++ b/projects/plugins/boost/changelog/update-depricate-lazy#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "2.1.2-alpha",
+	"version": "2.2.0-alpha",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -73,7 +73,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ2_1_2_alpha",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ2_2_0_alpha",
 		"allow-plugins": {
 			"roots/wordpress-core-installer": true,
 			"automattic/jetpack-autoloader": true,

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a23517d0d48a65e10c9e9bfab31be629",
+    "content-hash": "45cdaafdefc675d48a2d5c57b591b525",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 2.1.2-alpha
+ * Version: 2.2.0-alpha
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'JETPACK_BOOST_VERSION', '2.1.2-alpha' );
+define( 'JETPACK_BOOST_VERSION', '2.2.0-alpha' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-boost",
-	"version": "2.1.2-alpha",
+	"version": "2.2.0-alpha",
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"directories": {
 		"test": "tests"


### PR DESCRIPTION
#33170 

## Proposed changes:
* Add a notice to lazy-loading mentioning that this feature is going away.
* Keep the module visible but disable the toggle if the feature is not available(force disabled).

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2e6-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<details>
<summary>See if you have the notice while the module is still working.</summary>
<img src="https://github.com/Automattic/jetpack/assets/3737780/e42aafd6-3ebe-4951-953d-7b60aa3a2b2e"/>
</details>
<details>
<summary>Install Gutenberg plugin 16.6.0+ or WP 6.4 and test if the module is force disabled</summary>
<img src="https://github.com/Automattic/jetpack/assets/3737780/305a5ecd-c8c7-4ca1-887a-7ff046aebbb7">
</details>