### PR TITLE
AI Tiered plan: Show "Request will reset..." message

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-usage-panel-curent-period-message
+++ b/projects/plugins/jetpack/changelog/update-ai-usage-panel-curent-period-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Tiered plan: Show "Request will reset..." message to the Usage Panel

--- a/projects/plugins/jetpack/changelog/update-tiered-plan-update-use-ai-feature
+++ b/projects/plugins/jetpack/changelog/update-tiered-plan-update-use-ai-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Tiered Plans: pick and expose tied plan data

--- a/projects/plugins/jetpack/changelog/update-tiered-plan-update-use-ai-feature
+++ b/projects/plugins/jetpack/changelog/update-tiered-plan-update-use-ai-feature
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-AI Tiered Plans: pick and expose tied plan data
+AI Tiered Plans: pick and expose tier plan data

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -18,6 +18,14 @@ export type AIFeatureProps = {
 	errorMessage: string;
 	errorCode: string;
 	upgradeType: UpgradeTypeProp;
+	currentTier: {
+		value: 0 | 1 | 100 | 200 | 500;
+	};
+	usagePeriod: {
+		currentStart: string;
+		nextStart: string;
+		requestsCount: number;
+	};
 };
 
 const NUM_FREE_REQUESTS_LIMIT = 20;
@@ -33,6 +41,14 @@ export const AI_Assistant_Initial_State = {
 	errorMessage: aiAssistantFeature?.[ 'error-message' ] || '',
 	errorCode: aiAssistantFeature?.[ 'error-code' ],
 	upgradeType: aiAssistantFeature?.[ 'upgrade-type' ] || 'default',
+	usagePeriod: {
+		currentStart: aiAssistantFeature?.[ 'usage-period' ]?.[ 'current-start' ],
+		nextStart: aiAssistantFeature?.[ 'usage-period' ]?.[ 'next-start' ],
+		requestsCount: aiAssistantFeature?.[ 'usage-period' ]?.[ 'requests-count' ] || 0,
+	},
+	currentTier: {
+		value: aiAssistantFeature?.[ 'current-tier' ]?.value || 1,
+	},
 };
 
 export async function getAIFeatures(): Promise< AIFeatureProps > {
@@ -50,6 +66,14 @@ export async function getAIFeatures(): Promise< AIFeatureProps > {
 			errorMessage: response[ 'error-message' ],
 			errorCode: response[ 'error-code' ],
 			upgradeType: response[ 'upgrade-type' ],
+			usagePeriod: {
+				currentStart: response[ 'usage-period' ]?.[ 'current-start' ],
+				nextStart: response[ 'usage-period' ]?.[ 'next-start' ],
+				requestsCount: response[ 'usage-period' ]?.[ 'requests-count' ] || 0,
+			},
+			currentTier: {
+				value: response[ 'current-tier' ]?.value || 1,
+			},
 		};
 	} catch ( error ) {
 		console.error( error ); // eslint-disable-line no-console

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -18,9 +18,12 @@ export type AIFeatureProps = {
 	errorMessage: string;
 	errorCode: string;
 	upgradeType: UpgradeTypeProp;
+<<<<<<< HEAD
 	currentTier: {
 		value: 0 | 1 | 100 | 200 | 500;
 	};
+=======
+>>>>>>> bbcdd9b573 (update useAiFeature data)
 	usagePeriod: {
 		currentStart: string;
 		nextStart: string;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -18,12 +18,9 @@ export type AIFeatureProps = {
 	errorMessage: string;
 	errorCode: string;
 	upgradeType: UpgradeTypeProp;
-<<<<<<< HEAD
 	currentTier: {
 		value: 0 | 1 | 100 | 200 | 500;
 	};
-=======
->>>>>>> bbcdd9b573 (update useAiFeature data)
 	usagePeriod: {
 		currentStart: string;
 		nextStart: string;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -69,18 +69,16 @@ function UsageControl( {
 		resetMsg = sprintf( __( 'Requests will reset in %1$d days.', 'jetpack' ), numberOfDays );
 	}
 
-	let help = __( 'Unlimited requests for your site', 'jetpack' );
+	let help = __( 'Unlimited requests for your site.', 'jetpack' );
 
 	if ( ! hasFeature ) {
 		// translators: %1$d: number of requests allowed in the free plan
 		help = sprintf( __( '%1$d free requests for your site', 'jetpack' ), requestsLimit );
-	} else {
-		help += '. ' + resetMsg;
 	}
 
 	const limitReached = isOverLimit && ! hasFeature;
 	if ( limitReached ) {
-		help = __( 'You have reached your plan requests limit', 'jetpack' );
+		help = __( 'You have reached your plan requests limit.', 'jetpack' );
 	}
 
 	// build messages
@@ -98,8 +96,16 @@ function UsageControl( {
 
 	const usage = requestsCount / requestsLimit;
 
+	const helpComponent = (
+		<>
+			{ help }
+			<br />
+			{ hasFeature ? resetMsg : null }
+		</>
+	);
+
 	return (
-		<BaseControl help={ help } label={ __( 'Usage', 'jetpack' ) }>
+		<BaseControl help={ helpComponent } label={ __( 'Usage', 'jetpack' ) }>
 			<p>{ hasFeature ? unlimitedPlanUsageMessage : freeUsageMessage }</p>
 			{ ! hasFeature && <UsageBar usage={ usage } limitReached={ limitReached } /> }
 		</BaseControl>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -75,12 +75,12 @@ function UsageControl( {
 		// translators: %1$d: number of requests allowed in the free plan
 		help = sprintf( __( '%1$d free requests for your site', 'jetpack' ), requestsLimit );
 	} else {
-		help += ' ' + resetMsg;
+		help += '. ' + resetMsg;
 	}
 
 	const limitReached = isOverLimit && ! hasFeature;
 	if ( limitReached ) {
-		help = __( 'You have reached your plan requests limit.', 'jetpack' );
+		help = __( 'You have reached your plan requests limit', 'jetpack' );
 	}
 
 	// build messages

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -51,9 +51,10 @@ function UsageControl( {
 	requestsCount,
 	requestsLimit,
 	usagePeriod,
+	currentTier,
 }: Pick<
 	AIFeatureProps,
-	'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' | 'usagePeriod'
+	'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' | 'usagePeriod' | 'currentTier'
 > ) {
 	// Compute the number of days from now to the next period
 	let resetMsg = '';
@@ -69,7 +70,12 @@ function UsageControl( {
 		resetMsg = sprintf( __( 'Requests will reset in %1$d days.', 'jetpack' ), numberOfDays );
 	}
 
-	let help = __( 'Unlimited requests for your site.', 'jetpack' );
+	const isUnlimitedTier = currentTier?.value === 1;
+	let help = '';
+
+	if ( isUnlimitedTier ) {
+		help = __( 'Unlimited requests for your site.', 'jetpack' );
+	}
 
 	if ( ! hasFeature ) {
 		// translators: %1$d: number of requests allowed in the free plan
@@ -80,6 +86,18 @@ function UsageControl( {
 	if ( limitReached ) {
 		help = __( 'You have reached your plan requests limit.', 'jetpack' );
 	}
+
+	const helpComponent = (
+		<>
+			{ help }
+			{ hasFeature && ! isUnlimitedTier ? (
+				<>
+					<br />
+					{ resetMsg }
+				</>
+			) : null }
+		</>
+	);
 
 	// build messages
 	const freeUsageMessage = sprintf(
@@ -95,14 +113,6 @@ function UsageControl( {
 	);
 
 	const usage = requestsCount / requestsLimit;
-
-	const helpComponent = (
-		<>
-			{ help }
-			<br />
-			{ hasFeature ? resetMsg : null }
-		</>
-	);
 
 	return (
 		<BaseControl help={ helpComponent } label={ __( 'Usage', 'jetpack' ) }>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -74,13 +74,13 @@ function UsageControl( {
 	if ( ! hasFeature ) {
 		// translators: %1$d: number of requests allowed in the free plan
 		help = sprintf( __( '%1$d free requests for your site', 'jetpack' ), requestsLimit );
+	} else {
 		help += ' ' + resetMsg;
 	}
 
 	const limitReached = isOverLimit && ! hasFeature;
 	if ( limitReached ) {
 		help = __( 'You have reached your plan requests limit.', 'jetpack' );
-		help += ' ' + resetMsg;
 	}
 
 	// build messages

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -55,13 +55,20 @@ function UsageControl( {
 	'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' | 'currentPeriod'
 > ) {
 	// Compute the number of days from start to now
-	const currentPediorStart = new Date( currentPeriod.start );
-	const numberOfDays = Math.floor(
-		( Date.now() - currentPediorStart.getTime() ) / ( 1000 * 60 * 60 * 24 )
-	);
+	let resetMsg = '';
+	if ( currentPeriod?.start ) {
+		const currentPediorStart = new Date( currentPeriod.start );
+		const currentPeriodEnd = new Date( currentPediorStart );
+		currentPeriodEnd.setMonth( currentPeriodEnd.getMonth() + 1 );
 
-	// translators: %1$d: number of days
-	const resetMsg = sprintf( __( 'Requests will reset in %1$d days.', 'jetpack' ), numberOfDays );
+		// Number of days in the current period
+		const numberOfDays = Math.floor(
+			( currentPeriodEnd.getTime() - Date.now() ) / ( 1000 * 60 * 60 * 24 )
+		);
+
+		// translators: %1$d: number of days
+		resetMsg = sprintf( __( 'Requests will reset in %1$d days.', 'jetpack' ), numberOfDays );
+	}
 
 	let help = __( 'Unlimited requests for your site', 'jetpack' );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -60,7 +60,7 @@ function UsageControl( {
 	if ( usagePeriod?.nextStart ) {
 		const nextPeriodStart = new Date( usagePeriod.nextStart );
 
-		// Number of days in the current period
+		// Number of days until the next period
 		const numberOfDays = Math.ceil(
 			( nextPeriodStart.getTime() - Date.now() ) / ( 1000 * 60 * 60 * 24 )
 		);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -4,13 +4,14 @@
 import { BaseControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
-import './style.scss';
 /**
  * Types
  */
 import type { UsageBarProps } from './types';
 import type { AIFeatureProps } from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import type React from 'react';
+
+import './style.scss';
 
 /**
  * UsageBar component

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -61,7 +61,7 @@ function UsageControl( {
 		const nextPeriodStart = new Date( usagePeriod.nextStart );
 
 		// Number of days in the current period
-		const numberOfDays = Math.floor(
+		const numberOfDays = Math.ceil(
 			( nextPeriodStart.getTime() - Date.now() ) / ( 1000 * 60 * 60 * 24 )
 		);
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -55,7 +55,7 @@ function UsageControl( {
 	AIFeatureProps,
 	'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' | 'usagePeriod'
 > ) {
-	// Compute the number of days from start to now
+	// Compute the number of days from now to the next period
 	let resetMsg = '';
 	if ( usagePeriod?.currentStart ) {
 		const nextPeriodStart = new Date( usagePeriod.nextStart );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -49,17 +49,32 @@ function UsageControl( {
 	hasFeature,
 	requestsCount,
 	requestsLimit,
-}: Pick< AIFeatureProps, 'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' > ) {
+	currentPeriod,
+}: Pick<
+	AIFeatureProps,
+	'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' | 'currentPeriod'
+> ) {
+	// Compute the number of days from start to now
+	const currentPediorStart = new Date( currentPeriod.start );
+	const numberOfDays = Math.floor(
+		( Date.now() - currentPediorStart.getTime() ) / ( 1000 * 60 * 60 * 24 )
+	);
+
+	// translators: %1$d: number of days
+	const resetMsg = sprintf( __( 'Requests will reset in %1$d days.', 'jetpack' ), numberOfDays );
+
 	let help = __( 'Unlimited requests for your site', 'jetpack' );
 
 	if ( ! hasFeature ) {
 		// translators: %1$d: number of requests allowed in the free plan
 		help = sprintf( __( '%1$d free requests for your site', 'jetpack' ), requestsLimit );
+		help += ' ' + resetMsg;
 	}
 
 	const limitReached = isOverLimit && ! hasFeature;
 	if ( limitReached ) {
 		help = __( 'You have reached your plan requests limit.', 'jetpack' );
+		help += ' ' + resetMsg;
 	}
 
 	// build messages

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -57,7 +57,7 @@ function UsageControl( {
 > ) {
 	// Compute the number of days from now to the next period
 	let resetMsg = '';
-	if ( usagePeriod?.currentStart ) {
+	if ( usagePeriod?.nextStart ) {
 		const nextPeriodStart = new Date( usagePeriod.nextStart );
 
 		// Number of days in the current period

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -50,21 +50,19 @@ function UsageControl( {
 	hasFeature,
 	requestsCount,
 	requestsLimit,
-	currentPeriod,
+	usagePeriod,
 }: Pick<
 	AIFeatureProps,
-	'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' | 'currentPeriod'
+	'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' | 'usagePeriod'
 > ) {
 	// Compute the number of days from start to now
 	let resetMsg = '';
-	if ( currentPeriod?.start ) {
-		const currentPediorStart = new Date( currentPeriod.start );
-		const currentPeriodEnd = new Date( currentPediorStart );
-		currentPeriodEnd.setMonth( currentPeriodEnd.getMonth() + 1 );
+	if ( usagePeriod?.currentStart ) {
+		const nextPeriodStart = new Date( usagePeriod.nextStart );
 
 		// Number of days in the current period
 		const numberOfDays = Math.floor(
-			( currentPeriodEnd.getTime() - Date.now() ) / ( 1000 * 60 * 60 * 24 )
+			( nextPeriodStart.getTime() - Date.now() ) / ( 1000 * 60 * 60 * 24 )
 		);
 
 		// translators: %1$d: number of days

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -5,7 +5,6 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import './style.scss';
 import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
 import useAIFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import { canUserPurchasePlan } from '../../../../blocks/ai-assistant/lib/connection';
@@ -17,7 +16,7 @@ export default function UsagePanel() {
 	const canUpgrade = canUserPurchasePlan();
 
 	// fetch usage data
-	const { hasFeature, requestsCount, requestsLimit, isOverLimit } = useAIFeature();
+	const { hasFeature, requestsCount, requestsLimit, isOverLimit, currentPeriod } = useAIFeature();
 
 	return (
 		<div className="jetpack-ai-usage-panel">
@@ -26,6 +25,7 @@ export default function UsagePanel() {
 				hasFeature={ hasFeature }
 				requestsCount={ requestsCount }
 				requestsLimit={ requestsLimit }
+				currentPeriod={ currentPeriod }
 			/>
 
 			{ ! hasFeature && canUpgrade && (

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -28,15 +27,6 @@ export default function UsagePanel() {
 				requestsCount={ requestsCount }
 				requestsLimit={ requestsLimit }
 			/>
-
-			{ false && (
-				<p className="muted">
-					{
-						// translators: %1$d: number of days until the next usage count reset
-						sprintf( __( 'Requests will reset in %1$d days.', 'jetpack' ), 10 )
-					}
-				</p>
-			) }
 
 			{ ! hasFeature && canUpgrade && (
 				<Button

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -17,7 +17,8 @@ export default function UsagePanel() {
 	const canUpgrade = canUserPurchasePlan();
 
 	// fetch usage data
-	const { hasFeature, requestsCount, requestsLimit, isOverLimit, usagePeriod } = useAIFeature();
+	const { hasFeature, requestsCount, requestsLimit, isOverLimit, usagePeriod, currentTier } =
+		useAIFeature();
 
 	return (
 		<div className="jetpack-ai-usage-panel">
@@ -27,6 +28,7 @@ export default function UsagePanel() {
 				requestsCount={ requestsCount }
 				requestsLimit={ requestsLimit }
 				usagePeriod={ usagePeriod }
+				currentTier={ currentTier }
 			/>
 
 			{ ! hasFeature && canUpgrade && (

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -9,6 +9,7 @@ import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout
 import useAIFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import { canUserPurchasePlan } from '../../../../blocks/ai-assistant/lib/connection';
 import UsageControl from '../usage-bar';
+
 import './style.scss';
 
 export default function UsagePanel() {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -17,7 +17,7 @@ export default function UsagePanel() {
 	const canUpgrade = canUserPurchasePlan();
 
 	// fetch usage data
-	const { hasFeature, requestsCount, requestsLimit, isOverLimit, currentPeriod } = useAIFeature();
+	const { hasFeature, requestsCount, requestsLimit, isOverLimit, usagePeriod } = useAIFeature();
 
 	return (
 		<div className="jetpack-ai-usage-panel">
@@ -26,7 +26,7 @@ export default function UsagePanel() {
 				hasFeature={ hasFeature }
 				requestsCount={ requestsCount }
 				requestsLimit={ requestsLimit }
-				currentPeriod={ currentPeriod }
+				usagePeriod={ usagePeriod }
 			/>
 
 			{ ! hasFeature && canUpgrade && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up of https://github.com/Automattic/jetpack/pull/33843

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Tiered plan: Show "Request will reset..." message

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the Jetpack AI sidebar
* Identify the Usage panel
* Confirm the following states

#### Free plan / Free requests available

Here, the site doesn't have a plan/tired plan. So the app only shows the available free requests.

<img width="288" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/9fb808b7-4bff-473e-935c-076b6ab20881">

#### After upgrading the site with the AI Assistant plan

After getting the AI Assistant plan, we decided that for now, it's okay not to show the msg either (p1698786571928789/1698704331.131829-slack-C054LN8RNVA)

<img width="284" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/6f93798f-6231-4838-b0e3-ec8c7046a0d9">