### PR TITLE
CRM: Change the DB custom field value column to TEXT and update the queries

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-change-db-custom-field-column-to-text
+++ b/projects/plugins/crm/changelog/update-crm-change-db-custom-field-column-to-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Convert the custom field value column into TEXT and change queries to use MATCH/AGAINST SQL syntax

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
@@ -1190,8 +1190,13 @@ class zbsDAL_companies extends zbsDAL_ObjectLayer {
                 
                     // simplistic add
                     // NOTE: This IGNORES ownership of custom field lines.
-                    $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE zbscf_objval LIKE %s AND zbscf_objtype = ".ZBS_TYPE_COMPANY.")",'%'.$searchPhrase.'%');
-
+	                // @codingStandardsIgnoreStart
+	                if ( jpcrm_migration_table_has_index( $ZBSCRM_t['customfields'], 'search' ) ) {
+		                $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE MATCH(zbscf_objval) AGAINST(%s) AND zbscf_objtype = ".ZBS_TYPE_COMPANY.")",$searchPhrase);
+	                } else {
+		                $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE zbscf_objval LIKE %s AND zbscf_objtype = ".ZBS_TYPE_COMPANY.")",'%'.$searchPhrase.'%');
+	                }
+	                // @codingStandardsIgnoreEnd
                 }
 
                 // This generates a query like 'zbsco_fname LIKE %s OR zbsco_lname LIKE %s', 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Events.php
@@ -540,8 +540,13 @@ class zbsDAL_events extends zbsDAL_ObjectLayer {
                 
                     // simplistic add
                     // NOTE: This IGNORES ownership of custom field lines.
-                    $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE zbscf_objval LIKE %s AND zbscf_objtype = ".ZBS_TYPE_TASK.")",'%'.$searchPhrase.'%');
-
+	                // @codingStandardsIgnoreStart
+	                if ( jpcrm_migration_table_has_index( $ZBSCRM_t['customfields'], 'search' ) ) {
+		                $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE MATCH(zbscf_objval) AGAINST(%s) AND zbscf_objtype = ".ZBS_TYPE_TASK.")",$searchPhrase);
+	                } else {
+                        $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE zbscf_objval LIKE %s AND zbscf_objtype = ".ZBS_TYPE_TASK.")",'%'.$searchPhrase.'%');
+					}
+	                // @codingStandardsIgnoreEnd
                 }
 
                 // This generates a query like 'zbse_fname LIKE %s OR zbse_lname LIKE %s', 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Forms.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Forms.php
@@ -525,8 +525,13 @@ class zbsDAL_forms extends zbsDAL_ObjectLayer {
                 
                     // simplistic add
                     // NOTE: This IGNORES ownership of custom field lines.
-                    $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE zbscf_objval LIKE %s AND zbscf_objtype = ".ZBS_TYPE_FORM.")",'%'.$searchPhrase.'%');
-
+	                // @codingStandardsIgnoreStart
+	                if ( jpcrm_migration_table_has_index( $ZBSCRM_t['customfields'], 'search' ) ) {
+		                $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE MATCH(zbscf_objval) AGAINST(%s) AND zbscf_objtype = ".ZBS_TYPE_FORM.")",$searchPhrase);
+	                } else {
+                        $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE zbscf_objval LIKE %s AND zbscf_objtype = ".ZBS_TYPE_FORM.")",'%'.$searchPhrase.'%');
+					}
+	                // @codingStandardsIgnoreEnd
                 }
 
                 // This generates a query like 'zbsf_fname LIKE %s OR zbsf_lname LIKE %s', 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
@@ -714,8 +714,13 @@ class zbsDAL_invoices extends zbsDAL_ObjectLayer {
                 
                     // simplistic add
                     // NOTE: This IGNORES ownership of custom field lines.
-                    $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE zbscf_objval LIKE %s AND zbscf_objtype = ".ZBS_TYPE_INVOICE.")",'%'.$searchPhrase.'%');
-
+	                // @codingStandardsIgnoreStart
+	                if ( jpcrm_migration_table_has_index( $ZBSCRM_t['customfields'], 'search' ) ) {
+		                $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE MATCH(zbscf_objval) AGAINST(%s) AND zbscf_objtype = ".ZBS_TYPE_INVOICE.")",$searchPhrase);
+	                } else {
+                        $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE zbscf_objval LIKE %s AND zbscf_objtype = ".ZBS_TYPE_INVOICE.")",'%'.$searchPhrase.'%');
+					}
+	                // @codingStandardsIgnoreEnd
                 }
 
                 // This generates a query like 'zbsi_fname LIKE %s OR zbsi_lname LIKE %s', 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Quotes.php
@@ -617,8 +617,13 @@ class zbsDAL_quotes extends zbsDAL_ObjectLayer {
                 
                     // simplistic add
                     // NOTE: This IGNORES ownership of custom field lines.
-                    $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE zbscf_objval LIKE %s AND zbscf_objtype = ".ZBS_TYPE_QUOTE.")",'%'.$searchPhrase.'%');
-
+	                // @codingStandardsIgnoreStart
+	                if ( jpcrm_migration_table_has_index( $ZBSCRM_t['customfields'], 'search' ) ) {
+		                $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE MATCH(zbscf_objval) AGAINST(%s) AND zbscf_objtype = ".ZBS_TYPE_QUOTE.")",$searchPhrase);
+	                } else {
+                        $searchWheres['search_customfields'] = array('ID','IN',"(SELECT zbscf_objid FROM ".$ZBSCRM_t['customfields']." WHERE zbscf_objval LIKE %s AND zbscf_objtype = ".ZBS_TYPE_QUOTE.")",'%'.$searchPhrase.'%');
+					}
+	                // @codingStandardsIgnoreEnd
                 }
 
 				// This generates a query like 'zbsq_fname LIKE %s OR zbsq_lname LIKE %s', 

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -489,6 +489,10 @@ function zeroBSCRM_pages_admin_display_custom_fields_table($id = -1, $objectType
 		     		$html .= '<td class="zbs-view-vital-customfields-'.esc_attr($v['type']).'">' . str_replace(',',', ',esc_html( $v['value'] ) )  . '</td>';
 		     		break;
 
+				case 'textarea':
+					$html .= '<td class="zbs-view-vital-customfields-' . esc_attr( $v['type'] ) . '"><div class="textarea-scrollable">' . nl2br( esc_html( $v['value'] ) ) . '</div></td>';
+					break;
+
 		     	default:
 		     		$html .= '<td class="zbs-view-vital-customfields-'.esc_attr($v['type']).'">' . nl2br( esc_html( $v['value'] ) ) . '</td>';
 		     		break;

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.singleview.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.singleview.scss
@@ -129,7 +129,10 @@
 
 		// specifically allow textarea field types to expand beyond overflow:
 		tr td.zbs-view-vital-customfields-textarea {
-
+			.textarea-scrollable {
+				max-height: 600px;
+				overflow-y: auto;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #

## Proposed changes:

This is a draft PR to show the changes we have to do to adapt the current code/queries to use the `FULLTEXT` index benefits after changing the column `zbscf_objval` type from `VARCHAR(2000)` to `TEXT`. We have to adapt 6 queries for the different entities:

- Transactions
- Companies
- Events
- Forms
- Invoices
- Quotes

The query for Contact is already updated.

Also, this PR improves the UI/UX when a custom field is a textarea type, adding scrollable capabilities in the View.

**Important** 

- Note that I've not added the migration to this PR yet. Ensure in your database that you change the column type of `zbscf_objval` to `TEXT`.
- I've added `@codingStandardsIgnoreStart` to the query line because it has many complaints for a single line.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

