### PR TITLE
custom-css: PHP Rector updates (scss)

### DIFF
--- a/projects/plugins/jetpack/changelog/scss-rector-updates
+++ b/projects/plugins/jetpack/changelog/scss-rector-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+custom-css: Upgrades for PHP 8 (scss)

--- a/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/scss.inc.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/scss.inc.php
@@ -149,7 +149,7 @@ class scssc {
 			return;
 		}
 
-		$i = count($this->extends);
+		$i = is_countable( $this->extends ) ? count( $this->extends ) : 0;
 		$this->extends[] = array($target, $origin);
 
 		foreach ($target as $part) {
@@ -208,7 +208,9 @@ class scssc {
 					}
 				}
 
-				$origin[$j][count($origin[$j]) - 1] = $this->combineSelectorSingle(end($new), $rem);
+				if ( is_countable( $origin[$j] ) ) {
+					$origin[$j][count($origin[$j]) - 1] = $this->combineSelectorSingle(end($new), $rem);
+				}
 			}
 
 			$outOrigin = array_merge($outOrigin, $origin);
@@ -273,7 +275,7 @@ class scssc {
 					$this->matchExtends($result, $out, $i, false);
 
 					// selector sequence merging
-					if (!empty($before) && count($new) > 1) {
+					if ( ! empty($before) && is_countable( $new ) && count($new) > 1) {
 						$result2 = array_merge(
 							array_slice($new, 0, -1),
 							$k > 0 ? array_slice($before, $k) : $before,
@@ -565,7 +567,7 @@ class scssc {
 		}
 		$m1 = '';
 		$t1 = '';
-		if (count($type1) > 1) {
+		if ( is_countable( $type1 ) && count($type1) > 1 ) {
 			$m1= strtolower($type1[0]);
 			$t1= strtolower($type1[1]);
 		} else {
@@ -573,7 +575,7 @@ class scssc {
 		}
 		$m2 = '';
 		$t2 = '';
-		if (count($type2) > 1) {
+		if ( is_countable( $type2 ) && count($type2) > 1 ) {
 			$m2 = strtolower($type2[0]);
 			$t2 = strtolower($type2[1]);
 		} else {
@@ -612,7 +614,9 @@ class scssc {
 		}
 		if ($rawPath[0] == "list") {
 			// handle a list of strings
-			if (count($rawPath[2]) == 0) return false;
+			if ( ! is_countable( $rawPath[2] ) || count($rawPath[2]) == 0 ) {
+				return false;
+			}
 			foreach ($rawPath[2] as $path) {
 				if ($path[0] != "string") return false;
 			}
@@ -1247,7 +1251,7 @@ class scssc {
 			$g = round($g);
 			$b = round($b);
 
-			if (count($value) == 5 && $value[4] != 1) { // rgba
+			if ( is_countable( $value ) && count($value) == 5 && $value[4] != 1 ) { // rgba
 				return 'rgba('.$r.', '.$g.', '.$b.', '.$value[4].')';
 			}
 
@@ -1283,10 +1287,10 @@ class scssc {
 			list(, $interpolate, $left, $right) = $value;
 			list(,, $whiteLeft, $whiteRight) = $interpolate;
 
-			$left = count($left[2]) > 0 ?
+			$left = is_countable( $left[2] ) && count($left[2]) > 0 ?
 				$this->compileValue($left).$whiteLeft : "";
 
-			$right = count($right[2]) > 0 ?
+			$right = is_countable( $right[2] ) && count($right[2]) > 0 ?
 				$whiteRight.$this->compileValue($right) : "";
 
 			return $left.$this->compileValue($interpolate).$right;
@@ -1876,7 +1880,7 @@ class scssc {
 				$h = 60 * ($green - $blue) / $d;
 			elseif ($green == $max)
 				$h = 60 * ($blue - $red) / $d + 120;
-			elseif ($blue == $max)
+			else
 				$h = 60 * ($red - $green) / $d + 240;
 		}
 
@@ -2364,7 +2368,7 @@ class scssc {
 	protected static $lib_length = array("list");
 	protected function lib_length($args) {
 		$list = $this->coerceList($args[0]);
-		return count($list[2]);
+		return is_countable( $list[2] ) ? count($list[2]) : 0;
 	}
 
 	protected static $lib_nth = array("list", "n");
@@ -2698,11 +2702,11 @@ class scss_parser {
 		$this->rootParser = $rootParser;
 
 		if (empty(self::$operatorStr)) {
-			self::$operatorStr = $this->makeOperatorStr(self::$operators);
+			self::$operatorStr = static::makeOperatorStr(self::$operators);
 
-			$commentSingle = $this->preg_quote(self::$commentSingle);
-			$commentMultiLeft = $this->preg_quote(self::$commentMultiLeft);
-			$commentMultiRight = $this->preg_quote(self::$commentMultiRight);
+			$commentSingle = static::preg_quote(self::$commentSingle);
+			$commentMultiLeft = static::preg_quote(self::$commentMultiLeft);
+			$commentMultiRight = static::preg_quote(self::$commentMultiRight);
 			self::$commentMulti = $commentMultiLeft.'.*?'.$commentMultiRight;
 			self::$whitePattern = '/'.$commentSingle.'[^\n]*\s*|('.self::$commentMulti.')\s*|\s+/Ais';
 		}
@@ -3092,7 +3096,7 @@ class scss_parser {
 			return true;
 		}
 
-		if ($def[0] == "list") {
+		if ( $def[0] == "list" && is_countable( $value[2] ) ) {
 			return $this->stripDefault($value[2][count($value[2]) - 1]);
 		}
 
@@ -3115,7 +3119,7 @@ class scss_parser {
 			}
 		}
 
-		return $this->match($this->preg_quote($what), $m, $eatWhitespace);
+		return $this->match( static::preg_quote($what), $m, $eatWhitespace );
 	}
 
 	// tree builders
@@ -3158,9 +3162,11 @@ class scss_parser {
 
 	// last child that was appended
 	protected function last() {
-		$i = count($this->env->children) - 1;
-		if (isset($this->env->children[$i]))
-			return $this->env->children[$i];
+		if ( is_countable( $this->env->children ) ) {
+			$i = count($this->env->children) - 1;
+			if (isset($this->env->children[$i]))
+				return $this->env->children[$i];
+		}
 	}
 
 	// high level parsers (they return parts of ast)
@@ -3266,6 +3272,7 @@ class scss_parser {
 	}
 
 	protected function genericList(&$out, $parseItem, $delim="", $flatten=true) {
+		$value = null; // output param; init for rector
 		$s = $this->seek();
 		$items = array();
 		while ($this->$parseItem($value)) {
@@ -4030,7 +4037,7 @@ class scss_parser {
 		} else {
 			$validChars = $allowNewline ? "." : "[^\n]";
 		}
-		if (!$this->match('('.$validChars.'*?)'.$this->preg_quote($what), $m, !$until)) return false;
+		if (!$this->match('('.$validChars.'*?)' . static::preg_quote($what), $m, !$until)) return false;
 		if ($until) $this->count -= strlen($what); // give back $what
 		$out = $m[1];
 		return true;
@@ -4157,7 +4164,7 @@ class scss_parser {
 
 	// turn list of length 1 into value type
 	protected function flattenList($value) {
-		if ($value[0] == "list" && count($value[2]) == 1) {
+		if ($value[0] == "list" && is_countable( $value[2] ) && count($value[2]) == 1) {
 			return $this->flattenList($value[2][0]);
 		}
 		return $value;
@@ -4299,7 +4306,8 @@ class scss_formatter_nested extends scss_formatter {
 		foreach ($block->children as $i => $child) {
 			// echo "*** block: ".$block->depth." child: ".$child->depth."\n";
 			$this->block($child);
-			if ($i < count($block->children) - 1) {
+			$children_count = is_countable( $block->children ) ? count( $block->children ) : 0;
+			if ($i < $children_count - 1) {
 				echo $this->break;
 
 				if (isset($block->children[$i + 1])) {


### PR DESCRIPTION
## Proposed changes:

* Updated php rector issues for `custom-css/custom-css/preprocessors/scss.inc.php` for our php8 migration rector repo ( see: 32481-pb/#js ) 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Copy to sandbox
```
scp ./projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/scss.inc.php wpcom-sandbox:public_html/./wp-content/mu-plugins/jetpack-plugin/sun/modules/custom-css/custom-css/preprocessors/scss.inc.php
scp ./projects/plugins/jetpack/modules/custom-css/custom-css/preprocessors/scss.inc.php wpcom-sandbox:public_html/./wp-content/mu-plugins/jetpack-plugin/moon/modules/custom-css/custom-css/preprocessors/scss.inc.php
```
* Have a simple site with personal plan or better
* Go to customizer -> additional css
* Add this css
```
// Variables
$primary-bg-color: #f4f4f4;
$secondary-bg-color: #4CAF50;
$text-color: #333;

// Mixin for text styling
@mixin text-styling($size, $color: $text-color) {
  font-size: $size;
  color: $color;
}

// Global styles to check if SCSS is working
body {
  background-color: $primary-bg-color;
  @include text-styling(16px);
}

h1 {
  @include text-styling(36px, #ff0000);
}

// Nested Rules
.container {
  width: 100%;
  padding: 15px;
  background-color: $secondary-bg-color;
  @include text-styling(18px, white);

  .box {
    width: 50%;
    margin: 10px auto;
    padding: 10px;
    background-color: white;
    border: 1px solid $secondary-bg-color;

    h2 {
      @include text-styling(24px, $secondary-bg-color);
    }
  }
}
```
* Change preprocessor to SCSS
* Save
* The site should now have a gray background with large text
![2023-10-26_15-05](https://github.com/Automattic/jetpack/assets/937354/7b267567-85a2-4fe5-befc-f03f92f7b332)


