### PR TITLE
Jetpack: add UsagePanel story

### DIFF
--- a/projects/js-packages/storybook/changelog/update-jetpack-add-usage-panel-story
+++ b/projects/js-packages/storybook/changelog/update-jetpack-add-usage-panel-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Storybook: register ./extensions folder of the Jetpack plugin project

--- a/projects/js-packages/storybook/composer.json
+++ b/projects/js-packages/storybook/composer.json
@@ -39,6 +39,7 @@
 				"packages/search",
 				"plugins/protect",
 				"plugins/boost",
+				"plugins/jetpack",
 				"packages/videopress"
 			]
 		},

--- a/projects/js-packages/storybook/storybook/projects.js
+++ b/projects/js-packages/storybook/storybook/projects.js
@@ -10,6 +10,7 @@ const projects = [
 	'../../../packages/my-jetpack/_inc/components',
 	'../../../packages/search/src/dashboard/components',
 	'../../../plugins/protect/src/js/components',
+	'../../../plugins/jetpack/extensions/',
 	'../../../plugins/boost/app/assets/src',
 	'../../../packages/videopress/src/client/admin/components',
 	'../../../packages/videopress/src/client/components',

--- a/projects/plugins/jetpack/changelog/update-jetpack-add-usage-panel-story
+++ b/projects/plugins/jetpack/changelog/update-jetpack-add-usage-panel-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: add UsagePanel story

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/stories/index.stories.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/stories/index.stories.tsx
@@ -1,0 +1,59 @@
+/*
+ * External Dependencies
+ */
+import React from 'react';
+/*
+ * Internal Dependencies
+ */
+import UsagePanel from '..';
+
+export default {
+	title: 'Plugins/Jetpack/Extensions/UsagePanel',
+	component: UsagePanel,
+	parameters: {
+		docs: {
+			autodocs: false,
+		},
+	},
+};
+
+const DefaultTemplate = () => {
+	const props = {};
+
+	return <UsagePanel { ...props } />;
+};
+
+export const aiAssistantFeatureUnsupported = DefaultTemplate.bind( {} );
+aiAssistantFeatureUnsupported.parameters = {
+	mockData: [
+		{
+			url: 'wpcom/v2/jetpack-ai/ai-assistant-feature?_locale=user',
+			method: 'GET',
+			status: 200,
+			response: {
+				'has-feature': false,
+				'requests-count': 11,
+				'requests-limit': 20,
+			},
+		},
+	],
+};
+aiAssistantFeatureUnsupported.storyName = 'AI Assistant feature unsupported';
+
+export const aiAssisstantFeatureSupported = DefaultTemplate.bind( {} );
+aiAssisstantFeatureSupported.parameters = {
+	mockData: [
+		{
+			url: 'wpcom/v2/jetpack-ai/ai-assistant-feature?_locale=user',
+			method: 'GET',
+			status: 200,
+			response: {
+				'has-feature': true,
+				'requests-count': 120,
+				'requests-limit': 20,
+			},
+		},
+	],
+};
+
+aiAssisstantFeatureSupported.storyName = 'AI Assistant feature supported';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the UsagePanel story. For this:

* Register the `./extensions` folder of the Jetpack plugin to collect storybook stories
* Create a simple `UsagePanel story

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: add UsagePanel story

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the storybook server

```
cd projects/js-packages/storybook/
```

```
 pnpm run storybook:dev
```

* Take a look at both UsagePanel stories 

http://localhost:50240/?path=/story/plugins-jetpack-extensions-usagepanel--ai-assistant-feature-unsupported

<img width="900" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/8caa4ee1-a585-4848-855d-b7503318c540">

http://localhost:50240/?path=/story/plugins-jetpack-extensions-usagepanel--ai-assisstant-feature-supported
<img width="898" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/a819c3ee-c8ed-4c48-a857-87c51b2ccaf6">

 
_Disclaimer: the `Docs` page doesn't work correctly because there is a malfunction when mocking the` ai-assistant-feature` request._

