### PR TITLE
NL: Improve "get access" wording on self-hosted

### DIFF
--- a/projects/plugins/jetpack/changelog/add-modal-mixed-approach
+++ b/projects/plugins/jetpack/changelog/add-modal-mixed-approach
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscription block. Improve wording to get access to content.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1093,9 +1093,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 				'https://subscribe.wordpress.com/memberships/jwt'
 			);
 		}
-		$access_question = $is_paid_post
-			? __( 'Already a paid subscriber?', 'jetpack' )
-			: __( 'Already a subscriber?', 'jetpack' );
+		$access_question = get_paywall_access_question( $newsletter_access_level );
 
 		$sign_in = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->
 <p class="has-text-align-center" style="font-size:14px"><a href="' . $sign_in_link . '">' . esc_html( $access_question ) . '</a></p>
@@ -1125,6 +1123,31 @@ function get_paywall_blocks( $newsletter_access_level ) {
 </div>
 <!-- /wp:group -->
 ';
+}
+
+/**
+ * Returns Get Access question for the paywall
+ *
+ * @param string $post_access_level The newsletter access level.
+ * @return string.
+ */
+function get_paywall_access_question( $post_access_level ) {
+	switch ( $post_access_level ) {
+		case Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS:
+		case Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS:
+			$tier = Jetpack_Memberships::get_post_tier();
+			if ( $tier !== null ) {
+				return sprintf(
+				// translators:  Placeholder is the tier name
+					__( 'I am already a <i>%s</i> paid-subscriber', 'jetpack' ),
+					esc_html( $tier->post_title )
+				);
+			} else {
+				return esc_html__( 'I am already a paid-subscriber', 'jetpack' );
+			}
+		default:
+			return esc_html__( 'I am already a subscriber', 'jetpack' );
+	}
 }
 
 /**

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -9,6 +9,8 @@
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
 use Automattic\Jetpack\Status\Host;
+use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
+use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID_SETTINGS;
 
 require_once __DIR__ . '/../../extensions/blocks/subscriptions/constants.php';
 
@@ -42,7 +44,14 @@ class Jetpack_Memberships {
 	 *
 	 * @var string
 	 */
-	public static $post_access_level_meta_name = \Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
+	public static $post_access_level_meta_name = META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
+
+	/**
+	 * Post meta that will store the tier ID of access for newsletters
+	 *
+	 * @var string
+	 */
+	public static $post_access_tier_meta_name = META_NAME_FOR_POST_TIER_ID_SETTINGS;
 
 	/**
 	 * Button block type to use.
@@ -479,6 +488,32 @@ class Jetpack_Memberships {
 			$post_access_level = Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY;
 		}
 		return $post_access_level;
+	}
+
+	/**
+	 * Get the post tier plan
+	 *
+	 * If no ID is provided, the method tries to get it from the global post object.
+	 *
+	 * @param int|null $post_id The ID of the post. Default is null.
+	 *
+	 * @return WP_Post|null the actual post tier.
+	 */
+	public static function get_post_tier( $post_id = null ) {
+		if ( ! $post_id ) {
+			$post_id = get_the_ID();
+		}
+
+		if ( ! $post_id ) {
+			return null;
+		}
+
+		$post_tier_id = get_post_meta( $post_id, self::$post_access_tier_meta_name, true );
+		if ( empty( $post_tier_id ) ) {
+			return null;
+		}
+
+		return get_post( $post_tier_id );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Improve "get access" questions depending on state of the actual post

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get a self-hosted JP instance with different types of paywall posts 
* Open different paywalled post (free-subscribers, paid-subscribers)
* Notice the different wording 
* Example: https://frequent-sailfish.jurassic.ninja/
<img width="647" alt="Screenshot 2023-10-27 at 15 58 28" src="https://github.com/Automattic/jetpack/assets/790558/562446da-f7ee-4aa6-b9b4-69429ed1c8ff">


<img width="686" alt="Screenshot 2023-10-27 at 15 58 10" src="https://github.com/Automattic/jetpack/assets/790558/6b7c8548-a94a-4305-bfe9-5cbc6719bb69">

