### PR TITLE
Update/classic widget to hide form if subscribed

### DIFF
--- a/projects/plugins/jetpack/changelog/update-classic-widget-to-hide-form-if-subscribed
+++ b/projects/plugins/jetpack/changelog/update-classic-widget-to-hide-form-if-subscribed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update classic Jetpack widget to not show up if user is subscribed

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -111,6 +111,9 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 	 * @param array $instance The settings for the particular instance of the widget.
 	 */
 	public function widget( $args, $instance ) {
+		if ( self::is_wpcom() && ! self::wpcom_has_status_message() && self::is_current_user_subscribed() ) {
+			return null;
+		}
 		if ( self::is_jetpack() &&
 			/** This filter is documented in modules/contact-form/grunion-contact-form.php */
 			false === apply_filters( 'jetpack_auto_fill_logged_in_user', false )


### PR DESCRIPTION
## Proposed changes:

* Hide entire widget if the user didn't just submit the form and they are subscribed

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-mnl-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Because this is a legacy widget, I found the easiest way to test this is to go manually paste the code into the wpcom codebase where the mirror of this lives.

1. Go to fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Swrgcnpx%2Qcyhtva%2Scebqhpgvba%2Szbqhyrf%2Sfhofpevcgvbaf%2Sivrjf.cuc%3Se%3Q39550r4o-og and make the same edits as this PR
2. Go to https://jetpack.com/blog, logged into an account that is not subscribed. You should see the form
![image](https://github.com/Automattic/jetpack/assets/65001528/12f123ca-87e2-486b-b95c-f079a42ec61a)
3. Enter your email to subscribe
You should see the message saying you are subscribed
![image](https://github.com/Automattic/jetpack/assets/65001528/b1e0036d-9ad3-43f7-aca3-175496d4ad8d)
4. Go to https://jetpack.com/blog again and the widget should be gone
![image](https://github.com/Automattic/jetpack/assets/65001528/afc215f4-8edc-4ab1-958b-36a4a90f9e2a)