### PR TITLE
Poc/tiered upgrade nudge

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-lib-tiers
+++ b/projects/plugins/jetpack/changelog/add-ai-lib-tiers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add AI tiers definition

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -28,7 +28,7 @@ const DefaultUpgradePrompt = (): React.ReactNode => {
 	const upgradeCTA = sprintf(
 		/** translators: string is next upgrade limit */
 		__( 'Upgrade to %s requests', 'jetpack' ),
-		nextTier?.readableLimit || nextTier.limit
+		nextTier.readableLimit || nextTier.limit
 	);
 
 	if ( ! canUpgrade ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import React from 'react';
 /*
  * Internal dependencies
@@ -11,6 +11,7 @@ import { Nudge } from '../../../../shared/components/upgrade-nudge';
 import useAICheckout from '../../hooks/use-ai-checkout';
 import useAIFeature from '../../hooks/use-ai-feature';
 import { canUserPurchasePlan } from '../../lib/connection';
+import { getNextTierByUsage } from '../../lib/tiers';
 
 /**
  * The default upgrade prompt for the AI Assistant block, containing the Upgrade button and linking
@@ -21,6 +22,14 @@ import { canUserPurchasePlan } from '../../lib/connection';
 const DefaultUpgradePrompt = (): React.ReactNode => {
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
 	const canUpgrade = canUserPurchasePlan();
+
+	const { requestsCount } = useAIFeature();
+	const nextTier = getNextTierByUsage( requestsCount );
+	const upgradeCTA = sprintf(
+		/** translators: string is next upgrade limit */
+		__( 'Upgrade to %s requests', 'jetpack' ),
+		nextTier?.readableLimit || nextTier.limit
+	);
 
 	if ( ! canUpgrade ) {
 		return (
@@ -47,7 +56,7 @@ const DefaultUpgradePrompt = (): React.ReactNode => {
 
 	return (
 		<Nudge
-			buttonText={ 'Upgrade' }
+			buttonText={ upgradeCTA }
 			checkoutUrl={ checkoutUrl }
 			className={ 'jetpack-ai-upgrade-banner' }
 			description={ createInterpolateElement(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/tiers/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/tiers/index.ts
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export type AiAssistantTier = {
+	slug: string;
+	limit: number;
+	readableLimit?: string;
+};
+
+const TIER_AI_FREE: AiAssistantTier = {
+	slug: 'ai-assistant-tier-free',
+	limit: 20,
+};
+
+const TIER_AI_MONTHLY_100: AiAssistantTier = {
+	slug: 'ai-assistant-tier-100',
+	limit: 100,
+};
+
+const TIER_AI_MONTHLY_200: AiAssistantTier = {
+	slug: 'ai-assistant-tier-200',
+	limit: 200,
+};
+
+const TIER_AI_MONTHLY_500: AiAssistantTier = {
+	slug: 'ai-assistant-tier-500',
+	limit: 500,
+};
+
+const TIER_AI_UNLIMITED: AiAssistantTier = {
+	slug: 'ai-assistant-tier-unlimited',
+	limit: Infinity,
+	readableLimit: __( 'unlimited', 'jetpack' ),
+};
+
+const TIERS = [
+	TIER_AI_FREE,
+	TIER_AI_MONTHLY_100,
+	TIER_AI_MONTHLY_200,
+	TIER_AI_MONTHLY_500,
+	TIER_AI_UNLIMITED,
+];
+
+/**
+ * Function getNextTierByUsage
+ * Given a current usage, returns the next TIER whose limit is higher than the current usage.
+ *
+ * @param {number} usage - The current usage.
+ * @returns {AiAssistantTier} The next AiAssistantTier whose limit is higher than the current usage.
+ */
+export function getNextTierByUsage( usage: number ): AiAssistantTier {
+	return TIERS.find( tier => tier.limit > usage );
+}


### PR DESCRIPTION
PoC for tiered upgrades.

Follow up for #33891 

## Proposed changes:
This PR uses the tiers to build the corresponding upgrade nudge.
We're still lacking some _current plan_ information and a way to deal with a migration from regular plans to tiered. Some of this information should/could be stored and retrieved only from backend, which we might end up doing once the backend implementation is ready.
<img width="634" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/506a65c5-7865-482b-af29-1c4582d8513a">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use a free plan and reach the requests limit. See the upgrade nudge on the block, the button should now read some "Upgrade to X requests". Reaching each tier limit should suggest the next tier based on usage. (100, 200, 500, unlimited)