### PR TITLE
CRM: Address columns bug when odd fields above address column

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3319-address-columns-bug-when-odd-fields-above
+++ b/projects/plugins/crm/changelog/fix-crm-3319-address-columns-bug-when-odd-fields-above
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed display issues on the Add and Edit pages that occurred when moving fields

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
@@ -163,21 +163,14 @@
 					}
 					$field_group = '';
 
-					/*
-					 * We need to know if we are in the first column or not because
-					 * when we have a group (e.g. addresses), they should start in
-					 * the first column. We are using only two columns.
-					 */
-					$is_first_column = false;
 					foreach ( $fields as $field_key => $field_value ) {
-						$is_first_column = ! $is_first_column;
-						$show_field      = ! isset( $field_value['opt'] ) || isset( $zbsFieldsEnabled[ $field_value['opt'] ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-						$show_field      = isset( $fields_to_hide['company'] )
+						$show_field = ! isset( $field_value['opt'] ) || isset( $zbsFieldsEnabled[ $field_value['opt'] ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+						$show_field = isset( $fields_to_hide['company'] )
 							&& is_array( $fields_to_hide['company'] )
 							&& in_array( $field_key, $fields_to_hide['company'] ) // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 							? false
 							: $show_field;
-						$show_field      = isset( $field_value[0] )
+						$show_field = isset( $field_value[0] )
 							&& 'selectcountry' === $field_value[0]
 							&& 0 === $show_country_fields
 							? false
@@ -187,9 +180,6 @@
 							if ( $show_addresses !== 1 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 								continue;
 							} elseif ( $field_group === '' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-								if ( ! $is_first_column ) {
-									echo '<div class="jpcrm-empty-form-group">&nbsp;</div>';
-								}
 								echo '<div class="jpcrm-form-grid" style="padding:0px;grid-template-columns: 1fr;">';
 								echo '<div class="jpcrm-form-group"><label>';
 								echo esc_html__( $field_value['area'], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -257,21 +257,14 @@
 		}
 		$field_group = '';
 
-		/*
-			* We need to know if we are in the first column or not because
-			* when we have a group (e.g. addresses), they should start in
-			* the first column. We are using only two columns.
-			*/
-		$is_first_column = false;
 		foreach ( $fields as $field_key => $field_value ) {
-			$is_first_column = ! $is_first_column;
-			$show_field      = ! isset( $field_value['opt'] ) || isset( $zbsFieldsEnabled[ $field_value['opt'] ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			$show_field      = isset( $fields_to_hide['customer'] )
+			$show_field = ! isset( $field_value['opt'] ) || isset( $zbsFieldsEnabled[ $field_value['opt'] ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$show_field = isset( $fields_to_hide['customer'] )
 				&& is_array( $fields_to_hide['customer'] )
 				&& in_array( $field_key, $fields_to_hide['customer'] ) // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 				? false
 				: $show_field;
-			$show_field      = isset( $field_value[0] )
+			$show_field = isset( $field_value[0] )
 				&& 'selectcountry' === $field_value[0]
 				&& 0 === $show_country_fields
 				? false
@@ -281,9 +274,6 @@
 				if ( $show_addresses !== 1 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					continue;
 				} elseif ( $field_group === '' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-					if ( ! $is_first_column ) {
-						echo '<div class="jpcrm-empty-form-group">&nbsp;</div>';
-					}
 					echo '<div class="jpcrm-form-grid" style="padding:0px;grid-template-columns: 1fr;">';
 					echo '<div class="jpcrm-form-group"><label>';
 					echo esc_html__( $field_value['area'], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
* Fixed a bug that happened when moving any field above 'Addresses' in the 'Contact Fields' or 'Company Fields', to result in an odd number.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3319

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Field Sorts - [/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=fieldsorts](http://norubbish.local/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=fieldsorts)
* Move the `Email` fields from both `Contact Fields:` section and `Company Fields:` up, just above `Addresses`.
* Open and Add or Edit page for both a Contact and a Company

In `trunk` the Address section will be misplaced in the screen.
In `fix/crm/3319-address-columns-bug-when-odd-fields-above` everything will be displayed correctly.

