### PR TITLE
Fix Social Image Generator debouncing

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-sig-debounce
+++ b/projects/js-packages/publicize-components/changelog/fix-sig-debounce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Social Image Generator debouncing

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.41.0",
+	"version": "0.41.1-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/social-image-generator/panel/index.js
+++ b/projects/js-packages/publicize-components/src/components/social-image-generator/panel/index.js
@@ -27,7 +27,7 @@ const SocialImageGeneratorPanel = ( { prePublish = false } ) => {
 			{ isEnabled && (
 				<>
 					<hr />
-					<GeneratedImagePreview shouldDebounce={ false } />
+					<GeneratedImagePreview />
 					<hr />
 					<Button
 						variant="secondary"


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix Social Image Generator debouncing

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this PR
* Add Jetpack Social Advanced plan to the site
* Goto post edit page
* Turn ON "Enable Social Image" under "Social Image Generator" section
* Open the Network tab in browser dev tools
* Change the post title
* Confirm that there is not a network request for every key stroke
* Confirm that the requests are denounced by 1.5 seconds

