### PR TITLE
Prevent adding tier to payload when not provided

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -550,6 +550,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	private function get_payload_for_product( WP_REST_Request $request ) {
 		$is_editable             = isset( $request['is_editable'] ) ? (bool) $request['is_editable'] : null;
 		$type                    = isset( $request['type'] ) ? $request['type'] : null;
+		$tier                    = isset( $request['tier'] ) ? $request['tier'] : null;
 		$buyer_can_change_amount = isset( $request['buyer_can_change_amount'] ) && (bool) $request['buyer_can_change_amount'];
 
 		$payload = array(
@@ -562,8 +563,11 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 			'welcome_email_content'        => $request['welcome_email_content'],
 			'subscribe_as_site_subscriber' => $request['subscribe_as_site_subscriber'],
 			'multiple_per_user'            => $request['multiple_per_user'],
-			'tier'                         => $request['tier'],
 		);
+
+		if ( null !== $tier ) {
+			$payload['tier'] = $tier;
+		}
 
 		// If we pass directly the value "null", it will break the argument validation.
 		if ( null !== $is_editable ) {

--- a/projects/plugins/jetpack/changelog/fix-optional-tier-param
+++ b/projects/plugins/jetpack/changelog/fix-optional-tier-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Prevent issue on jetpack proxy when tier is added


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Adding plan from paid-content block.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix a bug found by @chrismccluskey 
* Do not add "tier" to payload as `null` when not provided

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Jn instance
* Set Jetpack
* Create a plan from a premium-content and make sure it gets added
* It would return a 500 before

