### PR TITLE
Newsletter Categories: Update pre-publish/post-publish panels to display newsletter categories

### DIFF
--- a/projects/plugins/jetpack/changelog/update-pre-publish-panel
+++ b/projects/plugins/jetpack/changelog/update-pre-publish-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update the pre-publish panel to display the newsletter categories that the post will be sent to

--- a/projects/plugins/jetpack/changelog/update-pre-publish-panel
+++ b/projects/plugins/jetpack/changelog/update-pre-publish-panel
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Update the pre-publish panel to display the newsletter categories that the post will be sent to
+Update the pre-publish and post-publish panels to display the newsletter categories that the post will be sent to

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -26,7 +26,10 @@ import {
 	NewsletterAccessDocumentSettings,
 	NewsletterAccessPrePublishSettings,
 } from '../../shared/memberships/settings';
-import { getShowMisconfigurationWarning } from '../../shared/memberships/utils';
+import {
+	getFormattedCategories,
+	getShowMisconfigurationWarning,
+} from '../../shared/memberships/utils';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import metadata from './block.json';
 import EmailPreview from './email-preview';
@@ -190,6 +193,21 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 
 	const postVisibility = useSelect( select => select( editorStore ).getEditedPostVisibility() );
 
+	const { newsletterCategories, newsletterCategoriesEnabled } = useSelect( select => {
+		const { getNewsletterCategories, getNewsletterCategoriesEnabled } = select(
+			'jetpack/membership-products'
+		);
+
+		return {
+			newsletterCategories: getNewsletterCategories(),
+			newsletterCategoriesEnabled: getNewsletterCategoriesEnabled(),
+		};
+	} );
+
+	const postCategories = useSelect( select =>
+		select( editorStore ).getEditedPostAttribute( 'categories' )
+	);
+
 	const reachCount = getReachForAccessLevelKey(
 		accessLevel,
 		emailSubscribers,
@@ -201,7 +219,7 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 		subscriberType = __( 'paid subscribers', 'jetpack' );
 	}
 
-	const numberOfSubscribersText = sprintf(
+	let numberOfSubscribersText = sprintf(
 		/* translators: %1s is the post name,  %2s is the number of subscribers in numerical format, %3s Options are paid subscribers or subscribers */
 		__(
 			'<postPublishedLink>%1$s</postPublishedLink> was sent to <strong>%2$s %3$s</strong>.',
@@ -211,6 +229,26 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 		reachCount,
 		subscriberType
 	);
+
+	if (
+		newsletterCategoriesEnabled &&
+		newsletterCategories.length &&
+		accessLevel !== accessOptions.paid_subscribers.key
+	) {
+		const formattedCategoryNames = getFormattedCategories( postCategories, newsletterCategories );
+
+		if ( formattedCategoryNames ) {
+			numberOfSubscribersText = sprintf(
+				// translators: %1s is the post name,  %2s is the list of categories
+				__(
+					'<postPublishedLink>%1$s</postPublishedLink> was sent to everyone subscribed to %2$s.',
+					'jetpack'
+				),
+				postName,
+				formattedCategoryNames
+			);
+		}
+	}
 
 	const showMisconfigurationWarning = getShowMisconfigurationWarning( postVisibility, accessLevel );
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -335,7 +335,7 @@ export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
 						__( 'This post will be sent to everyone subscribed to %1$s.', 'jetpack' ),
 						formattedCategoryNames
 					),
-					{ b: <strong /> }
+					{ strong: <strong /> }
 				);
 			}
 		}

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -306,6 +306,10 @@ export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
 		} );
 	} );
 
+	const postNewsletterCategories = newsletterCategories.filter( category =>
+		postCategories.includes( category.id )
+	);
+
 	if ( isLoading ) {
 		return (
 			<Flex direction="column" align="center">
@@ -322,10 +326,10 @@ export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
 				return __( 'This post will be sent to paid subscribers only.', 'jetpack' );
 			}
 		}
-		if ( newsletterCategories && newsletterCategories.length > 0 ) {
+		if ( hasNonNewsletterCategory || postNewsletterCategories?.length > 0 ) {
 			const categoryNames = hasNonNewsletterCategory
 				? __( "'All Content'", 'jetpack' )
-				: newsletterCategories.map( category => category.name ).join( ', ' );
+				: postNewsletterCategories.map( category => category.name ).join( ', ' );
 
 			return createInterpolateElement(
 				sprintf(

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.js
@@ -100,7 +100,9 @@ export const getFormattedCategories = ( postCategories, newsletterCategories ) =
 		categoryNames.push( __( 'all content', 'jetpack' ) );
 	}
 
-	const formattedCategoriesArray = categoryNames.map( categoryName => `<b>${ categoryName }</b>` );
+	const formattedCategoriesArray = categoryNames.map(
+		categoryName => `<strong>${ categoryName }</strong>`
+	);
 	let formattedCategories = '';
 
 	if ( formattedCategoriesArray.length === 1 ) {

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.js
@@ -84,7 +84,7 @@ export const getFormattedCategories = ( postCategories, newsletterCategories ) =
 		? postCategories
 		: [ UNCATEGORIZED_CATEGORY_ID ];
 
-	// If the post has a non newsletter category, then it's going to be sent to 'All Content' subscribers
+	// If the post has a non newsletter category, then it's going to be sent to 'All content' subscribers
 	const hasNonNewsletterCategory = updatedPostCategories.some( postCategory => {
 		return ! newsletterCategories.some( newsletterCategory => {
 			return newsletterCategory.id === postCategory;
@@ -97,7 +97,7 @@ export const getFormattedCategories = ( postCategories, newsletterCategories ) =
 		.map( category => category.name );
 
 	if ( hasNonNewsletterCategory ) {
-		categoryNames.push( __( 'all content', 'jetpack' ) );
+		categoryNames.push( __( 'All content', 'jetpack' ) );
 	}
 
 	const formattedCategoriesArray = categoryNames.map(

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.js
@@ -1,6 +1,6 @@
 import { Button, ToolbarButton, Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { _x, __ } from '@wordpress/i18n';
+import { _x, __, sprintf } from '@wordpress/i18n';
 import { accessOptions } from './constants';
 
 /**
@@ -69,3 +69,56 @@ export default function GetAddPaidPlanButton( { context = 'other', hasNewsletter
 		</Button>
 	);
 }
+
+const UNCATEGORIZED_CATEGORY_ID = 1;
+
+/**
+ * Get the formatted list of categories for a post.
+ * @param {Array} postCategories - list of category IDs for the post
+ * @param {Array} newsletterCategories - list of the site's newsletter categories
+ * @returns {string} - formatted list of categories
+ */
+export const getFormattedCategories = ( postCategories, newsletterCategories ) => {
+	// If the post has no categories, then it's going to have the 'Uncategorized' category
+	const updatedPostCategories = postCategories.length
+		? postCategories
+		: [ UNCATEGORIZED_CATEGORY_ID ];
+
+	// If the post has a non newsletter category, then it's going to be sent to 'All Content' subscribers
+	const hasNonNewsletterCategory = updatedPostCategories.some( postCategory => {
+		return ! newsletterCategories.some( newsletterCategory => {
+			return newsletterCategory.id === postCategory;
+		} );
+	} );
+
+	// Get the newsletter category names for the post
+	const categoryNames = newsletterCategories
+		.filter( category => updatedPostCategories.includes( category.id ) )
+		.map( category => category.name );
+
+	if ( hasNonNewsletterCategory ) {
+		categoryNames.push( __( 'all content', 'jetpack' ) );
+	}
+
+	const formattedCategoriesArray = categoryNames.map( categoryName => `<b>${ categoryName }</b>` );
+	let formattedCategories = '';
+
+	if ( formattedCategoriesArray.length === 1 ) {
+		formattedCategories = formattedCategoriesArray[ 0 ];
+	} else if ( formattedCategoriesArray.length === 2 ) {
+		// translators: %1$s: first category name, %2$s: second category name
+		formattedCategories = sprintf( __( '%1$s and %2$s', 'jetpack' ), ...formattedCategoriesArray );
+	} else {
+		const allButLast = formattedCategoriesArray.slice( 0, -1 ).join( `${ __( ',', 'jetpack' ) } ` );
+		const last = formattedCategoriesArray[ formattedCategoriesArray.length - 1 ];
+
+		formattedCategories = sprintf(
+			// translators: %1$s: a comma-separated list of category names except for the last one, %2$s: the name of the last category
+			__( '%1$s, and %2$s', 'jetpack' ),
+			allButLast,
+			last
+		);
+	}
+
+	return formattedCategories;
+};

--- a/projects/plugins/jetpack/extensions/store/membership-products/actions.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/actions.js
@@ -108,3 +108,8 @@ export const setSubscriberCounts = subscriberCounts => ( {
 	type: 'SET_SUBSCRIBER_COUNTS',
 	subscriberCounts,
 } );
+
+export const setNewsletterCategories = newsletterCategories => ( {
+	type: 'SET_NEWSLETTER_CATEGORIES',
+	newsletterCategories,
+} );

--- a/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
@@ -11,6 +11,7 @@ export const DEFAULT_STATE = {
 		emailSubscribers: null,
 		paidSubscribers: null,
 	},
+	newsletterCategories: [],
 };
 
 export default function reducer( state = DEFAULT_STATE, action ) {
@@ -32,6 +33,11 @@ export default function reducer( state = DEFAULT_STATE, action ) {
 			return {
 				...state,
 				subscriberCounts: action.subscriberCounts,
+			};
+		case 'SET_NEWSLETTER_CATEGORIES':
+			return {
+				...state,
+				newsletterCategories: action.newsletterCategories,
 			};
 	}
 	return state;

--- a/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
@@ -11,7 +11,10 @@ export const DEFAULT_STATE = {
 		emailSubscribers: null,
 		paidSubscribers: null,
 	},
-	newsletterCategories: [],
+	newsletterCategories: {
+		enabled: false,
+		categories: [],
+	},
 };
 
 export default function reducer( state = DEFAULT_STATE, action ) {

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -230,7 +230,12 @@ export const getNewsletterCategories =
 
 		try {
 			const response = await fetchNewsletterCategories();
-			dispatch( setNewsletterCategories( response.newsletter_categories ) );
+			dispatch(
+				setNewsletterCategories( {
+					enabled: response.enabled,
+					categories: response.newsletter_categories,
+				} )
+			);
 		} catch ( error ) {
 			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
 			onError( error.message, registry );

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -13,12 +13,15 @@ import {
 	setSiteSlug,
 	setConnectedAccountDefaultCurrency,
 	setSubscriberCounts,
+	setNewsletterCategories,
 } from './actions';
 import { API_STATE_CONNECTED, API_STATE_NOTCONNECTED } from './constants';
 import { onError } from './utils';
 
 const EXECUTION_KEY = 'membership-products-resolver-getProducts';
 const SUBSCRIBER_COUNT_EXECUTION_KEY = 'membership-products-resolver-getSubscriberCounts';
+const GET_NEWSLETTER_CATEGORIES_EXECUTION_KEY =
+	'membership-products-resolver-getNewsletterCategories';
 let hydratedFromAPI = false;
 
 const fetchMemberships = async () => {
@@ -66,6 +69,31 @@ const mapAPIResponseToMembershipProductsStoreData = ( response, registry, dispat
 const fetchSubscriberCounts = async () => {
 	const response = await apiFetch( {
 		path: '/wpcom/v2/subscribers/counts',
+	} );
+
+	if ( ! response || typeof response !== 'object' ) {
+		throw new Error( 'Unexpected API response' );
+	}
+
+	/**
+	 * WP_Error returns a list of errors with custom names:
+	 * `errors: { foo: [ 'message' ], bar: [ 'message' ] }`
+	 * Since we don't know their names, to get the message, we transform the object
+	 * into an array, and just pick the first message of the first error.
+	 *
+	 * @see https://developer.wordpress.org/reference/classes/wp_error/
+	 */
+	const wpError = response?.errors && Object.values( response.errors )?.[ 0 ]?.[ 0 ];
+	if ( wpError ) {
+		throw new Error( wpError );
+	}
+
+	return response;
+};
+
+const fetchNewsletterCategories = async () => {
+	const response = await apiFetch( {
+		path: '/wpcom/v2/newsletter-categories',
 	} );
 
 	if ( ! response || typeof response !== 'object' ) {
@@ -186,6 +214,23 @@ export const getSubscriberCounts =
 					paidSubscribers: response.counts.paid_subscribers,
 				} )
 			);
+		} catch ( error ) {
+			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
+			onError( error.message, registry );
+		}
+		executionLock.release( lock );
+	};
+
+export const getNewsletterCategories =
+	() =>
+	async ( { dispatch, registry } ) => {
+		await executionLock.blockExecution( GET_NEWSLETTER_CATEGORIES_EXECUTION_KEY );
+
+		const lock = executionLock.acquire( GET_NEWSLETTER_CATEGORIES_EXECUTION_KEY );
+
+		try {
+			const response = await fetchNewsletterCategories();
+			dispatch( setNewsletterCategories( response.newsletter_categories ) );
 		} catch ( error ) {
 			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
 			onError( error.message, registry );

--- a/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
@@ -27,4 +27,6 @@ export const isInvalidProduct = ( state, productId ) =>
 
 export const getSubscriberCounts = state => state.subscriberCounts;
 
-export const getNewsletterCategories = state => state.newsletterCategories;
+export const getNewsletterCategories = state => state.newsletterCategories.categories;
+
+export const getNewsletterCategoriesEnabled = state => state.newsletterCategories.enabled;

--- a/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
@@ -26,3 +26,5 @@ export const isInvalidProduct = ( state, productId ) =>
 	!! productId && ! getProduct( state, productId );
 
 export const getSubscriberCounts = state => state.subscriberCounts;
+
+export const getNewsletterCategories = state => state.newsletterCategories;

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
@@ -9,6 +9,7 @@ import {
 	setProducts,
 	setSiteSlug,
 	setConnectedAccountDefaultCurrency,
+	setNewsletterCategories,
 } from '../actions';
 import * as utils from '../utils';
 
@@ -299,5 +300,19 @@ describe( 'Membership Products Actions', () => {
 		expect( selectedProductCallback ).toHaveBeenCalledWith( apiResponseProduct.id );
 		expect( noticeMock ).not.toHaveBeenCalled();
 		expect( getMessageMock ).not.toHaveBeenCalled();
+	} );
+
+	test( 'Set newsletter categories works as expected', () => {
+		// Given
+		const anyValidNewsletterCategoriesWithType = {
+			type: 'SET_NEWSLETTER_CATEGORIES',
+			newsletterCategories: ANY_VALID_DATA,
+		};
+
+		// When
+		const result = setNewsletterCategories( ANY_VALID_DATA );
+
+		// Then
+		expect( result ).toStrictEqual( anyValidNewsletterCategoriesWithType );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/reducer-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/reducer-test.js
@@ -106,4 +106,25 @@ describe( 'Membership products reducer testing', () => {
 		// Then
 		expect( returnedState ).toStrictEqual( { ...DEFAULT_STATE, siteSlug: anySiteSlug } );
 	} );
+
+	test( 'set newsletter categories action type adds the newsletter categories to the returned state.', () => {
+		// Given
+		const anyNewsletterCategories = {
+			enabled: true,
+			categories: [ { name: 'Any Category' } ],
+		};
+		const anySetNewsletterCategoriesAction = {
+			type: 'SET_NEWSLETTER_CATEGORIES',
+			newsletterCategories: anyNewsletterCategories,
+		};
+
+		// When
+		const returnedState = reducer( DEFAULT_STATE, anySetNewsletterCategoriesAction );
+
+		// Then
+		expect( returnedState ).toStrictEqual( {
+			...DEFAULT_STATE,
+			newsletterCategories: anyNewsletterCategories,
+		} );
+	} );
 } );

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/selectors-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/selectors-test.js
@@ -1,4 +1,9 @@
-import { getNewsletterProducts, getProducts } from '../selectors';
+import {
+	getNewsletterCategories,
+	getNewsletterCategoriesEnabled,
+	getNewsletterProducts,
+	getProducts,
+} from '../selectors';
 
 describe( 'Membership Products Selectors', () => {
 	test( 'GetProducts and getNewsletterProducts works as expected', () => {
@@ -23,5 +28,21 @@ describe( 'Membership Products Selectors', () => {
 
 		expect( getProducts( state ) ).toStrictEqual( state.products );
 		expect( getNewsletterProducts( state ) ).toStrictEqual( [ newsletter_product ] );
+	} );
+
+	test( 'getNewsletterCategories and getNewsletterCategoriesEnabled works as expected', () => {
+		const state = {
+			newsletterCategories: {
+				categories: [ 'category1', 'category2' ],
+				enabled: true,
+			},
+		};
+
+		expect( getNewsletterCategories( state ) ).toStrictEqual(
+			state.newsletterCategories.categories
+		);
+		expect( getNewsletterCategoriesEnabled( state ) ).toStrictEqual(
+			state.newsletterCategories.enabled
+		);
 	} );
 } );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/83636

## Proposed changes:

* Create getNewsletterCategories selector
* Update pre-publish panel to display newsletter categories
* Update post-publish panel to display newsletter categories

<img width="275" alt="Screenshot 2023-11-01 at 12 04 08" src="https://github.com/Automattic/jetpack/assets/3113712/39e9ddfb-adf9-4841-82c8-c0bbaeed1662">
<img width="282" alt="Screenshot 2023-11-01 at 12 04 29" src="https://github.com/Automattic/jetpack/assets/3113712/135520a2-308a-4dd5-999d-3e64be1ebef6">
<img width="282" alt="Screenshot 2023-11-02 at 16 55 34" src="https://github.com/Automattic/jetpack/assets/3113712/ffc48bd1-013e-41d3-a09f-89e6f82b37f9">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Apply this PR to your local
* Spin up a JurassicTube site
* Enable and select some Newsletter Categories
* Go to your site > Posts > Add New
* Choose a Newsletter Category as the post category
  * Type some content and click Publish
  * You should see `This post will be sent to everyone subscribed to {category name}`
  * If you choose multiple newsletter categories, you should see them separated by comma
* Select a category that isn't Newsletter Category
  * You should see `This post will be sent to everyone subscribed to all content`
* Do not select categories (it should work as if you selected Unsubscribed)
  * If Unsubscribed is a Newsletter Category, you should see `This post will be sent to everyone subscribed to Unsubscribed`
  * If not, you should see `This post will be sent to everyone subscribed to all content`
* Include a paid content (using the Paid Content block, not the Paywall block)
  * You should see `This post will be sent to paid subscribers only.`
* Disable Newsletter Category feature and select any category
  * You should see `This post will be sent to all subscribers.`
* The same logic should apply to the post-publish panel