### PR TITLE
Storybook: remove Jetpack plugin from deps to fix builds in trunk

### DIFF
--- a/projects/js-packages/storybook/changelog/update-storybook-remove-jetpack-plugin
+++ b/projects/js-packages/storybook/changelog/update-storybook-remove-jetpack-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Storybook: remove Jetpack plugin from deps to fix builds in trunk

--- a/projects/js-packages/storybook/composer.json
+++ b/projects/js-packages/storybook/composer.json
@@ -39,7 +39,6 @@
 				"packages/search",
 				"plugins/protect",
 				"plugins/boost",
-				"plugins/jetpack",
 				"packages/videopress"
 			]
 		},

--- a/projects/js-packages/storybook/storybook/projects.js
+++ b/projects/js-packages/storybook/storybook/projects.js
@@ -10,7 +10,6 @@ const projects = [
 	'../../../packages/my-jetpack/_inc/components',
 	'../../../packages/search/src/dashboard/components',
 	'../../../plugins/protect/src/js/components',
-	'../../../plugins/jetpack/extensions/',
 	'../../../plugins/boost/app/assets/src',
 	'../../../packages/videopress/src/client/admin/components',
 	'../../../packages/videopress/src/client/components',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Looks like https://github.com/Automattic/jetpack/pull/33771 in combination with https://github.com/Automattic/jetpack/pull/33720 breaks the build in [trunk](https://github.com/Automattic/jetpack/actions/runs/6643488102/job/18050630458).

Let's remove the Jetpack plugin from the Storybook dependencies to fix the build in trunk.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Storybook: remove Jetpack plugin from deps to fix builds in trunk

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1698254253825379-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Wait for the `Build / Build all projects (pull_request)` test