### PR TITLE
Always return false for 'jetpack_sharing_enabled' in case if module i…

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-postmeta-callback
+++ b/projects/plugins/jetpack/changelog/fix-sharing-postmeta-callback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Always return false for 'jetpack_sharing_enabled' in case if module is not active

--- a/projects/plugins/jetpack/extensions/plugins/sharing/sharing.php
+++ b/projects/plugins/jetpack/extensions/plugins/sharing/sharing.php
@@ -37,8 +37,8 @@ add_action(
 					$post_type,
 					'jetpack_sharing_enabled',
 					array(
-						'get_callback' => function ( array $post ) {
-							return (bool) ! get_post_meta( $post['id'], 'sharing_disabled', true );
+						'get_callback' => function () {
+							return false;
 						},
 						'schema'       => array(
 							'description' => __( 'Are sharing buttons enabled?', 'jetpack' ),


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/33728

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Currently, we need to register PostTypes alongside Sharing feature even if module is disabled. However, we will always return `false` for `jetpack_sharing_enabled` .

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up the branch locally and tunnel with JT to your sandbox
* Build `plugins/jetpack`
* Navigate to `/wp-admin/admin.php?page=jetpack_modules` and make sure that Sharing module is disabled
* Check `https://[site]/wp-json/wp/v2/posts/[postID]` where "jetpack_sharing_enabled":`false`
* Enable sharing module, but keep it disable for the post, "jetpack_sharing_enabled":`false` should still be present
* If enabling Sharing for particular post, then "jetpack_sharing_enabled" should become `true`