### PR TITLE
CRM: 3379 - bump minimum WP to 6.0

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -7,7 +7,7 @@
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm
- * Requires at least: 5.0
+ * Requires at least: 6.0
  * Requires PHP: 7.3
  * License: GPLv2
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/projects/plugins/crm/changelog/fix-crm-3379-bump_minimum_wp_to_6.0
+++ b/projects/plugins/crm/changelog/fix-crm-3379-bump_minimum_wp_to_6.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Requires WordPress 6.0 or higher.

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, kallehauge, cleacos, diegogarciarodrigues, bradshawtm,
 Tags: CRM, Invoice, Woocommerce CRM, Clients, Lead Generation, contacts, customers, billing, email marketing, Marketing Automation, contact form, automations
 Tested up to: 6.4
 Stable tag: 6.2.0
-Requires at least: 5.0
+Requires at least: 6.0
 Requires PHP: 7.3
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3379 - bump minimum WP to 6.0

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
See pbhBOz-46H-p2; we've decided to change the minimum WP version to 6.0 to move closer to our other plugins.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

N/A