### PR TITLE
Lazy Images: remove from Jetpack plugin

### DIFF
--- a/projects/plugins/jetpack/3rd-party/woocommerce.php
+++ b/projects/plugins/jetpack/3rd-party/woocommerce.php
@@ -134,29 +134,3 @@ function jetpack_woocommerce_infinite_scroll_style() {
 	}';
 	wp_add_inline_style( 'woocommerce-layout', $custom_css );
 }
-
-/**
- * Adds compat for WooCommerce and Lazy Loading.
- */
-function jetpack_woocommerce_lazy_images_compat() {
-	wp_add_inline_script(
-		'wc-cart-fragments',
-		"
-		jQuery( 'body' ).bind( 'wc_fragments_refreshed', function() {
-			var jetpackLazyImagesLoadEvent;
-			try {
-				jetpackLazyImagesLoadEvent = new Event( 'jetpack-lazy-images-load', {
-					bubbles: true,
-					cancelable: true
-				} );
-			} catch ( e ) {
-				jetpackLazyImagesLoadEvent = document.createEvent( 'Event' )
-				jetpackLazyImagesLoadEvent.initEvent( 'jetpack-lazy-images-load', true, true );
-			}
-			jQuery( 'body' ).get( 0 ).dispatchEvent( jetpackLazyImagesLoadEvent );
-		} );
-		"
-	);
-}
-
-add_action( 'wp_enqueue_scripts', 'jetpack_woocommerce_lazy_images_compat', 11 );

--- a/projects/plugins/jetpack/_inc/client/components/contextualized-connection/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/contextualized-connection/index.jsx
@@ -109,12 +109,6 @@ const ContextualizedConnection = props => {
 								) }
 							</li>
 							<li>
-								{ createInterpolateElement(
-									__( '<strong>Free</strong> lazy image loading', 'jetpack' ),
-									{ strong: <strong /> }
-								) }
-							</li>
-							<li>
 								{ createInterpolateElement( __( '<strong>Free</strong> SEO tools', 'jetpack' ), {
 									strong: <strong />,
 								} ) }

--- a/projects/plugins/jetpack/_inc/client/performance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/index.jsx
@@ -19,7 +19,7 @@ class Performance extends Component {
 			hasConnectedOwner: this.props.hasConnectedOwner,
 		};
 
-		const found = [ 'photon', 'videopress', 'lazy-images', 'photon-cdn', 'search' ].some(
+		const found = [ 'photon', 'videopress', 'photon-cdn', 'search' ].some(
 			this.props.isModuleFound
 		);
 

--- a/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
@@ -1,11 +1,8 @@
 import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import classNames from 'classnames';
 import { FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
-import SimpleNotice from 'components/notice';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
@@ -148,50 +145,13 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 			}
 		};
 
-		trackDeprecatedLazyImagesLearnMore = () => {
-			analytics.tracks.recordJetpackClick( {
-				target: 'learn-more',
-				feature: 'lazy-images',
-				extra: 'deprecated-link',
-			} );
-		};
-
-		displayLazyImagesNotice = () => {
-			const disableStatusMessage = this.props.gutenbergInfo.hasInteractivityApi
-				? __( 'We’ve consequently disabled the Lazy Images feature on your site.', 'jetpack' )
-				: __( 'This feature will consequently be removed from Jetpack in November.', 'jetpack' );
-
-			return (
-				<SimpleNotice showDismiss={ false } status="is-info" className="jp-form-settings-notice">
-					{ __(
-						'Modern browsers now support lazy loading, and WordPress itself bundles lazy loading features for images and videos.',
-						'jetpack'
-					) }{ ' ' }
-					{ disableStatusMessage }{ ' ' }
-					{
-						<ExternalLink
-							href={ getRedirectUrl( 'jetpack-support-lazy-images' ) }
-							onClick={ this.trackDeprecatedLazyImagesLearnMore }
-						>
-							{ __( 'Learn more', 'jetpack' ) }
-						</ExternalLink>
-					}
-				</SimpleNotice>
-			);
-		};
-
 		render() {
 			const foundPhoton = this.props.isModuleFound( 'photon' );
 			const foundAssetCdn = this.props.isModuleFound( 'photon-cdn' );
-			const foundLazyImages = this.props.isModuleFound( 'lazy-images' );
 
-			if ( ! foundPhoton && ! foundLazyImages && ! foundAssetCdn ) {
+			if ( ! foundPhoton && ! foundAssetCdn ) {
 				return null;
 			}
-
-			const lazyImages = this.props.module( 'lazy-images' );
-			const isLazyimagesActive = this.props.getOptionValue( 'lazy-images' );
-			const isLazyimagesForceDisabled = this.props.gutenbergInfo.hasInteractivityApi;
 
 			// Check if any of the CDN options are on.
 			const siteAcceleratorStatus =
@@ -322,33 +282,6 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 									</ModuleToggle>
 								) }
 							</FormFieldset>
-						</SettingsGroup>
-					) }
-
-					{ foundLazyImages && (
-						<SettingsGroup
-							hasChild
-							module={ lazyImages }
-							className={ classNames( 'jp-form-settings-group--lazy_images', {
-								'jp-form-settings-group--lazy_images_disabled': ! isLazyimagesActive,
-							} ) }
-						>
-							{ this.displayLazyImagesNotice() }
-							<ModuleToggle
-								slug="lazy-images"
-								disabled={
-									this.props.isUnavailableInOfflineMode( 'lazy-images' ) ||
-									! isLazyimagesActive ||
-									isLazyimagesForceDisabled
-								}
-								activated={ isLazyimagesActive && ! isLazyimagesForceDisabled }
-								toggling={ this.props.isSavingAnyOption( 'lazy-images' ) }
-								toggleModule={ this.toggleModule }
-							>
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Enable Lazy Loading for images', 'jetpack' ) }
-								</span>
-							</ModuleToggle>
 						</SettingsGroup>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/performance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/performance/style.scss
@@ -22,19 +22,3 @@
 		}
 	}
 }
-
-/* Lazy Images */
-.jp-form-settings-group--lazy_images {
-	.jp-form-settings-notice {
-		a.components-external-link {
-			color: $white;
-		}
-	}
-	&.jp-form-settings-group--lazy_images_disabled {
-		.jp-form-toggle-explanation {
-			color: $gray-5;
-		}
-	}
-}
-
-

--- a/projects/plugins/jetpack/_inc/client/state/modules/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/modules/reducer.js
@@ -269,14 +269,13 @@ export function hasAnyOfTheseModules( state, modules = [] ) {
 /**
  * Check that the site has any of the performance features available.
  *
- * @param  {Object} state   Global state tree
+ * @param {object} state   - Global state tree
  *
- * @return {boolean}        True if at least one of the performance features is available
+ * @returns {boolean}        True if at least one of the performance features is available
  */
 export function hasAnyPerformanceFeature( state ) {
 	return hasAnyOfTheseModules( state, [
 		'carousel',
-		'lazy-images',
 		'photon',
 		'photon-cdn',
 		'search',

--- a/projects/plugins/jetpack/_inc/client/state/modules/test/selectors.js
+++ b/projects/plugins/jetpack/_inc/client/state/modules/test/selectors.js
@@ -166,7 +166,7 @@ describe( 'items selectors', () => {
 				jetpack: {
 					modules: {
 						items: {
-							'lazy-images': {},
+							photon: {},
 						},
 					},
 				},

--- a/projects/plugins/jetpack/changelog/rm-lazy-images-jetpack
+++ b/projects/plugins/jetpack/changelog/rm-lazy-images-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Lazy Images: remove the feature from the plugin. You can now rely on WordPress' own Lazy Image features on your site.

--- a/projects/plugins/jetpack/changelog/rm-lazy-images-jetpack#2
+++ b/projects/plugins/jetpack/changelog/rm-lazy-images-jetpack#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -116,8 +116,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			<# var i = 0;
 			if ( data.items.length ) {
 			_.each( data.items, function( item, key, list ) {
-				if ( item === undefined ) return;
-				if ( 'lazy-images' == item.module && ! item.activated ) return; #>
+				if ( item === undefined ) return; #>
 				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #><# if ( item.activated ) { #> active<# } #><# if ( ! item.available ) { #> unavailable<# } #>" id="{{{ item.module }}}">
 					<th scope="row" class="check-column">
 						<input type="checkbox" name="modules[]" value="{{{ item.module }}}" {{{ item.disabled }}} />

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -300,11 +300,6 @@ class Jetpack {
 			'Rank Math'                            => 'seo-by-rank-math/rank-math.php',
 			'Slim SEO'                             => 'slim-seo/slim-seo.php',
 		),
-		'lazy-images'        => array(
-			'Lazy Load'              => 'lazy-load/lazy-load.php',
-			'BJ Lazy Load'           => 'bj-lazy-load/bj-lazy-load.php',
-			'Lazy Load by WP Rocket' => 'rocket-lazy-load/rocket-lazy-load.php',
-		),
 	);
 
 	/**
@@ -5976,11 +5971,6 @@ endif;
 			'jetpack_cache_plans'                          => array(
 				'replacement' => null,
 				'version'     => 'jetpack-6.1.0',
-			),
-
-			'jetpack_lazy_images_skip_image_with_atttributes' => array(
-				'replacement' => 'jetpack_lazy_images_skip_image_with_attributes',
-				'version'     => 'jetpack-6.5.0',
 			),
 			'jetpack_enable_site_verification'             => array(
 				'replacement' => null,

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -34,7 +34,6 @@
 		"automattic/jetpack-import": "@dev",
 		"automattic/jetpack-ip": "@dev",
 		"automattic/jetpack-jitm": "@dev",
-		"automattic/jetpack-lazy-images": "@dev",
 		"automattic/jetpack-licensing": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-my-jetpack": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "efbfa6f913dfce5c8a13cf87a6e4cf99",
+    "content-hash": "d4543bd5fa21fe0b226972d98ea56739",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1522,72 +1522,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Just in time messages for Jetpack",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "automattic/jetpack-lazy-images",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/lazy-images",
-                "reference": "c820678bb5aeb6ced11f6b73c68a8006f29649c8"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-status": "@dev"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "automattic/wordbless": "dev-master",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-lazy-images",
-                "textdomain": "jetpack-lazy-images",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-lazy-images/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "phpunit": [
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ],
-                "post-install-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "post-update-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Speed up your site and create a smoother viewing experience by loading images as visitors scroll down the screen, instead of all at once. Modern browsers now support lazy loading, and WordPress itself bundles lazy loading features for images and videos. This feature will consequently be deprecated in November 2023.",
             "transport-options": {
                 "relative": true
             }
@@ -5746,7 +5680,6 @@
         "automattic/jetpack-import": 20,
         "automattic/jetpack-ip": 20,
         "automattic/jetpack-jitm": 20,
-        "automattic/jetpack-lazy-images": 20,
         "automattic/jetpack-licensing": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-my-jetpack": 20,

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
@@ -9,13 +9,6 @@ function swiperInit( swiper ) {
 	swiperResize( swiper );
 	swiperApplyAria( swiper );
 
-	/*
-	 * Dispatch the jetpack-lazy-images-load event to set up lazy loading for
-	 * the slideshow's duplicate first and last images.
-	 */
-	const bodyEl = document.querySelector( 'body' );
-	bodyEl.dispatchEvent( new Event( 'jetpack-lazy-images-load' ) );
-
 	swiper.el
 		.querySelector( '.wp-block-jetpack-slideshow_button-pause' )
 		.addEventListener( 'click', function () {

--- a/projects/plugins/jetpack/modules/lazy-images.php
+++ b/projects/plugins/jetpack/modules/lazy-images.php
@@ -1,34 +1,30 @@
 <?php
 /**
- * Module Name: Lazy Images
- * Module Description: Improve your site's speed by only loading images visible on the screen. Modern browsers now support lazy loading, and WordPress itself bundles lazy loading features for images and videos. This feature will consequently be removed from Jetpack in November 2023.
- * Sort Order: 24
- * Recommendation Order: 14
- * First Introduced: 5.6.0
- * Requires Connection: No
- * Auto Activate: No
- * Module Tags: Appearance, Recommended
- * Feature: Appearance
- * Additional Search Queries: mobile, theme, fast images, fast image, image, lazy, lazy load, lazyload, images, lazy images, thumbnail, image lazy load, lazy loading, load, loading
+ * Deprecated since version 12.8.0.
  *
+ * Jetpack’s Lazy Loading feature was first introduced in 2018.
+ * At the time, few other tools offered such functionality.
+ * It offered a much needed performance boost to WordPress sites,
+ * especially those with a large number of images.
+ *
+ * A couple of years later, a new lazy loading web standard was introduced,
+ * and WordPress itself started supporting this standard.
+ * Today, modern browsers all support lazy loading,
+ * and WordPress itself comes with built-in lazy loading functionality for images and videos.
+ *
+ * Considering this positive change, Jetpack’s Lazy Loading feature is no longer necessary.
+ *
+ * @deprecated
  * @package automattic/jetpack
  */
 
 /**
- * The core of this module has been migrated to an standalone reusable package.
+ * Deactivate module if it is still active.
  *
- * @since 8.8
+ * @since $$next-version$$
  */
+if ( Jetpack::is_module_active( 'lazy-images' ) ) {
+	Jetpack::deactivate_module( 'lazy-images' );
+}
 
-/*
- * Initialize lazy images on the wp action so that conditional
- * tags are safe to use.
- *
- * As an example, this is important if a theme wants to disable lazy images except
- * on single posts, pages, or attachments by short-circuiting lazy images when
- * is_singular() returns false.
- *
- * See: https://github.com/Automattic/jetpack/issues/8888
- */
-
-add_action( 'wp', array( 'Automattic\\Jetpack\\Jetpack_Lazy_Images', 'instance' ) );
+_deprecated_file( basename( __FILE__ ), 'jetpack-$$next-version$$' );

--- a/projects/plugins/jetpack/modules/module-info.php
+++ b/projects/plugins/jetpack/modules/module-info.php
@@ -462,27 +462,6 @@ function jetpack_photon_more_info() {
 add_action( 'jetpack_module_more_info_photon', 'jetpack_photon_more_info' );
 
 /**
- * Lazy Images support link.
- */
-function jetpack_lazy_images_more_link() {
-	echo esc_url( Redirect::get_url( 'jetpack-support-lazy-images' ) );
-}
-add_action( 'jetpack_learn_more_button_lazy-images', 'jetpack_lazy_images_more_link' );
-
-/**
- * Lazy Images description.
- */
-function jetpack_lazy_images_more_info() {
-	esc_html_e(
-		'Improve your site\'s speed by only loading images visible on the screen.
-		Modern browsers now support lazy loading, and WordPress itself bundles lazy loading features for images and videos.
-		This feature will consequently be removed from Jetpack in November 2023.',
-		'jetpack'
-	);
-}
-add_action( 'jetpack_module_more_info_lazy-images', 'jetpack_lazy_images_more_info' );
-
-/**
  * Tiled Galleries support link.
  */
 function jetpack_tiled_gallery_more_link() {

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -338,7 +338,6 @@ class Jetpack_Plugin_Search {
 				array_flip(
 					array(
 						'contact-form',
-						'lazy-images',
 						'monitor',
 						'photon',
 						'photon-cdn',

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentysixteen.php
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentysixteen.php
@@ -62,18 +62,3 @@ function twentysixteen_remove_share() {
 	}
 }
 add_action( 'loop_start', 'twentysixteen_remove_share' );
-
-/**
- * Add inline script for lazy load compat in Twenty Sixteen.
- */
-function twentysixteen_jetpack_lazy_images_compat() {
-	// Since TwentySixteen outdents when window is resized, let's trigger a window resize
-	// every time we lazy load an image on the TwentySixteen theme.
-	wp_add_inline_script(
-		'jetpack-lazy-images',
-		"jQuery( document.body ).on( 'jetpack-lazy-loaded-image', function () { jQuery( window ).trigger( 'resize' ); } );"
-	);
-}
-
-// Priority needs to be 11 here so that we have already enqueued jetpack-lazy-images.
-add_action( 'wp_enqueue_scripts', 'twentysixteen_jetpack_lazy_images_compat', 11 );

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -35,7 +35,6 @@ You can purchase all of Jetpack’s security features in our [Security bundle](h
 Get blazing fast site speed with Jetpack. Jetpack’s free CDN (content delivery network) auto optimizes your images. Watch your page load times decrease — we’ll optimize your images and serve them from our own powerful global network, and speed up your site on mobile devices to reduce bandwidth usage and save money!
 
 * Image CDN for images and core static files, like CSS and JavaScript, served from our servers, not yours, which saves you money and bandwidth.
-* Lazy load images for a super fast experience, even on mobile. Jetpack’s lazy loading automatically delays the loading of media on your posts and pages until your visitors scroll down to where they appear on the page.
 * Unlimited, high speed, ad free video hosting keeps the focus on your content, not on ads or recommendations that lead people off site.
 * Custom site search is incredibly powerful and customizable. Helps your visitors instantly find the right content so they read and buy more. Works great with WooCommerce / eCommerce sites to help filter products so customers get what they want on your site faster.
 * Recommended to use with WP Super Cache for ultimate WordPress site speed.
@@ -188,7 +187,6 @@ Jetpack is the ultimate toolkit for WP for both the classic editor and the block
 * Google Analytics (GA) — Track your WordPress site statistics thanks to Google Analytics.
 * Infinite Scroll — Pulls the next posts automatically into view when the reader approaches the bottom of the page.
 * JSON API — Authorizes applications and services to securely connect to your blog, and allows them to use your content or offer you new functionality.
-* Lazy Load Images — Makes pages load faster by only lazy loading images that are on the screen, and loads other images as the user scrolls
 * Likes — Allows readers to show their appreciation for your posts with a single click.
 * Markdown — Allows you to compose posts and comments with links, lists, and other styles using regular characters and punctuation marks. Markdown is used by writers and bloggers who want a quick and easy way to write rich text without having to take their hands off the keyboard.
 * Malware detection - automatic malware scans that help protect your WP website with an automated resolution.

--- a/projects/plugins/jetpack/tests/php/src/test_class-jetpack-modules-overrides.php
+++ b/projects/plugins/jetpack/tests/php/src/test_class-jetpack-modules-overrides.php
@@ -63,16 +63,16 @@ class WP_Test_Jetpack_Modules_Overrides extends WP_UnitTestCase {
 
 		add_filter( $filter_name, array( $this, 'force_active_modules' ) );
 		$expected = array(
-			'photon'      => 'active',
-			'lazy-images' => 'active',
+			'photon'     => 'active',
+			'photon-cdn' => 'active',
 		);
 		$this->assertSame( $expected, $this->instance->get_overrides( false ) );
 
 		add_filter( $filter_name, array( $this, 'force_inactive_module' ) );
 		$expected = array(
-			'photon'      => 'active',
-			'lazy-images' => 'active',
-			'sitemaps'    => 'inactive',
+			'photon'     => 'active',
+			'photon-cdn' => 'active',
+			'sitemaps'   => 'inactive',
 		);
 		$this->assertSame( $expected, $this->instance->get_overrides( false ) );
 
@@ -101,8 +101,8 @@ class WP_Test_Jetpack_Modules_Overrides extends WP_UnitTestCase {
 
 		add_filter( $filter_name, array( $this, 'force_active_modules' ) );
 		$expected = array(
-			'photon'      => 'active',
-			'lazy-images' => 'active',
+			'photon'     => 'active',
+			'photon-cdn' => 'active',
 		);
 		$this->assertSame( $expected, $this->instance->get_overrides() );
 
@@ -121,14 +121,14 @@ class WP_Test_Jetpack_Modules_Overrides extends WP_UnitTestCase {
 	 */
 	public function test_get_module_override( $filter_name ) {
 		$this->assertFalse( $this->instance->get_module_override( 'photon' ) );
-		$this->assertFalse( $this->instance->get_module_override( 'lazy-images' ) );
+		$this->assertFalse( $this->instance->get_module_override( 'photon-cdn' ) );
 		$this->assertFalse( $this->instance->get_module_override( 'sitemaps' ) );
 
 		add_filter( $filter_name, array( $this, 'force_active_modules' ) );
 		add_filter( $filter_name, array( $this, 'force_inactive_module' ) );
 
 		$this->assertSame( 'active', $this->instance->get_module_override( 'photon' ) );
-		$this->assertSame( 'active', $this->instance->get_module_override( 'lazy-images' ) );
+		$this->assertSame( 'active', $this->instance->get_module_override( 'photon-cdn' ) );
 		$this->assertSame( 'inactive', $this->instance->get_module_override( 'sitemaps' ) );
 	}
 
@@ -137,14 +137,14 @@ class WP_Test_Jetpack_Modules_Overrides extends WP_UnitTestCase {
 	 */
 
 	/**
-	 * Helper to force active Photon and Lazy Images
+	 * Helper to force active Photon and the Asset CDN.
 	 *
 	 * @param array $modules Jetpack modules.
 	 *
 	 * @return array Jetpack modules.
 	 */
 	public function force_active_modules( $modules ) {
-		return array_merge( $modules, array( 'photon', 'lazy-images' ) );
+		return array_merge( $modules, array( 'photon', 'photon-cdn' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/test-get-modules.php
+++ b/projects/plugins/jetpack/tests/php/test-get-modules.php
@@ -45,7 +45,6 @@ class WP_Test_Get_Modules extends WP_UnitTestCase {
 			'infinite-scroll',
 			'json-api',
 			'latex',
-			'lazy-images',
 			'likes',
 			'markdown',
 			'masterbar',

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -85,7 +85,6 @@ const supportedModules = [
 	'masterbar',
 	'videopress',
 	'comment-likes',
-	'lazy-images',
 	'scan',
 	'wordads',
 	'theme-tools/responsive-videos',

--- a/tools/e2e-commons/helpers/plan-helper.js
+++ b/tools/e2e-commons/helpers/plan-helper.js
@@ -194,7 +194,6 @@ function getPlanData(
 				'markdown',
 				'comments',
 				'likes',
-				'lazy-images',
 				'infinite-scroll',
 				'wordads',
 				'sso',


### PR DESCRIPTION
Fixes #33171

## Proposed changes:

We deprecated the feature and issued notices to our users still using it in #33208. It is now time to remove it entirely.

- If the module is still enabled, we disable it.
- We do not display the feature in any of our UI elements anymore.
- We declare the file as deprecated, so we can safely remove it in a future version of the plugin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

Let's also take that opportunity to close related issues:

Fixes #10016
Fixes #9827
Fixes #24002
Fixes #9043
Fixes #11054
Fixes #8905
Fixes #17640
Fixes #15073
Fixes #16421
Fixes #8879
Fixes #9509
Fixes #9974
Fixes #9896
Fixes #8917
Fixes #10046
Fixes #8897
Fixes #9929
Fixes #9595
Fixes #10606
Fixes #12344
Fixes #10607
Fixes #25659
Fixes #29585
Fixes #14191
Fixes #13518
Fixes #10707
Fixes #8996
Fixes #8773
Fixes #8281
Fixes #14161
Fixes #31877
Fixes #14281

## Jetpack product discussion

* #33049

## Does this pull request change what data or activity we track or use?

* Yes, it removes all Lazy Image links from the UI, and thus the attached tracking disappears with them.

## Testing instructions:

* You can start with a site running `trunk`, using the Lazy Images module: connect your site to WordPress.com, and in WP CLI, enable the module (you cannot enable it via the UI anymore): `wp jetpack module activate lazy-images`
* Switch to this branch.
* Go to Jetpack > Settings > Performance
    * You should not see any mentions of Lazy Images anymore.
* Go to Jetpack > Settings > Modules
    * No mention of the feature there either.
* Back to the CLI, run `wp jetpack module list`
    * No mention of the feature there either.

