### PR TITLE
wp-admin Site Default: Fix/remove submenu from my sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-remove-submenu-from-my-sites
+++ b/projects/plugins/jetpack/changelog/fix-remove-submenu-from-my-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: It is a very trivial change
+
+

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -394,6 +394,9 @@ class Masterbar {
 			$bar->remove_node( $node->id );
 		}
 
+		// This disables a submenu from being placed under the My Sites button.
+		add_filter( 'jetpack_load_admin_menu_class', '__return_true' );
+
 		// Here we add the My sites and Reader buttons
 		$this->wpcom_adminbar_add_secondary_groups( $bar );
 		$this->add_my_sites_submenu( $bar );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/4405

When SSO is disabled, a submenu appears under the My Sites button. This submenu is not styled correctly and should not be there in the first place. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* A filter is used to determine if the standard menu should be loaded. This diff adds a filter to return true, preventing the submenu from being added.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this PR on a WoA site. You can do this by using the Jetpack Beta Tester or by syncing changes to a WoA dev blog.
* Enable the classic interface via the hosting configuration.
* Disable SSO via https://wordpress.com/settings/security - Disable the `Allow users to log in to this site using WordPress.com accounts` toggle.
* Go to the wp-admin interface of your WoA site and you should see the standard WordPress menu on the left (it will not have any of the Calypso links). 
* Move your mouse over the `My Sites` button in the admin bar and observe that, aside from hover feedback on the button itself, there is nothing strange happening.