### PR TITLE
My Plan: update link to licensing management page

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -529,7 +529,25 @@ class MyPlanHeader extends React.Component {
 			<Card compact>
 				<div className="jp-landing__licensing-actions">
 					{ 'header' === position && (
-						<span>{ __( 'Got a license key? Activate it here.', 'jetpack' ) }</span>
+						<span>
+							{ createInterpolateElement(
+								/* translators: %s is the link to the License management page. */
+								__( 'Got a license key? <a>Activate it here.</a>', 'jetpack' ),
+								{
+									a: (
+										<a
+											href={
+												! window.Initial_State?.useMyJetpackLicensingUI
+													? siteAdminUrl + 'admin.php?page=jetpack#/license/activation'
+													: siteAdminUrl + 'admin.php?page=my-jetpack#/add-license'
+											}
+											onClick={ this.trackLicenseActivationClick }
+											className="jp-landing__licensing-actions-link"
+										/>
+									),
+								}
+							) }
+						</span>
 					) }
 					<div
 						className={ classnames( 'jp-landing__licensing-actions-item', {
@@ -548,21 +566,7 @@ class MyPlanHeader extends React.Component {
 							</Button>
 						) }
 
-						{ 'header' === position ? (
-							<Button
-								href={
-									! window.Initial_State?.useMyJetpackLicensingUI
-										? siteAdminUrl + 'admin.php?page=jetpack#/license/activation'
-										: siteAdminUrl + 'admin.php?page=my-jetpack#/add-license'
-								}
-								onClick={ this.trackLicenseActivationClick }
-								primary
-								compact
-								rna
-							>
-								{ _x( 'Activate a Product', 'Navigation item.', 'jetpack' ) }
-							</Button>
-						) : (
+						{ 'footer' === position && (
 							<Button
 								href={ siteAdminUrl + 'admin.php?page=jetpack#/recommendations' }
 								onClick={ this.trackRecommendationsClick }

--- a/projects/plugins/jetpack/_inc/client/my-plan/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/style.scss
@@ -3,63 +3,64 @@
 @import '../scss/typography';
 
 .jp-landing__plans {
-  	margin-top: 48px;
+	margin-top: 48px;
 	margin-bottom: 24px;
-  	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
+	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 
 	.dops-button {
 		margin-right: 10px;
 	}
 
 	.dops-card.is-compact {
-	  margin-bottom: 0;
-	  border-bottom: 1px solid var(--jp-gray);
+		margin-bottom: 0;
+		border-bottom: 1px solid var(--jp-gray);
 
-	  	@include breakpoint( "<960px" ) {
-		border-bottom: 0;
-	  	}
+		@include breakpoint( "<960px" ) {
+			border-bottom: 0;
+		}
 	}
 
-  	.dops-card:first-child {
-	  border-radius: 4px 4px 0 0;
+	.dops-card:first-child {
+		border-radius: 4px 4px 0 0;
 	}
 
-  	.dops-card:last-child {
-	  border-radius: 0 0 4px 4px;
+	.dops-card:last-child {
+		border-radius: 0 0 4px 4px;
 
-	  @include breakpoint( "<960px" ) {
-		padding-top: 0;
-	  }
+		@include breakpoint( "<960px" ) {
+			padding-top: 0;
+		}
 	}
 
-  	.dops-card:nth-last-child(2) {
-	  @include breakpoint( "<960px" ) {
-		border-bottom: 0;
-	  }
+	.dops-card:nth-last-child(2) {
+		@include breakpoint( "<960px" ) {
+			border-bottom: 0;
+		}
 	}
 
-  	.my-plan-card__tag-line a {
-	  color: $black;
-	  text-decoration-line: underline;
+	.my-plan-card__tag-line a,
+	a.jp-landing__licensing-actions-link {
+		color: $black;
+		text-decoration-line: underline;
 
-	  &:hover {
-		text-decoration-thickness: 3px;
-	  }
+		&:hover {
+			text-decoration-thickness: 3px;
+		}
 
-	  &:focus {
-		text-decoration-line: none;
-		border-radius: 2px;
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) black;
-		outline: 3px solid transparent;
-	  }
+		&:focus {
+			text-decoration-line: none;
+			border-radius: 2px;
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) black;
+			outline: 3px solid transparent;
+		}
 	}
 }
 
 .jp-landing__card-header {
 	margin-top: 0;
-  	margin-bottom: 8px;
+	margin-bottom: 8px;
 	font-size: 20px;
-  	font-weight: 500;
+	font-weight: 500;
 	color: $black;
 }
 
@@ -91,13 +92,13 @@
 		}
 
 		@include breakpoint( "<660px" ) {
-		  	flex-direction: unset;
+			flex-direction: unset;
 			flex: 1;
 		}
 
 		.dops-button {
 			margin-right: 0;
-		  	margin-left: 16px;
+			margin-left: 16px;
 		}
 	}
 
@@ -110,14 +111,14 @@
 		justify-content: flex-end;
 
 		@include breakpoint( "<660px" ) {
-		  justify-content: space-around;
-		  a {
-			margin: 0;
+			justify-content: space-around;
+			a {
+				margin: 0;
 
-			&.is-compact {
-			  width: 48%;
+				&.is-compact {
+					width: 48%;
+				}
 			}
-		  }
 		}
 	}
 }
@@ -152,8 +153,8 @@
 	box-sizing: border-box;
 	margin: 0 rem( 8px );
 	background-color: $white;
-  	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
-  	border-radius: 4px;
+	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
+	border-radius: 4px;
 
 	&:last-child {
 		max-width: 100%;
@@ -188,9 +189,9 @@
 
 .jp-landing__plan-features-img {
 	width: rem( 48px );
-  	padding: 24px 24px 24px 0;
+	padding: 24px 24px 24px 0;
 	line-height: 1;
-  	display: flex;
+	display: flex;
 
 	@include breakpoint( ">960px" ) {
 		width: rem( 48px );
@@ -199,19 +200,19 @@
 
 .jp-landing__plan-features-icon {
 	display: block;
-  	width: 48px;
+	width: 48px;
 }
 
 .jp-landing__plan-features-text,
 .jp-landing__licensing-actions{
 	flex: 1;
 	font-size: $font-body-small;
-  	color: var(--jp-gray-80);
+	color: var(--jp-gray-80);
 
 	a,
 	button {
-	  font-weight: 500;
-	  font-size: var(--font-body-extra-small);
+		font-weight: 500;
+		font-size: var(--font-body-extra-small);
 	}
 }
 
@@ -236,19 +237,19 @@
 }
 
 .jp-landing__plan-features-card:nth-child(odd) {
-  margin-right: 24px;
+	margin-right: 24px;
 
-  @include breakpoint( "<660px" ) {
-	margin-right: 8px;
-  }
+	@include breakpoint( "<660px" ) {
+		margin-right: 8px;
+	}
 }
 
 .jp-landing__plan-features-card:nth-child(even) {
-  margin-left: 0;
+	margin-left: 0;
 
-  @include breakpoint( "<660px" ) {
-	margin-left: 8px;
-  }
+	@include breakpoint( "<660px" ) {
+		margin-left: 8px;
+	}
 }
 
 .jp-landing__plan-features-title.is-placeholder {

--- a/projects/plugins/jetpack/changelog/update-licensing-link-my-plan-header
+++ b/projects/plugins/jetpack/changelog/update-licensing-link-my-plan-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard / My Plan: update the link to licensing management for a better UX in the My Plan header.


### PR DESCRIPTION
Fixes #33803

## Proposed changes:

Let's update the link to the licensing management page according to the discussion and screenshots in #33803:

> Get rid of the primary CTA “Activate a product”
> Use the copy “Activate it here” for that action instead.

> **Note**
> @keoshi I did not make any changes to the "Recommendations" link at the bottom of the header.

This also fixes some spaces <> tabs mixes in the stylesheet for that page.

**Before**

<img width="1118" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/c60437ec-dff5-46d5-bcdd-ea392cedb49b">

**After**

<img width="1091" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/16464826-dd1c-49c4-a74d-063c4b12af45">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Open your browser's JavaScript console.
* Enable debugging to see Tracks events by pasting the following: `localStorage.setItem( 'debug', 'dops:analytics*' );`
* Go to Jetpack > Dashboard > My Plan
* Check the header of the page according to the screenshot above.
* Click on the "Activate it here" link.
    * The link should direct to the right page.
    * You should see a tracks event triggered in your JS console.
