### PR TITLE
Backport mu-wpcom-plugin 1.7.6, jetpack 12.8-a.11 Changes

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.44.3] - 2023-10-31
+### Fixed
+- Fix IconTooltip Popover styles. [#33856]
+
 ## [0.44.2] - 2023-10-30
 ### Changed
 - Social: Update Nextdoor icon styling so it's round. [#33834]
@@ -864,6 +868,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.44.3]: https://github.com/Automattic/jetpack-components/compare/0.44.2...0.44.3
 [0.44.2]: https://github.com/Automattic/jetpack-components/compare/0.44.1...0.44.2
 [0.44.1]: https://github.com/Automattic/jetpack-components/compare/0.44.0...0.44.1
 [0.44.0]: https://github.com/Automattic/jetpack-components/compare/0.43.4...0.44.0

--- a/projects/js-packages/components/changelog/fix-tooltips
+++ b/projects/js-packages/components/changelog/fix-tooltips
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix IconTooltip Popover styles

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.44.3-alpha",
+	"version": "0.44.3",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2023-10-31
+### Added
+- Add sending Jetpack version to BlazePress Calypso App. [#33823]
+
 ## [0.11.0] - 2023-10-23
 ### Added
 - DSP media endpoints allowlisting. [#33598]
@@ -225,6 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.12.0]: https://github.com/automattic/jetpack-blaze/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/automattic/jetpack-blaze/compare/v0.10.4...v0.11.0
 [0.10.4]: https://github.com/automattic/jetpack-blaze/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/automattic/jetpack-blaze/compare/v0.10.2...v0.10.3

--- a/projects/packages/blaze/changelog/add-provide-current-jetpack-version-for-blaze-app
+++ b/projects/packages/blaze/changelog/add-provide-current-jetpack-version-for-blaze-app
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add sending Jetpack version to BlazePress Calypso App

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.12.0-alpha",
+	"version": "0.12.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.12.0-alpha';
+	const PACKAGE_VERSION = '0.12.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.5] - 2023-10-31
+### Fixed
+- Fixes style for multiple choice checkbox in Froms block. [#33827]
+
 ## [0.22.4] - 2023-10-23
 ### Changed
 - Updated package dependencies. [#33646] [#33687]
@@ -348,6 +352,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.22.5]: https://github.com/automattic/jetpack-forms/compare/v0.22.4...v0.22.5
 [0.22.4]: https://github.com/automattic/jetpack-forms/compare/v0.22.3...v0.22.4
 [0.22.3]: https://github.com/automattic/jetpack-forms/compare/v0.22.2...v0.22.3
 [0.22.2]: https://github.com/automattic/jetpack-forms/compare/v0.22.1...v0.22.2

--- a/projects/packages/forms/changelog/fix-form-block-styles
+++ b/projects/packages/forms/changelog/fix-form-block-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixes style for multiple choice checkbox in Froms block

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.22.5-alpha",
+	"version": "0.22.5",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.22.5-alpha';
+	const PACKAGE_VERSION = '0.22.5';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.16.1] - 2023-10-31
+### Fixed
+- Clicking on the 'Choose a plan' task would not redirect to the plans page. [#33872]
+
 ## [4.16.0] - 2023-10-30
 ### Added
 - Add launchpad checklist for host-site intent. [#33698]
@@ -410,6 +414,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[4.16.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.16.0...v4.16.1
 [4.16.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.15.1...v4.16.0
 [4.15.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.15.0...v4.15.1
 [4.15.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.14.0...v4.15.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-plan-completed-task-path
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-plan-completed-task-path
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Clicking on a the Chosse a plan task would not redirect to the plans page

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.16.1-alpha",
+	"version": "4.16.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.16.1-alpha';
+	const PACKAGE_VERSION = '4.16.1';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.60.1] - 2023-10-31
+
 ## [1.60.0] - 2023-10-26
 ### Removed
 - Remove Jetpack option jetpack-memberships-connected-account-id. [#32354]
@@ -962,6 +964,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.60.1]: https://github.com/Automattic/jetpack-sync/compare/v1.60.0...v1.60.1
 [1.60.0]: https://github.com/Automattic/jetpack-sync/compare/v1.59.2...v1.60.0
 [1.59.2]: https://github.com/Automattic/jetpack-sync/compare/v1.59.1...v1.59.2
 [1.59.1]: https://github.com/Automattic/jetpack-sync/compare/v1.59.0...v1.59.1

--- a/projects/packages/sync/changelog/fix-dedicated-sync-init-hook-priority
+++ b/projects/packages/sync/changelog/fix-dedicated-sync-init-hook-priority
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update Dedicated Sync init hook priority to 200
-
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.60.1-alpha';
+	const PACKAGE_VERSION = '1.60.1';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.8-a.11 - 2023-10-31
+### Enhancements
+- Add a new block for supporting Nextdoor embeds. [#33751]
+- AI Assistant: Expose current period start in the ai-assistant-feature endpoint. [#33843]
+- Newsletters: Add level for all paid subscribers. [#33841]
+- Refactor blocks registration [#33682] [#33689] [#33694] [#33840]
+- Subscribe block: Change "followers" term to "subscribers". [#33860]
+
+### Improved compatibility
+- Add NL tier type. [#33757]
+
+### Bug fixes
+- Fix Cookie Consent block icon. [#33869]
+- Fixes style for multiple choice checkbox in Froms block. [#33827]
+- Fix issue in tier selector when tier is null. [#33879]
+- Fix unresponsive Simple Payment block. [#33889]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- custom-css: Upgrades for PHP 8. [#33816]
+- Plugin assets: Add mag-16 language versions of our banners. [#33850]
+
 ## 12.8-a.9 - 2023-10-30
 ### Enhancements
 - Earn: Rename Earn to Monetize. [#33741]

--- a/projects/plugins/jetpack/changelog/add-fix-issue-with-tier_id-value
+++ b/projects/plugins/jetpack/changelog/add-fix-issue-with-tier_id-value
@@ -1,4 +1,0 @@
-Significance: minor
-Type: bugfix
-
-Fix issue in tier selector when tier is null

--- a/projects/plugins/jetpack/changelog/add-fix-tier-issue
+++ b/projects/plugins/jetpack/changelog/add-fix-tier-issue
@@ -1,5 +1,0 @@
-Significance: patch
-Type: enhancement
-Comment: Small fix on "get access" link
-
-

--- a/projects/plugins/jetpack/changelog/add-nextdoor-embed-block
+++ b/projects/plugins/jetpack/changelog/add-nextdoor-embed-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add a new block for supporting Nextdoor embeds

--- a/projects/plugins/jetpack/changelog/add-provide-current-jetpack-version-for-blaze-app
+++ b/projects/plugins/jetpack/changelog/add-provide-current-jetpack-version-for-blaze-app
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-provide-current-jetpack-version-for-blaze-app#2
+++ b/projects/plugins/jetpack/changelog/add-provide-current-jetpack-version-for-blaze-app#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Added automattic/jetpack-constants dependency to Blaze App package.json.
-
-

--- a/projects/plugins/jetpack/changelog/add-tiers-type
+++ b/projects/plugins/jetpack/changelog/add-tiers-type
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-Add NL tier type

--- a/projects/plugins/jetpack/changelog/custom-css-rector-updates
+++ b/projects/plugins/jetpack/changelog/custom-css-rector-updates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-custom-css: Upgrades for PHP 8

--- a/projects/plugins/jetpack/changelog/fix-cookie-consent-icon
+++ b/projects/plugins/jetpack/changelog/fix-cookie-consent-icon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix Cookie Consent block icon

--- a/projects/plugins/jetpack/changelog/fix-form-block-styles
+++ b/projects/plugins/jetpack/changelog/fix-form-block-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fixes style for multiple choice checkbox in Froms block

--- a/projects/plugins/jetpack/changelog/fix-simple-payment-block
+++ b/projects/plugins/jetpack/changelog/fix-simple-payment-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix unresponsive Simple Payment block

--- a/projects/plugins/jetpack/changelog/fix-wp-admin-post-list-newsletter
+++ b/projects/plugins/jetpack/changelog/fix-wp-admin-post-list-newsletter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Newsletters: Add level for all paid subscribers

--- a/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-4
+++ b/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Refactor blocks registration

--- a/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-5
+++ b/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Refactor blocks registration

--- a/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-6
+++ b/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Refactor blocks registration

--- a/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-7
+++ b/projects/plugins/jetpack/changelog/refactor-production-blocks-registration-7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Refactor blocks registration

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-introduce-current-period-start
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-introduce-current-period-start
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: expose current period start in the ai-assistant-feature endpoint

--- a/projects/plugins/jetpack/changelog/update-jetpack-plugin-assets-mag-16
+++ b/projects/plugins/jetpack/changelog/update-jetpack-plugin-assets-mag-16
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Plugin assets: add mag-16 language versions of our banners.

--- a/projects/plugins/jetpack/changelog/update-subscribe-block-followers-to-subscribers
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-followers-to-subscribers
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscribe block: change "followers" term to "subscribers"

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_10",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_8_a_11",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/nextdoor.php
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/nextdoor.php
@@ -2,7 +2,7 @@
 /**
  * Nextdoor Block.
  *
- * @since $$next-version$$
+ * @since 12.8
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.8-a.10
+ * Version: 12.8-a.11
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.8-a.10' );
+define( 'JETPACK__VERSION', '12.8-a.11' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.8.0-a.10",
+	"version": "12.8.0-a.11",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.6 - 2023-10-31
+### Changed
+- Internal updates.
+
 ## 1.7.5 - 2023-10-30
 
 ## 1.7.4 - 2023-10-26

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_5"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_6"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.7.5
+ * Version: 1.7.6
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.7.5",
+	"version": "1.7.6",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 1.7.6, jetpack 12.8-a.11

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.