### PR TITLE
Social: Fix initial state feature discrepancy

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-initial-state-feature-discrepancy
+++ b/projects/packages/publicize/changelog/fix-social-initial-state-feature-discrepancy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue where Social initial states were messed up

--- a/projects/packages/publicize/src/auto-conversion-settings/class-settings.php
+++ b/projects/packages/publicize/src/auto-conversion-settings/class-settings.php
@@ -83,17 +83,18 @@ class Settings {
 	 * Check if the auto conversion feature is enabled.
 	 *
 	 * @param string $type Whether video or image.
+	 * @param bool   $ignore_module Whether to ignore if the Publicize module is active. Used for populating the initial state.
 	 *
 	 * @return bool True if the feature is enabled, false otherwise.
 	 */
-	public function is_enabled( $type ) {
+	public function is_enabled( $type, $ignore_module = false ) {
 		// If the feature isn't available it should never be enabled.
 		if ( ! $this->is_available( $type ) ) {
 			return false;
 		}
 
 		// The feature cannot be enabled without Publicize.
-		if ( ! ( new Modules() )->is_active( 'publicize' ) ) {
+		if ( ! $ignore_module && ! ( new Modules() )->is_active( 'publicize' ) ) {
 			return false;
 		}
 

--- a/projects/packages/publicize/src/social-image-generator/class-settings.php
+++ b/projects/packages/publicize/src/social-image-generator/class-settings.php
@@ -81,16 +81,18 @@ class Settings {
 	/**
 	 * Check if SIG is enabled.
 	 *
+	 * @param bool $ignore_module Whether to ignore if the Publicize module is active. Used for populating the initial state.
+	 *
 	 * @return bool True if SIG is enabled, false otherwise.
 	 */
-	public function is_enabled() {
+	public function is_enabled( $ignore_module = false ) {
 		// If the feature isn't available it should never be enabled.
 		if ( ! $this->is_available() ) {
 			return false;
 		}
 
 		// SIG cannot be enabled without Publicize.
-		if ( ! ( new Modules() )->is_active( 'publicize' ) ) {
+		if ( ! $ignore_module && ! ( new Modules() )->is_active( 'publicize' ) ) {
 			return false;
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -301,12 +301,12 @@ class Jetpack_Redux_State_Helper {
 		return array(
 			'socialImageGeneratorSettings' => array(
 				'available'       => $sig_settings->is_available(),
-				'enabled'         => $sig_settings->is_enabled(),
+				'enabled'         => $sig_settings->is_enabled( true ),
 				'defaultTemplate' => $sig_settings->get_default_template(),
 			),
 			'autoConversionSettings'       => array(
 				'available' => $auto_conversion_settings->is_available( 'image' ),
-				'image'     => $auto_conversion_settings->is_enabled( 'image' ),
+				'image'     => $auto_conversion_settings->is_enabled( 'image', true ),
 			),
 		);
 	}

--- a/projects/plugins/jetpack/changelog/fix-social-initial-state-feature-discrepancy
+++ b/projects/plugins/jetpack/changelog/fix-social-initial-state-feature-discrepancy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed an issue where Social initial states were messed up

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -741,13 +741,13 @@ class Jetpack_Gutenberg {
 				'hasPaidPlan'                     => $publicize->has_paid_plan(),
 				'isEnhancedPublishingEnabled'     => $publicize->has_enhanced_publishing_feature(),
 				'isSocialImageGeneratorAvailable' => $sig_settings->is_available(),
-				'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
+				'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled( true ),
 				'dismissedNotices'                => $publicize->get_dismissed_notices(),
 				'isInstagramConnectionSupported'  => $publicize->has_instagram_connection_feature(),
 				'isMastodonConnectionSupported'   => $publicize->has_mastodon_connection_feature(),
 				'autoConversionSettings'          => array(
 					'available' => $auto_conversion_settings->is_available( 'image' ),
-					'image'     => $auto_conversion_settings->is_enabled( 'image' ),
+					'image'     => $auto_conversion_settings->is_enabled( 'image', true ),
 				),
 				'jetpackSharingSettingsUrl'       => esc_url_raw( admin_url( 'admin.php?page=jetpack#/sharing' ) ),
 			);

--- a/projects/plugins/social/changelog/fix-social-initial-state-feature-discrepancy
+++ b/projects/plugins/social/changelog/fix-social-initial-state-feature-discrepancy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue where Social initial states were messed up

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -251,12 +251,12 @@ class Jetpack_Social {
 					'sharesData'                   => $publicize->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) ),
 					'socialImageGeneratorSettings' => array(
 						'available'       => $sig_settings->is_available(),
-						'enabled'         => $sig_settings->is_enabled(),
+						'enabled'         => $sig_settings->is_enabled( true ),
 						'defaultTemplate' => $sig_settings->get_default_template(),
 					),
 					'autoConversionSettings'       => array(
 						'available' => $auto_conversion_settings->is_available( 'image' ),
-						'image'     => $auto_conversion_settings->is_enabled( 'image' ),
+						'image'     => $auto_conversion_settings->is_enabled( 'image', true ),
 					),
 				)
 			);

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -33,6 +33,7 @@ const Admin = () => {
 
 	const {
 		isModuleEnabled,
+		isUpdatingJetpackSettings,
 		showPricingPage,
 		hasPaidPlan,
 		isShareLimitEnabled,
@@ -44,6 +45,7 @@ const Admin = () => {
 		const store = select( SOCIAL_STORE_ID );
 		return {
 			isModuleEnabled: store.isModuleEnabled(),
+			isUpdatingJetpackSettings: store.isUpdatingJetpackSettings(),
 			showPricingPage: store.showPricingPage(),
 			hasPaidPlan: store.hasPaidPlan(),
 			isShareLimitEnabled: store.isShareLimitEnabled(),
@@ -87,8 +89,12 @@ const Admin = () => {
 						{ shouldShowAdvancedPlanNudge && <AdvancedUpsellNotice /> }
 						<InstagramNotice onUpgrade={ onUpgradeToggle } />
 						<SocialModuleToggle />
-						{ isModuleEnabled && isAutoConversionAvailable && <AutoConversionToggle /> }
-						{ isModuleEnabled && isSocialImageGeneratorAvailable && <SocialImageGeneratorToggle /> }
+						{ isModuleEnabled && isAutoConversionAvailable && (
+							<AutoConversionToggle disabled={ isUpdatingJetpackSettings } />
+						) }
+						{ isModuleEnabled && isSocialImageGeneratorAvailable && (
+							<SocialImageGeneratorToggle disabled={ isUpdatingJetpackSettings } />
+						) }
 					</AdminSection>
 					<AdminSectionHero>
 						<InfoSection />

--- a/projects/plugins/social/src/js/components/auto-conversion-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/auto-conversion-toggle/index.tsx
@@ -9,7 +9,11 @@ import ToggleSection from '../toggle-section';
 import { SocialStoreSelectors } from '../types/types';
 import styles from './styles.module.scss';
 
-const AutoConversionToggle: React.FC = () => {
+interface AutoConversionToggleProps {
+	disabled?: boolean;
+}
+
+const AutoConversionToggle: React.FC< AutoConversionToggleProps > = ( { disabled } ) => {
 	const { isEnabled, isUpdating } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
 		return {
@@ -30,7 +34,7 @@ const AutoConversionToggle: React.FC = () => {
 	return (
 		<ToggleSection
 			title={ __( 'Automatically convert images for compatibility', 'jetpack-social' ) }
-			disabled={ isUpdating }
+			disabled={ isUpdating || disabled }
 			checked={ isEnabled }
 			onChange={ toggleStatus }
 		>

--- a/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
@@ -9,7 +9,13 @@ import ToggleSection from '../toggle-section';
 import { SocialStoreSelectors } from '../types/types';
 import styles from './styles.module.scss';
 
-const SocialImageGeneratorToggle: React.FC = () => {
+interface SocialImageGeneratorToggleProps {
+	disabled?: boolean;
+}
+
+const SocialImageGeneratorToggle: React.FC< SocialImageGeneratorToggleProps > = ( {
+	disabled,
+} ) => {
 	const [ currentTemplate, setCurrentTemplate ] = useState( null );
 	const { isEnabled, isUpdating, defaultTemplate } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
@@ -44,19 +50,19 @@ const SocialImageGeneratorToggle: React.FC = () => {
 				fullWidth={ isSmall }
 				className={ styles.button }
 				variant="secondary"
-				disabled={ isUpdating || ! isEnabled }
+				disabled={ isUpdating || ! isEnabled || disabled }
 				onClick={ open }
 			>
 				{ __( 'Change default template', 'jetpack-social' ) }
 			</Button>
 		),
-		[ isEnabled, isSmall, isUpdating ]
+		[ disabled, isEnabled, isSmall, isUpdating ]
 	);
 
 	return (
 		<ToggleSection
 			title={ __( 'Enable Social Image Generator', 'jetpack-social' ) }
-			disabled={ isUpdating }
+			disabled={ isUpdating || disabled }
 			checked={ isEnabled }
 			onChange={ toggleStatus }
 		>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue where feature toggles would appear disabled after turning on Publicize for the first time.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added an option to ignore if Publicize is enabled, which we can use for populating the initial states
* Fixed a minor issue where feature toggles could be updated while Publicize was still turning on

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/orgs/Automattic/projects/733/views/2?pane=issue&itemId=43051048
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Without this patch:
* Create a JN site
* Connect Jetpack and select the free plan
* Go to settings->Sharing, and enable auto-sharing
* Notice that the auto-conversion setting is displayed as disabled
* Refreshing the page solves it
* On your JT site turning Publicize off in the admin page or Jetpack settings, refreshing and then turning it on causes the same issue

With this patch
* Doing the same, it should reflect the state for the first time too.

