### PR TITLE
Properly remove "tier_id" meta when selection non-paid newsletter access

### DIFF
--- a/projects/plugins/jetpack/changelog/add-fix-issue-with-tier_id-value
+++ b/projects/plugins/jetpack/changelog/add-fix-issue-with-tier_id-value
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Fix issue in tier selector when tier is null

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -51,23 +51,23 @@ export function getReachForAccessLevelKey( accessLevelKey, emailSubscribers, pai
 
 export function useSetAccess() {
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
-	const [ , setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
-
+	const [ metas, setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	return value => {
+		// We are removing the tier ID meta
+		delete metas[ META_NAME_FOR_POST_TIER_ID_SETTINGS ];
 		setPostMeta( {
+			...metas,
 			[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ]: value,
-			// When a access is set, we need to clear the tier
-			[ META_NAME_FOR_POST_TIER_ID_SETTINGS ]: null,
 		} );
 	};
 }
 
 export function useSetTier() {
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
-	const [ , setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
-
+	const [ metas, setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	return value => {
 		setPostMeta( {
+			...metas,
 			[ META_NAME_FOR_POST_TIER_ID_SETTINGS ]: value,
 		} );
 	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See https://github.com/Automattic/jetpack/pull/33838#issuecomment-1785192785
Fixes https://github.com/Automattic/wp-calypso/issues/83694

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Properly remove tier_id meta when selecting non paid-ssubscriber NL access

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On production
* Select a non-paid-subscriber access and notice the issue when saving
<img width="500" alt="Screenshot 2023-10-31 at 12 15 53" src="https://github.com/Automattic/jetpack/assets/790558/6a0b1efa-40b7-4e10-b87b-ca5d7f273d70">
* Patch this on your sandbox and sandbox the site
* You should be able to post without error

