### PR TITLE
wp-admin Site Default: Link "Themes" to the WordPress.com Marketplace

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-redirect-themes-menu-to-wpcom-marketplace
+++ b/projects/plugins/jetpack/changelog/fix-redirect-themes-menu-to-wpcom-marketplace
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Change links for Appearance > Themes on Atomic sites with wpcom_admin_interface option set to wp-admin to point to WPCOM Marketplace

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -288,7 +288,7 @@ class Admin_Menu extends Base_Admin_Menu {
 			$default_customize_background_slug_2 => add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), $customize_url ),
 		);
 
-		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'themes.php' ) ) {
+		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'themes.php' ) || self::CLASSIC_VIEW === $this->get_preferred_view( 'themes.php' ) ) {
 			$submenus_to_update['themes.php'] = 'https://wordpress.com/themes/' . $this->domain;
 		}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4339

## Proposed changes:

This PR adds a redirection from Appearance > Themes to WPCOM Marketplace when the `wpcom_admin_interface` is set to `wp-admin` on an Atomic site.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? N/A
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an Atomic site and make it WoA
* Install [Jetpack beta tester](https://jetpack.com/download-jetpack-beta/) plugin
* Navigate to /wp-admin/admin.php?page=jetpack-beta
* Select Jetpack -> Manage
* Search for the feature branch fix/redirect-themes-menu-to-wpcom-marketplace and activate that branch
* Navigate to `Settings > Hosting Configuratio` on wpcalypso.wordpress.com
* Set the interface to be Classic
* Refresh the page to make sure that the navigation is reset to `wp-admin` 
* Navigate to `Appearance > Themes`
* Confirm that you are brought to WordPress.com Marketplace: https://wordpress.com/themes/{yourSite}
* Confirm that you can toggle the classic and default view on the top of the page:

https://github.com/Automattic/jetpack/assets/25575134/ef564f05-3f3f-42ff-92c0-43a9a22e3ff4

**To test on Simple**:

* Run `bin/jetpack-downloader test jetpack fix/redirect-themes-menu-to-wpcom-marketplace` on your sandbox
* Sandbox the public API
* Navigate to `Appearance > Themes`
* Confirm you are being brought to WordPress.com Marketplace
* Navigate to `yourSimpleSite/wpadmin`
* Navigate to `Appearance > Themes`
* Confirm that you remain in `yourSimpleSimple/wp-admin/themes.php`
* Unsandbox the public API
* Confirm that the flow for the Simple sites remains the same as when sandboxed

**Current Simple Sites flow**:

https://github.com/Automattic/jetpack/assets/25575134/7c39deb0-7679-4b4b-8d6a-39ecab692f7e

**Simple Sites Flow tih changes**:

https://github.com/Automattic/jetpack/assets/25575134/2074b58e-d456-4376-88a9-e93fb54b6866

* Test on the Jetpack self-hosted site (you can use Jurassic Ninja) by following the same steps as on WoA 
