### PR TITLE
Jetpack AI: Remove performance offending code to solve editor loading issues

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -388,13 +388,9 @@ class Jetpack_AI_Helper {
 			/*
 			 * Usage since the last plan purchase day
 			 */
-			$usage_period_start = WPCOM\Jetpack_AI\Usage\Helper::get_usage_period_start_date( $blog_id );
-			$usage_period_start = isset( $usage_period_start ) ? $usage_period_start->format( 'Y-m-d H:i:s' ) : null;
-
-			$usage_next_period_start = WPCOM\Jetpack_AI\Usage\Helper::get_usage_next_period_start_date( $blog_id );
-			$usage_next_period_start = isset( $usage_next_period_start ) ? $usage_next_period_start->format( 'Y-m-d H:i:s' ) : null;
-
-			$usage_period_requests_count = WPCOM\Jetpack_AI\Usage\Helper::get_current_period_requests_count( $blog_id );
+			$usage_period_start          = null;
+			$usage_next_period_start     = null;
+			$usage_period_requests_count = 0;
 
 			/*
 			 * Get current tier value, a number representing

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -401,7 +401,7 @@ class Jetpack_AI_Helper {
 			 * - 100, 200, 500 represents a site with the new plans,
 			 * with the respective number of allowed requests.
 			 */
-			$current_tier_value = $has_ai_assistant_feature ? WPCOM\Jetpack_AI\Usage\Helper::get_tier_usage_quantity( $blog_id ) : 0;
+			$current_tier_value = $has_ai_assistant_feature ? 1 : 0;
 
 			// Check if the site requires an upgrade.
 			$require_upgrade = $is_over_limit && ! $has_ai_assistant_feature;

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-comment-slow-lines
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-comment-slow-lines
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: Temporarely remove performance sensitive function calls to solve loading issue.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Context: p1698841418962749-slack-CBG1CP4EN

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the calls to the Usage Helper to solve problems while loading the editor on BLOG_ID = 1
* Since the lines are being used by features still in beta, we can remove it for now while figure out how to solve the performance issues
* This will impact the information being displayed on the Usage Panel

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the code to confirm the calls are not present
* Apply the patch to your sandbox and go to the WordPress.com Console
* Execute a request to `wpcom/v2` `/sites/$wpcom_site/jetpack-ai/ai-assistant-feature` and confirm the `current-period` usage information is `0` or `null` for any site you test, even when the site has the Jetpack AI plan:

<img width="600" alt="Screenshot 2023-11-01 at 11 48 58" src="https://github.com/Automattic/jetpack/assets/6760046/9f0bc5df-191a-4026-a39a-948abd9c9c3a">

---

- Additionally, sandbox the `wordpress.com` domain and make sure the editor is loading properly for any post available