### PR TITLE
AI Tiered Plans: pick and expose tier plan data

### DIFF
--- a/projects/plugins/jetpack/changelog/update-tiered-plan-update-use-ai-feature
+++ b/projects/plugins/jetpack/changelog/update-tiered-plan-update-use-ai-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Tiered Plans: pick and expose tied plan data

--- a/projects/plugins/jetpack/changelog/update-tiered-plan-update-use-ai-feature
+++ b/projects/plugins/jetpack/changelog/update-tiered-plan-update-use-ai-feature
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-AI Tiered Plans: pick and expose tied plan data
+AI Tiered Plans: pick and expose tier plan data

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -18,6 +18,14 @@ export type AIFeatureProps = {
 	errorMessage: string;
 	errorCode: string;
 	upgradeType: UpgradeTypeProp;
+	currentTier: {
+		value: 0 | 1 | 100 | 200 | 500;
+	};
+	usagePeriod: {
+		currentStart: string;
+		nextStart: string;
+		requestsCount: number;
+	};
 };
 
 const NUM_FREE_REQUESTS_LIMIT = 20;
@@ -33,6 +41,14 @@ export const AI_Assistant_Initial_State = {
 	errorMessage: aiAssistantFeature?.[ 'error-message' ] || '',
 	errorCode: aiAssistantFeature?.[ 'error-code' ],
 	upgradeType: aiAssistantFeature?.[ 'upgrade-type' ] || 'default',
+	usagePeriod: {
+		currentStart: aiAssistantFeature?.[ 'usage-period' ]?.[ 'current-start' ],
+		nextStart: aiAssistantFeature?.[ 'usage-period' ]?.[ 'next-start' ],
+		requestsCount: aiAssistantFeature?.[ 'usage-period' ]?.[ 'requests-count' ] || 0,
+	},
+	currentTier: {
+		value: aiAssistantFeature?.[ 'current-tier' ]?.value || 1,
+	},
 };
 
 export async function getAIFeatures(): Promise< AIFeatureProps > {
@@ -50,6 +66,14 @@ export async function getAIFeatures(): Promise< AIFeatureProps > {
 			errorMessage: response[ 'error-message' ],
 			errorCode: response[ 'error-code' ],
 			upgradeType: response[ 'upgrade-type' ],
+			usagePeriod: {
+				currentStart: response[ 'usage-period' ]?.[ 'current-start' ],
+				nextStart: response[ 'usage-period' ]?.[ 'next-start' ],
+				requestsCount: response[ 'usage-period' ]?.[ 'requests-count' ] || 0,
+			},
+			currentTier: {
+				value: response[ 'current-tier' ]?.value || 1,
+			},
 		};
 	} catch ( error ) {
 		console.error( error ); // eslint-disable-line no-console


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up of https://github.com/Automattic/jetpack/pull/33894

This PR registers, collect and expose tier plan data from the useAiFeature() custom hook.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Tiered Plans: pick and expose tied plan data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open your dev tool of your favorite client (firefox, chrome, etc)
* Select the `Source` tab
* Browse the `use-ai-fearture` folder

<img width="703" alt="Screenshot 2023-10-31 at 18 54 16" src="https://github.com/Automattic/jetpack/assets/77539/d68509de-6d8b-45df-8362-901e54d3c751">

* Select the `index.ts` file
* Add a breakpoint just after returning the hook data (click on the L93):

<img width="705" alt="Screenshot 2023-10-31 at 19 02 25" src="https://github.com/Automattic/jetpack/assets/77539/1f30df04-3787-497d-bfc5-415dc14ebbf0">

* In the block editor, open the Jetpack AI panel
* The app should stop running
* Mouse over the `data` variable
* Confirm you see the `currentTier` and the `usagePeriod` there


<img width="427" alt="Screenshot 2023-10-31 at 19 05 22" src="https://github.com/Automattic/jetpack/assets/77539/e5428b8f-69da-4f76-9578-a9f9bc5a770c">
