### PR TITLE
AI Assistant: expose `usage-period` in the ai-assistant-feature endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -391,7 +391,10 @@ class Jetpack_AI_Helper {
 			$usage_period_start = WPCOM\Jetpack_AI\Usage\Helper::get_usage_period_start_date( $blog_id );
 			$usage_period_start = isset( $usage_period_start ) ? $usage_period_start->format( 'Y-m-d H:i:s' ) : null;
 
-			$usage_period_requests_count = WPCOM\Jetpack_AI\Usage\Helper::get_usage_period_requests_count( $blog_id );
+			$usage_next_period_start = WPCOM\Jetpack_AI\Usage\Helper::get_usage_next_period_start_date( $blog_id );
+			$usage_next_period_start = isset( $usage_next_period_start ) ? $usage_next_period_start->format( 'Y-m-d H:i:s' ) : null;
+
+			$usage_period_requests_count = WPCOM\Jetpack_AI\Usage\Helper::get_current_period_requests_count( $blog_id );
 
 			// Check if the site requires an upgrade.
 			$require_upgrade = $is_over_limit && ! $has_ai_assistant_feature;

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -388,10 +388,10 @@ class Jetpack_AI_Helper {
 			/*
 			 * Usage since the last plan purchase day
 			 */
-			$current_period_start = WPCOM\Jetpack_AI\Usage\Helper::get_usage_period_start_date( $blog_id );
-			$current_period_start = isset( $current_period_start ) ? $current_period_start->format( 'Y-m-d H:i:s' ) : null;
+			$usage_period_start = WPCOM\Jetpack_AI\Usage\Helper::get_usage_period_start_date( $blog_id );
+			$usage_period_start = isset( $usage_period_start ) ? $usage_period_start->format( 'Y-m-d H:i:s' ) : null;
 
-			$current_period_requests_count = WPCOM\Jetpack_AI\Usage\Helper::get_current_period_requests_count( $blog_id );
+			$usage_period_requests_count = WPCOM\Jetpack_AI\Usage\Helper::get_usage_period_requests_count( $blog_id );
 
 			// Check if the site requires an upgrade.
 			$require_upgrade = $is_over_limit && ! $has_ai_assistant_feature;
@@ -404,9 +404,9 @@ class Jetpack_AI_Helper {
 				'is-over-limit'        => $is_over_limit,
 				'requests-count'       => $requests_count,
 				'requests-limit'       => $requests_limit,
-				'current-period'       => array(
-					'start'          => $current_period_start,
-					'requests-count' => $current_period_requests_count,
+				'usage-period'         => array(
+					'start'          => $usage_period_start,
+					'requests-count' => $usage_period_requests_count,
 				),
 				'site-require-upgrade' => $require_upgrade,
 				'upgrade-type'         => $upgrade_type,

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -408,7 +408,8 @@ class Jetpack_AI_Helper {
 				'requests-count'       => $requests_count,
 				'requests-limit'       => $requests_limit,
 				'usage-period'         => array(
-					'start'          => $usage_period_start,
+					'current-start'  => $usage_period_start,
+					'next-start'     => $usage_next_period_start,
 					'requests-count' => $usage_period_requests_count,
 				),
 				'site-require-upgrade' => $require_upgrade,

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -388,6 +388,9 @@ class Jetpack_AI_Helper {
 			/*
 			 * Usage since the last plan purchase day
 			 */
+			$current_period_start = WPCOM\Jetpack_AI\Usage\Helper::get_usage_period_start_date( $blog_id );
+			$current_period_start = isset( $current_period_start ) ? $current_period_start->format( 'Y-m-d H:i:s' ) : null;
+
 			$current_period_requests_count = WPCOM\Jetpack_AI\Usage\Helper::get_current_period_requests_count( $blog_id );
 
 			// Check if the site requires an upgrade.
@@ -397,14 +400,17 @@ class Jetpack_AI_Helper {
 			$upgrade_type = wpcom_is_vip( $blog_id ) ? 'vip' : 'default';
 
 			return array(
-				'has-feature'                   => $has_ai_assistant_feature,
-				'is-over-limit'                 => $is_over_limit,
-				'requests-count'                => $requests_count,
-				'current-period-requests-count' => $current_period_requests_count,
-				'requests-limit'                => $requests_limit,
-				'site-require-upgrade'          => $require_upgrade,
-				'upgrade-type'                  => $upgrade_type,
-				'current-tier'                  => array(
+				'has-feature'          => $has_ai_assistant_feature,
+				'is-over-limit'        => $is_over_limit,
+				'requests-count'       => $requests_count,
+				'requests-limit'       => $requests_limit,
+				'current-period'       => array(
+					'start'          => $current_period_start,
+					'requests-count' => $current_period_requests_count,
+				),
+				'site-require-upgrade' => $require_upgrade,
+				'upgrade-type'         => $upgrade_type,
+				'current-tier'         => array(
 					'value' => $has_ai_assistant_feature ? 1 : 0,
 				),
 			);

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-introduce-current-period-start
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-introduce-current-period-start
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: expose current period start in the ai-assistant-feature endpoint


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

It changes the response shape, collecting the usage=period data in the new `"usage-period"` field.

~requires D127135-code~ r279297-wpcom

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: expose current period start in the ai-assistant-feature endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes in your sandbox
* Get sandboxed
* Hit the ai-assistant-feature endpoint
* Confirm you see the `"usage-period"` field in the response

Before | After
-------|-----
<img width="317" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/e9af10af-075c-4cc0-adca-b993843db8b1">|<img width="397" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/dca93a99-0692-4ed5-b98e-015e857b1e93">