### PR TITLE
Subscribe block: use "subscribers" term instead of "followers" in the block at WP.com

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-followers-to-subscribers
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-followers-to-subscribers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe block: change "followers" term to "subscribers"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -724,8 +724,7 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 			<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>
 				<div class="wp-block-jetpack-subscriptions__subscount">
 					<?php
-					/* translators: %s: number of folks subscribing to the blog */
-					echo esc_html( sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $data['subscribers_total'], 'jetpack' ), number_format_i18n( $data['subscribers_total'] ) ) );
+					echo esc_html( Jetpack_Memberships::get_join_others_text( $data['subscribers_total'] ) );
 					?>
 				</div>
 			<?php endif; ?>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -724,8 +724,8 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 			<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>
 				<div class="wp-block-jetpack-subscriptions__subscount">
 					<?php
-					/* translators: %s: number of folks following the blog */
-					echo esc_html( sprintf( _n( 'Join %s other follower', 'Join %s other followers', $data['subscribers_total'], 'jetpack' ), number_format_i18n( $data['subscribers_total'] ) ) );
+					/* translators: %s: number of folks subscribing to the blog */
+					echo esc_html( sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $data['subscribers_total'], 'jetpack' ), number_format_i18n( $data['subscribers_total'] ) ) );
 					?>
 				</div>
 			<?php endif; ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Previously we used different strings for WP.com and Jetpack subscription blocks to show number of subscribers:

**Jetpack**
<img width="724" alt="Screenshot 2023-10-30 at 15 32 46" src="https://github.com/Automattic/jetpack/assets/87168/ecd5fa5b-d22d-4ce9-a07d-e6dfb3d02664">


**WP.com**
<img width="730" alt="Screenshot 2023-10-30 at 15 31 47" src="https://github.com/Automattic/jetpack/assets/87168/83384282-b7e6-4009-9b2d-48a6f6243b06">

This fixes both to use "subscribers" term.

(I don't know why we have separate HTML output for each environment, we should refactor away from that.)


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use same function to output subscriber count at Jetpack and WP.com

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert block in editor
* Go to sidebar, and "settings"
* Toggle to show subscriber count
* Sync to WP.com, and test how the block renders at frontend

