### PR TITLE
CRM: Removing usage of deprecated function utf8_encode

### DIFF
--- a/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
+++ b/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
@@ -503,8 +503,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTP() {
 	}
 
 	header( 'Content-Type: application/json' );
-	// requires zeroBSCRM_utf8ize for proper debug passing
-	echo json_encode( zeroBSCRM_utf8ize( $res ) );
+	echo wp_json_encode( $res, JSON_UNESCAPED_UNICODE );
 	exit();
 }
 
@@ -574,8 +573,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTPPorts() {
 
 	$res['open'] = $okay;
 	header( 'Content-Type: application/json' );
-	// requires zeroBSCRM_utf8ize for proper debug passing
-	echo json_encode( zeroBSCRM_utf8ize( $res ) );
+	echo wp_json_encode( $res, JSON_UNESCAPED_UNICODE );
 	exit();
 }
 

--- a/projects/plugins/crm/changelog/remove-crm-utf8_encode-usage
+++ b/projects/plugins/crm/changelog/remove-crm-utf8_encode-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Mail delivery: Removed usage of deprecated function utf8_encode

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -905,22 +905,6 @@ function zeroBSCRM_isJson( $str ) {
 		return $endArr;
 	}
 
-
-	// recursive utf8-ing 
-	// https://stackoverflow.com/questions/19361282/why-would-json-encode-return-an-empty-string
-	function zeroBSCRM_utf8ize($d) {
-	    if (is_array($d)) {
-	        foreach ($d as $k => $v) {
-	            $d[$k] = zeroBSCRM_utf8ize($v);
-	        }
-	    } else if (is_string ($d)) {
-			// TODO: utf8_encode has been deprecated in PHP 8.2, and needs to be replaced.
-			return utf8_encode($d); // phpcs:ignore
-	    }
-	    return $d;
-	}
-
-
 	// returns a filetype img if avail
 	// returns 48px from  https://github.com/redbooth/free-file-icons
 	// ... cpp has fullsize 512px variants, but NOT to be added to core, adds bloat


### PR DESCRIPTION
## Proposed changes:

* This PR removes the `utf8_encode` as it is now deprecated, and also removes the `zeroBSCRM_utf8ize` function in which it was located (it is not used by any extensions either). Instead, the two places in core CRM where the `zeroBSCRM_utf8ize` function was used (`zeroBSCRM_AJAX_mailDelivery_validateSMTP` and `zeroBSCRM_AJAX_mailDelivery_validateSMTPPorts`) now use `wp_json_encode()` with the `JSON_UNESCAPED_UNICODE` option` passed in.
* One suggestion was to use `mb_convert_encoding` to replace the original instance of `utf8_encode`, and I can confirm `mb_convert_encoding` does the same as `utf8_encode`, using example code provided here - https://www.php.net/manual/en/function.utf8-encode.php in testing.
* The other suggestion in the issue to remove unnecessary code also makes sense and is the approach used here.
* The output of `wp_json_encode( $res, JSON_UNESCAPED_UNICODE );` differs slightly to the original function, but from my perspective is a better output.
  * To clarify more, given a $res of `array(
		"debugs" => array("success:<h2>Debugging SMTP<\/h2>Some unexpected characters here: á"')
	);`, the previous output in the debug output would be `Debugging SMTP<\/h2>Some unexpected characters here: Ã¡` with original code, and
	`Debugging SMTP<\/h2>Some unexpected characters here: á` with new code (in `zeroBSCRM_AJAX_mailDelivery_validateSMTP`). The result is similar in `zeroBSCRM_AJAX_mailDelivery_validateSMTPPorts`, with the correct character being passed in. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3277
https://github.com/Automattic/jetpack/pull/32428

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test this out, you can try printing the following in your error log if not in either `zeroBSCRM_AJAX_mailDelivery_validateSMTP` or `zeroBSCRM_AJAX_mailDelivery_validateSMTPPorts`:
```
$res = array(
		"debugs" => array( "success:<h2>Debugging SMTP<\/h2>Some unexpected characters here: á" )
	);
```
Then on the branch:
```
error_log( wp_json_encode( $res, JSON_UNESCAPED_UNICODE ));
```
vs on trunk
```
error_log( json_encode( zeroBSCRM_utf8ize ($res ) ) );
```

* You can also test using an smtp value like á.smtp.com on both trunk and on the branch and visiting the network tab in the inspector console, clicking on the most recent admin-ajax.php call, and viewing the response (or error_log the response from `zeroBSCRM_AJAX_mailDelivery_validateSMTP` directly). For `zeroBSCRM_AJAX_mailDelivery_validateSMTPPorts` you can test by adding a $res into the code before the echo at the end of that function (use the $res above) - the result will display in the debug output.
* You can also test with a character encoding such as `\xEB` and the result should be the same.

