### PR TITLE
Backport mu-wpcom-plugin 1.7.4, jetpack 12.8-a.7 Changes

### DIFF
--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.1] - 2023-10-26
+### Fixed
+- Fixed Social Image Generator debouncing. [#33767]
+
 ## [0.41.0] - 2023-10-23
 ### Added
 - Added media restrictions for nextdoor media. [#33630]
@@ -479,6 +483,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.41.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.0...v0.41.1
 [0.41.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.40.2...v0.41.0
 [0.40.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.40.1...v0.40.2
 [0.40.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.40.0...v0.40.1

--- a/projects/js-packages/publicize-components/changelog/fix-sig-debounce
+++ b/projects/js-packages/publicize-components/changelog/fix-sig-debounce
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed Social Image Generator debouncing

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.41.1-alpha",
+	"version": "0.41.1",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.15.1] - 2023-10-26
+### Changed
+- Coming Soon feature: Be more defensive when checking for meta data. [#33769]
+
 ## [4.15.0] - 2023-10-16
 ### Added
 - Launchpad: Add earn-newsletter checklist. [#33200]
@@ -399,6 +403,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[4.15.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.15.0...v4.15.1
 [4.15.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.14.0...v4.15.0
 [4.14.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.13.0...v4.14.0
 [4.13.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.12.0...v4.13.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/class-launchpad-task-lists-rector-update
+++ b/projects/packages/jetpack-mu-wpcom/changelog/class-launchpad-task-lists-rector-update
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: PHP Compatibility Change
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-coming-soon-php81
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-coming-soon-php81
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Coming Soon feature: be more defensive when checking for meta data.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.15.1-alpha",
+	"version": "4.15.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.15.1-alpha';
+	const PACKAGE_VERSION = '4.15.1';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.60.0] - 2023-10-26
+### Removed
+- Remove Jetpack option jetpack-memberships-connected-account-id. [#32354]
+
 ## [1.59.2] - 2023-10-24
 ### Changed
 - Update sync version.
@@ -958,6 +962,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.60.0]: https://github.com/Automattic/jetpack-sync/compare/v1.59.2...v1.60.0
 [1.59.2]: https://github.com/Automattic/jetpack-sync/compare/v1.59.1...v1.59.2
 [1.59.1]: https://github.com/Automattic/jetpack-sync/compare/v1.59.0...v1.59.1
 [1.59.0]: https://github.com/Automattic/jetpack-sync/compare/v1.58.1...v1.59.0

--- a/projects/packages/sync/changelog/earn-remove-connected-account-id-option
+++ b/projects/packages/sync/changelog/earn-remove-connected-account-id-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-remove jetpack option jetpack-memberships-connected-account-id

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.60.0-alpha';
+	const PACKAGE_VERSION = '1.60.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.8-a.7 - 2023-10-26
+### Enhancements
+- Add a filter that allows disabling Scan module. [#33764]
+- AI Assistant: Add Upgrade button component on the UsagePanel. [#33720]
+- AI Assistant: Connect real usage data on the UsagePanel. [#33714]
+- AI Extension: Consolidate upgrade section of proofread and usage sections. [#33804]
+- AI Extension: Implement usage message in the UsageBar component. [#33794]
+- Alter the admin toolbar when the wpcom-admin-interface setting is set to wp-admin (fall back to the original WordPress menu). [#33707]
+- Change links for 'Appearance > Themes' on Atomic sites with wpcom_admin_interface option set to wp-admin to point to WP.com Marketplace. [#33772]
+- Jetpack: Add UsagePanel story. [#33771]
+- Jetpack: Improve process to extend paid blocks with upgrade banner. [#33752]
+- Jetpack AI: Expose current period usage data on feature endpoint. [#33623]
+- Link plugins to WP.com Marketplace on Atomic sites. [#33758]
+- Metered billing: Hide usage bar when site has AI plan. [#33770]
+- Register WordAds block earlier to make it more discoverable. [#33700]
+- Remove Jetpack option jetpack-memberships-connected-account-id. [#32354]
+
+### Improved compatibility
+- Donations Block: Update to be compatible with the upcoming version of WordPress, 6.4. [#33778]
+- General: Indicate full compatibility with the latest version of WordPress, 6.4. [#33776]
+- Lazy Images: Remove the feature from the plugin. You can now rely on WordPress' own Lazy Image features on your site. [#33782]
+
+### Bug fixes
+- Carousel: Resolve warning with AMP plugin. [#33738]
+- Fix block paid icon rendering error on simple sites. [#33807]
+- Fix the google fonts module is not loaded after the late initialization. [#33795]
+- Newsletter: If site has no plan, downgrade post access to subscribers-only. [#33750]
+- Prevent issue on jetpack proxy when tier is added. [#33788]
+- Require login on wpcom for paid content access without cookie or token. [#33761]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Refactor blocks registration. [#33086] [#33573] [#33604]
+
 ## 12.8-a.5 - 2023-10-24
 ### Enhancements
 - Jetpack: Add @wordpress/wordcount dependency. [#33745]

--- a/projects/plugins/jetpack/changelog/Link plugins to WPCOM Marketplace on Atomic sites
+++ b/projects/plugins/jetpack/changelog/Link plugins to WPCOM Marketplace on Atomic sites
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Link plugins to WPCOM Marketplace on Atomic sites

--- a/projects/plugins/jetpack/changelog/add-add-subscribers-only-if-sites-has-no-NL-plans
+++ b/projects/plugins/jetpack/changelog/add-add-subscribers-only-if-sites-has-no-NL-plans
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Newsletter: if site has no plan, downgrade post access to subscribers-only

--- a/projects/plugins/jetpack/changelog/add-wp-admin-toolbar-fixes
+++ b/projects/plugins/jetpack/changelog/add-wp-admin-toolbar-fixes
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Alter the admin toolbar when the wpcom-admin-interface setting is set to wp-admin (fall back to the original WordPress menu)

--- a/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-remove jetpack option jetpack-memberships-connected-account-id

--- a/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option-2
+++ b/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option-2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-google-fonts-module-might-not-be-loaded
+++ b/projects/plugins/jetpack/changelog/fix-google-fonts-module-might-not-be-loaded
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix the google fonts module is not loaded after the late initialization

--- a/projects/plugins/jetpack/changelog/fix-jetpack-carousel-amp-call
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-carousel-amp-call
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Carousel: resolve warning with AMP plugin.

--- a/projects/plugins/jetpack/changelog/fix-login-button-disappears-when-logged-in-to-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-login-button-disappears-when-logged-in-to-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Require login on wpcom for paid content access without cookie or token.

--- a/projects/plugins/jetpack/changelog/fix-optional-tier-param
+++ b/projects/plugins/jetpack/changelog/fix-optional-tier-param
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Prevent issue on jetpack proxy when tier is added

--- a/projects/plugins/jetpack/changelog/fix-paid-block-icon-rendering-error
+++ b/projects/plugins/jetpack/changelog/fix-paid-block-icon-rendering-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix block paid icon rendering error on simple sites

--- a/projects/plugins/jetpack/changelog/fix-redirect-themes-menu-to-wpcom-marketplace
+++ b/projects/plugins/jetpack/changelog/fix-redirect-themes-menu-to-wpcom-marketplace
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Change links for Appearance > Themes on Atomic sites with wpcom_admin_interface option set to wp-admin to point to WPCOM Marketplace

--- a/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-1
+++ b/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Refactor blocks registration

--- a/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-2
+++ b/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Refactor blocks registration

--- a/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-3
+++ b/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Refactor blocks registration

--- a/projects/plugins/jetpack/changelog/rm-donations-multiline
+++ b/projects/plugins/jetpack/changelog/rm-donations-multiline
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Donations Block: update to be compatible with the upcoming version of WordPress, 6.4.

--- a/projects/plugins/jetpack/changelog/rm-lazy-images-jetpack
+++ b/projects/plugins/jetpack/changelog/rm-lazy-images-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Lazy Images: remove the feature from the plugin. You can now rely on WordPress' own Lazy Image features on your site.

--- a/projects/plugins/jetpack/changelog/rm-lazy-images-jetpack#2
+++ b/projects/plugins/jetpack/changelog/rm-lazy-images-jetpack#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/scan-disable-module-filter
+++ b/projects/plugins/jetpack/changelog/scan-disable-module-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Add filter that allows disabling Scan module

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-upgrade-button-to-usage-panel
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-upgrade-button-to-usage-panel
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: add Upgrade button component on the UsagePanel.

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-connect-usage-data-to-usage-panel
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-connect-usage-data-to-usage-panel
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Connect real usage data on the UsagePanel.

--- a/projects/plugins/jetpack/changelog/update-ai-usage-panel-consolidate-upgrade-ui
+++ b/projects/plugins/jetpack/changelog/update-ai-usage-panel-consolidate-upgrade-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: consolidate upgrade section of proofread and usage sections

--- a/projects/plugins/jetpack/changelog/update-ai-usage-panel-show-limit-reached
+++ b/projects/plugins/jetpack/changelog/update-ai-usage-panel-show-limit-reached
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: implement usage message in the UsageBar component

--- a/projects/plugins/jetpack/changelog/update-hide-ai-usage-bar-when-unlimited
+++ b/projects/plugins/jetpack/changelog/update-hide-ai-usage-bar-when-unlimited
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Metered billing: hide usage bar when site has AI plan

--- a/projects/plugins/jetpack/changelog/update-improve-extend-with-upgrade-banner
+++ b/projects/plugins/jetpack/changelog/update-improve-extend-with-upgrade-banner
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Jetpack: improve process to extend paid blocks with upgrade banner

--- a/projects/plugins/jetpack/changelog/update-jetpack-add-usage-panel-story
+++ b/projects/plugins/jetpack/changelog/update-jetpack-add-usage-panel-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Jetpack: add UsagePanel story

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-expose-current-period-usage-on-feature-endpoint
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-expose-current-period-usage-on-feature-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Jetpack AI: expose current period usage data on feature endpoint.

--- a/projects/plugins/jetpack/changelog/update-jetpack-contributors
+++ b/projects/plugins/jetpack/changelog/update-jetpack-contributors
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update readme.txt contributors
-
-

--- a/projects/plugins/jetpack/changelog/update-make-wordads-discoverable
+++ b/projects/plugins/jetpack/changelog/update-make-wordads-discoverable
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Register wordads block earlier to make it more discoverable.

--- a/projects/plugins/jetpack/changelog/update-tested-up-to-64
+++ b/projects/plugins/jetpack/changelog/update-tested-up-to-64
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-General: indicate full compatibility with the latest version of WordPress, 6.4.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_6",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.8-a.6
+ * Version: 12.8-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.8-a.6' );
+define( 'JETPACK__VERSION', '12.8-a.7' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.8-a.7
+ * Version: 12.8-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.8-a.7' );
+define( 'JETPACK__VERSION', '12.8-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/lazy-images.php
+++ b/projects/plugins/jetpack/modules/lazy-images.php
@@ -21,10 +21,10 @@
 /**
  * Deactivate module if it is still active.
  *
- * @since $$next-version$$
+ * @since 12.8
  */
 if ( Jetpack::is_module_active( 'lazy-images' ) ) {
 	Jetpack::deactivate_module( 'lazy-images' );
 }
 
-_deprecated_file( basename( __FILE__ ), 'jetpack-$$next-version$$' );
+_deprecated_file( basename( __FILE__ ), 'jetpack-12.8' );

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.8.0-a.7",
+	"version": "12.8.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.8.0-a.6",
+	"version": "12.8.0-a.7",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.4 - 2023-10-26
+
 ## 1.7.3 - 2023-10-24
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_3"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_4"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.7.3
+ * Version: 1.7.4
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.7.3",
+	"version": "1.7.4",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 1.7.4, jetpack 12.8-a.7

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.