### PR TITLE
AI Extension: consolidate upgrade of proofread and usage sections

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-usage-panel-consolidate-upgrade-ui
+++ b/projects/plugins/jetpack/changelog/update-ai-usage-panel-consolidate-upgrade-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: consolidate upgrade section of proofread and usage sections

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -82,7 +82,7 @@ export default function AiAssistantPluginSidebar() {
 							<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
 						</BaseControl>
 					</PanelRow>
-					{ requireUpgrade && (
+					{ requireUpgrade && ! isUsagePanelAvailable && (
 						<PanelRow>
 							<Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } />
 						</PanelRow>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -75,12 +75,7 @@ function UsageControl( {
 		requestsCount
 	);
 
-	/*
-	 * Calculate usage. When hasFeature is true, the user has the paid plan,
-	 * that grants unlimited requests for now. To show something meaningful in
-	 * the usage bar, we use a very low usage value.
-	 */
-	const usage = hasFeature ? 0.1 : requestsCount / requestsLimit;
+	const usage = requestsCount / requestsLimit;
 
 	return (
 		<BaseControl help={ help } label={ __( 'Usage', 'jetpack' ) }>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR consolidated the upgrade section of the Jetpack AI panel, hiding the `AI FEEDBACK ON POST` upgrade component when the usage panel is enabled (beta extension)

Fixes #33780

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: consolidate upgrade section of proofread and usage sections

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a site that requires upgrades the plan
* Go to the block editor
* Open the AI Jetpack panel
* Disable `beta` extensions

* Confirm you see the upgrade component of the proofread section.

<img width="290" alt="Screenshot 2023-10-26 at 12 21 41" src="https://github.com/Automattic/jetpack/assets/77539/63411035-1d1a-4696-9a2e-1220d5688fac">

* Enable `beta` extensions

Before | After
-----|------
<img width="287" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/c74ccb1f-6d58-4733-87c8-b6d2e3c80545">| <img width="284" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/310c05a2-bb3b-40c6-9021-62d3d8d65dc9">



