### PR TITLE
Jetpack Sync: Update Dedicated Sync init hook priority to 200

### DIFF
--- a/projects/packages/sync/changelog/fix-dedicated-sync-init-hook-priority
+++ b/projects/packages/sync/changelog/fix-dedicated-sync-init-hook-priority
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update Dedicated Sync init hook priority to 200
+
+

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -110,7 +110,7 @@ class Actions {
 		// rely on 'jetpack_sync_before_send_queue_sync' are picked up and added to the queue if needed.
 		if ( Settings::is_dedicated_sync_enabled() && Dedicated_Sender::is_dedicated_sync_request() ) {
 			self::initialize_listener();
-			add_action( 'init', array( __CLASS__, 'add_dedicated_sync_sender_init' ), 0 );
+			add_action( 'init', array( __CLASS__, 'add_dedicated_sync_sender_init' ), 200 );
 			return;
 		}
 

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.60.0';
+	const PACKAGE_VERSION = '1.60.1-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 


### PR DESCRIPTION
Reverts the previous update of the Dedicated Sync `init` priority from 90 to 0 and sets it to 200 to ensure custom post types that are registered on init with a priority of `100` will still be synced.

It's important to note that this is a temporary solution till we update the logic of checking and syncing constants and callables before sending an action to WPCOM.

Our end goal in general is still to set the init hook priority to 0.

Please checkout linked discussions for more context.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- p1697623116284589-slack-C02JQ08G0
- p9dueE-7Vs-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Add a custom post type on init with priority > `90`. You can use a plugin like Code Snippets or modify your `functions.php` file as follows:
```
function add_lala_cpt() {
	$args = array(
		'public' => true,
		'label'  => 'Lala',
	);
	register_post_type( 'lala', $args );
}

add_action( 'init', 'add_lala_cpt', 200 );
```

- Ensure the `post_types` callable is synced with the `lala` cpt