### PR TITLE
Support multiple plans in Paid content block

### DIFF
--- a/projects/plugins/jetpack/changelog/earn-paid-content-support-multiple-plans
+++ b/projects/plugins/jetpack/changelog/earn-paid-content-support-multiple-plans
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Changing paid content block to allow selecting multiple plans.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
@@ -80,24 +80,25 @@ function current_visitor_can_access( $attributes, $block ) {
 		return true;
 	}
 
-	$selected_plan_id = null;
+	$selected_plan_ids = array();
 
-	if ( isset( $attributes['selectedPlanId'] ) ) {
-		$selected_plan_id = (int) $attributes['selectedPlanId'];
+	if ( isset( $attributes['selectedPlanIds'] ) ) {
+		$selected_plan_ids = $attributes['selectedPlanIds'];
 	}
 
-	if ( isset( $block ) && isset( $block->context['premium-content/planId'] ) ) {
-		$selected_plan_id = (int) $block->context['premium-content/planId'];
+	if ( isset( $block ) && isset( $block->context['premium-content/planIds'] ) ) {
+		$selected_plan_ids = $block->context['premium-content/planIds'];
 	}
 
-	if ( empty( $selected_plan_id ) ) {
+	if ( empty( $selected_plan_ids ) ) {
 		return false;
 	}
 
 	$paywall      = subscription_service();
 	$access_level = Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS; // Only paid subscribers should be granted access to the premium content
 	$tier_ids     = \Jetpack_Memberships::get_all_newsletter_plan_ids();
-	if ( in_array( $selected_plan_id, $tier_ids, true ) ) {
+	$tier_ids     = array_intersect( $tier_ids, $selected_plan_ids );
+	if ( ! empty( $tier_ids ) ) {
 		// If the selected plan is a tier, we want to check directly if user has a higher "tier".
 		// This is to prevent situation where the user upgrades and lose access to premium-gated content
 		$token          = $paywall->get_and_set_token_from_request();
@@ -107,10 +108,15 @@ function current_visitor_can_access( $attributes, $block ) {
 		$can_view = false;
 		if ( $is_valid_token ) {
 			$subscriptions = (array) $payload['subscriptions'];
-			$can_view      = ! $paywall->maybe_gate_access_for_user_if_tier( $selected_plan_id, $subscriptions );
+			foreach ( $tier_ids as $tier_id ) {
+				$can_view = ! $paywall->maybe_gate_access_for_user_if_tier( $tier_id, $subscriptions );
+				if ( $can_view ) {
+					break;
+				}
+			}
 		}
 	} else {
-		$can_view = $paywall->visitor_can_view_content( array( $selected_plan_id ), $access_level );
+		$can_view = $paywall->visitor_can_view_content( $selected_plan_ids, $access_level );
 	}
 
 	if ( $can_view ) {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
@@ -84,9 +84,13 @@ function current_visitor_can_access( $attributes, $block ) {
 
 	if ( isset( $attributes['selectedPlanIds'] ) ) {
 		$selected_plan_ids = $attributes['selectedPlanIds'];
+	} elseif ( isset( $attributes['selectedPlanId'] ) ) {
+		$selected_plan_ids = array( $attributes['selectedPlanId'] );
 	}
 
-	if ( isset( $block ) && isset( $block->context['premium-content/planIds'] ) ) {
+	if ( isset( $block ) && ! empty( $block->context['premium-content/planId'] ) ) {
+		$selected_plan_ids = array( $block->context['premium-content/planId'] );
+	} elseif ( isset( $block ) && ! empty( $block->context['premium-content/planIds'] ) ) {
 		$selected_plan_ids = $block->context['premium-content/planIds'];
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/block.json
@@ -45,6 +45,7 @@
 	},
 	"providesContext": {
 		"premium-content/planId": "selectedPlanId",
+		"premium-content/planIds": "selectedPlanIds",
 		"premium-content/isPreview": "isPreview",
 		"isPremiumContentChild": "isPremiumContentChild"
 	},
@@ -68,6 +69,10 @@
 		"selectedPlanId": {
 			"type": "number",
 			"default": 0
+		},
+		"selectedPlanIds": {
+			"type": "array",
+			"default": []
 		},
 		"isPreview": {
 			"type": "boolean",

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/block.json
@@ -44,7 +44,6 @@
 		"html": false
 	},
 	"providesContext": {
-		"premium-content/planId": "selectedPlanId",
 		"premium-content/planIds": "selectedPlanIds",
 		"premium-content/isPreview": "isPreview",
 		"isPremiumContentChild": "isPremiumContentChild"
@@ -65,10 +64,6 @@
 		"newPlanInterval": {
 			"type": "string",
 			"default": "1 month"
-		},
-		"selectedPlanId": {
-			"type": "number",
-			"default": 0
 		},
 		"selectedPlanIds": {
 			"type": "array",

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
@@ -12,8 +12,7 @@ const ALLOWED_BLOCKS = [
 ];
 
 function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
-	const planIds =
-		context[ 'premium-content/planIds' ] || [ context[ 'premium-content/planId' ] ] || [];
+	const planIds = context[ 'premium-content/planIds' ] || [];
 	const planId = planIds.reduce( ( acc, plan ) => {
 		if ( acc === null ) {
 			return plan;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
@@ -12,13 +12,15 @@ const ALLOWED_BLOCKS = [
 ];
 
 function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
-	const planIds = context ? context[ 'premium-content/planIds' ] : [];
+	const planIds =
+		context[ 'premium-content/planIds' ] || [ context[ 'premium-content/planId' ] ] || [];
 	const planId = planIds.reduce( ( acc, plan ) => {
 		if ( acc === null ) {
 			return plan;
 		}
 		return acc + '+' + plan;
 	}, null );
+
 	const isPreview = context ? context[ 'premium-content/isPreview' ] : false;
 
 	const previewTemplate = [

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
@@ -12,7 +12,13 @@ const ALLOWED_BLOCKS = [
 ];
 
 function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
-	const planId = context ? context[ 'premium-content/planId' ] : null;
+	const planIds = context ? context[ 'premium-content/planIds' ] : [];
+	const planId = planIds.reduce( ( acc, plan ) => {
+		if ( acc === null ) {
+			return plan;
+		}
+		return acc + '+' + plan;
+	}, null );
 	const isPreview = context ? context[ 'premium-content/isPreview' ] : false;
 
 	const previewTemplate = [

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
@@ -23,7 +23,7 @@ const settings = {
 	keywords: [ __( 'link', 'jetpack' ) ],
 	edit,
 	save,
-	usesContext: [ 'premium-content/planId', 'premium-content/isPreview' ],
+	usesContext: [ 'premium-content/planId', 'premium-content/planIds', 'premium-content/isPreview' ],
 	deprecated: [
 		{
 			attributes: {},

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
@@ -23,7 +23,7 @@ const settings = {
 	keywords: [ __( 'link', 'jetpack' ) ],
 	edit,
 	save,
-	usesContext: [ 'premium-content/planId', 'premium-content/planIds', 'premium-content/isPreview' ],
+	usesContext: [ 'premium-content/planIds', 'premium-content/isPreview' ],
 	deprecated: [
 		{
 			attributes: {},

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/deprecated/v2/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/deprecated/v2/index.js
@@ -1,0 +1,41 @@
+import save from '../../save';
+
+export default {
+	attributes: {
+		newPlanName: {
+			type: 'string',
+			default: 'Monthly Subscription',
+		},
+		newPlanCurrency: {
+			type: 'string',
+			default: 'USD',
+		},
+		newPlanPrice: {
+			type: 'number',
+			default: 5,
+		},
+		newPlanInterval: {
+			type: 'string',
+			default: '1 month',
+		},
+		selectedPlanId: {
+			type: 'number',
+			default: 0,
+		},
+		isPreview: {
+			type: 'boolean',
+			default: false,
+		},
+		isPremiumContentChild: {
+			type: 'boolean',
+			default: true,
+		},
+	},
+	isEligible: attributes => 'selectedPlanId' in attributes,
+	migrate: attributes => {
+		const { selectedPlanId, ...rest } = attributes;
+		const selectedPlanIds = selectedPlanId ? [ selectedPlanId ] : [];
+		return { ...rest, selectedPlanIds };
+	},
+	save,
+};

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -58,10 +58,10 @@ const BLOCK_NAME = 'premium-content';
 
 function Edit( props ) {
 	const [ selectedTab, selectTab ] = useState( tabs[ WALL_TAB ] );
-	const { isPreview, selectedPlanId } = props.attributes;
+	const { isPreview, selectedPlanIds } = props.attributes;
 	const { clientId, isSelected, className, setAttributes } = props;
 
-	const setSelectedProductId = productId => setAttributes( { selectedPlanId: productId } );
+	const setSelectedProductIds = productIds => setAttributes( { selectedPlanIds: productIds } );
 
 	const { isApiLoading, selectedBlock } = useSelect( selector => ( {
 		selectedBlock: selector( blockEditorStore ).getSelectedBlock(),
@@ -116,8 +116,8 @@ function Edit( props ) {
 						blockName={ BLOCK_NAME }
 						clientId={ clientId }
 						productType={ PRODUCT_TYPE_SUBSCRIPTION }
-						selectedProductId={ selectedPlanId }
-						setSelectedProductId={ setSelectedProductId }
+						selectedProductIds={ selectedPlanIds }
+						setSelectedProductIds={ setSelectedProductIds }
 					/>
 					<ViewSelector
 						options={ tabs }

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/editor.js
@@ -7,6 +7,7 @@ import { transformToCoreGroup } from './_inc/transform-to-core-group';
 import metadata from './block.json';
 import { name as buttonsBlockName, settings as buttonsBlockSettings } from './buttons/.';
 import deprecatedV1 from './deprecated/v1';
+import deprecatedV2 from './deprecated/v2';
 import edit from './edit';
 import {
 	name as loggedOutViewBlockName,
@@ -118,7 +119,7 @@ registerJetpackBlockFromMetadata(
 				},
 			],
 		},
-		deprecated: [ deprecatedV1 ],
+		deprecated: [ deprecatedV2, deprecatedV1 ],
 	},
 	[
 		{ name: loggedOutViewBlockName, settings: loggedOutViewBlockSettings },

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
@@ -28,7 +28,7 @@ function register_loggedout_view_block() {
 		LOGGEDOUT_VIEW_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_loggedout_view_block',
-			$uses             => array( 'premium-content/planId' ),
+			$uses             => array( 'premium-content/planIds' ),
 		)
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
@@ -28,7 +28,7 @@ function register_loggedout_view_block() {
 		LOGGEDOUT_VIEW_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_loggedout_view_block',
-			$uses             => array( 'premium-content/planIds' ),
+			$uses             => array( 'premium-content/planId', 'premium-content/planIds' ),
 		)
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -31,6 +31,7 @@ function register_block() {
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_block',
 			$provides         => array(
+				'premium-content/planId'  => 'selectedPlanId', // Deprecated.
 				'premium-content/planIds' => 'selectedPlanIds',
 				'isPremiumContentChild'   => 'isPremiumContentChild',
 			),

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -31,7 +31,6 @@ function register_block() {
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_block',
 			$provides         => array(
-				'premium-content/planId'  => 'selectedPlanId',
 				'premium-content/planIds' => 'selectedPlanIds',
 				'isPremiumContentChild'   => 'isPremiumContentChild',
 			),

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -31,8 +31,9 @@ function register_block() {
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_block',
 			$provides         => array(
-				'premium-content/planId' => 'selectedPlanId',
-				'isPremiumContentChild'  => 'isPremiumContentChild',
+				'premium-content/planId'  => 'selectedPlanId',
+				'premium-content/planIds' => 'selectedPlanIds',
+				'isPremiumContentChild'   => 'isPremiumContentChild',
 			),
 		)
 	);

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/subscriber-view.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/subscriber-view.php
@@ -28,7 +28,7 @@ function register_subscriber_view_block() {
 		SUBSCRIBER_VIEW_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_subscriber_view_block',
-			$uses             => array( 'premium-content/planId' ),
+			$uses             => array( 'premium-content/planIds' ),
 		)
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/subscriber-view.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/subscriber-view.php
@@ -28,7 +28,7 @@ function register_subscriber_view_block() {
 		SUBSCRIBER_VIEW_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_subscriber_view_block',
-			$uses             => array( 'premium-content/planIds' ),
+			$uses             => array( 'premium-content/planId', 'premium-content/planIds' ),
 		)
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/block.json
@@ -50,6 +50,10 @@
 		"planId": {
 			"type": "integer"
 		},
+		"planIds": {
+			"type": "array",
+			"default": []
+		},
 		"align": {
 			"type": "string"
 		},

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/block.json
@@ -50,10 +50,6 @@
 		"planId": {
 			"type": "integer"
 		},
-		"planIds": {
-			"type": "array",
-			"default": []
-		},
 		"align": {
 			"type": "string"
 		},

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -15,7 +15,7 @@ import { getBlockStyles } from './util';
 const BLOCK_NAME = 'recurring-payments';
 
 export default function Edit( { attributes, clientId, setAttributes } ) {
-	const { align, planId, width } = attributes;
+	const { align, planId, planIds, width } = attributes;
 	const editorType = getEditorType();
 	const postLink = useSelect( select => select( editorStore )?.getCurrentPost()?.link, [] );
 
@@ -43,6 +43,10 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	useEffect( () => {
 		updateSubscriptionPlan( planId );
 	}, [ planId, updateSubscriptionPlan ] );
+
+	const updateSubscriptionPlans = planIds => {
+		planIds.array.forEach( updateSubscriptionPlan );
+	};
 
 	/**
 	 * Filters the editor settings of the Payment Button block (`jetpack/recurring-payments`).
@@ -90,8 +94,8 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 				<ProductManagementControls
 					blockName={ BLOCK_NAME }
 					clientId={ clientId }
-					selectedProductId={ planId }
-					setSelectedProductId={ updateSubscriptionPlan }
+					selectedProductIds={ [ planId ] }
+					setSelectedProductIds={ updateSubscriptionPlans }
 				/>
 			) }
 			<InspectorControls>

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -16,13 +16,16 @@ const BLOCK_NAME = 'recurring-payments';
 
 export default function Edit( { attributes, clientId, setAttributes } ) {
 	const { align, planId, width } = attributes;
-	const planIds = useMemo( () => ( planId ? planId.split( '+' ) : [] ), [ planId ] );
+	const planIds = useMemo( () => {
+		const _planIds = ( '' + planId ).split( '+' ).map( id => parseInt( id, 10 ) );
+		return _planIds;
+	}, [ planId ] );
 	const editorType = getEditorType();
 	const postLink = useSelect( select => select( editorStore )?.getCurrentPost()?.link, [] );
 
 	const updateSubscriptionPlans = useCallback(
 		newPlanIds => {
-			const newPlanId = newPlanIds.join( '+' );
+			const newPlanId = newPlanIds !== planIds ? newPlanIds.join( '+' ) : planId;
 			const resolvePaymentUrl = paymentPlanId => {
 				if ( POST_EDITOR !== editorType || ! postLink ) {
 					return '#';
@@ -35,12 +38,11 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 
 			setAttributes( {
 				planId: newPlanId,
-				planIds: newPlanIds,
 				url: resolvePaymentUrl( newPlanId ),
 				uniqueId: `recurring-payments-${ newPlanId }`,
 			} );
 		},
-		[ editorType, postLink, setAttributes ]
+		[ editorType, planId, planIds, postLink, setAttributes ]
 	);
 
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/context.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/context.js
@@ -6,8 +6,8 @@ export const ProductManagementContext = createContext( {
 	clientId: undefined,
 	products: [],
 	productType: PRODUCT_TYPE_PAYMENT_PLAN,
-	selectedProductId: 0,
-	setSelectedProductId: () => {},
+	selectedProductIds: [],
+	setSelectedProductIds: () => {},
 } );
 
 export const useProductManagementContext = () => useContext( ProductManagementContext );

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
@@ -14,26 +14,26 @@ export default function ProductManagementControls( {
 	blockName,
 	clientId,
 	productType = PRODUCT_TYPE_PAYMENT_PLAN,
-	selectedProductId = 0,
-	setSelectedProductId = () => {},
+	selectedProductIds = [],
+	setSelectedProductIds = () => {},
 } ) {
 	const products = useSelect(
 		select =>
 			select( membershipProductsStore ).getProducts(
 				productType,
-				selectedProductId,
-				setSelectedProductId
+				selectedProductIds,
+				setSelectedProductIds
 			),
 		[]
 	);
 
-	const { connectUrl, isApiConnected, isSelectedProductInvalid } = useSelect( select => {
-		const { getConnectUrl, isApiStateConnected, isInvalidProduct } =
+	const { connectUrl, isApiConnected, areSelectedProductsInvalid } = useSelect( select => {
+		const { getConnectUrl, isApiStateConnected, hasInvalidProducts } =
 			select( membershipProductsStore );
 		return {
 			connectUrl: getConnectUrl(),
 			isApiConnected: isApiStateConnected(),
-			isSelectedProductInvalid: isInvalidProduct( selectedProductId ),
+			areSelectedProductsInvalid: hasInvalidProducts( selectedProductIds ),
 		};
 	} );
 
@@ -47,8 +47,8 @@ export default function ProductManagementControls( {
 		clientId,
 		products,
 		productType,
-		selectedProductId,
-		setSelectedProductId,
+		selectedProductIds,
+		setSelectedProductIds,
 	};
 
 	return (
@@ -64,7 +64,7 @@ export default function ProductManagementControls( {
 					<ProductManagementToolbarControl />
 				</>
 			) }
-			{ isApiConnected && isSelectedProductInvalid && <InvalidProductWarning /> }
+			{ isApiConnected && areSelectedProductsInvalid && <InvalidProductWarning /> }
 		</ProductManagementContext.Provider>
 	);
 }

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/inspector-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/inspector-control.js
@@ -27,7 +27,7 @@ const DEFAULT_INTERVAL = '1 month';
 const DEFAULT_IS_CUSTOM_AMOUNT = false;
 
 export default function ProductManagementInspectorControl() {
-	const { productType, setSelectedProductId } = useProductManagementContext();
+	const { productType, setSelectedProductIds } = useProductManagementContext();
 
 	const siteSlug = useSelect( select => select( membershipProductsStore ).getSiteSlug() );
 
@@ -63,7 +63,7 @@ export default function ProductManagementInspectorControl() {
 				is_editable: true,
 			},
 			productType,
-			setSelectedProductId,
+			setSelectedProductIds,
 			success => {
 				setApiState( API_STATE_NOT_REQUESTING );
 				if ( success ) {

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
@@ -38,16 +38,19 @@ function getProductDescription( product ) {
 }
 
 function Product( { onClose, product } ) {
-	const { selectedProductId, setSelectedProductId } = useProductManagementContext();
+	const { selectedProductIds, setSelectedProductIds } = useProductManagementContext();
 
 	const { id, title } = product;
-	const isSelected = selectedProductId && selectedProductId === id;
+	const isSelected = selectedProductIds && selectedProductIds.includes( id );
 	const icon = isSelected ? check : undefined;
 	const productDescription = product ? ' ' + getProductDescription( product ) : null;
 
 	const handleClick = event => {
 		event.preventDefault();
-		setSelectedProductId( id );
+		const selected = isSelected
+			? selectedProductIds.filter( productId => productId !== id )
+			: [ ...selectedProductIds, id ];
+		setSelectedProductIds( selected );
 		onClose();
 	};
 
@@ -99,22 +102,25 @@ function NewProduct( { onClose } ) {
 }
 
 export default function ProductManagementToolbarControl() {
-	const { products, productType, selectedProductId } = useProductManagementContext();
+	const { products, productType, selectedProductIds } = useProductManagementContext();
 
-	const { selectedProduct } = useSelect( select => {
-		const { getProduct } = select( membershipProductsStore );
+	const { selectedProducts } = useSelect( select => {
+		const { getSelectedProducts } = select( membershipProductsStore );
 		return {
-			selectedProduct: getProduct( selectedProductId ),
+			selectedProducts: getSelectedProducts( selectedProductIds ),
 		};
 	} );
 
 	let productDescription = null;
 	let subscriptionIcon = update;
 
-	if ( selectedProduct ) {
-		productDescription = getProductDescription( selectedProduct );
+	if ( selectedProducts.length > 1 ) {
+		productDescription = __( 'Multiple products selected', 'jetpack' );
+	} else if ( selectedProducts.length === 1 ) {
+		productDescription = getProductDescription( selectedProducts[ 0 ] );
 	}
-	if ( selectedProductId && ! selectedProduct ) {
+
+	if ( selectedProducts.length !== selectedProducts.length ) {
 		productDescription = getMessageByProductType( 'product not found', productType );
 		subscriptionIcon = warning;
 	}

--- a/projects/plugins/jetpack/extensions/store/membership-products/actions.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/actions.js
@@ -36,7 +36,7 @@ export const saveProduct =
 	(
 		product,
 		productType = PRODUCT_TYPE_PAYMENT_PLAN,
-		setSelectedProductId = () => {},
+		setSelectedProductIds = () => {},
 		callback = () => {},
 		shouldDisplayProductCreationNotice = true
 	) =>
@@ -87,7 +87,7 @@ export const saveProduct =
 			const products = registry.select( STORE_NAME ).getProducts();
 
 			dispatch( setProducts( products.concat( [ newProduct ] ) ) );
-			setSelectedProductId( newProduct.id );
+			setSelectedProductIds( [ newProduct.id ] );
 			if ( shouldDisplayProductCreationNotice ) {
 				onSuccess(
 					getMessageByProductType( 'successfully created product', productType ),

--- a/projects/plugins/jetpack/extensions/store/membership-products/actions.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/actions.js
@@ -87,6 +87,7 @@ export const saveProduct =
 			const products = registry.select( STORE_NAME ).getProducts();
 
 			dispatch( setProducts( products.concat( [ newProduct ] ) ) );
+			// TODO: Should we check the current selected product ids and add the new product id if it's not there?
 			setSelectedProductIds( [ newProduct.id ] );
 			if ( shouldDisplayProductCreationNotice ) {
 				onSuccess(

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -147,7 +147,7 @@ export const fetchNewsletterCategoriesSubscriptionsCount = async termIds => {
 
 const createDefaultProduct = async (
 	productType,
-	setSelectedProductId,
+	setSelectedProductIds,
 	dispatch,
 	shouldDisplayProductCreationNotice
 ) => {
@@ -160,7 +160,7 @@ const createDefaultProduct = async (
 				interval: '1 month',
 			},
 			productType,
-			setSelectedProductId,
+			setSelectedProductIds,
 			() => {},
 			shouldDisplayProductCreationNotice
 		)
@@ -170,33 +170,33 @@ const createDefaultProduct = async (
 const shouldCreateDefaultProduct = response =>
 	! response.products.length && response.connected_account_id;
 
-const setDefaultProductIfNeeded = ( selectedProductId, setSelectedProductId, select ) => {
-	if ( selectedProductId ) {
+const setDefaultProductIfNeeded = ( selectedProductIds, setSelectedProductIds, select ) => {
+	if ( selectedProductIds.length > 0 ) {
 		return;
 	}
 	const defaultProductId = select.getProductsNoResolver()[ 0 ]?.id;
 	if ( defaultProductId ) {
-		setSelectedProductId( defaultProductId );
+		setSelectedProductIds( [ defaultProductId ] );
 	}
 };
 
 export const getNewsletterTierProducts = (
 	productType = PRODUCT_TYPE_PAYMENT_PLAN,
-	selectedProductId = 0,
-	setSelectedProductId = () => {}
-) => getProducts( productType, selectedProductId, setSelectedProductId, false );
+	selectedProductIds = [],
+	setSelectedProductIds = () => {}
+) => getProducts( productType, selectedProductIds, setSelectedProductIds, false );
 
 export const getProducts =
 	(
 		productType = PRODUCT_TYPE_PAYMENT_PLAN,
-		selectedProductId = 0,
-		setSelectedProductId = () => {},
+		selectedProductIds = [],
+		setSelectedProductIds = () => {},
 		shouldDisplayProductCreationNotice = true
 	) =>
 	async ( { dispatch, registry, select } ) => {
 		await executionLock.blockExecution( EXECUTION_KEY );
 		if ( hydratedFromAPI ) {
-			setDefaultProductIfNeeded( selectedProductId, setSelectedProductId, select );
+			setDefaultProductIfNeeded( selectedProductIds, setSelectedProductIds, select );
 			return;
 		}
 
@@ -209,13 +209,13 @@ export const getProducts =
 				// Is ready to use and has no product set up yet. Let's create one!
 				await createDefaultProduct(
 					productType,
-					setSelectedProductId,
+					setSelectedProductIds,
 					dispatch,
 					shouldDisplayProductCreationNotice
 				);
 			}
 
-			setDefaultProductIfNeeded( selectedProductId, setSelectedProductId, select );
+			setDefaultProductIfNeeded( selectedProductIds, setSelectedProductIds, select );
 
 			hydratedFromAPI = true;
 		} catch ( error ) {

--- a/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
@@ -37,6 +37,9 @@ export const getNewsletterCategoriesEnabled = state => state.newsletterCategorie
 export const getNewsletterCategoriesSubscriptionsCount = state =>
 	state.newsletterCategoriesSubscriptionsCount;
 
-export const hasInvalidProducts = ( state, selectedProductIds ) =>
-	!! selectedProductIds &&
-	selectedProductIds.some( productId => isInvalidProduct( state, productId ) );
+export const hasInvalidProducts = ( state, selectedProductIds ) => {
+	return (
+		!! selectedProductIds &&
+		selectedProductIds.some( productId => isInvalidProduct( state, productId ) )
+	);
+};

--- a/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
@@ -13,6 +13,9 @@ export const getProductsNoResolver = state => getProducts( state );
 export const getProduct = ( state, productId ) =>
 	getProducts( state ).find( product => product.id === productId );
 
+export const getSelectedProducts = ( state, selectedProductIds ) =>
+	getProducts( state ).filter( product => selectedProductIds.includes( product.id ) );
+
 export const getNewsletterTierProducts = state =>
 	state.products.filter( product => product.type === TYPE_TIER );
 
@@ -33,3 +36,7 @@ export const getNewsletterCategoriesEnabled = state => state.newsletterCategorie
 
 export const getNewsletterCategoriesSubscriptionsCount = state =>
 	state.newsletterCategoriesSubscriptionsCount;
+
+export const hasInvalidProducts = ( state, selectedProductIds ) =>
+	!! selectedProductIds &&
+	selectedProductIds.some( productId => isInvalidProduct( state, productId ) );

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
@@ -114,7 +114,7 @@ describe( 'Membership Products Actions', () => {
 
 	test.each( productsForTitleTesting )( '$name', async testCase => {
 		// Given
-		const selectedProductIdCallback = anyFunction;
+		const selectedProductIdsCallback = anyFunction;
 		const paymentPlanProductType = PRODUCT_TYPE_PAYMENT_PLAN;
 		const noticeMock = jest.spyOn( utils, 'onError' ).mockImplementation( anyFunction );
 		const getMessageMock = jest
@@ -125,7 +125,7 @@ describe( 'Membership Products Actions', () => {
 		await saveProduct(
 			testCase.product,
 			paymentPlanProductType,
-			selectedProductIdCallback
+			selectedProductIdsCallback
 		)( anyFunction, anyFunction );
 
 		// Then

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
@@ -223,7 +223,7 @@ describe( 'Membership Products Actions', () => {
 			products: registryProductList.concat( [ apiResponseProduct ] ),
 			type: 'SET_PRODUCTS',
 		} );
-		expect( selectedProductCallback ).toHaveBeenCalledWith( apiResponseProduct.id );
+		expect( selectedProductCallback ).toHaveBeenCalledWith( [ apiResponseProduct.id ] );
 		expect( noticeMock ).toHaveBeenCalled();
 		expect( getMessageMock ).toHaveBeenCalledWith(
 			'successfully created product',
@@ -298,7 +298,7 @@ describe( 'Membership Products Actions', () => {
 			products: registryProductList.concat( [ apiResponseProduct ] ),
 			type: 'SET_PRODUCTS',
 		} );
-		expect( selectedProductCallback ).toHaveBeenCalledWith( apiResponseProduct.id );
+		expect( selectedProductCallback ).toHaveBeenCalledWith( [ apiResponseProduct.id ] );
 		expect( noticeMock ).not.toHaveBeenCalled();
 		expect( getMessageMock ).not.toHaveBeenCalled();
 	} );

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -353,7 +353,7 @@ class Jetpack_Memberships {
 		// This is string of '+` separated plan ids. Loop through them and
 		// filter out the ones that are not valid.  If none are valid, return.
 		// (Returning like this makes the button disappear.)
-		$plan_ids = explode( '+', $attributes['planId'] );
+		$plan_ids    = explode( '+', $attributes['planId'] );
 		$valid_plans = array();
 		foreach ( $plan_ids as $plan_id ) {
 			if ( ! is_numeric( $plan_id ) ) {

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -337,7 +337,7 @@ class Jetpack_Memberships {
 	 * @param string   $content - Recurring Payment block content.
 	 * @param WP_Block $block - Recurring Payment block instance.
 	 *
-	 * @return string|void
+	 * @return string|void - HTML for the button, void removes the button.
 	 */
 	public function render_button( $attributes, $content = null, $block = null ) {
 		Jetpack_Gutenberg::load_assets_as_required( self::$button_block_name, array( 'thickbox', 'wp-polyfill' ) );
@@ -350,14 +350,29 @@ class Jetpack_Memberships {
 			return;
 		}
 
-		$plan_id = (int) $attributes['planId'];
-		$product = get_post( $plan_id );
-		if ( ! $product || is_wp_error( $product ) ) {
+		// This is string of '+` separated plan ids. Loop through them and
+		// filter out the ones that are not valid.  If none are valid, return.
+		// (Returning like this makes the button disappear.)
+		$plan_ids = explode( '+', $attributes['planId'] );
+		$valid_plans = array();
+		foreach ( $plan_ids as $plan_id ) {
+			if ( ! is_numeric( $plan_id ) ) {
+				continue;
+			}
+			$product = get_post( $plan_id );
+			if ( ! $product || is_wp_error( $product ) ) {
+				continue;
+			}
+			if ( $product->post_type !== self::$post_type_plan || 'publish' !== $product->post_status ) {
+				continue;
+			}
+			$valid_plans[] = $plan_id;
+		}
+
+		if ( empty( $valid_plans ) ) {
 			return;
 		}
-		if ( $product->post_type !== self::$post_type_plan || 'publish' !== $product->post_status ) {
-			return;
-		}
+		$plan_id = implode( '+', $valid_plans );
 
 		add_thickbox();
 

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -351,8 +351,7 @@ class Jetpack_Memberships {
 		}
 
 		// This is string of '+` separated plan ids. Loop through them and
-		// filter out the ones that are not valid.  If none are valid, return.
-		// (Returning like this makes the button disappear.)
+		// filter out the ones that are not valid.
 		$plan_ids    = explode( '+', $attributes['planId'] );
 		$valid_plans = array();
 		foreach ( $plan_ids as $plan_id ) {
@@ -369,6 +368,8 @@ class Jetpack_Memberships {
 			$valid_plans[] = $plan_id;
 		}
 
+		// If none are valid, return.
+		// (Returning like this makes the button disappear.)
 		if ( empty( $valid_plans ) ) {
 			return;
 		}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/test_class.jetpack-premium-content.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/test_class.jetpack-premium-content.php
@@ -152,24 +152,25 @@ class WP_Test_Jetpack_Premium_Content extends WP_UnitTestCase {
 		$regular_subscriber_id = $users_plans[1];
 		$paid_subscriber_id    = $users_plans[2];
 		$plan_id               = $users_plans[3];
+		$selected_plan_ids     = array( $plan_id );
 
 		// We setup the token for the regular user
 		wp_set_current_user( $non_subscriber_id );
 		$payload = $this->get_payload( false, false );
 		$this->set_returned_token( $payload );
-		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanId' => $plan_id ), array() ) );
+		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => $selected_plan_ids ), array() ) );
 
 		// We setup the token for the regular subscriber
 		wp_set_current_user( $regular_subscriber_id );
 		$payload = $this->get_payload( true, false );
 		$this->set_returned_token( $payload );
-		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanId' => $plan_id ), array() ) );
+		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => $selected_plan_ids ), array() ) );
 
 		// We setup the token for the paid user
 		wp_set_current_user( $paid_subscriber_id );
 		$payload = $this->get_payload( true, true );
 		$this->set_returned_token( $payload );
-		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanId' => $plan_id ), array() ) );
+		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => $selected_plan_ids ), array() ) );
 	}
 
 	/**
@@ -191,7 +192,7 @@ class WP_Test_Jetpack_Premium_Content extends WP_UnitTestCase {
 		$this->assertFalse( current_visitor_can_access( array(), array() ) );
 
 		// The plan id can be passed in 2 ways.
-		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanId' => $plan_id ), array() ) );
-		$this->assertTrue( current_visitor_can_access( array(), (object) array( 'context' => array( 'premium-content/planId' => $plan_id ) ) ) );
+		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+		$this->assertTrue( current_visitor_can_access( array(), (object) array( 'context' => array( 'premium-content/planIds' => array( $plan_id ) ) ) ) );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Jetpack block component for https://github.com/Automattic/wp-calypso/issues/41606 and https://github.com/Automattic/gold/issues/202. Builds from #27757.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Modifies the paid content block to select multiple plans
* Adds handling to the paid content context for multiple plans
* Changes the handling in the recurring-payments block to use the planId string to represent multiple plans in a backwards compatible manner.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See D128981-code for testing instructions.