### PR TITLE
Fix flaky WAF test

### DIFF
--- a/projects/packages/waf/changelog/fix-flakey-waf-test
+++ b/projects/packages/waf/changelog/fix-flakey-waf-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed unit test.
+
+

--- a/projects/packages/waf/tests/php/integration/test-waf-rest-api.php
+++ b/projects/packages/waf/tests/php/integration/test-waf-rest-api.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Waf\REST_Controller;
+use Automattic\Jetpack\Waf\Waf_Rules_Manager;
 
 /**
  * Integration tests for the REST API endpoints registered by the WAF.
@@ -128,13 +129,16 @@ final class WafRestIntegrationTest extends WorDBless\BaseTestCase {
 	 * Test /jetpack/v4/waf POST.
 	 */
 	public function testUpdateWaf() {
+		// Mock the WPCOM request for retrieving the automatic rules.
+		add_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
+
 		// Mock the request.
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/waf' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
 				array(
-					'jetpack_waf_automatic_rules_enabled' => true,
+					Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME => true,
 				)
 			)
 		);
@@ -144,6 +148,9 @@ final class WafRestIntegrationTest extends WorDBless\BaseTestCase {
 
 		// Validate the response.
 		$this->assertFalse( is_wp_error( $response ) );
+
+		// Clean up.
+		remove_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a flaky unit test that was not mocking the response from the rules API.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Mock a successful respoonse from the rules API.
* Use the `AUTOMATIC_RULES_ENABLED_OPTION_NAME` constant to ensure test stays in sync.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1697714740992549-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `$ jetpack test packages/waf php`