### PR TITLE
Google Fonts Module: Fix the module might not be loaded after the late initialization

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-google-fonts-module-might-not-be-loaded
+++ b/projects/plugins/jetpack/changelog/fix-google-fonts-module-might-not-be-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix the google fonts module is not loaded after the late initialization

--- a/projects/plugins/jetpack/modules/google-fonts/load.php
+++ b/projects/plugins/jetpack/modules/google-fonts/load.php
@@ -15,5 +15,8 @@ add_action(
 			// Gutenberg Fonts API compatible.
 			require_once __DIR__ . '/wordpress-6.3/load-google-fonts.php';
 		}
-	}
+	},
+	// Ensure the action is loaded after the late_initialization.
+	// See projects/plugins/jetpack/class.jetpack.php.
+	999
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/83484, p1698272685592449-slack-C02FMH4G8

Follow up from https://github.com/Automattic/jetpack/pull/33203

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The jetpack module might [be loaded during the plugins_loaded action](https://github.com/Automattic/jetpack/blob/6d9562b89b96e83c9f6d8d5c76723ec5827ee7e6/projects/plugins/jetpack/class.jetpack.php#L957) and it leads to the Google Fonts module not being loaded as we also hooked the callback onto the plugins_loaded action

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to WoA site
* Install changes from this PR
* Go to the Site Editor
* Ensure you're able to see the Google Fonts when you want to change the font famliy!