### PR TITLE
Internal release: record stat to track how often unverified domain email nag is shown

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/suspended-domains-add-bump-stats-for-nag
+++ b/projects/packages/jetpack-mu-wpcom/changelog/suspended-domains-add-bump-stats-for-nag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Internal release: add bump stats for unverfied domain email nag

--- a/projects/packages/jetpack-mu-wpcom/changelog/suspended-domains-add-bump-stats-for-nag
+++ b/projects/packages/jetpack-mu-wpcom/changelog/suspended-domains-add-bump-stats-for-nag
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Internal release: add bump stats for unverfied domain email nag
+Internal release: add bump stat for unverfied domain email nag

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -50,20 +50,6 @@ function get_domain_with_unverified_email() {
 }
 
 /**
- * Bump the MC stat for wpcom-domain-email-nag-shown.
- *
- * @param string $domain the domain to bump the stat for.
- */
-function bump_mc_stats( $domain ) {
-	$pixel_url = sprintf(
-		'http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_%s=%s',
-		'wpcom-domain-email-nag-shown',
-		$domain
-	);
-	wp_remote_get( $pixel_url );
-}
-
-/**
  * Decides whether to render to the email nag.
  */
 function domain_email_nag() {
@@ -77,7 +63,11 @@ function domain_email_nag() {
 		return;
 	}
 
-	bump_mc_stats( $domain );
+	$pixel_url = sprintf(
+		'http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_%s=%s',
+		'wpcom_frontend_unverified_domain_email_nag_shown',
+		$domain
+	);
 
 	wp_enqueue_style( 'wpcom-domain-email-nag-style', plugins_url( 'domain-nag.style.css', __FILE__ ), array(), Jetpack_Mu_Wpcom::PACKAGE_VERSION );
 
@@ -89,11 +79,12 @@ function domain_email_nag() {
 
 	?>
 	<div class="wp-domain-nag-sticky-message">
+		<img src="<?php echo esc_url( $pixel_url ); ?>" alt="" style="display:none;" />
 		<div class="wp-domain-nag-inner">
 			<p class="wp-domain-nag-text"><?php echo wp_kses( $notice, array( 'strong' => array() ) ); ?></p>
 			<a class="button" href="<?php echo esc_url( get_account_url() ); ?>"><?php esc_html_e( 'Fix', 'jetpack-mu-wpcom' ); ?></a>
 		</div>
-	</div>	
+	</div>
 	<?php
 }
 add_action( 'wp_footer', __NAMESPACE__ . '\domain_email_nag' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -65,8 +65,8 @@ function domain_email_nag() {
 
 	$pixel_url = sprintf(
 		'http://pixel.wp.com/b.gif?v=wpcom-no-pv&x_%s=%s',
-		'wpcom_frontend_unverified_domain_email_nag_shown',
-		$domain
+		'wpcom_frontend_unverified_domain_email_nag',
+		'shown'
 	);
 
 	wp_enqueue_style( 'wpcom-domain-email-nag-style', plugins_url( 'domain-nag.style.css', __FILE__ ), array(), Jetpack_Mu_Wpcom::PACKAGE_VERSION );

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -63,6 +63,8 @@ function domain_email_nag() {
 		return;
 	}
 
+	bump_stats_extras( 'wpcom-domain-email-nag-shown', $domain );
+
 	wp_enqueue_style( 'wpcom-domain-email-nag-style', plugins_url( 'domain-nag.style.css', __FILE__ ), array(), Jetpack_Mu_Wpcom::PACKAGE_VERSION );
 
 	$notice = sprintf(
@@ -77,7 +79,7 @@ function domain_email_nag() {
 			<p class="wp-domain-nag-text"><?php echo wp_kses( $notice, array( 'strong' => array() ) ); ?></p>
 			<a class="button" href="<?php echo esc_url( get_account_url() ); ?>"><?php esc_html_e( 'Fix', 'jetpack-mu-wpcom' ); ?></a>
 		</div>
-	</div>
+	</div>	
 	<?php
 }
 add_action( 'wp_footer', __NAMESPACE__ . '\domain_email_nag' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -44,7 +44,7 @@ function get_domain() {
  */
 function is_custom_domain() {
 	$domain = get_domain();
-	return ! str_ends_with( $domain, 'wpcomstaging.com' ) && ! str_ends_with( $domain, 'wordpress.com' );
+	return ! str_ends_with( $domain, '.wpcomstaging.com' ) && ! str_ends_with( $domain, '.wordpress.com' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -51,7 +51,7 @@ function is_custom_domain() {
  * Decides whether to render to the email nag.
  */
 function domain_email_nag() {
-	if ( ! is_on_frontend_and_logged_in() && is_custom_domain() ) {
+	if ( ! is_on_frontend_and_logged_in() && ! is_custom_domain() ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -65,7 +65,7 @@ function domain_email_nag() {
 
 	$script = <<<'EOD'
 		const base = 'https://public-api.wordpress.com';
-		const path = '/rest/v1/domains/%d/is-domain-email-unverified';
+		const path = '/wpcom/v2/sites/%d/has-unverified-domain-email';
 
 		fetch(base + path).then(function (result) {
 			if (result) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -65,7 +65,7 @@ function domain_email_nag() {
 
 	$script = <<<'EOD'
 		const base = 'https://public-api.wordpress.com';
-		const path = '/wpcom/v2/sites/%d/has-unverified-domain-email';
+		const path = '/wpcom/v2/sites/%d/domains/has-unverified-domain-email';
 
 		fetch(base + path).then(function (result) {
 			if (result) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -63,7 +63,7 @@ function domain_email_nag() {
 		sprintf(
 			"
 			const base = 'https://public-api.wordpress.com';
-			const path = '/v1/domains/%s/is-domain-email-unverified';
+			const path = '/v1/domains/%d/is-domain-email-unverified';
 			
 			fetch(base + path).then(function (result) {
 				if (result) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -64,7 +64,7 @@ function domain_email_nag() {
 	}
 
 	$pixel_url = sprintf(
-		'http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_%s=%s',
+		'http://pixel.wp.com/b.gif?v=wpcom-no-pv&x_%s=%s',
 		'wpcom_frontend_unverified_domain_email_nag_shown',
 		$domain
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -50,6 +50,20 @@ function get_domain_with_unverified_email() {
 }
 
 /**
+ * Bump the MC stat for wpcom-domain-email-nag-shown.
+ *
+ * @param string $domain the domain to bump the stat for.
+ */
+function bump_mc_stats( $domain ) {
+	$pixel_url = sprintf(
+		'http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_%s=%s',
+		'wpcom-domain-email-nag-shown',
+		$domain
+	);
+	wp_remote_get( $pixel_url );
+}
+
+/**
  * Decides whether to render to the email nag.
  */
 function domain_email_nag() {
@@ -63,7 +77,7 @@ function domain_email_nag() {
 		return;
 	}
 
-	bump_stats_extras( 'wpcom-domain-email-nag-shown', $domain );
+	bump_mc_stats( $domain );
 
 	wp_enqueue_style( 'wpcom-domain-email-nag-style', plugins_url( 'domain-nag.style.css', __FILE__ ), array(), Jetpack_Mu_Wpcom::PACKAGE_VERSION );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/domain-email-nag/domain-email-nag.php
@@ -63,27 +63,30 @@ function domain_email_nag() {
 		return;
 	}
 
-	$script = sprintf(
-		"
+	$script = <<<'EOD'
 		const base = 'https://public-api.wordpress.com';
-		const path = '/v1/domains/%d/is-domain-email-unverified';
-		
+		const path = '/rest/v1/domains/%d/is-domain-email-unverified';
+
 		fetch(base + path).then(function (result) {
 			if (result) {
 				result.json().then(function (body) {
 					if (body.unverified) {
 						const nag = document.querySelector('.wp-domain-nag-sticky-message');
+						console.log( nag );
 						if (nag) {
 							nag.style.display = 'block';
 							const statUrl =
-								'http://pixel.wp.com/b.gif?v=wpcom-no-pv&x_wpcom_frontend_unverified_domain_email_nag=shown';
+								'https://pixel.wp.com/b.gif?v=wpcom-no-pv&x_wpcom_frontend_unverified_domain_email_nag=shown';
 							fetch(statUrl);
 						}
 					}
 				});
 			}
 		});
-	",
+EOD;
+
+	$script = sprintf(
+		$script,
 		$blog_id
 	);
 
@@ -102,7 +105,7 @@ function domain_email_nag() {
 			<a class="button" href="<?php echo esc_url( get_account_url() ); ?>"><?php esc_html_e( 'Fix', 'jetpack-mu-wpcom' ); ?></a>
 		</div>
 	</div>
-	<script><?php echo esc_js( $script ); ?></script>
+	<script><?php echo $script; // phpcs:ignore -- output generated on server ?></script>
 	<?php
 }
 add_action( 'wp_footer', __NAMESPACE__ . '\domain_email_nag' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes n/a
Related https://github.com/Automattic/jetpack/pull/33390

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Record a stat for how many times email nag added in https://github.com/Automattic/jetpack/pull/33390 is displayed

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the patch to your sandbox as per this comment https://github.com/Automattic/jetpack/pull/33855#issuecomment-1785044907
* Sandbox the wordpress.com subdomain for your site. 
* Follow the test plan here to get a site with an unverified email https://github.com/Automattic/wp-calypso/pull/83597
* Go to the site's front end and confirm a nah is shown. Check bump stat `wpcom_frontend_unverified_domain_email_nag_shown` and see that the stat has increased (there might be a delay)
* Is the stat name I used appropriate?

