### PR TITLE
AI Extension: iterate over the UsageBar component

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-usage-panel-show-limit-reached
+++ b/projects/plugins/jetpack/changelog/update-ai-usage-panel-show-limit-reached
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: implement usage message in the UsageBar component

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -9,7 +9,7 @@ import { useEffect, useState } from '@wordpress/element';
 export type UpgradeTypeProp = 'vip' | 'default';
 import type { SiteAIAssistantFeatureEndpointResponseProps } from '../../../../types';
 
-type AIFeatureProps = {
+export type AIFeatureProps = {
 	hasFeature: boolean;
 	isOverLimit: boolean;
 	requestsCount: number;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import classNames from 'classnames';
 import './style.scss';
 /**
  * Types
@@ -14,7 +15,10 @@ import type React from 'react';
  * @param {UsageBarProps} props - Component props.
  * @returns {React.ReactNode}     UsageBar react component.
  */
-const UsageBar: React.FC< UsageBarProps > = ( { usage } ) => {
+const UsageBar: React.FC< UsageBarProps > = ( {
+	usage,
+	isOverLimit,
+}: UsageBarProps ): React.ReactNode => {
 	if ( usage == null ) {
 		return null;
 	}
@@ -27,7 +31,12 @@ const UsageBar: React.FC< UsageBarProps > = ( { usage } ) => {
 
 	return (
 		<div className="ai-assistant-usage-bar-wrapper">
-			<div className="ai-assistant-usage-bar-usage" style={ style }></div>
+			<div
+				className={ classNames( 'ai-assistant-usage-bar-usage', {
+					'is-over-limit': isOverLimit,
+				} ) }
+				style={ style }
+			></div>
 		</div>
 	);
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -50,7 +50,13 @@ function UsageControl( {
 	requestsCount,
 	requestsLimit,
 }: Pick< AIFeatureProps, 'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' > ) {
-	let help = hasFeature ? __( 'Unlimited requests for your site', 'jetpack' ) : undefined;
+	let help = __( 'Unlimited requests for your site', 'jetpack' );
+
+	if ( ! hasFeature ) {
+		// translators: %1$d: number of requests allowed in the free plan
+		help = sprintf( __( '%1$d free requests for your site', 'jetpack' ), requestsLimit );
+	}
+
 	const limitReached = isOverLimit && ! hasFeature;
 	if ( limitReached ) {
 		help = __( 'You have reached your plan requests limit.', 'jetpack' );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -79,7 +79,7 @@ function UsageControl( {
 	return (
 		<BaseControl help={ help } label={ __( 'Usage', 'jetpack' ) }>
 			<p>{ hasFeature ? unlimitedPlanUsageMessage : freeUsageMessage }</p>
-			<UsageBar usage={ usage } limitReached={ limitReached } />
+			{ ! hasFeature && <UsageBar usage={ usage } limitReached={ limitReached } /> }
 		</BaseControl>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -2,13 +2,14 @@
  * Internal dependencies
  */
 import { BaseControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import './style.scss';
 /**
  * Types
  */
-import type { UsageBarProps, UsageControlProps } from './types';
+import type { UsageBarProps } from './types';
+import type { AIFeatureProps } from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import type React from 'react';
 
 /**
@@ -43,15 +44,41 @@ const UsageBar: React.FC< UsageBarProps > = ( {
 	);
 };
 
-export function UsageControl( { usage, isOverLimit, hasFeature }: UsageControlProps ) {
+export function UsageControl( {
+	isOverLimit,
+	hasFeature,
+	requestsCount,
+	requestsLimit,
+}: Pick< AIFeatureProps, 'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' > ) {
 	let help = hasFeature ? __( 'Unlimited requests for your site', 'jetpack' ) : undefined;
 	const limitReached = isOverLimit && ! hasFeature;
 	if ( limitReached ) {
 		help = __( 'You have reached your plan requests limit.', 'jetpack' );
 	}
 
+	// build messages
+	const freeUsageMessage = sprintf(
+		// translators: %1$d: current request counter; %2$d: request allowance;
+		__( '%1$d / %2$d free requests.', 'jetpack' ),
+		requestsCount,
+		requestsLimit
+	);
+	const unlimitedPlanUsageMessage = sprintf(
+		// translators: placeholder is the current request counter;
+		__( '%d / ∞ requests.', 'jetpack' ),
+		requestsCount
+	);
+
+	/*
+	 * Calculate usage. When hasFeature is true, the user has the paid plan,
+	 * that grants unlimited requests for now. To show something meaningful in
+	 * the usage bar, we use a very low usage value.
+	 */
+	const usage = hasFeature ? 0.1 : requestsCount / requestsLimit;
+
 	return (
 		<BaseControl help={ help } label={ __( 'Usage', 'jetpack' ) }>
+			<p>{ hasFeature ? unlimitedPlanUsageMessage : freeUsageMessage }</p>
 			<UsageBar usage={ usage } limitReached={ limitReached } />
 		</BaseControl>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -27,7 +27,8 @@ const UsageBar: React.FC< UsageBarProps > = ( {
 	}
 
 	let help = hasFeature ? __( 'Unlimited requests for your site', 'jetpack' ) : undefined;
-	if ( isOverLimit ) {
+	const limitReached = isOverLimit && ! hasFeature;
+	if ( limitReached ) {
 		help = __( 'You have reached your plan requests limit.', 'jetpack' );
 	}
 
@@ -42,7 +43,7 @@ const UsageBar: React.FC< UsageBarProps > = ( {
 			<div className="ai-assistant-usage-bar-wrapper">
 				<div
 					className={ classNames( 'ai-assistant-usage-bar-usage', {
-						'is-over-limit': isOverLimit,
+						'is-limit-reached': limitReached,
 					} ) }
 					style={ style }
 				></div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -8,7 +8,7 @@ import './style.scss';
 /**
  * Types
  */
-import type { UsageBarProps } from './types';
+import type { UsageBarProps, UsageControlProps } from './types';
 import type React from 'react';
 
 /**
@@ -19,17 +19,10 @@ import type React from 'react';
  */
 const UsageBar: React.FC< UsageBarProps > = ( {
 	usage,
-	isOverLimit,
-	hasFeature,
+	limitReached,
 }: UsageBarProps ): React.ReactNode => {
 	if ( usage == null ) {
 		return null;
-	}
-
-	let help = hasFeature ? __( 'Unlimited requests for your site', 'jetpack' ) : undefined;
-	const limitReached = isOverLimit && ! hasFeature;
-	if ( limitReached ) {
-		help = __( 'You have reached your plan requests limit.', 'jetpack' );
 	}
 
 	const normalizedUsage = Math.max( Math.min( usage, 1 ), 0 );
@@ -39,17 +32,29 @@ const UsageBar: React.FC< UsageBarProps > = ( {
 	};
 
 	return (
-		<BaseControl help={ help }>
-			<div className="ai-assistant-usage-bar-wrapper">
-				<div
-					className={ classNames( 'ai-assistant-usage-bar-usage', {
-						'is-limit-reached': limitReached,
-					} ) }
-					style={ style }
-				></div>
-			</div>
-		</BaseControl>
+		<div className="ai-assistant-usage-bar-wrapper">
+			<div
+				className={ classNames( 'ai-assistant-usage-bar-usage', {
+					'is-limit-reached': limitReached,
+				} ) }
+				style={ style }
+			></div>
+		</div>
 	);
 };
+
+export function UsageControl( { usage, isOverLimit, hasFeature }: UsageControlProps ) {
+	let help = hasFeature ? __( 'Unlimited requests for your site', 'jetpack' ) : undefined;
+	const limitReached = isOverLimit && ! hasFeature;
+	if ( limitReached ) {
+		help = __( 'You have reached your plan requests limit.', 'jetpack' );
+	}
+
+	return (
+		<BaseControl help={ help } label={ __( 'Usage', 'jetpack' ) }>
+			<UsageBar usage={ usage } limitReached={ limitReached } />
+		</BaseControl>
+	);
+}
 
 export default UsageBar;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -18,7 +18,7 @@ import type React from 'react';
  * @param {UsageBarProps} props - Component props.
  * @returns {React.ReactNode}     UsageBar react component.
  */
-const UsageBar: React.FC< UsageBarProps > = ( {
+export const UsageBar: React.FC< UsageBarProps > = ( {
 	usage,
 	limitReached,
 }: UsageBarProps ): React.ReactNode => {
@@ -44,7 +44,7 @@ const UsageBar: React.FC< UsageBarProps > = ( {
 	);
 };
 
-export function UsageControl( {
+function UsageControl( {
 	isOverLimit,
 	hasFeature,
 	requestsCount,
@@ -84,4 +84,4 @@ export function UsageControl( {
 	);
 }
 
-export default UsageBar;
+export default UsageControl;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -1,6 +1,8 @@
 /**
  * Internal dependencies
  */
+import { BaseControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import './style.scss';
 /**
@@ -18,9 +20,15 @@ import type React from 'react';
 const UsageBar: React.FC< UsageBarProps > = ( {
 	usage,
 	isOverLimit,
+	hasFeature,
 }: UsageBarProps ): React.ReactNode => {
 	if ( usage == null ) {
 		return null;
+	}
+
+	let help = hasFeature ? __( 'Unlimited requests for your site', 'jetpack' ) : undefined;
+	if ( isOverLimit ) {
+		help = __( 'You have reached your plan requests limit.', 'jetpack' );
 	}
 
 	const normalizedUsage = Math.max( Math.min( usage, 1 ), 0 );
@@ -30,14 +38,16 @@ const UsageBar: React.FC< UsageBarProps > = ( {
 	};
 
 	return (
-		<div className="ai-assistant-usage-bar-wrapper">
-			<div
-				className={ classNames( 'ai-assistant-usage-bar-usage', {
-					'is-over-limit': isOverLimit,
-				} ) }
-				style={ style }
-			></div>
-		</div>
+		<BaseControl help={ help }>
+			<div className="ai-assistant-usage-bar-wrapper">
+				<div
+					className={ classNames( 'ai-assistant-usage-bar-usage', {
+						'is-over-limit': isOverLimit,
+					} ) }
+					style={ style }
+				></div>
+			</div>
+		</BaseControl>
 	);
 };
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
@@ -7,7 +7,7 @@
 		border-radius: 2px;
 		background-color: var(--jp-gray-5);
 		overflow: hidden;
-		margin: 1em 0;
+		margin: 0;
 	}
 
 	&-usage {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
@@ -15,7 +15,7 @@
 		border-radius: 2px;
 		background-color: var(--jp-green-40 );
 
-		&.is-over-limit {
+		&.is-limit-reached {
 			background-color: var(--jp-red);
 		}
 	}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
@@ -14,5 +14,9 @@
 		height: 100%;
 		border-radius: 2px;
 		background-color: var(--jp-green-40 );
+
+		&.is-over-limit {
+			background-color: var(--jp-red);
+		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
@@ -9,20 +9,3 @@ export type UsageBarProps = {
 	 */
 	limitReached: boolean;
 };
-
-export type UsageControlProps = {
-	/**
-	 * The current usage, as a percentage represented by a number between 0 and 1.
-	 */
-	usage: number;
-
-	/**
-	 * True if the usage is over the limit.
-	 */
-	isOverLimit: boolean;
-
-	/**
-	 * True if the AI Assistant feature is supported.
-	 */
-	hasFeature: boolean;
-};

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
@@ -3,4 +3,9 @@ export type UsageBarProps = {
 	 * The current usage, as a percentage represented by a number between 0 and 1.
 	 */
 	usage: number;
+
+	/**
+	 * True if the usage is over the limit.
+	 */
+	isOverLimit: boolean;
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
@@ -7,6 +7,18 @@ export type UsageBarProps = {
 	/**
 	 * True if the usage is over the limit.
 	 */
+	limitReached: boolean;
+};
+
+export type UsageControlProps = {
+	/**
+	 * The current usage, as a percentage represented by a number between 0 and 1.
+	 */
+	usage: number;
+
+	/**
+	 * True if the usage is over the limit.
+	 */
 	isOverLimit: boolean;
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
@@ -8,4 +8,9 @@ export type UsageBarProps = {
 	 * True if the usage is over the limit.
 	 */
 	isOverLimit: boolean;
+
+	/**
+	 * True if the AI Assistant feature is supported.
+	 */
+	hasFeature: boolean;
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
-import { BaseControl } from '@wordpress/components';
+import { Button, BaseControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -41,17 +40,11 @@ export default function UsagePanel() {
 	 */
 	const usage = hasFeature ? 0.1 : requestsCount / requestsLimit;
 
-	const help = hasFeature ? __( 'Unlimited requests for your site', 'jetpack' ) : undefined;
-
 	return (
-		<BaseControl
-			className="jetpack-ai-usage-panel-control"
-			label={ __( 'Usage', 'jetpack' ) }
-			help={ help }
-		>
+		<BaseControl className="jetpack-ai-usage-panel-control" label={ __( 'Usage', 'jetpack' ) }>
 			<p>{ hasFeature ? unlimitedPlanUsageMessage : freeUsageMessage }</p>
 
-			<UsageBar usage={ usage } isOverLimit={ isOverLimit } />
+			<UsageBar usage={ usage } isOverLimit={ isOverLimit } hasFeature={ hasFeature } />
 
 			{ false && (
 				<p className="muted">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -10,7 +10,7 @@ import './style.scss';
 import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
 import useAIFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import { canUserPurchasePlan } from '../../../../blocks/ai-assistant/lib/connection';
-import { UsageControl } from '../usage-bar';
+import UsageControl from '../usage-bar';
 import './style.scss';
 
 export default function UsagePanel() {
@@ -20,17 +20,9 @@ export default function UsagePanel() {
 	// fetch usage data
 	const { hasFeature, requestsCount, requestsLimit, isOverLimit } = useAIFeature();
 
-	/*
-	 * Calculate usage. When hasFeature is true, the user has the paid plan,
-	 * that grants unlimited requests for now. To show something meaningful in
-	 * the usage bar, we use a very low usage value.
-	 */
-	const usage = hasFeature ? 0.1 : requestsCount / requestsLimit;
-
 	return (
 		<div className="jetpack-ai-usage-panel-control">
 			<UsageControl
-				usage={ usage }
 				isOverLimit={ isOverLimit }
 				hasFeature={ hasFeature }
 				requestsCount={ requestsCount }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -21,7 +21,7 @@ export default function UsagePanel() {
 	const { hasFeature, requestsCount, requestsLimit, isOverLimit } = useAIFeature();
 
 	return (
-		<div className="jetpack-ai-usage-panel-control">
+		<div className="jetpack-ai-usage-panel">
 			<UsageControl
 				isOverLimit={ isOverLimit }
 				hasFeature={ hasFeature }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Button, BaseControl } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -10,7 +10,7 @@ import './style.scss';
 import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
 import useAIFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import { canUserPurchasePlan } from '../../../../blocks/ai-assistant/lib/connection';
-import UsageBar from '../usage-bar';
+import { UsageControl } from '../usage-bar';
 import './style.scss';
 
 export default function UsagePanel() {
@@ -41,10 +41,10 @@ export default function UsagePanel() {
 	const usage = hasFeature ? 0.1 : requestsCount / requestsLimit;
 
 	return (
-		<BaseControl className="jetpack-ai-usage-panel-control" label={ __( 'Usage', 'jetpack' ) }>
+		<div className="jetpack-ai-usage-panel-control">
 			<p>{ hasFeature ? unlimitedPlanUsageMessage : freeUsageMessage }</p>
 
-			<UsageBar usage={ usage } isOverLimit={ isOverLimit } hasFeature={ hasFeature } />
+			<UsageControl usage={ usage } isOverLimit={ isOverLimit } hasFeature={ hasFeature } />
 
 			{ false && (
 				<p className="muted">
@@ -66,6 +66,6 @@ export default function UsagePanel() {
 					Upgrade
 				</Button>
 			) }
-		</BaseControl>
+		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -19,7 +19,7 @@ export default function UsagePanel() {
 	const canUpgrade = canUserPurchasePlan();
 
 	// fetch usage data
-	const { hasFeature, requestsCount, requestsLimit } = useAIFeature();
+	const { hasFeature, requestsCount, requestsLimit, isOverLimit } = useAIFeature();
 
 	// build messages
 	const freeUsageMessage = sprintf(
@@ -51,7 +51,7 @@ export default function UsagePanel() {
 		>
 			<p>{ hasFeature ? unlimitedPlanUsageMessage : freeUsageMessage }</p>
 
-			{ ! hasFeature && <UsageBar usage={ usage } /> }
+			<UsageBar usage={ usage } isOverLimit={ isOverLimit } />
 
 			{ false && (
 				<p className="muted">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -20,19 +20,6 @@ export default function UsagePanel() {
 	// fetch usage data
 	const { hasFeature, requestsCount, requestsLimit, isOverLimit } = useAIFeature();
 
-	// build messages
-	const freeUsageMessage = sprintf(
-		// translators: %1$d: current request counter; %2$d: request allowance;
-		__( '%1$d / %2$d free requests.', 'jetpack' ),
-		requestsCount,
-		requestsLimit
-	);
-	const unlimitedPlanUsageMessage = sprintf(
-		// translators: placeholder is the current request counter;
-		__( '%d / ∞ requests.', 'jetpack' ),
-		requestsCount
-	);
-
 	/*
 	 * Calculate usage. When hasFeature is true, the user has the paid plan,
 	 * that grants unlimited requests for now. To show something meaningful in
@@ -42,9 +29,13 @@ export default function UsagePanel() {
 
 	return (
 		<div className="jetpack-ai-usage-panel-control">
-			<p>{ hasFeature ? unlimitedPlanUsageMessage : freeUsageMessage }</p>
-
-			<UsageControl usage={ usage } isOverLimit={ isOverLimit } hasFeature={ hasFeature } />
+			<UsageControl
+				usage={ usage }
+				isOverLimit={ isOverLimit }
+				hasFeature={ hasFeature }
+				requestsCount={ requestsCount }
+				requestsLimit={ requestsLimit }
+			/>
 
 			{ false && (
 				<p className="muted">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/style.scss
@@ -1,7 +1,6 @@
 @import '@automattic/jetpack-base-styles/style';
 
 .jetpack-ai-usage-panel-control {
-    width: 100%;
 
     p.muted {
         color: var(--jp-gray-50 );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/style.scss
@@ -1,12 +1,9 @@
 @import '@automattic/jetpack-base-styles/style';
 
-.jetpack-ai-usage-panel-control {
+.jetpack-ai-usage-panel {
+    width: 100%;
 
     p.muted {
         color: var(--jp-gray-50 );
-    }
-
-    .components-base-control__help {
-        margin-top: -8px;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR:

* Introduce a new `<UsageControl />` component
* Move part of the logic from `<UsagePanel />` to `<UsageControl />`
* Remove `<BaseControl />` from `<usagePanel />`
* Set red color when the free requests limit is achieved 

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: iterate over the UsageBar component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### `<UsageControl />`

* Go to the block editor
* Confirm how the Usage section looks depending on the site plan and AI requests 

Free plan / Available free requests | Free plan / Limit reached | AI plan
---------|---------|---------
<img width="286" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/dd9d24fc-4f11-4c79-81d5-7e6339d744df"> |  <img width="286" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/b1b58b7c-d3fd-46f0-a84d-e19b08ee3825"> | <img width="285" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/0e4d6bd6-33a8-40eb-8a98-cf32f95e165f">


### Structure and hierarchy of components 

#### <UsagePanel />

The general component. Contains the `<PanelControl />` and the upgrade button.

I dislike the `Panel` suffix since, in the end, it isn't a panel from the PoV of Gutenberg core.

<img width="543" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/e7461479-b30f-44e1-9c7c-b8e64997cc7d">


#### `<UsageControl />`

It supports the Label, help, and the `<UsageBar />` instance. Here is where `<BaseControl />` should be used.

<img width="578" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/deb9aa97-33b8-4790-92e4-ac6707d0407e">

#### `<UsageBar />`

<img width="573" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/cb042243-e5ec-4ccd-ae8c-4a658a59efb9">
