### PR TITLE
Fix Assistant page not showing Jetpack header & footer on some Assistant routes.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -111,6 +111,21 @@ const recommendationsRoutes = [
 	'/recommendations/summary',
 	'/recommendations/vaultpress-backup',
 	'/recommendations/vaultpress-for-woocommerce',
+	'/recommendations/welcome-backup',
+	'/recommendations/welcome-complete',
+	'/recommendations/welcome-security',
+	'/recommendations/welcome-starter',
+	'/recommendations/welcome-antispam',
+	'/recommendations/welcome-videopress',
+	'/recommendations/welcome-search',
+	'/recommendations/welcome-scan',
+	'/recommendations/welcome-golden-token',
+	'/recommendations/server-credentials',
+	'/recommendations/backup-activated',
+	'/recommendations/backup-activated',
+	'/recommendations/antispam-activated',
+	'/recommendations/videopress-activated',
+	'/recommendations/search-activated',
 ];
 
 const myJetpackRoutes = [ 'my-jetpack ' ];

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -120,12 +120,12 @@ const recommendationsRoutes = [
 	'/recommendations/welcome-search',
 	'/recommendations/welcome-scan',
 	'/recommendations/welcome-golden-token',
-	'/recommendations/server-credentials',
 	'/recommendations/backup-activated',
-	'/recommendations/backup-activated',
+	'/recommendations/scan-activated',
 	'/recommendations/antispam-activated',
 	'/recommendations/videopress-activated',
 	'/recommendations/search-activated',
+	'/recommendations/server-credentials',
 ];
 
 const myJetpackRoutes = [ 'my-jetpack ' ];

--- a/projects/plugins/jetpack/changelog/fix-assistant-not-showing-header
+++ b/projects/plugins/jetpack/changelog/fix-assistant-not-showing-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix Assistant not showing Jetpack header on some Assistant routes.


### PR DESCRIPTION
It was noticed that the Assistant page was not showing the Jetpack header & footer on some Assistant routes such as, `/recommendations/welcome-complete`, `/recommendations/welcome-security`, and more. This PR fixes this issue. -( See Before & After images below).

Internal reference: p1692692869338869-slack-C01264051NE
Internal issue/ticket: https://github.com/orgs/Automattic/projects/724/views/2?pane=issue&itemId=36542126

#### Screenshots

**BEFORE** | **AFTER**
--- | ---
![Markup 2023-10-31 at 14 09 14](https://github.com/Automattic/jetpack/assets/11078128/61bc26a8-b310-480a-b4bf-b33355429051) | ![Markup 2023-10-31 at 14 11 04](https://github.com/Automattic/jetpack/assets/11078128/dc9bc8d2-b8e7-4b06-b8e5-f3ff5f685cea)







<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added missing assistant routes to recommendationsRoutes array.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up this branch in a local dev environment, OR:
- Run this branch on a Jurassic Ninja site using Jetpack Beta plugin.
- Go to: `/wp-admin/admin.php?page=jetpack#/recommendations/welcome-security` and verify you now see the Jetpack header and footer (Same as the AAG page and My Plan page). - See before & after screenshots above.
- You can compare with production and see that the header & footer were not showing before, on these routes.
- Test these other Assistant routes: - Verify the Jetpack header & footer are showing on these routes.
    - `/recommendations/welcome-backup`
    - `/recommendations/welcome-complete`
    - `/recommendations/welcome-starter`
    - `/recommendations/welcome-antispam`
    - `/recommendations/welcome-videopress`
    - `/recommendations/welcome-search`
    - `/recommendations/welcome-scan`
    - `/recommendations/welcome-golden-token`
    - `/recommendations/backup-activated`
    - `/recommendations/scan-activated`
    - `/recommendations/antispam-activated`
    - `/recommendations/videopress-activated`
    - `/recommendations/search-activated`
    - `/recommendations/server-credentials`
- 