### PR TITLE
Revert "Backport mu-wpcom-plugin 1.7.5, Jetpack 12.8-a.9 Changes"

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
-## [0.44.2] - 2023-10-30
-### Changed
-- Social: Update Nextdoor icon styling so it's round. [#33834]
-
 ## [0.44.1] - 2023-10-23
 ### Changed
 - Use pointer-events: None on arrow icon so its click behavior falls back to the container/underlying component. [#33733]
@@ -864,7 +860,6 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
-[0.44.2]: https://github.com/Automattic/jetpack-components/compare/0.44.1...0.44.2
 [0.44.1]: https://github.com/Automattic/jetpack-components/compare/0.44.0...0.44.1
 [0.44.0]: https://github.com/Automattic/jetpack-components/compare/0.43.4...0.44.0
 [0.43.4]: https://github.com/Automattic/jetpack-components/compare/0.43.3...0.43.4

--- a/projects/js-packages/components/changelog/update-nextdoor-connection-icon
+++ b/projects/js-packages/components/changelog/update-nextdoor-connection-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: Update Nextdoor icon styling so it's round.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.44.2",
+	"version": "0.44.2-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,10 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.24] - 2023-10-30
-### Fixed
-- Handle Akismet submenu even if Jetpack is present, as Jetpack now relies on this package to do so. [#33559]
-
 ## [0.2.23] - 2023-09-19
 ### Changed
 - Updated Jetpack submenu sort order so individual features are alpha-sorted. [#32958]
@@ -124,7 +120,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
-[0.2.24]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.23...0.2.24
 [0.2.23]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.22...0.2.23
 [0.2.22]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.21...0.2.22
 [0.2.21]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.20...0.2.21

--- a/projects/packages/admin-ui/changelog/fix-jetpack-anti-spam
+++ b/projects/packages/admin-ui/changelog/fix-jetpack-anti-spam
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Handle Akismet submenu even if Jetpack is present, as Jetpack now relies on this package to do so.

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.2.24",
+	"version": "0.2.24-alpha",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.2.24';
+	const PACKAGE_VERSION = '0.2.24-alpha';
 
 	/**
 	 * Whether this class has been initialized

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,13 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.16.0] - 2023-10-30
-### Added
-- Add launchpad checklist for host-site intent. [#33698]
-
-### Fixed
-- Disable fullscreen launchpad when completing the site_launched task. [#33819]
-
 ## [4.15.1] - 2023-10-26
 ### Changed
 - Coming Soon feature: Be more defensive when checking for meta data. [#33769]
@@ -410,7 +403,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
-[4.16.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.15.1...v4.16.0
 [4.15.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.15.0...v4.15.1
 [4.15.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.14.0...v4.15.0
 [4.14.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.13.0...v4.14.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-host-site-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-host-site-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add launchpad checklist for host-site intent

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-flashing-fullscreen-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-flashing-fullscreen-launchpad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Disable fullscreen launchpad when completing the site_launched task

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.16.0",
+	"version": "4.16.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.16.0';
+	const PACKAGE_VERSION = '4.16.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,10 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.11.0] - 2023-10-30
-### Added
-- Add site data to unpurchased state of VaultPress Backup card to My Jetpack. [#33607]
-
 ## [3.10.0] - 2023-10-23
 ### Added
 - Add jetpack-plans dependency. It will be use to restore the reverted change on #33410. [#33706]
@@ -1083,7 +1079,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
-[3.11.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.10.0...3.11.0
 [3.10.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.9.1...3.10.0
 [3.9.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.9.0...3.9.1
 [3.9.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.8.2...3.9.0

--- a/projects/packages/my-jetpack/changelog/update-unpurchased-backup-card-state-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-unpurchased-backup-card-state-my-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add site data to unpurchased state of VaultPress Backup card to My Jetpack

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.11.0",
+	"version": "3.11.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.11.0';
+	const PACKAGE_VERSION = '3.11.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,10 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.39.4] - 2023-10-30
-### Changed
-- Instant Search: rely on browsers' native lazy loading functionality when we want to lazy load images. [#33817]
-
 ## [0.39.3] - 2023-10-23
 ### Changed
 - Updated package dependencies. [#33646] [#33687]
@@ -830,7 +826,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
-[0.39.4]: https://github.com/Automattic/jetpack-search/compare/v0.39.3...v0.39.4
 [0.39.3]: https://github.com/Automattic/jetpack-search/compare/v0.39.2...v0.39.3
 [0.39.2]: https://github.com/Automattic/jetpack-search/compare/v0.39.1...v0.39.2
 [0.39.1]: https://github.com/Automattic/jetpack-search/compare/v0.39.0...v0.39.1

--- a/projects/packages/search/changelog/update-instant-search-lazy-images
+++ b/projects/packages/search/changelog/update-instant-search-lazy-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Instant Search: rely on browsers' native lazy loading functionality when we want to lazy load images.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.39.4",
+	"version": "0.39.4-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.39.4';
+	const VERSION = '0.39.4-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,12 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.19.2] - 2023-10-30
-### Fixed
-- VideoPress: Add ThemeProvider to Dropdown and Popover components. [#33825]
-
 ## [0.19.1] - 2023-10-24
-
 - Updated package dependencies.
 
 ## [0.19.0] - 2023-10-23
@@ -1166,7 +1161,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
-[0.19.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.17.6...v0.18.0

--- a/projects/packages/videopress/changelog/fix-videopress-dropdown-popover-gutenberg
+++ b/projects/packages/videopress/changelog/fix-videopress-dropdown-popover-gutenberg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Add ThemeProvider to Dropdown and Popover components

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.19.2",
+	"version": "0.19.2-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.19.2';
+	const PACKAGE_VERSION = '0.19.2-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.14] - 2023-10-30
-
 ## [0.11.13] - 2023-10-10
 ### Fixed
 - Escape email address when output in HTML. [#33536]
@@ -237,7 +235,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
-[0.11.14]: https://github.com/Automattic/jetpack-waf/compare/v0.11.13...v0.11.14
 [0.11.13]: https://github.com/Automattic/jetpack-waf/compare/v0.11.12...v0.11.13
 [0.11.12]: https://github.com/Automattic/jetpack-waf/compare/v0.11.11...v0.11.12
 [0.11.11]: https://github.com/Automattic/jetpack-waf/compare/v0.11.10...v0.11.11

--- a/projects/packages/waf/changelog/fix-flakey-waf-test
+++ b/projects/packages/waf/changelog/fix-flakey-waf-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed unit test.
+
+

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,25 +2,6 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 12.8-a.9 - 2023-10-30
-### Enhancements
-- Earn: Rename Earn to Monetize. [#33741]
-- Jetpack AI: Cache the AI assistant feature data for Jetpack sites. [#33391]
-- Jetpack AI: Expose current plan tier information on feature endpoint. [#33820]
-- Jetpack Dashboard: improve Akismet tooltip. [#33547]
-- Paywall: Improve already subscriber experience. [#33763]
-- Subscription block: Improve wording to get access to content. [#33835]
-- Utilize the Jetpack Admin UI package for handling the Akismet menu. [#33559]
-
-### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
-- Add subscribers auth endpoint. [#33815]
-- Dashboard / My Plan: update the link to licensing management for a better UX in the My Plan header. [#33813]
-- Dashboard: Remove link to "My Jetpack". [#33811]
-- Fix bug tier selector. [#33838]
-- Updated package dependencies. [#33821] [#33826]
-- Update lockfile. [#33607]
-- scssphp: Upgrade from 0.0.9 to 0.0.12. [#33822]
-
 ## 12.8-a.7 - 2023-10-26
 ### Enhancements
 - Add a filter that allows disabling Scan module. [#33764]

--- a/projects/plugins/jetpack/changelog/add-fix-issue-with-tier-selector
+++ b/projects/plugins/jetpack/changelog/add-fix-issue-with-tier-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+fix bug tier selector

--- a/projects/plugins/jetpack/changelog/add-modal-mixed-approach
+++ b/projects/plugins/jetpack/changelog/add-modal-mixed-approach
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscription block. Improve wording to get access to content.

--- a/projects/plugins/jetpack/changelog/add-subscribers-auth-endpoint-2
+++ b/projects/plugins/jetpack/changelog/add-subscribers-auth-endpoint-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add subscribers auth endpoint

--- a/projects/plugins/jetpack/changelog/fix-jetpack-dashboard-akismet-tooltip
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-dashboard-akismet-tooltip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack Dashboard: improve Akismet tooltip

--- a/projects/plugins/jetpack/changelog/fix-site-settings-php8-fatals
+++ b/projects/plugins/jetpack/changelog/fix-site-settings-php8-fatals
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: WordPress.com REST API: fix potential fatal error in API call to system running PHP8.
+
+

--- a/projects/plugins/jetpack/changelog/renovate-allure-playwright-2.x
+++ b/projects/plugins/jetpack/changelog/renovate-allure-playwright-2.x
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-playwright-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-playwright-monorepo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/rm-my-jetpack-react-dashboard
+++ b/projects/plugins/jetpack/changelog/rm-my-jetpack-react-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: remove link to "My Jetpack"

--- a/projects/plugins/jetpack/changelog/update-cache-ai-assistant-feature-data
+++ b/projects/plugins/jetpack/changelog/update-cache-ai-assistant-feature-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: cache the AI assistant feature data for Jetpack sites

--- a/projects/plugins/jetpack/changelog/update-dedupe-antispam
+++ b/projects/plugins/jetpack/changelog/update-dedupe-antispam
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Utilize the Jetpack Admin UI package for handling the Akismet menu

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-add-current-tier-plan-information
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-add-current-tier-plan-information
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: expose current plan tier information on feature endpoint.

--- a/projects/plugins/jetpack/changelog/update-licensing-link-my-plan-header
+++ b/projects/plugins/jetpack/changelog/update-licensing-link-my-plan-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard / My Plan: update the link to licensing management for a better UX in the My Plan header.

--- a/projects/plugins/jetpack/changelog/update-paywall-login-link-3
+++ b/projects/plugins/jetpack/changelog/update-paywall-login-link-3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Paywall: improve already subscriber experience

--- a/projects/plugins/jetpack/changelog/update-rename-earn-to-monetize
+++ b/projects/plugins/jetpack/changelog/update-rename-earn-to-monetize
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Earn: Rename Earn to Monetize

--- a/projects/plugins/jetpack/changelog/update-unpurchased-backup-card-state-my-jetpack
+++ b/projects/plugins/jetpack/changelog/update-unpurchased-backup-card-state-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update lockfile

--- a/projects/plugins/jetpack/changelog/upgrade-scssphp
+++ b/projects/plugins/jetpack/changelog/upgrade-scssphp
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+scssphp: Upgrade from 0.0.9 to 0.0.12

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_10",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.8-a.10
+ * Version: 12.8-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.8-a.10' );
+define( 'JETPACK__VERSION', '12.8-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.8.0-a.10",
+	"version": "12.8.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -291,86 +291,71 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 12.8-a.9 - 2023-10-30
+### 12.7 - 2023-10-12
 #### Enhancements
-- Add a filter that allows disabling Scan module.
-- Adds new modifications for the admin menu on Atomic sites that ensures that all links go to wp-admin except those that are only available in Calypso.
-- Add support for welcome message inside WP Admin.
-- AI Assistant: Add scaffolding for the Usage Panel.
-- AI Assistant: Add strikethrough Markdown syntax to Markdown generator.
-- AI Assistant: Add Upgrade button component on the UsagePanel.
-- AI Assistant: Add UsageBar component and add a sample of it to the Usage Panel.
-- AI Assistant: Connect real usage data on the UsagePanel.
-- AI Assistant: Enable backend prompts for 50% of production sites.
-- AI Assistant: Enable backend prompts for 100% of production sites.
-- AI Assistant: Enhance toolbar UX.
-- AI Assistant: Register ai-assistant-usage-panel beta extension.
-- AI Extension: Change the filter to populate the Jetpack Form block with AI components.
-- AI Extension: Consolidate upgrade section of proofread and usage sections.
-- AI Extension: Do not skip React hook instances.
-- AI Extension: Enable Form extension inside query loops.
-- AI Extension: Implement usage message in the UsageBar component.
-- AI Extension: Improve info message when selected blocks don't have content to modify.
-- AI Extension: Show "no content" notice when the extended block content is empty.
-- AI Extension: Use registerBlockType filter to extend Jetpack Form / children block instances.
-- AI Extension: Use registerBlockType to connect components with AI Data and UI Handler.
-- Allow users to retrieve subscriptions on self-hosted.
-- Alter the admin toolbar when the wpcom-admin-interface setting is set to wp-admin (fall back to the original WordPress menu).
-- Change links for 'Appearance > Themes' on Atomic sites with wpcom_admin_interface option set to wp-admin to point to WP.com Marketplace.
-- Earn: Rename Earn to Monetize.
-- Jetpack: Add @wordpress/wordcount dependency.
-- Jetpack: Add UsagePanel story.
-- Jetpack: Handle Proofread feature availability via jetpack_ai_enabled filter.
-- Jetpack: Improve process to extend paid blocks with upgrade banner.
-- Jetpack AI: Cache the AI assistant feature data for Jetpack sites.
-- Jetpack AI: Expose current period usage data on feature endpoint.
-- Jetpack AI: Expose current plan tier information on feature endpoint.
-- Jetpack Dashboard: improve Akismet tooltip.
-- Link plugins to WP.com Marketplace on Atomic sites.
-- Metered billing: Hide usage bar when site has AI plan.
-- Paywall: Improve already subscriber experience.
-- Register WordAds block earlier to make it more discoverable.
-- Remove Jetpack option jetpack-memberships-connected-account-id.
-- SEO Title & Description - Display the current nucount of characters, even when over the suggested limit.
-- Sitemaps: Update the colors used on the sitemap page to match updated Jetpack branding colors.
-- Subscribers: Allow admins to see subscribe modal.
-- Subscription block: Improve wording to get access to content.
-- Subscriptions: Do not display token in URL.
-- Utilize the Jetpack Admin UI package for handling the Akismet menu.
+- Added a new post publish panel for quick sharing.
+- AI Assistant: Modify language reminder for toolbar options.
+- AI Assistant: Start using backend to generate the prompts.
+- AI Assistant: Update block description.
+- AI Chat: Enhanced error presentation and UX improvements. [#33387]
+- AI Chat: Fix feedback section styles and include svg for icons.
+- AI Chat: Show guideline message.
+- AI Excerpt: Add `Beta` label to sidebar panel.
+- AI Excerpt: disable `Generate` button when there's no post content.
+- AI Extension: Add keyboard shortcut to stop action on forms.
+- AI Extension: Show AI Form extension with connection nudge for disconnected users.
+- AI Search Block: release the Jetpack AI Search Block.
+- Block Editor: add a new post publish panel for quick sharing.
+- Block Editor: display the SEO and Sharing editor panels in the block editor under the Jetpack side menu. [#33258]
+- Blogroll: Add blog appender site searching.
+- Blogroll: Disable blogroll appender sites that have been added to blogroll block.
+- Blogroll: Fix blogroll block typography editor styling.
+- Blogroll: move blogroll and blogroll-items blocks from beta to production, along with various improvements. [#33475]
+- Blogroll: Update blogroll appender height, max lines of text, and container scrolling.
+- Blogroll: Update CSS styling to allow blogroll block color styling customizations.
+- Blogroll Block: Add the ability to subscribe to recommended blogs.
+- Blogroll Block: Update blogroll appender styling and functionality.
+- Fix styling of multiple elements in the ai-chat block.
+- Improves the blogroll subscribe form alignment.
+- Jetpack Likes: display the Likes editor panel with an invitation to activate the feature when it is disabled.
+- Newsletter: launch the ability to create tiered newsletter plans.
+- Paywall: add a filter to define a custom paywall.
+- Paywall Block: Update description.
+- Sharing: add X sharing button.
+- Sidebar: Rename the "Inbox" menu to "My Mailboxes" for domain-only sites.
+- Social Menu & Social Media Icons: Add support for the X icon.
+- SSO: offer ability to force a site to use Jetpack SSO with Two-Factor Authentication for certain roles.
+- Subscription block: drop unnecessary .0 from big subscriber counts.
+- Update Blogroll appender accessibility.
 
 #### Improved compatibility
-- Connection: added protection for wpcom urls stored in the database during identity crisis.
-- Donations Block: Update to be compatible with the upcoming version of WordPress, 6.4.
-- General: Indicate full compatibility with the latest version of WordPress, 6.4.
-- Lazy Images: Remove the feature from the plugin. You can now rely on WordPress' own Lazy Image features on your site.
-- Make the jetpack_ai_enabled filter decide whether to register AI editor extensions.
-- Memberships: Prevent data to be retrieved from cache sites on WP.com.
-- Social: Remove the tweetstorm editor components.
+- Admin menu: Update view capabilities for Home & Stats to be independant from edit_posts.
+- AI Chat block: fix icon color in block selector.
+- Improve color handling for the newsletter categories.
+- Lazy Images: prepare feature for its deprecation, coming in November. You will be able to rely on Lazy loading features provided by WordPress itself.
+- Notifications: temporarily disable the notifications admin bar menu on any block editor page to allow for Gutenberg 16.7 compatability.
 
 #### Bug fixes
-- AI Assistant: Fix issue when getting AI assistant block instance.
-- AI Extension: Fix undefined 'disabled' I18nMenuDropdown prop bug.
-- AI Extension: Improve performance bug when extending blocks with AI Assistant.
-- Block Editor: Disable some of Twitter's Thread publishing tools since the feature is no longer accessible.
-- Blogging prompts block: Add default gravatar attribute to prevent js error.
-- Carousel: Resolve warning with AMP plugin.
-- Do not list one-time interval payment plans as newsletter plans.
-- Fix block paid icon rendering error on simple sites.
-- Fixed a bug that prevent customers from downloading invoices from the my account page in WooCommerce.
-- Fix issue when email was double encoded.
-- Fix Map block not rendering.
-- Fix missing block translations.
-- Fix the google fonts module is not loaded after the late initialization.
-- Jetpack: Fix performance issues by not calling useAnalytics hook for all paragraphs.
-- Newsletter: If site has no plan, downgrade post access to subscribers-only.
-- Prevent issue on jetpack proxy when tier is added.
-- Require login on wpcom for paid content access without cookie or token.
-- REST API: Fix GA settings field, wga, for settings endpoints on API version 1.3 and 1.4.
-- REST API settings endpoint: Fix google analytics option handling for Jetpack sites.
-- Subscribe modal: Match block markup with params.
-- The Google Photos media inserter only checks for the connection status when needed.
-- VideoPress: Avoid performance issues by calling useEffect for every block on typing.
-- YouTube embeds: Avoid errors when opening YouTube in a new window from a YouTube embed.
+- AI Assistant: do not register the editor plugin if the site is not connected to WordPress.com.
+- AI Chat: Remove extra request in $search->is_active() and only load initial state in editor.
+- AI Chat block: fix text wrapping in button for Firefox.
+- AI Excerpts: avoid errors on Custom Post Types that do not support excerpts.
+- AI Extension: Revert PR causing stream rendering issue on Firefox.
+- Block Editor: update the Likes and Sharing copy in the Jetpack menu to address grammatical mistake.
+- Carousel: avoid invalid markup notices in Google Pagespeed insights.
+- Dashboard: Avoid errors when dashboard is accessed by WordPress users with a custom non-admin role.
+- Dashboard: avoid errors when dashboard is accessed by WordPress users with a custom non-admin role.
+- Dashboard: do not display Apps and Support cards to users who do not need that information.
+- External Media: do not surface the endpoint to contributors, are unable to upload media anyway.
+- Fix menu focus state without My Jetpack.
+- Fix subscribe block button not showing on newline.
+- Google Doc block: fix Google Doc blocks not rendering in the editor.
+- Hide launchpad modal on first post for bloggers.
+- Shortcodes: improve validation of attributes dislayed with the Crowdsignal shortcode.
+- Site Editor: Fix block exception error in Site Editor.
+- Skip video file addition to upload queue if it fails the space/allowance check.
+- Subscriptions: Fix conditions for showing modal.
+- Subscriptions module: fix fatal error caused by undefined constant.
 
 --------
 

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -1,71 +1,9 @@
-## Jetpack 12.8
+## Jetpack 12.7
 
 ### Before you start:
 
 - **At any point during your testing, remember to [check your browser's JavaScript console](https://wordpress.org/support/article/using-your-browser-to-diagnose-javascript-errors/#step-3-diagnosis) and see if there are any errors reported by Jetpack there.**
 - Use the "Debug Bar" or "Query Monitor" WordPress plugins to help make PHP notices and warnings more noticeable and report anything of note you see.
-
-### AI Assistant
-
-[Beta extension]
-- Inside the editor, click the 'Jetpack' icon and open the 'AI Assistant' section.
-- There should be a usage meter indicating how many requests you've used.
-- Add/use an AI block, save the post/draft, and refresh the page.
-- The usage counter should increase.
-- If you're not on an AI plan, a visual usage bar should be shown along with an 'Upgrade' button.
-- Clicking the 'Upgrade' button should take you to the appropriate upgrade page.
-- After completing the flow and purchasing the upgrade, you should no longer see the visual usage indicator or the upgrade button. Instead a message should be displayed about you having unlimited requests.
-
-AI Extensions are now disabled for empty blocks preventing unnecessary requests.
-
-- Add an empty paragraph block. Adding a few spaces will work too.
-- Click the AI Extension button on the block toolbar.
-- There should be a notice indicating you need to add content before the options become enabled.
-
-You can use the new `jetpack_ai_enabled` filter to register the plugin.
-
-- Add the following filter to your site: `add_filter( 'jetpack_ai_enabled', '__return_false' );`.
-- AI features should now become unavailable on your site.
-
-### SEO/Sharing
-
-Character counts for SEO Title and SEO Description are now also displayed when over limit, instead of just getting a warning message.
-
-- Edit a post.
-- In the editor, click the 'Jetpack' icon and expand the 'SEO' section.
-- Click 'Activate Jetpack SEO' button if not already activated.
-- Type into the 'SEO Title' field.
-- Once you go past 70 characters, ensure you continue to see the current character count at the end '(xx used)', in addition to the warning.
-- Verify the same is true for 'SEO Description'.
-
-### Subscriptions
-
-Site administrators can now see the subscribe modal/popup for demo/debugging purposes.
-
-- Go to Jetpack > Settings > Newsletters and ensure the subscriber modal is enabled.
-- While logged in as an admin, go to a frontend post without a paywall or limited access, scroll, and confirm the modal loads.
-
-Not logged users shoudl see a 'retrieve subscriptions' link. [33656]
-
-### WordAds
-
-You should now be able to use Ad block before the module is enabled.
-
-- Navigate to `/wp-admin/admin.php?page=jetpack_modules` and make sure the Ads module is disabled.
-- Make sure you don't have a plan that supports Ads.
-- Create a new post.
-- You should not see the Ad block in the blocks inserter.
-- Purchase the 'Jetpack Complete' plan but make sure the Ads module remains disabled.
-- Create a new post. You should now see the Ad block in the inserter.
-- Add the Ad block to your post. It should contain an 'Activate WordAds' button.
-- Activate the module and check that the form works as expected.
-
-### Scan
-
-The scan module can now be disabled using a dedicated filter.
-
-- Add the following filter to your site: `add_filter( 'jetpack_disable_scan', '__return_true' );`.
-- Scan module should be distabled on your site.
 
 ### Add additional properties to WooCommerce analytics checkout and purchase events
 
@@ -106,6 +44,57 @@ The scan module can now be disabled using a dedicated filter.
 - Go to the Checkout page (Pages -> Checkout) and add extra blocks to the Checkout page.
 - Go to the Checkout block and ensure the additional blocks you added are in the `additional_blocks` property.
 - Change the checkout page to use the shortcode (`[woocommerce_checkout]`) and repeat these steps. Ensure the correct value is tracked for each event. **Note that the `checkout_page_contains_cart_shortcode` property is stored in a transient so this will be incorrect if changing, but it has been tested in another PR and is known to be working.**
+
+
+### SEO Tools/Sharing Sidebar
+
+There are some new options in the Jetpack sidebar in the block editor. To test:
+
+- Go to Posts > Add New.
+- Click on the Jetpack plugin sidebar.
+- Click on the "SEO" panel title.
+- Click on the button.
+- Verify that the module is enabled and working as expected.
+- Click on the "Likes and Sharing" panel title.
+- Click on the button.
+- Verify that the module is enabled and working as expected.
+
+### Jetpack AI Search Block
+
+We've launched and AI Search block, moving it from beta to production! To test, create a new post and add the AI Chat bot. Play around with the block and the sidebar settings and make sure things work in the editor and on the front end.
+
+## Known Issues:
+
+- Button styling can be improved.
+- It can sometimes be very slow.
+- The search can be very hit or miss depending on keywords used in the question.
+- It can only chat with posts & pages reliably. Products are harder to find.
+
+### New Quick Share Options
+
+We've added the quick-share options to the block editor panel. To test:
+
+* Open up a new post, there should not be anything new.
+* After publishing you should see the new Quick share Button if our panel is open
+* Clicking the icon should open the Quick share dropdown
+* Clicking on any of the icons there should work
+* Clicking the learn more on the dropdown should open the help modal and close the dropdown.
+
+### Add Forced 2FA Functionality when SSO is enabled
+
+We have a new filter that will allow someone to force 2FA to be enabled when SSO is also enabled. There's no UI for this yet, but it would be good to do some functionality testing. To do so:
+
+* Jetpack connnected + SSO enabled.
+* Connect an account that does not have 2fa enabled to the Jetpack site (either cycle the connection or make a new admin user connected to a non-2fa WP.com account.)
+* Create a new user with subscriber or contributor role.
+* Log out and log back into admin account with regular WP creds (not SSO) This should work.
+* Enable flag via `add_filter( 'jetpack_force_2fa', '__return_true' );`
+* Log out and log back in with regular WP creds. It should fail.
+* Log in with WP.com SSO with an account that has 2fa enabled. It should work.
+* Log out and login with the non-2fa WP.com account via SSO. It should fail.
+* Add a filter to modify the cap, e.g. `add_filter( 'jetpack_force_2fa_cap, function() { return 'read' } );`
+* Verify that the contributor forces SSO.
+
 
 ### And More!
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.7.5 - 2023-10-30
-
 ## 1.7.4 - 2023-10-26
 
 ## 1.7.3 - 2023-10-24

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-host-site-tasks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-host-site-tasks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-flashing-fullscreen-launchpad
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-flashing-fullscreen-launchpad
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_5"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_5_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.7.5
+ * Version: 1.7.5-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.7.5",
+	"version": "1.7.5-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
Reverts Automattic/jetpack#33866 .

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Build shouldn't fail.

