### PR TITLE
Add/fix issue with tier selector

### DIFF
--- a/projects/plugins/jetpack/changelog/add-fix-issue-with-tier-selector
+++ b/projects/plugins/jetpack/changelog/add-fix-issue-with-tier-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+fix bug tier selector

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -53,6 +53,8 @@ export function useSetAccess() {
 	return value => {
 		setPostMeta( {
 			[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ]: value,
+			// When a access is set, we need to clear the tier
+			[ META_NAME_FOR_POST_TIER_ID_SETTINGS ]: null,
 		} );
 	};
 }
@@ -77,7 +79,7 @@ function TierSelector() {
 	// Find the current tier meta
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	// Destructure the tierId from the meta (set tierId using the META_NAME_FOR_POST_TIER_ID_SETTINGS constant)
-	let [ { [ META_NAME_FOR_POST_TIER_ID_SETTINGS ]: tierId } ] = useEntityProp(
+	const [ { [ META_NAME_FOR_POST_TIER_ID_SETTINGS ]: tierId } ] = useEntityProp(
 		'postType',
 		postType,
 		'meta'
@@ -88,12 +90,6 @@ function TierSelector() {
 	// the hooks have to run before any early returns)
 	if ( products.length < 2 ) {
 		return;
-	}
-
-	// if no tier are selected, we select the lowest one
-	if ( ! tierId ) {
-		tierId = products[ products.length - 1 ].id;
-		setTimeout( () => setTier( tierId ) );
 	}
 
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix a bug whereyou could not deselect tiers and only have 'paid-susbcriber' access 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Apply this and check that you can easily get to that configuration:
* 
<img width="304" alt="Screenshot 2023-10-27 at 16 29 35" src="https://github.com/Automattic/jetpack/assets/790558/0b7a67c5-5567-4480-9dc0-49eb4e68159d">

