### PR TITLE
CRM: 3374 - allow events API endpoint to be filtered by owner

### DIFF
--- a/projects/plugins/crm/api/events.php
+++ b/projects/plugins/crm/api/events.php
@@ -28,7 +28,19 @@ jpcrm_api_check_http_method( array( 'GET' ) );
 // Process the pagination parameters from the query
 list( $page, $per_page ) = jpcrm_api_process_pagination();
 
-$owner = -1;
+/**
+ * Allow events to be filtered by owner. Docs are ambiguous about
+ * whether we should use `owned` or `owner`, so let's support both.
+ */
+// phpcs:disable WordPress.Security.NonceVerification.Recommended
+if ( isset( $_GET['owner'] ) && (int) $_GET['owner'] > 0 ) {
+	$owner = (int) $_GET['owner'];
+} elseif ( isset( $_GET['owned'] ) && (int) $_GET['owned'] > 0 ) {
+	$owner = (int) $_GET['owned'];
+} else {
+	$owner = -1;
+}
+// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 $args = array(
 	'withAssigned' => true,

--- a/projects/plugins/crm/changelog/fix-crm-3374-allow_events_API_filter_by_owner
+++ b/projects/plugins/crm/changelog/fix-crm-3374-allow_events_API_filter_by_owner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+API: allow events endpoint to be filtered by owner


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3374 - allow events API endpoint to be filtered by owner

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #33221, I inadvertently removed the ability to filter tasks returned by the `events` endpoint by owner. This PR restores that ability.

Note: prior to removal, the param used was `owned`. The [API docs](https://automattic.github.io/jetpack-crm-api-docs/#ownership-assignment) are ambiguous (may be `assign`, `owned`, or `owner`), and the Events endpoint example doesn't give the request example but uses `owner` in the response, so I allow for both `owned` and `owner`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a task assigned to user 1.
2. Create a task assigned to user 2.
3. Enable the API if not yet enabled.
4. Call the API `events` endpoint with no ownership param, with `owned`, and with `owner`.

In `trunk`, all tasks will be returned no matter the ownership param/value.

In the `fix/crm/3374-allow_events_API_filter_by_owner` branch, the following occurs:

* no param: all tasks
* `-1`: all tasks
* random string: all tasks
* WP ID: tasks assigned to WP user
* WP ID with no tasks assigned: no tasks