### PR TITLE
docker: Use mpm_event and php-fpm instead of mpm_prefork and mod_php

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
 	&& add-apt-repository ppa:ondrej/php \
 	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
 	&& apt-get update \
-	&& apt-get install -y \
+	&& apt-get --purge install -y \
 		apache2 \
 		git \
 		jq \
@@ -38,14 +38,15 @@ RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
 		ssmtp \
 		subversion \
 		sudo \
+		systemd-standalone-tmpfiles \
 		unzip \
 		vim \
 		zip \
 	&& apt-get remove --purge --auto-remove -y gpg software-properties-common \
 	&& find /var/ -name '*-old' -delete && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
 
-# Enable mod_rewrite in Apache.
-RUN a2enmod rewrite
+# Enable various Apache modules.
+RUN a2dismod mpm_prefork && a2enmod rewrite mpm_event proxy_fcgi http2
 
 # Install requested version of PHP.
 COPY ./config/php.ini /var/lib/jetpack-config/php.ini
@@ -53,6 +54,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
 	--mount=type=bind,source=./bin/ensure-php-version.sh,target=/usr/local/bin/ensure-php-version.sh \
 	: "${PHP_VERSION:?Build argument PHP_VERSION needs to be set and non-empty.}" \
 	&& ensure-php-version.sh "$PHP_VERSION" \
+	&& a2enconf "php$PHP_VERSION-fpm" \
 	&& find /var/ -name '*-old' -delete && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
 
 # Install requested version of Composer.

--- a/tools/docker/bin/ensure-php-version.sh
+++ b/tools/docker/bin/ensure-php-version.sh
@@ -20,11 +20,11 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Determine packages to install.
 PKGS=(
-	"libapache2-mod-php${VER}"
 	"php${VER}"
 	"php${VER}-bcmath"
 	"php${VER}-cli"
 	"php${VER}-curl"
+	"php${VER}-fpm"
 	"php${VER}-intl"
 	"php${VER}-ldap"
 	"php${VER}-mbstring"

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -7,6 +7,8 @@ set -e
 # If you modify anything here, remember to build the image again by running:
 # jetpack docker build-image
 
+source /etc/docker-args.sh
+
 user="${APACHE_RUN_USER:-www-data}"
 group="${APACHE_RUN_GROUP:-www-data}"
 
@@ -133,5 +135,7 @@ echo "Open http://${WP_DOMAIN}${WP_HOST_PORT}/ to see your site!"
 echo
 
 # Run apache in the foreground so the container keeps running
+echo "Running php-fpm"
+"/etc/init.d/php${PHP_VERSION}-fpm" start
 echo "Running Apache in the foreground"
 apachectl -D FOREGROUND


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The main hope here is that using mpm_event rather than mpm_prefork will make our E2E tests run better.

But mod_php is not compatible with mpm_event. The modern way to do things is to use php-fpm instead.

And while we're at it, we may as well enable apache's http2 module too. Although actually making effective use of that may take more work (if anyone cares), since HTTP/2 likes to run with TLS but our dev environment doesn't do TLS.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-2f3-p2#comment-1825

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Temporarily change https://github.com/Automattic/jetpack/blob/9e6f6dc25b4fc2c522a3062e19826678c1e4fdb3/tools/docker/docker-compose.yml#L37 to refer to `ghcr.io/automattic/jetpack-wordpress-dev:pr-33783` and restart your docker env (`jetpack docker stop && jetpack docker up -d`). Then make sure everything still works.
* If you can run the E2E tests locally and reproduce the kinds of problems mentioned in pc9hqz-2f3-p2, see if this helps.