### PR TITLE
Connection: make sure scheme history option is an array

### DIFF
--- a/projects/packages/connection/changelog/fix-connection-urls-scheme-history
+++ b/projects/packages/connection/changelog/fix-connection-urls-scheme-history
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make sure scheme history option is an array.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.58.2';
+	const PACKAGE_VERSION = '1.58.3-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-urls.php
+++ b/projects/packages/connection/src/class-urls.php
@@ -90,6 +90,7 @@ class Urls {
 		$option_key = self::HTTPS_CHECK_OPTION_PREFIX . $callable;
 
 		$parsed_url = wp_parse_url( $new_value );
+
 		if ( ! $parsed_url ) {
 			return $new_value;
 		}
@@ -98,7 +99,12 @@ class Urls {
 		} else {
 			$scheme = '';
 		}
-		$scheme_history   = get_option( $option_key, array() );
+		$scheme_history = get_option( $option_key, array() );
+
+		if ( ! is_array( $scheme_history ) ) {
+			$scheme_history = array();
+		}
+
 		$scheme_history[] = $scheme;
 
 		// Limit length to self::HTTPS_CHECK_HISTORY.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix a fatal caused by `jetpack_sync_https_history_*` options storing non-array values.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1698346478667619-slack-CDD9LQRSN

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack.
2. Update the `jetpack_sync_https_history_home_url` option with some random string:
```
wp option update jetpack_sync_https_history_home_url "asdf123"
```
3. Visit the Jetpack "Site Health" page: `/wp-admin/site-health.php?tab=debug`, confirm there are no fatals.
4. Scroll down to "Jetpack -> IDC URLs", confirm the URL's there are valid.