### PR TITLE
React Dashboard: remove link to "My Jetpack"

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/navigation/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/navigation/index.jsx
@@ -12,10 +12,8 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { hasConnectedOwner, isCurrentUserLinked, isOfflineMode } from 'state/connection';
 import {
-	getSiteAdminUrl,
 	getSiteRawUrl,
 	showRecommendations,
-	showMyJetpack,
 	userCanManageModules as _userCanManageModules,
 	userCanViewStats as _userCanViewStats,
 	getPurchaseToken,
@@ -64,10 +62,6 @@ export class Navigation extends React.Component {
 			path: 'recommendations',
 			is_new_recommendations_bubble_visible: isBubbleVisible,
 		} );
-	};
-
-	trackMyJetpackClick = () => {
-		this.trackNavClick( 'my-jetpack' );
 	};
 
 	componentDidMount() {
@@ -144,14 +138,6 @@ export class Navigation extends React.Component {
 							) }
 						</NavItem>
 					) }
-					{ this.props.showMyJetpack && (
-						<NavItem
-							path={ this.props.adminUrl + 'admin.php?page=my-jetpack' }
-							onClick={ this.trackMyJetpackClick }
-						>
-							{ _x( 'My Jetpack', 'Navigation item.', 'jetpack' ) }
-						</NavItem>
-					) }
 				</NavTabs>
 			);
 		} else {
@@ -192,8 +178,6 @@ export default connect( state => {
 		showRecommendations: showRecommendations( state ),
 		newRecommendationsCount: getNonViewedRecommendationsCount( state ),
 		siteUrl: getSiteRawUrl( state ),
-		adminUrl: getSiteAdminUrl( state ),
 		purchaseToken: getPurchaseToken( state ),
-		showMyJetpack: showMyJetpack( state ),
 	};
 } )( withRouter( Navigation ) );

--- a/projects/plugins/jetpack/_inc/client/components/navigation/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/navigation/test/component.js
@@ -125,11 +125,5 @@ describe( 'Navigation', () => {
 			expect( screen.getByRole( 'menuitem', { name: 'Recommendations 1' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'option', { name: 'Recommendations 1' } ) ).toBeInTheDocument();
 		} );
-
-		it( 'renders My Jetpack tab', () => {
-			render( <Navigation { ...currentTestProps } showMyJetpack={ true } /> );
-			expect( screen.getByRole( 'menuitem', { name: 'My Jetpack' } ) ).toBeInTheDocument();
-			expect( screen.getByRole( 'option', { name: 'My Jetpack' } ) ).toBeInTheDocument();
-		} );
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/rm-my-jetpack-react-dashboard
+++ b/projects/plugins/jetpack/changelog/rm-my-jetpack-react-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: remove link to "My Jetpack"


### PR DESCRIPTION
Fixes #33802

## Proposed changes:

Effectively reverts #23446.

**Before**

<img width="667" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/d3efa12f-7879-4525-a8f6-bce3333884bb">

**After**

<img width="586" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/d68796fa-3bf4-4ee2-8e1e-01884af45048">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* No

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Dashboard
* You should no longer see a "My Jetpack" link in the top navbar.
