### PR TITLE
Lanchpad: Customization hooks: Make more resilient

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-hooks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Launchpad hooks: Made more resilient against non-array values

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.16.1",
+	"version": "4.16.2-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.16.1';
+	const PACKAGE_VERSION = '4.16.2-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1702,13 +1702,15 @@ function wpcom_launchpad_is_edit_page_task_visible() {
  * if the subscription_options['invitation'] value
  * for the welcome message has changed on option update.
  *
- * @param string $old_value The old value of the welcome message.
- * @param string $value The new value of the welcome message.
+ * @param mixed $old_value The old value of the welcome message.
+ * @param mixed $value The new value of the welcome message.
  *
  * @return void
  */
 function wpcom_launchpad_mark_customize_welcome_message_complete_on_update( $old_value, $value ) {
-	if ( $value['invitation'] !== $old_value['invitation'] ) {
+	$new_invitation = is_array( $value ) && isset( $value['invitation'] ) ? $value['invitation'] : '';
+	$old_invitation = is_array( $old_value ) && isset( $old_value['invitation'] ) ? $old_value['invitation'] : '';
+	if ( $new_invitation !== $old_invitation ) {
 		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
 	}
 }
@@ -1719,12 +1721,12 @@ add_action( 'update_option_subscription_options', 'wpcom_launchpad_mark_customiz
  * if the subscription_options['invitation'] value
  * for the welcome message has been added.
  *
- * @param string $value The value of the welcome message.
+ * @param mixed $value The value of the welcome message.
  *
  * @return void
  */
 function wpcom_launchpad_mark_customize_welcome_message_complete_on_add( $value ) {
-	if ( $value['invitation'] ) {
+	if ( is_array( $value ) && $value['invitation'] ) {
 		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

* Make the customization complete hooks for launchpad no longer error if a string is passed in.

I noticed the `test_reset_all_options` test now fails on php8.  To run:

php7
```
phpunit -c ~/public_html/bin/tests/isolated/phpunit.xml --colors --testsuite=jp-2 --filter=test_reset_all_options
```

php8
```
/usr/local/php8.1/bin/php /usr/local/bin/phpunit -c ~/public_html/bin/tests/isolated/phpunit.xml --colors --testsuite=jp-2 --filter=test_reset_all_options
```

The function that is failing is:
```
function wpcom_launchpad_mark_customize_welcome_message_complete_on_add( $value ) {
	if ( $value['invitation'] ) {
		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
	}
}
add_action( 'add_option_subscription_options', 'wpcom_launchpad_mark_customize_welcome_message_complete_on_add', 10, 1 );
```

In both cases, `$value` is `string(20) "subscription_options"`. PHP7 lets it slide, but PHP8 fatal errors with `TypeError: Cannot access offset of type string on string`. 

This change prevents the fatal error and allows the test to pass. I also saw a nearby function that might suffer from the same thing and changed it too.  

**Note that I did not test any of the actual launchpad functionality.** - Maybe there's a better fix with changing the hook or the test?

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Copy file to sandbox
```
scp projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php wpcom-sandbox:./public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/sun/vendor/automattic/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
scp projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php wpcom-sandbox:./public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/moon/vendor/automattic/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
```

.
* Run tests

php7
```
phpunit -c ~/public_html/bin/tests/isolated/phpunit.xml --colors --testsuite=jp-2 --filter=test_reset_all_options
```

php8
```
/usr/local/php8.1/bin/php /usr/local/bin/phpunit -c ~/public_html/bin/tests/isolated/phpunit.xml --colors --testsuite=jp-2 --filter=test_reset_all_options
```