### PR TITLE
Cut a release for js-packages/config

### DIFF
--- a/projects/js-packages/config/CHANGELOG.md
+++ b/projects/js-packages/config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.22] - 2023-10-24
+### Fixed
+- Remove "private" flag from package.json so package can be published. [#33744]
+
 ## [0.1.21] - 2023-08-21
 ### Added
 - Publish package to npmjs.com. [#32515]
@@ -90,4 +94,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fixed and improved README
 
+[0.1.22]: https://github.com/Automattic/jetpack-config-js/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/Automattic/jetpack-config-js/compare/v0.1.20...v0.1.21

--- a/projects/js-packages/config/changelog/fix-clear-private-flag-from-published-js-packages
+++ b/projects/js-packages/config/changelog/fix-clear-private-flag-from-published-js-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Remove "private" flag from package.json so package can be published.

--- a/projects/js-packages/config/package.json
+++ b/projects/js-packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-config",
-	"version": "0.1.22-alpha",
+	"version": "0.1.22",
 	"description": "Handles Jetpack global configuration shared across all packages",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/config/#readme",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Release the package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1698093185230619/1690493398.174649-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge, then see that the package gets auto-released and published to npmjs.