### PR TITLE
Jetpack: improve process to extend paid blocks with upgrade banner

### DIFF
--- a/projects/plugins/jetpack/changelog/update-improve-extend-with-upgrade-banner
+++ b/projects/plugins/jetpack/changelog/update-improve-extend-with-upgrade-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: improve process to extend paid blocks with upgrade banner

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_4",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/index.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/index.js
@@ -10,7 +10,7 @@ import { uniq } from 'lodash';
 import paidBlockMediaPlaceholder from './media-placeholder';
 import paidBlockMediaReplaceFlow from './media-replace-flow';
 import renderPaidIcon from './render-paid-icon.js';
-import withUpgradeBanner from './with-upgrade-banner';
+import { blockEditWithUpgradeBanner } from './with-upgrade-banner';
 
 import './editor.scss';
 
@@ -55,8 +55,11 @@ const jetpackPaidBlock = ( settings, name ) => {
 // Extend BlockType.
 addFilter( 'blocks.registerBlockType', 'jetpack/paid-block', jetpackPaidBlock );
 
-// Extend BlockListBlock.
-addFilter( 'editor.BlockEdit', 'jetpack/paid-block-with-warning', withUpgradeBanner );
+addFilter(
+	'blocks.registerBlockType',
+	'jetpack/paid-block-with-upgrade-banner',
+	blockEditWithUpgradeBanner
+);
 
 // Take the control of the MediaPlaceholder.
 addFilter(

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -105,3 +105,15 @@ const withUpgradeBanner = createHigherOrderComponent(
 );
 
 export default withUpgradeBanner;
+
+export function blockEditWithUpgradeBanner( settings, name ) {
+	const requiredPlan = getRequiredPlan( name );
+	if ( ! requiredPlan ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		edit: withUpgradeBanner( settings.edit ),
+	};
+}

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -20,6 +20,10 @@ const withUpgradeBanner = createHigherOrderComponent(
 		// CAUTION: code added before this line will be executed for all blocks
 		// (also the paragraph block, every time on typing), not just paid
 		// blocks!
+		// NOTE: creating hooks conditionally is not a good practice,
+		// but still it's better than having the code executed for all blocks.
+		// @see https://legacy.reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+		// @todo: work on a better implementation.
 		if ( ! requiredPlan ) {
 			return <BlockEdit { ...props } />;
 		}

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -106,6 +106,17 @@ const withUpgradeBanner = createHigherOrderComponent(
 
 export default withUpgradeBanner;
 
+/**
+ * Helper function that extends the Edit function
+ * of the block with the upgrade banner,
+ * by using the `withUpgradeBanner` HOC.
+ * It has been designed to be bound with a `blocks.registerBlockType` call.
+ *
+ * @param {object} settings - The block settings.
+ * @param {string} name     - The block name.
+ * @returns {object}          The extended block settings.
+ */
+
 export function blockEditWithUpgradeBanner( settings, name ) {
 	const requiredPlan = getRequiredPlan( name );
 	if ( ! requiredPlan ) {

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -12,7 +12,7 @@ import { PaidBlockContext, PaidBlockProvider } from './components';
 import UpgradePlanBanner from './upgrade-plan-banner';
 import { trackUpgradeBannerImpression, trackUpgradeClickEvent } from './utils';
 
-export default createHigherOrderComponent(
+const withUpgradeBanner = createHigherOrderComponent(
 	BlockEdit => props => {
 		const { name, clientId, isSelected, attributes, setAttributes } = props || {};
 		const requiredPlan = getRequiredPlan( name );
@@ -99,3 +99,5 @@ export default createHigherOrderComponent(
 	},
 	'withUpgradeBanner'
 );
+
+export default withUpgradeBanner;

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.8-a.3
+ * Version: 12.8-a.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.8-a.3' );
+define( 'JETPACK__VERSION', '12.8-a.4' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.8.0-a.3",
+	"version": "12.8.0-a.4",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR changes the filter used to extend paid blocks with the Update banner to:
* avoid creating [withUpgradeBanner](https://github.com/Automattic/jetpack/blob/4ee6e5300297150a4621c3e7420d3ab84b68c536/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx#L15) HOC instances for all block instances.
* and thus avoid [instantiating hooks conditionally as is done right now.](https://github.com/Automattic/jetpack/blob/4ee6e5300297150a4621c3e7420d3ab84b68c536/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx#L30-L77), mentioned here https://github.com/Automattic/jetpack/pull/33725/files#r1367722478

**Follow-up of https://github.com/Automattic/jetpack/pull/33725**

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: improve the process to extend paid blocks with upgrade banner

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a Simple site with a `free` plan
* Go to the block editor
* Create different **free** block instances (paragraphs, heading, images, etc)
* Create only one instance of a paid block (Calendly)
* Open the React dev tool
* Filter by `withUpgradeBanner`

In the images below, I created several _**free**_ block instances (60 approx) and only one paid block instance (Calendly).
Before (trunk), there are 97 `withPaidBlock()` HOC instances.
After (This PR) There is only one `withPaidBlock()` instance.

Before | After
-------|-------
<img width="1728" alt="Screenshot 2023-10-24 at 11 05 13" src="https://github.com/Automattic/jetpack/assets/77539/9bafbf29-17fd-4121-98a5-caf14cbd646f">|<img width="1728" alt="Screenshot 2023-10-24 at 11 02 06" src="https://github.com/Automattic/jetpack/assets/77539/4be5cd85-2c60-4d9a-9f60-eda362a532af">

* Of course, confirm **the app shows the Upgrade banner for all paid blocks**. You can get them filtered by the `premium` word in the block inserter:

<img width="355" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/d7244246-b525-47be-8eb0-4ceb0ce9f3f0">

* Confirm once you create an instance of a paid block for a Site with Free plan, the block shows the upgrade banner:
<img width="678" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/4644d921-f7a4-4abf-8fea-6ae388b5ebaf">

