### PR TITLE
class-launchpad-task-lists: PHP Rector fixes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/class-launchpad-task-lists-rector-update
+++ b/projects/packages/jetpack-mu-wpcom/changelog/class-launchpad-task-lists-rector-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: PHP Compatibility Change
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -85,7 +85,7 @@ class Launchpad_Task_Lists {
 	 * @return bool True if successful, false if not.
 	 */
 	public function register_task( $task = array() ) {
-		if ( ! $this->validate_task( $task ) ) {
+		if ( ! static::validate_task( $task ) ) {
 			return false;
 		}
 		// TODO: Handle duplicate tasks


### PR DESCRIPTION
## Proposed changes:


* Applied PHP Rector fixes for this file from our PHP migration config.

```diff
1) ../../../public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/moon/vendor/automattic/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php:84

    ---------- begin diff ----------
@@ @@
         * @return bool True if successful, false if not.
         */
        public function register_task( $task = array() ) {
-               if ( ! $this->validate_task( $task ) ) {
+               if ( ! static::validate_task($task) ) {
                        return false;
                }
                // TODO: Handle duplicate tasks
    ----------- end diff -----------

Applied rules:
 * ThisCallOnStaticMethodToStaticCallRector (https://3v4l.org/rkiSC)
```
## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Unsure, you can try making the same change on wpcom

