### PR TITLE
Paywall: "Log in" Link – Improve the experience for WPCOM users

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-login-link-3
+++ b/projects/plugins/jetpack/changelog/update-paywall-login-link-3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Paywall: improve already subscriber experience


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Improves the experience for WPCOM Users accessing subscriptions.

* Paywall "Log in" link – use the Magic Link flow instead of the "code flow" .
* User is not authenticated but logged in to wpcom – authenticate the user instead of going through the code flow. 
* User is not authenticated and not logged in to wpcom – send the user to the magic link flow instead of the code flow.

Next steps:
* Add site context to the login screen.
* Add site context to emails.
* User is not authenticated and not logged in to wpcom – Using a similar iframe as the "code flow" one, request a login link from the iframe without leaving the site to keep more context.
 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Create a subscriber-only post in the following types of sites:

- Custom domain site
- Atomic site
- Jetpack site

Testing Scenarios:

- As a logged-in subscriber, test the link on all types of sites.
- As a logged-out subscriber, test the link on all types of sites.
