### PR TITLE
Add filter to disable Scan module

### DIFF
--- a/projects/plugins/jetpack/changelog/scan-disable-module-filter
+++ b/projects/plugins/jetpack/changelog/scan-disable-module-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add filter that allows disabling Scan module

--- a/projects/plugins/jetpack/modules/scan/scan.php
+++ b/projects/plugins/jetpack/modules/scan/scan.php
@@ -8,8 +8,10 @@
 
 namespace Automattic\Jetpack\Scan;
 
-require_once __DIR__ . '/class-admin-bar-notice.php';
-require_once __DIR__ . '/class-admin-sidebar-link.php';
+if ( ! apply_filters( 'jetpack_disable_scan', false ) ) {
+	require_once __DIR__ . '/class-admin-bar-notice.php';
+	require_once __DIR__ . '/class-admin-sidebar-link.php';
 
-Admin_Bar_Notice::instance();
-Admin_Sidebar_Link::instance();
+	Admin_Bar_Notice::instance();
+	Admin_Sidebar_Link::instance();
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds filter that allows disabling the Scan module.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a test site
* Install this branch
* Add the 'add_filter( 'jetpack_disable_scan', '__return_true' );' somewhere in your site and verify that the module is disabled.

