### PR TITLE
CRM: 3381 - replace deprecated constants

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3381-replace_deprecated_constants
+++ b/projects/plugins/crm/changelog/fix-crm-3381-replace_deprecated_constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Removed deprecated constants for better WP 6.4 compatibility
+
+

--- a/projects/plugins/crm/includes/jpcrm-templating.php
+++ b/projects/plugins/crm/includes/jpcrm-templating.php
@@ -215,7 +215,7 @@ function jpcrm_retrieve_template_variants( $original_template_path = '' ) {
 			),
 			array( 
 				'name' => __( 'Template Path directory', 'zero-bs-crm' ), 
-				'path' => TEMPLATEPATH . '/' . $zbs->template_path . '/'
+				'path' => get_template_directory() . '/' . $zbs->template_path . '/',
 			),
 			array( 
 				'name' => __( 'Theme Compat directory', 'zero-bs-crm' ), 

--- a/projects/plugins/crm/includes/jpcrm-templating.php
+++ b/projects/plugins/crm/includes/jpcrm-templating.php
@@ -211,7 +211,7 @@ function jpcrm_retrieve_template_variants( $original_template_path = '' ) {
 		$template_locations = array(
 			array( 
 				'name' => __( 'Theme directory', 'zero-bs-crm' ), 
-				'path' => STYLESHEETPATH . '/' . $zbs->template_path . '/' 
+				'path' => get_stylesheet_directory() . '/' . $zbs->template_path . '/',
 			),
 			array( 
 				'name' => __( 'Template Path directory', 'zero-bs-crm' ), 

--- a/projects/plugins/crm/includes/jpcrm-templating.php
+++ b/projects/plugins/crm/includes/jpcrm-templating.php
@@ -209,23 +209,23 @@ function jpcrm_retrieve_template_variants( $original_template_path = '' ) {
 		// Seeks out template files matching a pattern (in wp theme directories, and our core template directory)
 		// Adapted from locate_template: https://core.trac.wordpress.org/browser/tags/5.8/src/wp-includes/template.php#L697
 		$template_locations = array(
-			array( 
-				'name' => __( 'Theme directory', 'zero-bs-crm' ), 
+			array(
+				'name' => __( 'Theme directory', 'zero-bs-crm' ),
 				'path' => get_stylesheet_directory() . '/' . $zbs->template_path . '/',
 			),
 			array( 
-				'name' => __( 'Template Path directory', 'zero-bs-crm' ), 
+				'name' => __( 'Template Path directory', 'zero-bs-crm' ),
 				'path' => get_template_directory() . '/' . $zbs->template_path . '/',
 			),
 			array( 
 				'name' => __( 'Theme Compat directory', 'zero-bs-crm' ), 
-				'path' => ABSPATH . WPINC . '/theme-compat/' . $zbs->template_path . '/'
+				'path' => ABSPATH . WPINC . '/theme-compat/' . $zbs->template_path . '/',
 			),
 			array( 
-				'name' => __( 'Core Plugin', 'zero-bs-crm' ), 
-				'path' => ZEROBSCRM_PATH . 'templates/'
-			)
-		); 
+				'name' => __( 'Core Plugin', 'zero-bs-crm' ),
+				'path' => ZEROBSCRM_PATH . 'templates/',
+			),
+		);
 
 		// we flip the array, so that top-down preference is maintained
 		$template_locations = array_reverse( $template_locations );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3381 - replace deprecated constants

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
As of WP 6.4, the `TEMPLATEPATH` and `STYLESHEETPATH` constants are deprecated:

https://core.trac.wordpress.org/ticket/18298

This PR swaps them out for the equivalent functions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There shouldn't be any functional change here, and deprecated constants don't give PHP notices, so just verify the code looks grand.

