### PR TITLE
Add all-tier descriptor for Newsletter column

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wp-admin-post-list-newsletter
+++ b/projects/plugins/jetpack/changelog/fix-wp-admin-post-list-newsletter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletters: Add level for all paid subscribers

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -176,6 +176,9 @@ function render_newsletter_access_rows( $column_id, $post_id ) {
 	$access_level = get_post_meta( $post_id, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 
 	switch ( $access_level ) {
+		case Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS:
+			echo esc_html__( 'Paid Subscribers (all plans)', 'jetpack' );
+			break;
 		case Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS:
 			echo esc_html__( 'Paid Subscribers', 'jetpack' );
 			break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/196

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds a specific descriptor for newsletter posts that allow access to all paid tiers, not just a singular tier as it does currently.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Appears to rely on https://github.com/Automattic/jetpack/pull/33838 being merged first.

Once patched, create a post and select "Paid subscribers only" under Access.

![Screenshot 2023-10-27 at 11 55 47 AM](https://github.com/Automattic/jetpack/assets/8002138/444c7470-0927-4e56-924c-0a3db8400422)

Save the post and look at the post list in WP-Admin; it should show "Paid Subscribers (all plans)" under the Newsletter column



