### PR TITLE
CRM: 3382 - Fix PHP notice when contact is assigned to team member

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3382-php_notice_when_contact_has_assignee
+++ b/projects/plugins/crm/changelog/fix-crm-3382-php_notice_when_contact_has_assignee
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHP notice (unreleased regression from 33736)
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -1201,14 +1201,13 @@ function zeroBS_getOwnerObj( $wp_user_id = -1 ) {
 		 * fields are provided (e.g. don't show `user_pass`).
 		 */
 		$user_data = (object) array(
-			'ID'            => $user_data->data->ID,
-			'user_login'    => $user_data->data->user_login,
-			'user_nicename' => $user_data->data->user_nicename,
-			'display_name'  => $user_data->data->display_name,
+			'ID'            => $user->data->ID,
+			'user_login'    => $user->data->user_login,
+			'user_nicename' => $user->data->user_nicename,
+			'display_name'  => $user->data->display_name,
 		);
 
 		return array(
-
 			'ID'  => $wp_user_id,
 			'OBJ' => $user_data,
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3382 - Fix PHP notice when contact is assigned to team member

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This is a simple typo introduced in #33736 (`$user_data` → `$user`).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a contact.
2. Assign the contact to a team member.
3. View the contact profile.

In `trunk`, one gets a PHP notice.

In the `fix/crm/3382-php_notice_when_contact_has_assignee` branch, the PHP notice is no more.