### PR TITLE
Paywall: Add Subscribers auth endpoint standalone

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -771,8 +771,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'jetpack/v4',
 			'/subscribers/auth',
 			array(
-				'methods'  => WP_REST_Server::READABLE,
-				'callback' => __CLASS__ . '::set_subscriber_cookie_and_redirect',
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::set_subscriber_cookie_and_redirect',
+				'permission_callback' => '__return_true',
 			)
 		);
 	}

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -765,6 +765,16 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
 			)
 		);
+
+		// Save subscriber token and redirect
+		register_rest_route(
+			'jetpack/v4',
+			'/subscribers/auth',
+			array(
+				'methods'  => WP_REST_Server::READABLE,
+				'callback' => __CLASS__ . '::set_subscriber_cookie_and_redirect',
+			)
+		);
 	}
 
 	/**
@@ -799,6 +809,23 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'token'   => $json->token,
 			'blog_id' => $blog_id,
 		);
+	}
+
+	/**
+	 * Set subscriber cookie and redirect
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public static function set_subscriber_cookie_and_redirect() {
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
+		$token                = $subscription_service->get_and_set_token_from_request();
+		$payload              = $subscription_service->decode_token( $token );
+		$is_valid_token       = ! empty( $payload );
+		if ( $is_valid_token && isset( $payload['redirect_url'] ) ) {
+			return new WP_REST_Response( null, 302, array( 'location' => $payload['redirect_url'] ) );
+		}
+		return new WP_Error( 'invalid-token', 'Invalid Token' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-subscribers-auth-endpoint-2
+++ b/projects/plugins/jetpack/changelog/add-subscribers-auth-endpoint-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add subscribers auth endpoint


### PR DESCRIPTION
#33786 but without the log in link


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Same as #33786 but visit a url instead of clicking "log in", like this one: https://subscribe.wordpress.com/memberships/jwt?site_id=219433545&redirect_url=https://jetpack.jurassic.tube/2023/10/20/free-subs-post/&v2


