### PR TITLE
wp-admin Site Default: Link Plugins -> Add New to the WordPress.com Marketplace

### DIFF
--- a/projects/plugins/jetpack/changelog/Link plugins to WPCOM Marketplace on Atomic sites
+++ b/projects/plugins/jetpack/changelog/Link plugins to WPCOM Marketplace on Atomic sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Link plugins to WPCOM Marketplace on Atomic sites

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -135,6 +135,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Calypso plugins screens link.
 		$plugins_slug = 'https://wordpress.com/plugins/' . $this->domain;
 
+		// Link to the Marketplace from Plugins > Add New on Atomic sites where the wpcom_admin_interface option is set to wp-admin.
 		if ( self::CLASSIC_VIEW === $this->get_preferred_view( 'plugins.php' ) ) {
 			$submenus_to_update = array( 'plugin-install.php' => $plugins_slug );
 			$this->update_submenus( 'plugins.php', $submenus_to_update );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -130,14 +130,16 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_plugins_menu() {
 
-		if ( self::CLASSIC_VIEW === $this->get_preferred_view( 'plugins.php' ) ) {
-			return;
-		}
-
 		global $submenu;
 
 		// Calypso plugins screens link.
 		$plugins_slug = 'https://wordpress.com/plugins/' . $this->domain;
+
+		if ( self::CLASSIC_VIEW === $this->get_preferred_view( 'plugins.php' ) ) {
+			$submenus_to_update = array( 'plugin-install.php' => $plugins_slug );
+			$this->update_submenus( 'plugins.php', $submenus_to_update );
+			return;
+		}
 
 		// Link to the Marketplace on sites that can't manage plugins.
 		if (


### PR DESCRIPTION
Closes: https://github.com/Automattic/dotcom-forge/issues/4275

## Proposed changes:

This PR links `Plugins > Add New` tab to WordPress.com Marketplace when the `wp-admin` interface is enabled on an Atomic site from `Hosting Configuration` tab. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**To test on Atomic sites**: 
* Create an Atomic site and make it WoA
* Install [Jetpack beta tester](https://jetpack.com/download-jetpack-beta/) plugin
* Navigate to `/wp-admin/admin.php?page=jetpack-beta`
* Select `Jetpack -> Manage`
* Search for the feature branch `fix/link-plugins-to-wpcom-marketplace` and activate that branch
* Navigate to `Settings > Hosting Configuration` on wpcalypso.wordpress.com
* Set the interface to be Classic
* Navigate to `Plugins > Installed Plugins` and confirm you are brought to: /wp-admin/plugins.php
* Navigate to `Plugins > Add New` and confirm you are brought to https://wordpress.com/plugins/{yourSite} and can see WordPress.com Marketplace

https://github.com/Automattic/jetpack/assets/25575134/b1747124-5f73-4cad-b724-88be2686b467


* Navigate back  to `Settings > Hosting Configuration` on wpcalypso.wordpress.com
* Set the interface to be Default 
* Confirm that you remain in Calypso when navigating links for the `Plugins` submenu

* Test on a Simple site and confirm the Plugins menu in wp-admin works as before
* Test on a Jetpack site (can use Jurassic Ninja) with Jetpack Beta Tester and confirm that the menu remains unaffected 

