### PR TITLE
REST API settings endpoint (v1.3 and 1.4): Fix google analytics option handling for Jetpack sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-settings-endpoint-gt-1_2-wga
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-settings-endpoint-gt-1_2-wga
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+REST API: Fix GA settings field, wga, for settings endpoints on API version 1.3 and 1.4

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -159,7 +159,7 @@ class WPCOM_JSON_API_Site_Settings_V1_3_Endpoint extends WPCOM_JSON_API_Site_Set
 	 * @return array
 	 */
 	public function filter_site_settings_endpoint_get( $settings ) {
-		$option_name     = defined( 'IS_WPCOM' ) && IS_WPCOM ? 'wga' : 'jetpack_wga';
+		$option_name     = $this->get_google_analytics_option_name();
 		$option          = get_option( $option_name, array() );
 		$settings['wga'] = wp_parse_args( $option, $this->get_defaults() );
 		return $settings;


### PR DESCRIPTION
Continuation of https://github.com/Automattic/jetpack/pull/33730 for REST API settings endpoints on version 1.3 and 1.4 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `WPCOM_JSON_API_Site_Settings_Endpoint **versions 1.3 and 1.4**`: Rely on whether this is a Jetpack site instead of the environment (WPCOM vs remote site) in order to determine whether the `wga` or `jetpack_wga` option should be used for fetching/storing Google Analytics tracking data.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf5801-5l-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
- Using the [Developer console](https://developer.wordpress.com/docs/api/console/) check the `rest/v1.3/sites/[SITE_ID]/settings` and `rest/v1.4/sites/[SITE_ID]/settings` endpoint for both fetching and updating the `wga` setting
- Make sure to test on a Simple site too
- Bonus points for testing on a Jetpack site, forcing the endpoint to fetch the results from WPCOM (`?force=wpcom`)