### PR TITLE
Fix/login button disappears when logged in to wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-login-button-disappears-when-logged-in-to-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-login-button-disappears-when-logged-in-to-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Require login on wpcom for paid content access without cookie or token.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
@@ -48,7 +48,7 @@ function render_login_button_block( $attributes, $content ) {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$has_token_parameter = isset( $_GET['token'] );
 
-	$is_user_logged_in_on_wpcom = ( new Host() )->is_wpcom_platform() && is_user_logged_in();
+	$is_user_logged_in_on_wpcom = ( new Host() )->is_wpcom_simple() && is_user_logged_in();
 	if ( $is_user_logged_in_on_wpcom || $has_auth_cookie || $has_token_parameter ) {
 		// The viewer is logged it, so they shouldn't see the login button.
 		return '';

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Extensions\Premium_Content;
 
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
+use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 
 require_once dirname( __DIR__ ) . '/_inc/subscription-service/include.php';
@@ -47,7 +48,8 @@ function render_login_button_block( $attributes, $content ) {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$has_token_parameter = isset( $_GET['token'] );
 
-	if ( is_user_logged_in() || $has_auth_cookie || $has_token_parameter ) {
+	$is_user_logged_in_on_wpcom = ( new Host() )->is_wpcom_platform() && is_user_logged_in();
+	if ( $is_user_logged_in_on_wpcom || $has_auth_cookie || $has_token_parameter ) {
 		// The viewer is logged it, so they shouldn't see the login button.
 		return '';
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 168-gh-automattic/gold

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Require the is_user_logged_in check to be performed on wpcom platform.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Setup
- Sandbox the public api and subscriptions
- Create a new JN site, configure jetpack constant and setup global http
- Connect stripe and Jetpack on the JN site
- Setup paid plans for the paid content block
- Create a post with a paid content block

### Replicate the issue
- Open private window, purchase sub via paid content block and pay for plan.
- Close private window, then open a new private window and return to post, ensure you cannot read the post.
- Open new tab in private window and login to wordpress.com with the subscriber account you used to pay for plan.
- Return to the browser tab with the post containing the paid content block and refresh, you should still not see the content.
- Click login, login button disappears.

### Test the patch
- Close any private windows you had open previously from replicating the issue
- Activate this branch in JN
- Apply D126524-code to your sandbox
- Run `bin/jetpack-downloader test jetpack fix/login-button-disappears-when-logged-in-to-wpcom` and apply on top of D126524, answering `n` to the first question asking if you want apply it to trunk.
- Open a new private window and return to post, ensure you cannot read the post.
- Open new tab in private window and login to wordpress.com with the subscriber account you used to pay for plan.
- Return to the browser tab with the post containing the paid content block and refresh, you should still not see the content.
- Click login, and you should be able to see the content.