### PR TITLE
Jetpack AI: Add current tier information on the feature endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -378,6 +378,9 @@ class Jetpack_AI_Helper {
 				'requests-limit'                => $requests_limit,
 				'site-require-upgrade'          => $require_upgrade,
 				'upgrade-type'                  => $upgrade_type,
+				'current-tier'                  => array(
+					'value' => $has_ai_assistant_feature ? 1 : 0,
+				),
 			);
 		}
 

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-add-current-tier-plan-information
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-add-current-tier-plan-information
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: expose current plan tier information on feature endpoint.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #33792.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Include the `current-tier` field on the `ai-assistant-feature` endpoint to expose which tier the site has
* For sites without an upgrade, show `0`
* For sites with the current unlimited, premium upgrade, show `1` ("current plans should just assume a default qty of 1", as stated here: pbNhbs-8mq-p2)
* This will be extended in the near future when the new tiers become available

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your sandbox and sandbox the `public-api`
* Go to the WordPress.com Console: https://developer.wordpress.com/docs/api/console/
* We are going to request the `wpcom/v2` `/sites/$wpcom_site/jetpack-ai/ai-assistant-feature` endpoint
* For a site without the upgrade, you should see a response like this:

<img width="600" alt="Screenshot 2023-10-26 at 16 27 26" src="https://github.com/Automattic/jetpack/assets/6760046/8bd08433-e401-4dbc-8488-e559eca98a16">

* For a site with the upgrade, you should see a response like this:

<img width="600" alt="Screenshot 2023-10-26 at 16 26 37" src="https://github.com/Automattic/jetpack/assets/6760046/ecc2f57b-3a54-4c86-86f0-83ff9742b53b">
