### PR TITLE
Donations: remove unneeded multiline prop

### DIFF
--- a/projects/plugins/jetpack/changelog/rm-donations-multiline
+++ b/projects/plugins/jetpack/changelog/rm-donations-multiline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Donations Block: update to be compatible with the upcoming version of WordPress, 6.4.

--- a/projects/plugins/jetpack/extensions/blocks/donations/amount.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/amount.js
@@ -103,7 +103,6 @@ const Amount = ( {
 				<RichText
 					allowedFormats={ [] }
 					aria-label={ label }
-					multiline={ false }
 					onChange={ amount => setAmount( amount ) }
 					placeholder={ formatCurrency( defaultValue, currency, { symbol: '' } ) }
 					ref={ richTextRef }


### PR DESCRIPTION
Fixes #33642

## Proposed changes:

The prop was deprecated and will be removed. Since it was set to false it will not bring in any changes to the UI.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* #32865

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's connected to WordPress.com.
* Go to Posts > Add New
* Add a Donations block
* Ensure the different boxes displaying an amount you can donate are displayed properly.
