### PR TITLE
Gardening: handle issues waiting on 3rd parties when auto-triaging

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-update-board-triaged-3rd-party-fix
+++ b/projects/github-actions/repo-gardening/changelog/update-update-board-triaged-3rd-party-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Project Board triage: handle issues waiting on a third-party fix when auto-triaging.

--- a/projects/github-actions/repo-gardening/src/tasks/update-board/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/update-board/index.js
@@ -72,7 +72,7 @@ async function needsThirdPartyFix( octokit, owner, repo, number, action, eventLa
 		labels.push( eventLabel.name );
 	}
 
-	return labels.match( /^\[Status\] Needs (3rd Party|Core) Fix$/ );
+	return labels.some( label => label.match( /^\[Status\] Needs (3rd Party|Core) Fix$/ ) );
 }
 
 /**


### PR DESCRIPTION
## Proposed changes:

The "Status" field includes a "Needs Core/3rd Party Fix" option. Let's use that instead of "Triaged" whenever an issue is waiting on a third-party or Core, as indicated by a label on the issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* See p1698454148178029-slack-CQD1HH4MA

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This cannot be tested in this repo before merge, but you can test with an issue in a forked repo where you've merged this PR to `trunk`.

Here is an example:
https://github.com/jeherve/jetpack/issues/114

<img width="400" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/942c5bdb-ad7e-4909-8fa6-e1e7569faa10">

