### PR TITLE
Subscribe Block: Introduce "Subscribed" state

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-button
+++ b/projects/plugins/jetpack/changelog/update-subscribe-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe Block: Add Subscribed status

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -55,6 +55,38 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	}
 
 	/**
+	 * Get the token payload .
+	 *
+	 * @return array.
+	 */
+	public function get_token_payload() {
+		$token = $this->get_and_set_token_from_request();
+		if ( empty( $token ) ) {
+			return array();
+		}
+		$token_payload = $this->decode_token( $token );
+		if ( ! is_array( $token_payload ) ) {
+			return array();
+		}
+		return $token_payload;
+	}
+
+	/**
+	 * Get a token property, otherwise return false.
+	 *
+	 * @param string $key the property name.
+	 *
+	 * @return mixed|false.
+	 */
+	public function get_token_property( $key ) {
+		$token_payload = $this->get_token_payload();
+		if ( ! isset( $token_payload[ $key ] ) ) {
+			return false;
+		}
+		return $token_payload[ $key ];
+	}
+
+	/**
 	 * The user is visiting with a subscriber token cookie.
 	 *
 	 * This is theoretically where the cookie JWT signature verification
@@ -74,8 +106,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 		global $current_user;
 		$old_user = $current_user; // backup the current user so we can set the current user to the token user for paywall purposes
 
-		$token          = $this->get_and_set_token_from_request();
-		$payload        = $this->decode_token( $token );
+		$payload        = $this->get_token_payload();
 		$is_valid_token = ! empty( $payload );
 
 		if ( $is_valid_token && isset( $payload['user_id'] ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -535,7 +535,7 @@ function render_block( $attributes ) {
 		Jetpack_Gutenberg::load_styles_as_required( FEATURE_NAME );
 	}
 
-	$subscribe_email = '';
+	$subscribe_email = Jetpack_Memberships::get_current_user_subscriber_email();
 
 	/** This filter is documented in modules/contact-form/grunion-contact-form.php */
 	if ( is_wpcom() || false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
@@ -618,7 +618,7 @@ function render_for_website( $data, $classes, $styles ) {
 	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );
 	$tier_id            = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
 	$button_text        = wp_kses(
-		html_entity_decode( Jetpack_Memberships::is_current_user_subscribed() ? ( '✓ ' . $data['submit_button_text_subscribed'] ) : $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+		html_entity_decode( Jetpack_Memberships::get_current_user_subscriber_email() ? ( '✓ ' . $data['submit_button_text_subscribed'] ) : $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 		Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
 	);
 
@@ -639,12 +639,11 @@ function render_for_website( $data, $classes, $styles ) {
 					accept-charset="utf-8"
 					data-blog="<?php echo esc_attr( $blog_id ); ?>"
 					data-post_access_level="<?php echo esc_attr( $post_access_level ); ?>"
+					data-subscriber_email="<?php echo esc_attr( Jetpack_Memberships::get_current_user_subscriber_email() ); ?>"
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
 					<div class="wp-block-jetpack-subscriptions__form-elements">
-						<?php if ( Jetpack_Memberships::is_current_user_subscribed() ) : ?>
-						<input type="hidden" name="email" value="<?php echo esc_attr( $data['subscribe_email'] ); ?>">
-						<?php else : ?>
+						<?php if ( empty( $data['subscribe_email'] ) ) : ?>
 						<p id="subscribe-email">
 							<label
 								id="<?php echo esc_attr( $subscribe_field_id . '-label' ); ?>"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -642,7 +642,7 @@ function render_for_website( $data, $classes, $styles ) {
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
 					<div class="wp-block-jetpack-subscriptions__form-elements">
-						<?php if ( ! Jetpack_Memberships::is_current_user_subscribed() ) : ?>
+						<?php if ( Jetpack_Memberships::is_current_user_subscribed() ) : ?>
 						<input type="hidden" name="email" value="<?php echo esc_attr( $data['subscribe_email'] ); ?>">
 						<?php else : ?>
 						<p id="subscribe-email">

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -643,6 +643,8 @@ function render_for_website( $data, $classes, $styles ) {
 				>
 					<div class="wp-block-jetpack-subscriptions__form-elements">
 						<?php if ( ! Jetpack_Memberships::is_current_user_subscribed() ) : ?>
+						<input type="hidden" name="email" value="<?php echo esc_attr( $data['subscribe_email'] ); ?>">
+						<?php else : ?>
 						<p id="subscribe-email">
 							<label
 								id="<?php echo esc_attr( $subscribe_field_id . '-label' ); ?>"
@@ -701,11 +703,7 @@ function render_for_website( $data, $classes, $styles ) {
 							?>
 							<button type="submit"
 								<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-									class="<?php echo esc_attr( $classes['submit_button'] ); ?>
-														<?php
-														if ( Jetpack_Memberships::is_current_user_subscribed() ) :
-															?>
-										wp-block-jetpack-subscriptions__subscribed<?php endif; ?>"
+									class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
 								<?php endif; ?>
 								<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
 									style="<?php echo esc_attr( $styles['submit_button'] ); ?>"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -625,44 +625,37 @@ function render_for_website( $data, $classes, $styles ) {
 			'success_message' => $data['success_message'],
 		)
 	);
-
-	if ( Jetpack_Memberships::user_can_view_post() ) { ?>
-		<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
-		<div class="jetpack_subscription_widget">
-			<div class="wp-block-jetpack-subscriptions__container">
-				<div class="wp-block-jetpack-subscriptions__form-elements">
-					<p id="subscribe-submit"
-							<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
-								style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
-							<?php endif; ?>
-						>
-							<button type="submit"
-								<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-									class="<?php echo esc_attr( $classes['submit_button'] ); ?> wp-block-jetpack-subscriptions__subscribed"
-								<?php endif; ?>
-								<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
-									style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
-								<?php endif; ?>
-									name="jetpack_subscriptions_widget"
-							>
-								✓ 
-								<?php
-								echo wp_kses(
-									html_entity_decode( $data['subscribed_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-									Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
-								);
-								?>
-							</button>
-						</p>
-					</div>
-				</form>
-			</div>
-		</div>
-		</div>
-	<?php } else { ?>
+	?>
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
 		<div class="jetpack_subscription_widget">
 			<div class="wp-block-jetpack-subscriptions__container">
+			<?php if ( Jetpack_Memberships::user_can_view_post() ) : ?>
+				<div class="wp-block-jetpack-subscriptions__form-elements">
+					<p id="subscribe-submit"
+						<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
+							style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+						<?php endif; ?>
+					>
+						<button type="submit"
+							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
+								class="<?php echo esc_attr( $classes['submit_button'] ); ?> wp-block-jetpack-subscriptions__subscribed"
+							<?php endif; ?>
+							<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
+								style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
+							<?php endif; ?>
+								name="jetpack_subscriptions_widget"
+						>
+							✓
+							<?php
+							echo wp_kses(
+								html_entity_decode( $data['subscribed_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+							);
+							?>
+						</button>
+					</p>
+				</div>
+			<?php else : ?>
 				<form
 					action="<?php echo esc_url( $form_url ); ?>"
 					method="post"
@@ -755,12 +748,11 @@ function render_for_website( $data, $classes, $styles ) {
 						?>
 					</div>
 				<?php endif; ?>
+			<?php endif; ?>
 			</div>
 		</div>
 	</div>
-		<?php
-	}
-
+	<?php
 	return ob_get_clean();
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -563,6 +563,7 @@ function render_block( $attributes ) {
 		),
 		'subscribe_placeholder'  => get_attribute( $attributes, 'subscribePlaceholder', esc_html__( 'Type your email…', 'jetpack' ) ),
 		'submit_button_text'     => get_attribute( $attributes, 'submitButtonText', $is_paid_subscriber ? esc_html__( 'Upgrade', 'jetpack' ) : esc_html__( 'Subscribe', 'jetpack' ) ),
+		'subscribed_button_text' => get_attribute( $attributes, 'subscribedButtonText', esc_html__( '✓ Subscribed', 'jetpack' ) ),
 		'success_message'        => get_attribute(
 			$attributes,
 			'successMessage',
@@ -624,7 +625,40 @@ function render_for_website( $data, $classes, $styles ) {
 			'success_message' => $data['success_message'],
 		)
 	);
-	?>
+
+	if ( Jetpack_Memberships::user_can_view_post() ) { ?>
+		<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
+		<div class="jetpack_subscription_widget">
+			<div class="wp-block-jetpack-subscriptions__container">
+				<div class="wp-block-jetpack-subscriptions__form-elements">
+					<p id="subscribe-submit"
+							<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
+								style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+							<?php endif; ?>
+						>
+							<button type="submit"
+								<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
+									class="<?php echo esc_attr( $classes['submit_button'] ); ?> wp-block-jetpack-subscriptions__subscribed"
+								<?php endif; ?>
+								<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
+									style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
+								<?php endif; ?>
+									name="jetpack_subscriptions_widget"
+							>
+								<?php
+								echo wp_kses(
+									html_entity_decode( $data['subscribed_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+									Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+								);
+								?>
+							</button>
+						</p>
+					</div>
+				</form>
+			</div>
+		</div>
+		</div>
+	<?php } else { ?>
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
 		<div class="jetpack_subscription_widget">
 			<div class="wp-block-jetpack-subscriptions__container">
@@ -723,7 +757,8 @@ function render_for_website( $data, $classes, $styles ) {
 			</div>
 		</div>
 	</div>
-	<?php
+		<?php
+	}
 
 	return ob_get_clean();
 }
@@ -1030,6 +1065,9 @@ function get_paywall_access_question( $post_access_level ) {
  */
 function is_user_auth() {
 	if ( ( new Host() )->is_wpcom_simple() && is_user_logged_in() ) {
+		return true;
+	}
+	if ( current_user_can( 'manage_options' ) ) {
 		return true;
 	}
 	if ( class_exists( 'Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Jetpack_Token_Subscription_Service' ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -563,7 +563,7 @@ function render_block( $attributes ) {
 		),
 		'subscribe_placeholder'  => get_attribute( $attributes, 'subscribePlaceholder', esc_html__( 'Type your email…', 'jetpack' ) ),
 		'submit_button_text'     => get_attribute( $attributes, 'submitButtonText', $is_paid_subscriber ? esc_html__( 'Upgrade', 'jetpack' ) : esc_html__( 'Subscribe', 'jetpack' ) ),
-		'subscribed_button_text' => get_attribute( $attributes, 'subscribedButtonText', esc_html__( '✓ Subscribed', 'jetpack' ) ),
+		'subscribed_button_text' => get_attribute( $attributes, 'subscribedButtonText', esc_html__( 'Subscribed', 'jetpack' ) ),
 		'success_message'        => get_attribute(
 			$attributes,
 			'successMessage',
@@ -645,6 +645,7 @@ function render_for_website( $data, $classes, $styles ) {
 								<?php endif; ?>
 									name="jetpack_subscriptions_widget"
 							>
+								✓ 
 								<?php
 								echo wp_kses(
 									html_entity_decode( $data['subscribed_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -62,9 +62,14 @@ domReady( function () {
 	if ( ! form.payments_attached ) {
 		form.payments_attached = true;
 		form.addEventListener( 'submit', function ( event ) {
-			const email = form.querySelector( 'input[type=email]' ).value;
+			if ( form.resubmitted ) {
+				return;
+			}
 
-			if ( form.resubmitted || ! email ) {
+			const emailInput = form.querySelector( 'input[type=email]' );
+			const email = emailInput ? emailInput.value : form.dataset.subscriber_email;
+
+			if ( ! email ) {
 				return;
 			}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -8,31 +8,20 @@
 	&:has(input[name="email"]) {
 		.wp-block-jetpack-subscriptions__button,
 		.wp-block-button__link {
-			{
-				margin-inline-start: 0 !important;
-				border-start-start-radius: 0 !important;
-				border-end-start-radius: 0 !important;
-			}
+			margin-inline-start: 0 !important;
+			border-start-start-radius: 0 !important;
+			border-end-start-radius: 0 !important;
 		}
 	}
+
 	.components-text-control__input,
 	p#subscribe-email input[type=email] {
 		border-top-right-radius: 0 !important;
 		border-bottom-right-radius: 0 !important;
 	}
+
 	&:not(.wp-block-jetpack-subscriptions__use-newline) .components-text-control__input {
 		border-right-width: 0 !important;
-	}
-}
-
-.is-style-compact {
-	.wp-block-jetpack-subscriptions__button,
-	.wp-block-button__link {
-		&:not(.wp-block-jetpack-subscriptions__subscribed) {
-			margin-inline-start: 0 !important;
-			border-start-start-radius: 0 !important;
-			border-end-start-radius: 0 !important;
-		}
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -5,7 +5,7 @@
 }
 
 .is-style-compact {
-	&:has(input[name="email"]) {
+	&:has(input[type="email"]) {
 		.wp-block-jetpack-subscriptions__button,
 		.wp-block-button__link {
 			margin-inline-start: 0 !important;
@@ -34,10 +34,11 @@
 
 	.wp-block-jetpack-subscriptions__form,
 	form  {
-
-		.wp-block-jetpack-subscriptions__form-elements {
-			display: flex;
-			align-items: flex-start;
+		&:has(input[type="email"]) {
+			.wp-block-jetpack-subscriptions__form-elements {
+				display: flex;
+				align-items: flex-start;
+			}
 		}
 
 		.wp-block-jetpack-subscriptions__textfield .components-text-control__input,

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -5,12 +5,14 @@
 }
 
 .is-style-compact {
-	.wp-block-jetpack-subscriptions__button,
-	.wp-block-button__link {
-		&:not(.wp-block-jetpack-subscriptions__subscribed) {
-			margin-inline-start: 0 !important;
-			border-start-start-radius: 0 !important;
-			border-end-start-radius: 0 !important;
+	&:has(input[name="email"]) {
+		.wp-block-jetpack-subscriptions__button,
+		.wp-block-button__link {
+			{
+				margin-inline-start: 0 !important;
+				border-start-start-radius: 0 !important;
+				border-end-start-radius: 0 !important;
+			}
 		}
 	}
 	.components-text-control__input,
@@ -20,6 +22,17 @@
 	}
 	&:not(.wp-block-jetpack-subscriptions__use-newline) .components-text-control__input {
 		border-right-width: 0 !important;
+	}
+}
+
+.is-style-compact {
+	.wp-block-jetpack-subscriptions__button,
+	.wp-block-button__link {
+		&:not(.wp-block-jetpack-subscriptions__subscribed) {
+			margin-inline-start: 0 !important;
+			border-start-start-radius: 0 !important;
+			border-end-start-radius: 0 !important;
+		}
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -7,9 +7,11 @@
 .is-style-compact {
 	.wp-block-jetpack-subscriptions__button,
 	.wp-block-button__link {
-		margin-left: 0 !important;
-		border-top-left-radius: 0 !important;
-		border-bottom-left-radius: 0 !important;
+		&:not(.wp-block-jetpack-subscriptions__subscribed) {
+			margin-inline-start: 0 !important;
+			border-start-start-radius: 0 !important;
+			border-end-start-radius: 0 !important;
+		}
 	}
 	.components-text-control__input,
 	p#subscribe-email input[type=email] {

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -795,10 +795,10 @@ class Jetpack_Memberships {
 	 *
 	 * @return boolean
 	 */
-	public static function is_current_user_subscribed() {
+	public static function get_current_user_subscriber_email() {
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
-		return $subscription_service->get_token_property( 'blog_sub' ) === Token_Subscription_Service::BLOG_SUB_ACTIVE;
+		return $subscription_service->get_token_property( 'blog_subscriber' );
 	}
 }
 Jetpack_Memberships::get_instance();

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -789,5 +789,16 @@ class Jetpack_Memberships {
 		/* translators: %s: number of folks following the blog */
 		return sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $subscribers_total, 'jetpack' ), number_format_i18n( $subscribers_total ) );
 	}
+
+	/**
+	 * Returns if the current user is subscribed or not.
+	 *
+	 * @return boolean
+	 */
+	public static function is_current_user_subscribed() {
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
+		return $subscription_service->get_token_property( 'blog_sub' ) === Token_Subscription_Service::BLOG_SUB_ACTIVE;
+	}
 }
 Jetpack_Memberships::get_instance();

--- a/tools/e2e-commons/pages/wp-admin/blocks/subscribe.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/subscribe.js
@@ -37,9 +37,6 @@ export default class SubscribeBlock extends EditorCanvas {
 	 */
 	async isRenderedInFrontend( frontendPage ) {
 		await frontendPage.waitForElementToBeVisible(
-			".wp-block-jetpack-subscriptions__container input[name='email']"
-		);
-		await frontendPage.waitForElementToBeVisible(
 			'.wp-block-jetpack-subscriptions__container button'
 		);
 		return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Improve the user interaction with the Subscribe block, provide feedback when they are subscribed.

<img width="519" alt="Screenshot 2023-10-31 at 15 55 59" src="https://github.com/Automattic/jetpack/assets/104869/910cf043-23e4-4025-b8a7-4cb38fa22725">

Before:

<img width="381" alt="Screenshot 2023-11-01 at 16 13 42" src="https://github.com/Automattic/jetpack/assets/104869/b8912305-aa0d-4c67-b1b4-203cbf0a1757">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that the Subscribe block reflects the "Subscribed" state when a user is subscribed.
* Check the Subscribe state under different styles and variations of the block.

