### PR TITLE
Update Calypso URL for launchpad add subscribers task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-calypso-url-for-launchpad-add-subscribers-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-calypso-url-for-launchpad-add-subscribers-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Ensure that the URL for the Add Subscribers task will trigger the right modal

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -195,7 +195,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/subscribers/' . $data['site_slug_encoded'];
+				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
 			},
 		),
 		'migrate_content'                 => array(

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-calypso-url-for-launchpad-add-subscribers-task
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-calypso-url-for-launchpad-add-subscribers-task
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds `#add-subscribers` to the Calypso URL for the "Add Subscribers" launchpad task so the task will automatically show the "Add Subscribers" modal.
  - This hash handling was added in https://github.com/Automattic/wp-calypso/pull/80325, and even if it isn't present, the additional hash will be a no-op

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

This is a WordPress.com-specific feature.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No changes to tracking or activity.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Before applying this change, you need to have a WordPress.com site in the right state. To get that set up, follow these steps:
  - Go to [https://wordpress.com/setup/newsletter] and start the flow to create a new Newsletter site
  - Work through the flow until you see the newsletter goals step, where you are asked how you want to get started, and are presented with three options: "Free newsletter", "Paid newsletter", and "Import an existing newsletter"
  - Choose "Import an existing newsletter"
  - You should then see the fullscreen launchpad
  - Click on the "Skip for now" link in the top right corner
  - You should now see a task list in Customer Home, and the task list should include an "Add subscribers" task
  - Copy this URL, as you're going to want it to test with and without the patch
* Navigate to My Home for your site without any changes applied, and click on the "Add subscribers" task
* Verify that you are taken to the subscribers screen, but the "Add subscribers" modal is _not_ displayed by default
* Use the instructions in [this comment below](https://github.com/Automattic/jetpack/pull/33913#issuecomment-1789054461) to apply this patch to a WordPress.com development sandbox, and ensure that requests for `public-api.wordpress.com` are routed via that sandbox
* Navigate back to My Home for this site
* Verify that the "Add subscribers" task is visible, and the link for the task includes `#add-subscribers` as a suffix.
* Click on the "Add subscribers" task, and verify that the Add subscribers modal is visible on the page