### PR TITLE
Fix unresponsive Simple Payment block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-simple-payment-block
+++ b/projects/plugins/jetpack/changelog/fix-simple-payment-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix unresponsive Simple Payment block

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 3,
+	"apiVersion": 1,
 	"name": "jetpack/simple-payments",
 	"title": "Pay with PayPal",
 	"description": "Add credit and debit card payment buttons with minimal setup. Good for collecting donations or payments for products and services.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1698765346173339-slack-C052XEUUBL4

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The Simple Payment block sometimes switches from editing to preview mode when tabbing through the inputs, in which case it doesn't seem to accept focus anymore. I believe this is due to the version of the block API being used. This PR switches it back to 1.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Get the _Complete_ plan
- Visit `wp-admin/post-new.php` and add the _Pay with Paypal_ block
- Check that you can enter values in the different inputs, and that you can focus out and back in the block

<img width="600" alt="Screenshot 2023-10-31 at 12 11 09 PM" src="https://github.com/Automattic/jetpack/assets/1620183/080cd369-8c8e-4112-af63-045c2d04cc31">
