### PR TITLE
Connection: improve connection info for multidomain setups

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
@@ -99,6 +99,14 @@ const ConnectionStatusCard = props => {
 		[ onDisconnected, setConnectionStatus ]
 	);
 
+	/**
+	 * Compare the two values and set IsMultidomain to true if they are the same
+	 */
+	const isMultidomain =
+		window.myJetpackInitialState.siteSuffix !== window.myJetpackInitialState.wpcomURLSuffix;
+
+	const isIDC = window.hasOwnProperty( 'JP_IDENTITY_CRISIS__INITIAL_STATE' ) ?? false;
+
 	return (
 		<div className={ styles[ 'connection-status-card' ] }>
 			<H3>{ title }</H3>
@@ -119,7 +127,7 @@ const ConnectionStatusCard = props => {
 				<img src={ cloud } alt="" className={ styles.cloud } />
 				<div
 					className={ classNames( styles.line, {
-						[ styles.disconnected ]: ! isRegistered || ! isUserConnected,
+						[ styles.disconnected ]: ! isRegistered || ! isUserConnected || isIDC,
 					} ) }
 				/>
 				<div className={ styles[ 'avatar-wrapper' ] }>
@@ -142,16 +150,44 @@ const ConnectionStatusCard = props => {
 					/>
 				) : (
 					<>
-						<ConnectionListItem
-							onClick={ openManageConnectionDialog }
-							text={ __( 'Site connected.', 'jetpack-my-jetpack' ) }
-							actionText={
-								isUserConnected && userConnectionData.currentUser?.isMaster
-									? __( 'Manage', 'jetpack-my-jetpack' )
-									: null
-							}
-						/>
-						{ isUserConnected && (
+						{ isIDC && (
+							<ConnectionListItem
+								text={ __( 'This site is in Safe Mode.', 'jetpack-my-jetpack' ) }
+								status="error"
+							/>
+						) }
+						{ isMultidomain && ! isIDC && (
+							<div>
+								<ConnectionListItem
+									text={ __( 'This site is using multiple domains.', 'jetpack-my-jetpack' ) }
+								/>
+								<ConnectionListItem
+									onClick={ openManageConnectionDialog }
+									text={ sprintf(
+										/* translators: placeholder is domain name */
+										__( 'Site connected as %s', 'jetpack-my-jetpack' ),
+										window.myJetpackInitialState.wpcomURL
+									) }
+									actionText={
+										isUserConnected && userConnectionData.currentUser?.isMaster
+											? __( 'Manage', 'jetpack-my-jetpack' )
+											: ' '
+									}
+								/>
+							</div>
+						) }
+						{ ! isMultidomain && ! isIDC && (
+							<ConnectionListItem
+								onClick={ openManageConnectionDialog }
+								text={ __( 'Site connected.', 'jetpack-my-jetpack' ) }
+								actionText={
+									isUserConnected && userConnectionData.currentUser?.isMaster
+										? __( 'Manage', 'jetpack-my-jetpack' )
+										: ' '
+								}
+							/>
+						) }
+						{ isUserConnected && ! isIDC && (
 							<ConnectionListItem
 								onClick={ openManageConnectionDialog }
 								actionText={ __( 'Manage', 'jetpack-my-jetpack' ) }
@@ -167,7 +203,8 @@ const ConnectionStatusCard = props => {
 						) }
 						{ isUserConnected &&
 							userConnectionData?.connectionOwner &&
-							! userConnectionData.currentUser?.isMaster && (
+							! userConnectionData.currentUser?.isMaster &&
+							! isIDC && (
 								<ConnectionListItem
 									text={ sprintf(
 										/* translators: placeholder is the username of the Jetpack connection owner */

--- a/projects/packages/my-jetpack/changelog/add-multidomain-cxn-info
+++ b/projects/packages/my-jetpack/changelog/add-multidomain-cxn-info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Connection: improve connection card for multidomain setups.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -211,6 +211,8 @@ class Initializer {
 					'isEnabled'       => Jetpack_Manage::could_use_jp_manage(),
 					'isAgencyAccount' => Jetpack_Manage::is_agency_account(),
 				),
+				'wpcomURL'              => self::get_site()->data->URL,
+				'wpcomURLSuffix'        => ( new Status() )->get_site_suffix( self::get_site()->data->URL ),
 			)
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Add connection information for multidomain sites. 

Currently, I added these changes to My Jetpack.

Multidomain site when accessing My Jetpack from a secondary domain:
<img width="588" alt="Screenshot 2023-10-30 at 11 22 08" src="https://github.com/Automattic/jetpack/assets/1242807/bc26f8b1-c689-4f9c-bccc-db6386a416ed">

My Jetpack when site is in Safe Mode:
<img width="496" alt="Screenshot 2023-10-30 at 13 07 44" src="https://github.com/Automattic/jetpack/assets/1242807/0f69b5c1-ba40-4341-a31c-387a7b9949c1">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check the primay connected domain and compare it to the currently used one.
* If not in IDC, display information about the primary domain.
* Sites with only one domain will see no difference.
* Add Safe Mode notification to My Jetpack connection card.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You need a site that's using two domains (JT site can be used).
* Use one domain to create the connection. Check the Connection card on My Jetpack page. It should look same as it does before applying this branch.
* Access My Jetpack using the secondary domain. It should look as in screenshot above.

