### PR TITLE
Add/add/subscribers only if sites has no nl plans

### DIFF
--- a/projects/plugins/jetpack/changelog/add-add-subscribers-only-if-sites-has-no-NL-plans
+++ b/projects/plugins/jetpack/changelog/add-add-subscribers-only-if-sites-has-no-NL-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: if site has no plan, downgrade post access to subscribers-only

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -543,8 +543,20 @@ class Jetpack_Memberships {
 		}
 
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
-		$paywall       = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
-		$can_view_post = $paywall->visitor_can_view_content( self::get_all_newsletter_plan_ids(), $post_access_level );
+		$paywall = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
+
+		$all_newsletters_plan_ids = self::get_all_newsletter_plan_ids();
+
+		if ( 0 === count( $all_newsletters_plan_ids ) &&
+			Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS === $post_access_level ||
+			Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS === $post_access_level
+		) {
+			// The post is paywalled but there is no newsletter plans on the site.
+			// We de-escalate the post level to subscribers-only
+			$post_access_level = Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS;
+		}
+
+		$can_view_post = $paywall->visitor_can_view_content( $all_newsletters_plan_ids, $post_access_level );
 
 		self::$user_can_view_post_cache[ $cache_key ] = $can_view_post;
 		return $can_view_post;

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -552,7 +552,7 @@ class Jetpack_Memberships {
 			Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS === $post_access_level
 		) {
 			// The post is paywalled but there is no newsletter plans on the site.
-			// We de-escalate the post level to subscribers-only
+			// We downgrade the post level to subscribers-only
 			$post_access_level = Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/189

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allow post access as simple site subscriber if no plans are available on the site

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See https://github.com/Automattic/jetpack/pull/33716#issuecomment-1776919771
* You can follow the whole instructions there or just go to https://obnoxious-tropic.jurassic.ninja/2023/10/24/paid-subscriber-only/ in a new incognito window and subscribe. 
* You need to make sure the JN instance is on this branch (via [wp-admin](https://obnoxious-tropic.jurassic.ninja/wp-admin/admin.php?page=jetpack-beta) )
* It should let you in as soon as the subscription is confirmed

