### PR TITLE
AI Aissistant: introduce tiers definition

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-lib-tiers
+++ b/projects/plugins/jetpack/changelog/add-ai-lib-tiers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add AI tiers definition

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/tiers/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/tiers/index.ts
@@ -7,32 +7,38 @@ export type AiAssistantTier = {
 	slug: string;
 	limit: number;
 	readableLimit?: string;
+	value: number;
 };
 
 const TIER_AI_FREE: AiAssistantTier = {
 	slug: 'ai-assistant-tier-free',
 	limit: 20,
+	value: 0,
 };
 
 const TIER_AI_MONTHLY_100: AiAssistantTier = {
 	slug: 'ai-assistant-tier-100',
 	limit: 100,
+	value: 100,
 };
 
 const TIER_AI_MONTHLY_200: AiAssistantTier = {
 	slug: 'ai-assistant-tier-200',
 	limit: 200,
+	value: 200,
 };
 
 const TIER_AI_MONTHLY_500: AiAssistantTier = {
 	slug: 'ai-assistant-tier-500',
 	limit: 500,
+	value: 500,
 };
 
 const TIER_AI_UNLIMITED: AiAssistantTier = {
 	slug: 'ai-assistant-tier-unlimited',
 	limit: Infinity,
 	readableLimit: __( 'unlimited', 'jetpack' ),
+	value: 1,
 };
 
 const TIERS = [

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/tiers/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/tiers/index.ts
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export type AiAssistantTier = {
+	slug: string;
+	limit: number;
+	readableLimit?: string;
+};
+
+const TIER_AI_FREE: AiAssistantTier = {
+	slug: 'ai-assistant-tier-free',
+	limit: 20,
+};
+
+const TIER_AI_MONTHLY_100: AiAssistantTier = {
+	slug: 'ai-assistant-tier-100',
+	limit: 100,
+};
+
+const TIER_AI_MONTHLY_200: AiAssistantTier = {
+	slug: 'ai-assistant-tier-200',
+	limit: 200,
+};
+
+const TIER_AI_MONTHLY_500: AiAssistantTier = {
+	slug: 'ai-assistant-tier-500',
+	limit: 500,
+};
+
+const TIER_AI_UNLIMITED: AiAssistantTier = {
+	slug: 'ai-assistant-tier-unlimited',
+	limit: Infinity,
+	readableLimit: __( 'unlimited', 'jetpack' ),
+};
+
+const TIERS = [
+	TIER_AI_FREE,
+	TIER_AI_MONTHLY_100,
+	TIER_AI_MONTHLY_200,
+	TIER_AI_MONTHLY_500,
+	TIER_AI_UNLIMITED,
+];
+
+/**
+ * Function getNextTierByUsage
+ * Given a current usage, returns the next TIER whose limit is higher than the current usage.
+ *
+ * @param {number} usage - The current usage.
+ * @returns {AiAssistantTier} The next AiAssistantTier whose limit is higher than the current usage.
+ */
+export function getNextTierByUsage( usage: number ): AiAssistantTier {
+	return TIERS.find( tier => tier.limit > usage );
+}


### PR DESCRIPTION
Add tiers definition for consumption

## Proposed changes:
This PR adds the base files for tiers definition for later consumption on upgrade and checkout processes.

Tiers are defined as 

- TIER_AI_FREE
- TIER_AI_MONTHLY_100
- TIER_AI_MONTHLY_200
- TIER_AI_MONTHLY_500
- TIER_AI_UNLIMITED

and carry basic information:
- slug
- limit
- readableLimit (optional, for UI usage when limit is something needing translation)

A simple `getNextTierByUsage` is also available, receiving a usage and returning the next tier that would fit the needs of the user.

NOTE: we could solve all things internally by using `useAIFeature.requestsCount` instead of receiving params, still a PoC

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/orgs/Automattic/projects/667/views/14

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
There is no noticeable change, this PR is just introductory for the base files needed and should mostly work as a PoC.
TBD
