### PR TITLE
Add/blogging-prompts: Add bloganuary field

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -306,6 +306,10 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 			$data['answered_link_text'] = __( 'View all responses', 'jetpack' );
 		}
 
+		if ( rest_is_field_included( 'bloganuary_id', $fields ) ) {
+			$data['bloganuary_id'] = 'bloganuary-' . $this->prepare_date_response( $prompt->post_date_gmt );
+		}
+
 		return $data;
 	}
 
@@ -442,6 +446,10 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 				),
 				'answered_link_text'    => array(
 					'description' => __( 'Text for the link to answers for the prompt.', 'jetpack' ),
+					'type'        => 'string',
+				),
+				'bloganuary_id'         => array(
+					'description' => __( 'Id used by the bloganuary promotion', 'jetpack' ),
 					'type'        => 'string',
 				),
 			),

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -332,6 +332,9 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 	 */
 	protected function get_bloganuary_id( $post_date_gmt ) {
 		$post_year_day = gmdate( 'Y-d', strtotime( $post_date_gmt ) );
+		if ( $this->force_year ) {
+			$post_year_day = $this->force_year . '-' . gmdate( 'd', strtotime( $post_date_gmt ) );
+		}
 		return 'bloganuary-' . $post_year_day;
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -306,11 +306,33 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 			$data['answered_link_text'] = __( 'View all responses', 'jetpack' );
 		}
 
-		if ( rest_is_field_included( 'bloganuary_id', $fields ) ) {
-			$data['bloganuary_id'] = 'bloganuary-' . $this->prepare_date_response( $prompt->post_date_gmt );
+		if ( $this->is_in_bloganuary( $prompt->post_date_gmt ) && rest_is_field_included( 'bloganuary_id', $fields ) ) {
+			$data['bloganuary_id'] = $this->get_bloganuary_id( $prompt->post_date_gmt );
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Return true if the post is in "Bloganuary"
+	 *
+	 * @param string $post_date_gmt Post date in GMT.
+	 * @return bool True if the post is in "Bloganuary".
+	 */
+	protected function is_in_bloganuary( $post_date_gmt ) {
+		$post_month = gmdate( 'm', strtotime( $post_date_gmt ) );
+		return $post_month === '01';
+	}
+
+	/**
+	 * Return the bloganuary id of the form `bloganuary-yyyy-dd`
+	 *
+	 * @param string $post_date_gmt Post date in GMT.
+	 * @return string Bloganuary id.
+	 */
+	protected function get_bloganuary_id( $post_date_gmt ) {
+		$post_year_day = gmdate( 'Y-d', strtotime( $post_date_gmt ) );
+		return 'bloganuary-' . $post_year_day;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-blogging-prompts-bloganuary-field
+++ b/projects/plugins/jetpack/changelog/add-blogging-prompts-bloganuary-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add bloganuary date field to blogging prompts api. This field will be used for the bloganuary promotion.


### PR DESCRIPTION
Part of pe7F0s-1iI-p2.

"Bloganuary" is a yearly promotion where bloggers are encouraged to write a blog post every day in January.

In order to integrate the writing prompts feature with the bloganuary promotion we were requested to add a new tag to posts created from blogging prompts. Id is of the form `bloganuary-yyyy-dd`.

This tag will be used so that bloggers can find other answers written as part of bloganuary.

## Proposed changes:

This change adds the ID to posts returned by the blogging-prompts v3 endpoint.

It would be possible to generate the ID on the front end, but I think that having it come from the back end would be a better design.


### Other information:

Note currently the endpoint is unused but it should be used by both calypso and the apps soon. pctCYC-KA-p2#comment-1085

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply the diff to calypso.

Call the API like so:

`https://public-api.wordpress.com/wpcom/v3/sites/<site_id>/blogging-prompts?after=--01-01&force_year=2024&order=desc`

It requires the `Authorization` and `Cookie` headers from a logged in claypso session