### PR TITLE
AI Assistant: hide usage bar when site supports AI assistant feature

### DIFF
--- a/projects/plugins/jetpack/changelog/update-hide-ai-usage-bar-when-unlimited
+++ b/projects/plugins/jetpack/changelog/update-hide-ai-usage-bar-when-unlimited
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Metered billing: hide usage bar when site has AI plan

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -89,12 +89,7 @@ export default function AiAssistantPluginSidebar() {
 					) }
 					{ isUsagePanelAvailable && (
 						<PanelRow>
-							<BaseControl
-								className="jetpack-ai-usage-panel-control__header"
-								label={ __( 'Usage', 'jetpack' ) }
-							>
-								<UsagePanel />
-							</BaseControl>
+							<UsagePanel />
 						</PanelRow>
 					) }
 				</PanelBody>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -2,14 +2,17 @@
  * Internal dependencies
  */
 import './style.scss';
-import { UsageBarProps } from './types';
+/**
+ * Types
+ */
+import type { UsageBarProps } from './types';
 import type React from 'react';
 
 /**
- * Usage Bar component
+ * UsageBar component
  *
  * @param {UsageBarProps} props - Component props.
- * @returns {React.ReactNode} - UsageBar react component.
+ * @returns {React.ReactNode}     UsageBar react component.
  */
 const UsageBar: React.FC< UsageBarProps > = ( { usage } ) => {
 	if ( usage == null ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
+import { BaseControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout
 import useAIFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import { canUserPurchasePlan } from '../../../../blocks/ai-assistant/lib/connection';
 import UsageBar from '../usage-bar';
+import './style.scss';
 
 export default function UsagePanel() {
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
@@ -39,8 +41,10 @@ export default function UsagePanel() {
 	 */
 	const usage = hasFeature ? 0.1 : requestsCount / requestsLimit;
 
+	const help = hasFeature ? __( 'Unlimited requests for your site', 'jetpack' ) : undefined;
+
 	return (
-		<div className="jetpack-ai-usage-panel-control">
+		<BaseControl className="jetpack-ai-usage-panel-control" help={ help }>
 			<p>{ hasFeature ? unlimitedPlanUsageMessage : freeUsageMessage }</p>
 
 			<UsageBar usage={ usage } />
@@ -65,6 +69,6 @@ export default function UsagePanel() {
 					Upgrade
 				</Button>
 			) }
-		</div>
+		</BaseControl>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -47,7 +47,7 @@ export default function UsagePanel() {
 		<BaseControl className="jetpack-ai-usage-panel-control" help={ help }>
 			<p>{ hasFeature ? unlimitedPlanUsageMessage : freeUsageMessage }</p>
 
-			<UsageBar usage={ usage } />
+			{ ! hasFeature && <UsageBar usage={ usage } /> }
 
 			{ false && (
 				<p className="muted">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -44,7 +44,11 @@ export default function UsagePanel() {
 	const help = hasFeature ? __( 'Unlimited requests for your site', 'jetpack' ) : undefined;
 
 	return (
-		<BaseControl className="jetpack-ai-usage-panel-control" help={ help }>
+		<BaseControl
+			className="jetpack-ai-usage-panel-control"
+			label={ __( 'Usage', 'jetpack' ) }
+			help={ help }
+		>
 			<p>{ hasFeature ? unlimitedPlanUsageMessage : freeUsageMessage }</p>
 
 			{ ! hasFeature && <UsageBar usage={ usage } /> }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/style.scss
@@ -3,10 +3,6 @@
 .jetpack-ai-usage-panel-control {
     width: 100%;
 
-    &__header {
-        width: 100%;
-    }
-
     p.muted {
         color: var(--jp-gray-50 );
     }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/style.scss
@@ -10,4 +10,8 @@
     p.muted {
         color: var(--jp-gray-50 );
     }
+
+    .components-base-control__help {
+        margin-top: -8px;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates over the Usage Panel:

* Hide the usage bar when the site supports unlimited requests 
* Show a help when the site supports unlimited requests

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Metered billing: hide usage bar when site has AI plan

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
([discussion](p1698171772640649/1697829634.443029-slack-C054LN8RNVA))


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the Jetpack AI panel

. | Before | After
------|-------|-------
Jetpack site / AI plan | <img width="286" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/84ac2eb1-9f2b-415c-8d46-7b71c064005f"> |<img width="288" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/bfa99b8f-d481-43f8-a6bc-8841b01be333">
Simple site | <img width="284" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/c97ac56e-1115-44ff-8801-50bfe8be6c27"> | <img width="286" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/aa6b9d87-c047-45ec-b1ae-a95ce599d8a9">



