### PR TITLE
Fix block paid icon rendering error on simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-paid-block-icon-rendering-error
+++ b/projects/plugins/jetpack/changelog/fix-paid-block-icon-rendering-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix block paid icon rendering error on simple sites

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
@@ -82,12 +82,21 @@ $icon-background-color: #fff;
 
 // Paid Icons: Only show if upgrade is possible.
 .jetpack-enable-upgrade-nudge {
-	.block-editor-block-icon > svg {
-		overflow: visible;
+
+	.block-editor-block-icon {
+		position: relative;
+
+		> svg {
+			overflow: visible;
+		}
 	}
 
 	.jetpack-paid-block-symbol {
 		display: block;
+
+		position: absolute;
+		left: calc(100% - 1px);
+		top: 3px;
 	}
 
 	.components-placeholder__label .jetpack-paid-block-symbol {

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
@@ -91,7 +91,7 @@ $icon-background-color: #fff;
 		}
 	}
 
-	.jetpack-paid-block-symbol {
+	svg.jetpack-paid-block-symbol {
 		display: block;
 
 		position: absolute;

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/paid-symbol.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/paid-symbol.js
@@ -1,22 +1,23 @@
-import { Circle } from '@wordpress/components';
+import { SVG, Circle } from '@wordpress/components';
 
 export default ( {
-	cx = 23,
-	cy = 3,
+	cx = 0,
+	cy = 0,
 	r = 4,
 	fill = '#e34c84',
 	stroke = '#ffffff',
 	strokeWidth = '2',
 } ) => {
 	return (
-		<Circle
-			className="jetpack-paid-block-symbol"
-			cx={ cx }
-			cy={ cy }
-			r={ r }
-			fill={ fill }
-			stroke={ stroke }
-			strokeWidth={ strokeWidth }
-		/>
+		<SVG className="jetpack-paid-block-symbol">
+			<Circle
+				cx={ cx }
+				cy={ cy }
+				r={ r }
+				fill={ fill }
+				stroke={ stroke }
+				strokeWidth={ strokeWidth }
+			/>
+		</SVG>
 	);
 };

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/render-paid-icon.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/render-paid-icon.js
@@ -1,5 +1,4 @@
 import { isUpgradable } from '@automattic/jetpack-shared-extension-utils';
-import { cloneElement } from '@wordpress/element';
 import PaidSymbol from './paid-symbol';
 
 /**
@@ -9,19 +8,26 @@ import PaidSymbol from './paid-symbol';
  * @returns {object} The default icon enhanced with the PaidSymbol
  */
 const renderPaidIcon = icon => {
+	const paidSymbol = <PaidSymbol key="paid-symbol" />;
+
 	if ( icon?.src ) {
-		icon = {
+		return {
 			...icon,
-			src: cloneElement( icon.src, {
-				children: [ icon.src.props.children, <PaidSymbol key="paid-symbol" /> ],
-			} ),
+			src: (
+				<>
+					{ icon.src }
+					{ paidSymbol }
+				</>
+			),
 		};
-	} else if ( icon?.props?.children ) {
-		icon = cloneElement( icon, {
-			children: [ icon.props.children, <PaidSymbol key="paid-symbol" /> ],
-		} );
 	}
-	return icon;
+
+	return (
+		<>
+			{ icon }
+			{ paidSymbol }
+		</>
+	);
 };
 
 export default renderPaidIcon;

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/test/render-paid-icon.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/test/render-paid-icon.js
@@ -13,10 +13,12 @@ const iconWithSrc = {
 
 const iconWithSrcWithPaidIcon = {
 	src: (
-		<SVG xmlns="http://www.w3.org/2000/svg">
-			<G />
+		<>
+			<SVG xmlns="http://www.w3.org/2000/svg">
+				<G />
+			</SVG>
 			<PaidSymbol key="paid-symbol" />
-		</SVG>
+		</>
 	),
 	foreground: '#50575e',
 };
@@ -28,10 +30,12 @@ const iconWithouthSrc = (
 );
 
 const iconWithouthSrcWithPaidIcon = (
-	<SVG xmlns="http://www.w3.org/2000/svg">
-		<G />
+	<>
+		<SVG xmlns="http://www.w3.org/2000/svg">
+			<G />
+		</SVG>
 		<PaidSymbol key="paid-symbol" />
-	</SVG>
+	</>
 );
 
 describe( 'renderPaidIcon enhance the default block icon', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1698301270746459-slack-C01U2KGS2PQ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
https://github.com/Automattic/jetpack/pull/33086 introduced an issue with simple sites. It caused the block paid icon to raise an exception (see thread linked above) and prevented users from adding blocks altogether when creating a new post. This PR fixes it by preventing the block icon from being modified and adding the paid icon as a sibling instead.

<img width="829" alt="Screenshot 2023-10-26 at 12 16 19 PM" src="https://github.com/Automattic/jetpack/assets/1620183/dcc55b6b-f167-43c9-a094-2cb6c7f1ff91">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Download this branch
- Build the Jetpack plugin: `jetpack build plugins/jetpack`
- Sync the plugin with your sandbox: `jetpack rsync jetpack`
- Visit your sandboxed site and go to `wordpress.com/post/:site`
- Try adding a new block by clicking on the + button
<img width="441" alt="Screenshot 2023-10-26 at 12 07 08 PM" src="https://github.com/Automattic/jetpack/assets/1620183/20b8f8d8-f9ed-4943-8f33-7cbcd80d31bf">

- You shouldn't see the error anymore
- Search the WhatsApp block
- Notice it has a circle in one of the top corners
<img width="359" alt="Screenshot 2023-10-26 at 12 07 16 PM" src="https://github.com/Automattic/jetpack/assets/1620183/91f499d8-91e6-460d-88da-ebf47100f1ea">
