### PR TITLE
custom-css: PHP Rector updates (lessc)

### DIFF
--- a/projects/plugins/jetpack/changelog/custom-css-rector-updates
+++ b/projects/plugins/jetpack/changelog/custom-css-rector-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+custom-css: Upgrades for PHP 8

--- a/projects/plugins/jetpack/modules/custom-css/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css.php
@@ -867,6 +867,7 @@ class Jetpack_Custom_CSS_Enhancements {
 	 */
 	public static function customize_value_custom_css( $css, $setting ) {
 		// Find the current preprocessor.
+		$preprocessor       = null;
 		$jetpack_custom_css = get_theme_mod( 'jetpack_custom_css', array() );
 		if ( isset( $jetpack_custom_css['preprocessor'] ) ) {
 			$preprocessor = $jetpack_custom_css['preprocessor'];

--- a/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -1696,7 +1696,7 @@ class lessc {
 	protected function op_color_number($op, $lft, $rgt) {
 		if ($rgt[0] == '%') $rgt[1] /= 100;
 
-		$lftCount = is_countable( $lft ) ? count( $lft ) : 0;
+		$lftCount = is_countable( $lft ) ? count( $lft ) : 1;
 		return $this->op_color_color($op, $lft,
 			array_fill(1, $lftCount - 1, $rgt[1]));
 	}

--- a/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -1290,7 +1290,7 @@ class lessc {
 		} else {
 			if ($value[0] !== "list" || $value[1] != ",") $this->throwError("expecting list");
 			$values = $value[2];
-			$numValues = is_countable( $value ) ? count( $values ) : 0;
+			$numValues = is_countable( $values ) ? count( $values ) : 0;
 			if ($expectedArgs != $numValues) {
 				if ($name) {
 					$name = $name . ": ";

--- a/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -2414,8 +2414,6 @@ class lessc_parser {
 		if (empty($this->buffer)) return false;
 		$s = $this->seek();
 
-		$block = null; // Initialize for wpcom's rector.
-
 		if ($this->whitespace()) {
 			return true;
 		}
@@ -2515,6 +2513,7 @@ class lessc_parser {
 			} catch (exception $e) {
 				$this->seek($s);
 				$this->throwError($e->getMessage());
+				$block = null; // Rector.
 			}
 
 			$hidden = false;

--- a/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -3457,7 +3457,7 @@ class lessc_parser {
 	}
 
 	protected function genericList(&$out, $parseItem, $delim="", $flatten=true) {
-		$value = null;
+		$value = null; // Initialize output parameter to make wpcom's rector happy.
 		$s = $this->seek();
 		$items = array();
 		while ($this->$parseItem($value)) {

--- a/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -2415,7 +2415,7 @@ class lessc_parser {
 		if (empty($this->buffer)) return false;
 		$s = $this->seek();
 
-		$block = null;
+		$block = null; // Initialize for wpcom's rector.
 
 		if ($this->whitespace()) {
 			return true;
@@ -3022,9 +3022,9 @@ class lessc_parser {
 	// arguments are separated by , unless a ; is in the list, then ; is the
 	// delimiter.
 	protected function argumentDef(&$args, &$isVararg) {
-		$value  = null;
-		$rhs    = null;
-		$newArg = null;
+		$value  = null; // Initialize output variable to make wpcom's rector happy.
+		$rhs    = null; // Initialize output variable to make wpcom's rector happy.
+		$newArg = null; // Initialize variable for rector.
 		$s = $this->seek();
 		if (!$this->literal('(')) return false;
 

--- a/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -1304,7 +1304,6 @@ class lessc {
 	}
 
 	protected function toHSL($color) {
-		$H = null;
 		if ($color[0] == 'hsl') return $color;
 
 		$r = $color[1] / 255;
@@ -1325,7 +1324,7 @@ class lessc {
 
 			if ($r == $max) $H = ($g - $b)/($max - $min);
 			elseif ($g == $max) $H = 2.0 + ($b - $r)/($max - $min);
-			elseif ($b == $max) $H = 4.0 + ($r - $g)/($max - $min);
+			else $H = 4.0 + ($r - $g)/($max - $min);
 
 		}
 


### PR DESCRIPTION
## Proposed changes:

* Updated php rector issues for `custom-css/custom-css.php` and `custom-css/custom-css/preprocessors/lessc.inc.php` for our php8 migration rector repo ( see: 32481-pb/#js ) 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Copy to sandbox
```
scp ./projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php wpcom-sandbox:public_html/./wp-content/mu-plugins/jetpack-plugin/moon/modules/custom-css/custom-css/preprocessors/lessc.inc.php
scp ./projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/lessc.inc.php wpcom-sandbox:public_html/./wp-content/mu-plugins/jetpack-plugin/sun/modules/custom-css/custom-css/preprocessors/lessc.inc.php
scp ./projects/plugins/jetpack/modules/custom-css/custom-css.php wpcom-sandbox:public_html/./wp-content/mu-plugins/jetpack-plugin/sun/modules/custom-css/custom-css.php
scp ./projects/plugins/jetpack/modules/custom-css/custom-css.php wpcom-sandbox:public_html/./wp-content/mu-plugins/jetpack-plugin/moon/modules/custom-css/custom-css.php
```

(maybe the bot commands in the comment below are easier)

* have a simple site with premium plan or better
* in the customizer, go to the additional css panel. Add this css and change the dropdown to use the less preprocessor

```
// Variables
@primary-bg-color: #f4f4f4;
@secondary-bg-color: #4CAF50;
@text-color: #333;

// Mixin for text styling
.text-styling(@size, @color: @text-color) {
  font-size: @size;
  color: @color;
}

// Global styles to check if LESS is working
body {
  background-color: @primary-bg-color;
  .text-styling(56px);
}

h1 {
  .text-styling(36px, #ff0000);
}

// Nested Rules
.container {
  width: 100%;
  padding: 15px;
  background-color: @secondary-bg-color;
  .text-styling(18px, white);

  .box {
    width: 50%;
    margin: 10px auto;
    padding: 10px;
    background-color: white;
    border: 1px solid @secondary-bg-color;

    h2 {
      .text-styling(24px, @secondary-bg-color);
    }
  }
}

``` 

![2023-10-26_14-04](https://github.com/Automattic/jetpack/assets/937354/b8c8baf5-7844-436e-a340-9a37afa970db)


Save and the front-end of the site should now have a gray background with large text

### Note

There's one rector fix I didn't make:

![2023-10-26_14-06](https://github.com/Automattic/jetpack/assets/937354/4f50d257-deb6-4c90-9506-d8bdee7d0cc1)

The file treats `$importDir` strangle by initially assigning it to '' but always casting it to an array.. It seems safe to change to `[]`, but I wasn't 100% sure so I didn't.. should we?