### PR TITLE
CRM: Resolves #3377 - PHP fatal in Client Portal with WooSync invoice

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3377-php_fatal_on_invoice_from_woo
+++ b/projects/plugins/crm/changelog/fix-crm-3377-php_fatal_on_invoice_from_woo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WooSync: catch PHP error in Client Portal invoice if WooCommerce is disabled

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -843,6 +843,10 @@ function zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id = -1, $template = 
 
 		$inv_to = $zbs->DAL->contacts->getContact( $zbs_customer_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
+		if ( ! $inv_to ) {
+			$inv_to = array();
+		}
+
 		// object type flag used downstream, I wonder if we should put these in at the DAL level..
 		$inv_to['objtype'] = ZBS_TYPE_CONTACT;
 	}

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -868,6 +868,13 @@ class Woo_Sync {
 	 */
 	public function render_pay_via_woo_checkout_button( $invoice_id = -1 ) {
 
+		global $zbs;
+
+		// We can't generate a Woo payment button if WooCommerce isn't active
+		if ( ! $zbs->woocommerce_is_active() ) {
+			return false;
+		}
+
 		if ( $invoice_id > 0 ) {
 
 			$api = $this->get_invoice_meta( $invoice_id, 'api' );

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -874,20 +874,15 @@ class Woo_Sync {
 			$order_post_id = $this->get_invoice_meta( $invoice_id, 'order_post_id' );
 
 			// intercept pay button and set to pay via woo checkout
-			if ( empty( $api ) ) {
+			if ( empty( $api ) && ! empty( $order_post_id ) ) {
+				remove_filter( 'invoicing_pro_paypal_button', 'zeroBSCRM_paypalbutton', 1 );
+				remove_filter( 'invoicing_pro_stripe_button', 'zeroBSCRM_stripebutton', 1 );
+				$order        = wc_get_order( $order_post_id );
+				$payment_page = $order->get_checkout_payment_url();
+				$res          = '<h3>' . __( 'Pay Invoice', 'zero-bs-crm' ) . '</h3>';
+				$res         .= '<a href="' . esc_url( $payment_page ) . '" class="ui button btn">' . __( 'Pay Now', 'zero-bs-crm' ) . '</a>';
 
-				if ( !empty( $order_post_id ) ) {
-
-					remove_filter( 'invoicing_pro_paypal_button', 'zeroBSCRM_paypalbutton' , 1 );
-					remove_filter( 'invoicing_pro_stripe_button', 'zeroBSCRM_stripebutton', 1 );
-					$order = wc_get_order( $order_post_id );
-					$payment_page = $order->get_checkout_payment_url();
-					$res = '<h3>' . __( "Pay Invoice", 'zero-bs-crm' ) . '</h3>';
-					$res .= '<a href="' . esc_url( $payment_page ) . '" class="ui button btn">' . __( "Pay Now", 'zero-bs-crm' ) .'</a>';
-
-					return $res;
-
-				}
+				return $res;
 			}
 
 			return $invoice_id;

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -375,10 +375,8 @@ class Woo_Sync {
 	 */
 	private function init_features( ) {
 
-		global $zbs;
-
 		// Contact Tabs
-		if ( $zbs->isDAL2() && zeroBSCRM_is_customer_view_page() ){
+		if ( zeroBSCRM_is_customer_view_page() ) {
 
 			require_once JPCRM_WOO_SYNC_ROOT_PATH . 'includes/jpcrm-woo-sync-contact-tabs.php';
 			$this->contact_tabs = Woo_Sync_Contact_Tabs::instance();

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -872,7 +872,14 @@ class Woo_Sync {
 
 		// We can't generate a Woo payment button if WooCommerce isn't active
 		if ( ! $zbs->woocommerce_is_active() ) {
-			return false;
+			// show an error if an invoice admin
+			if ( zeroBSCRM_permsInvoices() ) {
+				$admin_alert  = '<b>' . esc_html__( 'Admin note', 'zero-bs-crm' ) . ':</b> ';
+				$admin_alert .= esc_html__( 'Please enable WooCommerce to show the payment link here.', 'zero-bs-crm' );
+				return $admin_alert;
+			} else {
+				return false;
+			}
 		}
 
 		if ( $invoice_id > 0 ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3377 - PHP fatal on Client Portal invoice

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If WooSync is enabled, we generate a Woo payment link in the Client Portal invoice. However, if WooCommerce is deactivated, it gave a 500 error.

This PR prevents it from trying to generate said link if WooCommerce is not active. It also shows a message to admins to help them know what to do.

I also caught a PHP deprecation notice reported in the same issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure WooSync is enabled and set to create invoices.
2. Create a WooCommerce order of "pending payment" status.
3. Go to the invoice in the Client Portal. You'll see a "Pay Now" link.
4. Disable the WooCommerce plugin.
5. Return to the invoice in the Client Portal.

In `trunk`, you'll get a 500 error.

In the `fix/crm/3377-php_fatal_on_invoice_from_woo` branch, regular users will not see a "Pay Now" button (this is expected) and admins will see a notice:

![image](https://github.com/Automattic/jetpack/assets/32492176/20b6a4d7-1ea6-4a7d-99a1-77ab86c617a9)

6. With PHP 8.2 enabled, create an invoice that is not assigned to a user.
7. View the invoice in the Client Portal.

In `trunk`, you'll get a PHP deprecation notice.

In the `fix/crm/3377-php_fatal_on_invoice_from_woo` branch, the notice is no more.
