### PR TITLE
Subscribe block: refactor block rendering into a single function

### DIFF
--- a/projects/plugins/jetpack/changelog/update-refactor_render_subscribe_form
+++ b/projects/plugins/jetpack/changelog/update-refactor_render_subscribe_form
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscribe block: refactor block rendering into a single function

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -609,11 +609,12 @@ function get_post_access_level_for_current_post() {
  */
 function render_for_website( $data, $classes, $styles ) {
 	$blog_id            = \Jetpack_Options::get_option( 'id' );
-	$form_id            = 'subscribe-blog-' . $data['widget_id'];
+	$widget_id_suffix   = Jetpack_Subscriptions_Widget::$instance_count > 1 ? '-' . Jetpack_Subscriptions_Widget::$instance_count : '';
+	$form_id            = 'subscribe-blog' . $widget_id_suffix;
 	$form_url           = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '#';
 	$post_access_level  = get_post_access_level_for_current_post();
 	$post_id            = get_the_ID();
-	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field-', $data['widget_id'] );
+	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );
 	$tier_id            = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
 
 	ob_start();

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -580,11 +580,8 @@ function render_block( $attributes ) {
 	if ( ! jetpack_is_frontend() ) {
 		return render_for_email( $data, $styles );
 	}
-	if ( is_wpcom() ) {
-		return render_wpcom_subscribe_form( $data, $classes, $styles );
-	}
 
-	return render_jetpack_subscribe_form( $data, $classes, $styles );
+	return render_for_website( $data, $classes, $styles );
 }
 
 /**
@@ -602,7 +599,7 @@ function get_post_access_level_for_current_post() {
 }
 
 /**
- * Renders the WP.com version of the subscriptions block.
+ * Renders the subscriptions block at the site.
  *
  * @param array $data    Array containing block view data.
  * @param array $classes Array containing the classes for different block elements.
@@ -610,11 +607,14 @@ function get_post_access_level_for_current_post() {
  *
  * @return string
  */
-function render_wpcom_subscribe_form( $data, $classes, $styles ) {
-	global $current_blog;
-
-	$form_id = 'subscribe-blog' . ( Jetpack_Subscriptions_Widget::$instance_count > 1 ? '-' . Jetpack_Subscriptions_Widget::$instance_count : '' );
-	$url     = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '';
+function render_for_website( $data, $classes, $styles ) {
+	$blog_id            = get_current_blog_id();
+	$form_id            = 'subscribe-blog-' . $data['widget_id'];
+	$form_url           = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '#';
+	$post_access_level  = get_post_access_level_for_current_post();
+	$post_id            = get_the_ID();
+	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field-', $data['widget_id'] );
+	$tier_id            = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
 
 	ob_start();
 
@@ -623,154 +623,12 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 			'success_message' => $data['success_message'],
 		)
 	);
-
-	$post_access_level = get_post_access_level_for_current_post();
-	$post_id           = get_the_ID();
-	$tier_id           = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
-
-	?>
-	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
-		<div class="wp-block-jetpack-subscriptions__container">
-
-			<form
-				action="<?php echo esc_url( $url ); ?>"
-				method="post"
-				accept-charset="utf-8"
-				data-blog="<?php echo esc_attr( get_current_blog_id() ); ?>"
-				data-post_access_level="<?php echo esc_attr( $post_access_level ); ?>"
-				id="<?php echo esc_attr( $form_id ); ?>"
-			>
-
-				<div class="wp-block-jetpack-subscriptions__form-elements">
-					<?php
-					$email_field_id  = 'subscribe-field';
-					$email_field_id .= Jetpack_Subscriptions_Widget::$instance_count > 1
-						? '-' . Jetpack_Subscriptions_Widget::$instance_count
-						: '';
-					$label_field_id  = $email_field_id . '-label';
-					?>
-					<p id="subscribe-email">
-						<label
-							id="<?php echo esc_attr( $label_field_id ); ?>"
-							for="<?php echo esc_attr( $email_field_id ); ?>"
-							class="screen-reader-text"
-						>
-							<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
-						</label>
-
-						<?php
-						printf(
-							'<input
-								required="required"
-								type="email"
-								name="email"
-								%1$s
-								style="%2$s"
-								placeholder="%3$s"
-								value="%4$s"
-								id="%5$s"
-							/>',
-							( ! empty( $classes['email_field'] )
-								? 'class="' . esc_attr( $classes['email_field'] ) . '"'
-								: ''
-							),
-							( ! empty( $styles['email_field'] )
-								? esc_attr( $styles['email_field'] )
-								: 'width: 95%; padding: 1px 10px'
-							),
-							esc_attr( $data['subscribe_placeholder'] ),
-							esc_attr( $data['subscribe_email'] ),
-							esc_attr( $email_field_id )
-						);
-						?>
-					</p>
-
-					<p id="subscribe-submit"
-						<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
-							style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
-						<?php endif; ?>
-					>
-						<input type="hidden" name="action" value="subscribe"/>
-						<input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
-						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
-						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
-						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
-						<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
-						<?php
-						if ( ! empty( $post_id ) ) {
-							echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
-						}
-						?>
-						<?php
-						if ( ! empty( $tier_id ) ) {
-							echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
-						}
-						?>
-						<button type="submit"
-							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
-							<?php endif; ?>
-							<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
-								style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
-							<?php endif; ?>
-						>
-							<?php
-							echo wp_kses(
-								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
-							);
-							?>
-						</button>
-					</p>
-				</div>
-			</form>
-			<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>
-				<div class="wp-block-jetpack-subscriptions__subscount">
-					<?php
-					echo esc_html( Jetpack_Memberships::get_join_others_text( $data['subscribers_total'] ) );
-					?>
-				</div>
-			<?php endif; ?>
-		</div>
-	</div>
-	<?php
-
-	return ob_get_clean();
-}
-
-/**
- * Renders the Jetpack version of the subscriptions block.
- *
- * @param array $data    Array containing block view data.
- * @param array $classes Array containing the classes for different block elements.
- * @param array $styles  Array containing the styles for different block elements.
- *
- * @return string
- */
-function render_jetpack_subscribe_form( $data, $classes, $styles ) {
-	$form_id            = sprintf( 'subscribe-blog-%s', $data['widget_id'] );
-	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field', $data['widget_id'] );
-
-	ob_start();
-
-	Jetpack_Subscriptions_Widget::render_widget_status_messages(
-		array(
-			'success_message' => $data['success_message'],
-		)
-	);
-
-	$blog_id           = \Jetpack_Options::get_option( 'id' );
-	$post_access_level = get_post_access_level_for_current_post();
-	$post_id           = get_the_ID();
-	$tier_id           = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
-
 	?>
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
 		<div class="jetpack_subscription_widget">
 			<div class="wp-block-jetpack-subscriptions__container">
-
 				<form
-					action="#"
+					action="<?php echo esc_url( $form_url ); ?>"
 					method="post"
 					accept-charset="utf-8"
 					data-blog="<?php echo esc_attr( $blog_id ); ?>"
@@ -779,22 +637,38 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 				>
 					<div class="wp-block-jetpack-subscriptions__form-elements">
 						<p id="subscribe-email">
-							<label id="jetpack-subscribe-label"
+							<label
+								id="<?php echo esc_attr( $subscribe_field_id . '-label' ); ?>"
+								for="<?php echo esc_attr( $subscribe_field_id ); ?>"
 								class="screen-reader-text"
-								for="<?php echo esc_attr( $subscribe_field_id . '-' . $data['widget_id'] ); ?>">
+							>
 								<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
 							</label>
-							<input type="email" name="email" required="required"
-								<?php if ( ! empty( $classes['email_field'] ) ) : ?>
-									class="<?php echo esc_attr( $classes['email_field'] ); ?> required"
-								<?php endif; ?>
-								<?php if ( ! empty( $styles['email_field'] ) ) : ?>
-									style="<?php echo esc_attr( $styles['email_field'] ); ?>"
-								<?php endif; ?>
-								value="<?php echo esc_attr( $data['subscribe_email'] ); ?>"
-								id="<?php echo esc_attr( $subscribe_field_id . '-' . $data['widget_id'] ); ?>"
-								placeholder="<?php echo esc_attr( $data['subscribe_placeholder'] ); ?>"
-							/>
+							<?php
+							printf(
+								'<input
+									required="required"
+									type="email"
+									name="email"
+									%1$s
+									style="%2$s"
+									placeholder="%3$s"
+									value="%4$s"
+									id="%5$s"
+								/>',
+								( ! empty( $classes['email_field'] )
+									? 'class="' . esc_attr( $classes['email_field'] ) . '"'
+									: ''
+								),
+								( ! empty( $styles['email_field'] )
+									? esc_attr( $styles['email_field'] )
+									: 'width: 95%; padding: 1px 10px'
+								),
+								esc_attr( $data['subscribe_placeholder'] ),
+								esc_attr( $data['subscribe_email'] ),
+								esc_attr( $subscribe_field_id )
+							);
+							?>
 						</p>
 
 						<p id="subscribe-submit"
@@ -808,18 +682,14 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 							<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
 							<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 							<?php
+							wp_nonce_field( 'blogsub_subscribe_' . $blog_id, '_wpnonce', false );
+
 							if ( ! empty( $post_id ) ) {
 								echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
 							}
-							?>
-							<?php
+
 							if ( ! empty( $tier_id ) ) {
 								echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
-							}
-							?>
-							<?php
-							if ( is_user_logged_in() ) {
-								wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
 							}
 							?>
 							<button type="submit"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -608,7 +608,7 @@ function get_post_access_level_for_current_post() {
  * @return string
  */
 function render_for_website( $data, $classes, $styles ) {
-	$blog_id            = get_current_blog_id();
+	$blog_id            = \Jetpack_Options::get_option( 'id' );
 	$form_id            = 'subscribe-blog-' . $data['widget_id'];
 	$form_url           = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '#';
 	$post_access_level  = get_post_access_level_for_current_post();

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -762,8 +762,8 @@ class Jetpack_Subscriptions {
 	 */
 	public function widget_submit() {
 		// Check the nonce.
-		if ( is_user_logged_in() ) {
-			check_admin_referer( 'blogsub_subscribe_' . get_current_blog_id() );
+		if ( ! wp_verify_nonce( 'blogsub_subscribe_' . \Jetpack_Options::get_option( 'id' ) ) ) {
+			return false;
 		}
 
 		if ( empty( $_REQUEST['email'] ) || ! is_string( $_REQUEST['email'] ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Block rendering was done in two separate functions for Jetpack and WP.com sites, although the rendering seemed identical at both with minor differences. Combining rendering into one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test:

*  Subscribe block on WP.com simple
*  Subscribe block on Jetpack self hosted
* Subscribe widget
