### PR TITLE
VideoPress Package: Update bug URL

### DIFF
--- a/.github/files/lint-project-structure.sh
+++ b/.github/files/lint-project-structure.sh
@@ -140,11 +140,11 @@ for PROJECT in projects/*/*; do
 			LINE=$(jq --stream -r 'if length == 1 then .[0][:-1] else .[0] end | if . == ["bugs","url"] then ",line=\( input_line_number )" else empty end' "$PROJECT/package.json")
 			echo "::error file=$PROJECT/package.json$LINE::Setting the project's bug URL to the raw issues list makes no sense. Target the project's label instead, i.e. \"$URL2\"."
 		fi
-		if [[ "$URL" == "https://github.com/Automattic/jetpack/labels/"* && "$URL" != "$URL2" ]]; then
+		if [[ "$URL" == "https://github.com/Automattic/jetpack/labels/"* && "${URL,,}" != "${URL2,,}" ]]; then
 			EXIT=1
 			LINE=$(jq --stream -r 'if length == 1 then .[0][:-1] else .[0] end | if . == ["bugs","url"] then ",line=\( input_line_number )" else empty end' "$PROJECT/package.json")
 			printf -v URL3 "%b" "$(sed -E 's/\\/\\\\/g;s/%([0-9a-fA-F]{2})/\\x\1/g' <<<"$URL")"
-			if [[ "$URL3" == "$URL2" ]]; then
+			if [[ "${URL3,,}" == "${URL2,,}" ]]; then
 				echo "::error file=$PROJECT/package.json$LINE::The \`.bugs.url\` gets (brokenly) passed through \`encodeURI\` by \`npm bugs\`, so it should not be encoded in package.json. Sigh. Try \"$URL2\" instead."
 			else
 				echo "::error file=$PROJECT/package.json$LINE::The \`.bugs.url\` appears to be pointing to the wrong label. Try \"$URL2\" instead."

--- a/projects/packages/videopress/changelog/kraftbj-patch-3
+++ b/projects/packages/videopress/changelog/kraftbj-patch-3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: It is only updating the URL in the package.json for capitalization. Not important for any changelog.
+
+

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -5,7 +5,7 @@
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {
-		"url": "https://github.com/Automattic/jetpack/labels/[Package] Videopress"
+		"url": "https://github.com/Automattic/jetpack/labels/[Package] VideoPress"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Fixes #25722

## Proposed changes:
* Update the bug URL
* The name does not need to be regenerated. GitHub allows various capitalization, but any capitalization will match any other. Package label already renamed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None, since the label is already renamed, it is effectively a moot point. But, let's not leave loose ends.

