### PR TITLE
Repo Gardening: flag contact form changes in package as well

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gardening-contact-form-label
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-contact-form-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Labelling: handle automatic labeling of Contact Form changes in the package.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -129,6 +129,15 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			keywords.add( 'Actions' );
 		}
 
+		// The Contact Form feature now lives in both a package and a Jetpack module.
+		const contactForm = file.match( /^projects\/packages\/forms\/(?<blocks>src\/blocks)?/ );
+		if ( contactForm !== null ) {
+			keywords.add( '[Feature] Contact Form' );
+			if ( contactForm.groups.blocks ) {
+				keywords.add( '[Block] Contact Form' );
+			}
+		}
+
 		// Docker.
 		const docker = file.match( /^(projects\/plugins\/boost\/docker|tools\/docker)\// );
 		if ( docker !== null ) {


### PR DESCRIPTION
## Proposed changes:

The Contact Form feature used to live only as a module in the Jetpack plugin. Now that it lives in a separate package, we should still continue to automatically add the labels we were adding when the feature lived in the Jetpack plugin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This cannot be tested in this repo, you will need to test in a fork. Here is an example:
https://github.com/jeherve/jetpack/pull/113
