### PR TITLE
Add/app promo meta data to admin

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -123,7 +123,7 @@ abstract class Jetpack_Admin_Page {
 		if ( current_user_can( 'jetpack_connect' ) && $connectable ) {
 			$this->add_connection_banner_actions();
 		}
-		add_action( 'wp_head', array( $this, 'add_ios_smart_banner' ) );
+		add_action( 'admin_head', array( $this, 'add_ios_smart_banner' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -123,6 +123,7 @@ abstract class Jetpack_Admin_Page {
 		if ( current_user_can( 'jetpack_connect' ) && $connectable ) {
 			$this->add_connection_banner_actions();
 		}
+		add_action( 'wp_head', array( $this, 'add_ios_smart_banner' ) );
 	}
 
 	/**
@@ -201,6 +202,12 @@ abstract class Jetpack_Admin_Page {
 		wp_enqueue_style( 'jetpack-admin', plugins_url( "css/jetpack-admin{$min}.css", JETPACK__PLUGIN_FILE ), array( 'genericons' ), JETPACK__VERSION . '-20121016' );
 		wp_style_add_data( 'jetpack-admin', 'rtl', 'replace' );
 		wp_style_add_data( 'jetpack-admin', 'suffix', $min );
+	}
+	/**
+	 * Adds iOS Smart banner to let folks know about the Jetpack app on iOS.
+	 */
+	public function add_ios_smart_banner() {
+		echo "<meta name=\"apple-itunes-app\" content=\"app-id=1565481562\" />\n";
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-app-promo-meta-data-to-admin
+++ b/projects/plugins/jetpack/changelog/add-app-promo-meta-data-to-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Adds Jetpack App iOS smart banner to the wp-admin pages.


### PR DESCRIPTION
This PR attemts to add a Jetpack App promot to the admin pages that shows up in safari. 


## Proposed changes:
* It does this using the https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners tech.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

## Testing instructions:
TBD
