### PR TITLE
Launchpad: Fix/plan completed task path

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-plan-completed-task-path
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-plan-completed-task-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Clicking on a the Chosse a plan task would not redirect to the plans page

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -90,7 +90,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$flow = get_option( 'site_intent' );
-				return '/setup/' . $flow . '/plans/?siteSlug=' . $data['site_slug_encoded'];
+				return '/setup/' . $flow . '/plans?siteSlug=' . $data['site_slug_encoded'];
 			},
 		),
 		'plan_selected'                   => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

More context: p1698701024528039-slack-C02FMH4G8

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ian noticed a problem clicking on the "Choose a plan" task, which wouldn't redirect the users to the plan page correctly. The user would be stuck on a white screen. 
* I noticed the problem was being caused due to a slash at the end of the plans' path.

``` php
return '/setup/' . $flow . '/plans/?siteSlug=' . $data['site_slug_encoded'];
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox
```sh
bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/plan-completed-task-path
```
* Make sure you are sandboxed
* On an incognito tab, navigate to https://wordpress.com/
* Scroll down the `Do it all with WordPress.com` section
* Choose `Blog ->`
* Create a new account
* Pick a design
* Go through the flow until you reach the Fullscreen launchpad
* Skip the Launchpad by clicking on the "Skip for now" in the top right corner
* You should be redirected to the Customer Home
* Click on the "Choose a plan" task in the Launchpad and make sure you are redirected to the plans page