### PR TITLE
Instant Search: switch to browsers' native image lazy loading

### DIFF
--- a/projects/packages/search/changelog/update-instant-search-lazy-images
+++ b/projects/packages/search/changelog/update-instant-search-lazy-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Instant Search: rely on browsers' native lazy loading functionality when we want to lazy load images.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.39.3",
+	"version": "0.39.4-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.39.3';
+	const VERSION = '0.39.4-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/instant-search/components/photon-image.jsx
+++ b/projects/packages/search/src/instant-search/components/photon-image.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import { usePhoton } from '../lib/hooks/use-photon';
 
 const PhotonImage = props => {
@@ -12,37 +12,11 @@ const PhotonImage = props => {
 		...otherProps
 	} = props;
 
-	const image = useRef();
-	const [ lazySrc, setLazySrc ] = useState( null );
 	const src = usePhoton( originalSrc, maxWidth, maxHeight, isPhotonEnabled );
 
-	// Enable lazy loading via IntersectionObserver if possible.
-	useEffect( () => {
-		// Wait until src is available
-		if ( ! src ) {
-			return;
-		}
-
-		let observer = null;
-		if ( lazyLoad && 'IntersectionObserver' in window ) {
-			observer = new window.IntersectionObserver( ( entries, obs ) => {
-				for ( const entry of entries ) {
-					if ( entry.isIntersecting ) {
-						setLazySrc( src );
-						obs.unobserve( entry.target );
-					}
-				}
-			} );
-			observer.observe( image.current );
-		} else {
-			setLazySrc( src );
-		}
-		return () => {
-			observer?.disconnect();
-		};
-	}, [ lazyLoad, src ] );
-
-	return <img alt={ alt } ref={ image } src={ lazySrc } { ...otherProps } />;
+	return (
+		<img alt={ alt } src={ src } loading={ `${ lazyLoad ? 'lazy' : 'eager' }` } { ...otherProps } />
+	);
 };
 
 export default PhotonImage;


### PR DESCRIPTION
## Proposed changes:

Now that all modern browsers support the `loading` attribute, let's use that and let browsers do the work.

See https://github.com/Automattic/jetpack/pull/33782#issuecomment-1781623598

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site:
    * With some posts with featured images
    * With a Jetpack Search plan
    * With instant search enabled under Jetpack > Settings > Performance
* On your site's home page, search for a string that will return posts (if you do not have a search form on your home page, add one or add `?s=searchterm` to your URL)
    * Check that the images are displayed properly and include the loading attribute.
    
