### PR TITLE
webpack-config: Default to 'source-map' in dev mode

### DIFF
--- a/projects/js-packages/boost-score-api/changelog/update-standardize-on-devtool-source-map
+++ b/projects/js-packages/boost-score-api/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.14",
+	"version": "0.1.15-alpha",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/webpack.config.cjs
+++ b/projects/js-packages/boost-score-api/webpack.config.cjs
@@ -4,7 +4,7 @@ const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpac
 module.exports = {
 	entry: './src/index.ts',
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isProduction ? false : 'source-map',
+	devtool: jetpackWebpackConfig.devtool,
 	module: {
 		strictExportPresence: true,
 		rules: [

--- a/projects/js-packages/image-guide/changelog/update-standardize-on-devtool-source-map
+++ b/projects/js-packages/image-guide/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-image-guide",
-	"version": "0.5.4",
+	"version": "0.5.5-alpha",
 	"description": "Go through the dom to analyze image size on screen vs actual file size.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/image-guide/#readme",
 	"type": "module",

--- a/projects/js-packages/image-guide/webpack.config.cjs
+++ b/projects/js-packages/image-guide/webpack.config.cjs
@@ -4,7 +4,7 @@ const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpac
 module.exports = {
 	entry: './src/index.ts',
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isProduction ? false : 'source-map',
+	devtool: jetpackWebpackConfig.devtool,
 	module: {
 		strictExportPresence: true,
 		rules: [

--- a/projects/js-packages/react-data-sync-client/changelog/update-standardize-on-devtool-source-map
+++ b/projects/js-packages/react-data-sync-client/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/js-packages/react-data-sync-client/webpack.config.cjs
+++ b/projects/js-packages/react-data-sync-client/webpack.config.cjs
@@ -6,7 +6,7 @@ const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpac
 module.exports = {
 	entry: './src/index.ts',
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isProduction ? false : 'source-map',
+	devtool: jetpackWebpackConfig.devtool,
 	module: {
 		strictExportPresence: true,
 		rules: [

--- a/projects/js-packages/svelte-data-sync-client/changelog/update-standardize-on-devtool-source-map
+++ b/projects/js-packages/svelte-data-sync-client/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/js-packages/svelte-data-sync-client/package.json
+++ b/projects/js-packages/svelte-data-sync-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-svelte-data-sync-client",
-	"version": "0.3.4",
+	"version": "0.3.5-alpha",
 	"description": "A Svelte.js client for the wp-js-data-sync package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/svelte-data-sync-client/#readme",
 	"type": "module",

--- a/projects/js-packages/svelte-data-sync-client/webpack.config.cjs
+++ b/projects/js-packages/svelte-data-sync-client/webpack.config.cjs
@@ -6,7 +6,7 @@ const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpac
 module.exports = {
 	entry: './src/index.ts',
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isProduction ? false : 'source-map',
+	devtool: jetpackWebpackConfig.devtool,
 	module: {
 		strictExportPresence: true,
 		rules: [

--- a/projects/js-packages/videopress-core/changelog/update-standardize-on-devtool-source-map
+++ b/projects/js-packages/videopress-core/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/js-packages/videopress-core/webpack.config.cjs
+++ b/projects/js-packages/videopress-core/webpack.config.cjs
@@ -6,7 +6,7 @@ const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpac
 module.exports = {
 	entry: './src/index.ts',
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isProduction ? false : 'source-map',
+	devtool: jetpackWebpackConfig.devtool,
 	module: {
 		strictExportPresence: true,
 		rules: [

--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -83,7 +83,7 @@ The default is development mode; set `NODE_ENV=production` in node's environment
 
 Webpack has several different devtools with various tradeoffs. This value selects an appropriate devtool for the mode.
 
-In development mode, we choose 'eval-cheap-module-source-map'. This provides correct line numbers and filenames for error messages, while still being reasonably fast to build.
+In development mode we choose 'source-map' for maximum debugability.
 
 In production mode we choose no devtool, mainly because we don't currently distribute source maps in production.
 

--- a/projects/js-packages/webpack-config/changelog/update-standardize-on-devtool-source-map
+++ b/projects/js-packages/webpack-config/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Default devtool in development mode is now 'source-map'. This is technically a breaking change, as now `.map` files will be generated in development mode.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "2.0.4",
+	"version": "3.0.0-alpha",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -23,7 +23,7 @@ const MyCssMinimizerPlugin = options => new CssMinimizerPlugin( options );
 const isProduction = process.env.NODE_ENV === 'production';
 const isDevelopment = ! isProduction;
 const mode = isProduction ? 'production' : 'development';
-const devtool = isProduction ? false : 'eval-cheap-module-source-map';
+const devtool = isProduction ? false : 'source-map';
 const output = {
 	filename: '[name].js',
 	chunkFilename: '[name].js?minify=false&ver=[contenthash]',

--- a/projects/packages/assets/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/assets/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/assets/webpack.config.js
+++ b/projects/packages/assets/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = [
 			},
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isProduction ? false : 'source-map',
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),

--- a/projects/packages/backup/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/backup/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.17.9';
+	const PACKAGE_VERSION = '1.17.10-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/backup/webpack.config.js
+++ b/projects/packages/backup/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = [
 			index: './src/js/index.js',
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),

--- a/projects/packages/forms/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/forms/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.22.5",
+	"version": "0.22.6-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.22.5';
+	const PACKAGE_VERSION = '0.22.6-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/tools/webpack.config.contact-form.js
+++ b/projects/packages/forms/tools/webpack.config.contact-form.js
@@ -10,7 +10,7 @@ const RemoveAssetWebpackPlugin = require( '@automattic/remove-asset-webpack-plug
 
 const sharedWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+	devtool: jetpackWebpackConfig.devtool,
 	output: {
 		...jetpackWebpackConfig.output,
 		path: path.join( __dirname, '..' ),

--- a/projects/packages/identity-crisis/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/identity-crisis/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.11.1",
+	"version": "0.11.2-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.11.1';
+	const PACKAGE_VERSION = '0.11.2-alpha';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/identity-crisis/webpack.config.js
+++ b/projects/packages/identity-crisis/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = [
 			index: './src/_inc/admin.jsx',
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),

--- a/projects/packages/jitm/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/jitm/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.5.1';
+	const PACKAGE_VERSION = '2.5.2-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/jitm/webpack.config.js
+++ b/projects/packages/jitm/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = [
 			index: './src/js/jetpack-jitm.js',
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),

--- a/projects/packages/my-jetpack/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/my-jetpack/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.11.0",
+	"version": "3.11.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.11.0';
+	const PACKAGE_VERSION = '3.11.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/webpack.config.js
+++ b/projects/packages/my-jetpack/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = [
 			index: './_inc/admin.jsx',
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),

--- a/projects/packages/plugin-deactivation/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/plugin-deactivation/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/plugin-deactivation/package.json
+++ b/projects/packages/plugin-deactivation/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plugin-deactivation",
-	"version": "0.1.6",
+	"version": "0.1.7-alpha",
 	"description": "Intercept plugin deactivation with a dialog",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plugin-deactivation/#readme",
 	"bugs": {

--- a/projects/packages/plugin-deactivation/src/class-deactivation-handler.php
+++ b/projects/packages/plugin-deactivation/src/class-deactivation-handler.php
@@ -21,7 +21,7 @@ class Deactivation_Handler {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.1.6';
+	const PACKAGE_VERSION = '0.1.7-alpha';
 
 	/**
 	 * Slug of the plugin to intercept deactivation for.

--- a/projects/packages/plugin-deactivation/webpack.config.js
+++ b/projects/packages/plugin-deactivation/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = [
 			index: './src/assets/js/deactivation.ts',
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),

--- a/projects/packages/publicize/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/publicize/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.36.4",
+	"version": "0.36.5-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/webpack.config.js
+++ b/projects/packages/publicize/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = [
 			[ 'classic-editor-connections' ]: './src/js/classic-editor-connections.js',
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isProduction ? false : 'source-map',
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),

--- a/projects/packages/search/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/search/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.39.4",
+	"version": "0.39.5-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.39.4';
+	const VERSION = '0.39.5-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/tools/webpack.customberg.config.js
+++ b/projects/packages/search/tools/webpack.customberg.config.js
@@ -4,7 +4,7 @@ const definePaletteColorsAsStaticVariables = require( './define-palette-colors-a
 
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+	devtool: jetpackWebpackConfig.devtool,
 	entry: {
 		'jp-search-configure': path.join( __dirname, '../src/customberg/index.jsx' ),
 	},

--- a/projects/packages/search/tools/webpack.dashboard.config.js
+++ b/projects/packages/search/tools/webpack.dashboard.config.js
@@ -3,7 +3,7 @@ const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpac
 
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+	devtool: jetpackWebpackConfig.devtool,
 	entry: {
 		'jp-search-dashboard': path.join( __dirname, '../src/dashboard/index.jsx' ),
 	},

--- a/projects/packages/search/tools/webpack.instant.config.js
+++ b/projects/packages/search/tools/webpack.instant.config.js
@@ -26,7 +26,7 @@ function requestToExternal( request ) {
 
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+	devtool: jetpackWebpackConfig.devtool,
 	entry: {
 		'jp-search': path.join( __dirname, '../src/instant-search/loader.js' ),
 	},

--- a/projects/packages/videopress/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/videopress/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = [
 			'divi-editor/index': './src/client/divi-editor/index.js',
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),

--- a/projects/packages/wordads/changelog/update-standardize-on-devtool-source-map
+++ b/projects/packages/wordads/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.55",
+	"version": "0.2.56-alpha",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.55';
+	const VERSION = '0.2.56-alpha';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/packages/wordads/tools/webpack.dashboard.config.js
+++ b/projects/packages/wordads/tools/webpack.dashboard.config.js
@@ -3,7 +3,7 @@ const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpac
 
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+	devtool: jetpackWebpackConfig.devtool,
 	entry: {
 		'jp-wordads-dashboard': path.join( __dirname, '../src/dashboard/index.jsx' ),
 	},

--- a/projects/plugins/crm/.gitignore
+++ b/projects/plugins/crm/.gitignore
@@ -4,7 +4,9 @@
 /.cache/
 /.phpunit.result.cache
 **/css/*.css
+**/css/*.css.map
 **/css/**/*.css
+**/css/**/*.css.map
 **/js/*.min.js.map
 **/js/**/*.min.js.map
 **/js/*.min.js

--- a/projects/plugins/crm/changelog/update-standardize-on-devtool-source-map
+++ b/projects/plugins/crm/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use 'source-map' devtool when building in development mode. No change to the production plugin.
+
+

--- a/projects/plugins/crm/webpack.config.js
+++ b/projects/plugins/crm/webpack.config.js
@@ -110,7 +110,7 @@ function getReactComponentViewMapping() {
 
 const crmWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: false,
+	devtool: jetpackWebpackConfig.devtool,
 	output: {
 		...jetpackWebpackConfig.output,
 		path: path.resolve( __dirname, '.' ),

--- a/projects/plugins/jetpack/changelog/update-standardize-on-devtool-source-map
+++ b/projects/plugins/jetpack/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Use 'source-map' devtool when building in development mode. No change to the production plugin.
+
+

--- a/projects/plugins/jetpack/changelog/update-standardize-on-devtool-source-map#2
+++ b/projects/plugins/jetpack/changelog/update-standardize-on-devtool-source-map#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/plugins/jetpack/changelog/update-standardize-on-devtool-source-map#2
+++ b/projects/plugins/jetpack/changelog/update-standardize-on-devtool-source-map#2
@@ -1,5 +1,5 @@
 Significance: patch
-Type: changed
+Type: other
 Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
 
 

--- a/projects/plugins/jetpack/tools/webpack.config.css.js
+++ b/projects/plugins/jetpack/tools/webpack.config.css.js
@@ -14,7 +14,7 @@ const glob = require( 'glob' );
 const webpack = jetpackWebpackConfig.webpack;
 const sharedWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+	devtool: jetpackWebpackConfig.devtool,
 	output: {
 		...jetpackWebpackConfig.output,
 		path: path.join( __dirname, '..' ),

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -6,7 +6,7 @@ const StaticSiteGeneratorPlugin = require( './static-site-generator-webpack-plug
 
 const sharedWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+	devtool: jetpackWebpackConfig.devtool,
 	output: {
 		...jetpackWebpackConfig.output,
 		path: path.join( __dirname, '../_inc/build' ),

--- a/projects/plugins/jetpack/tools/webpack.config.masterbar.js
+++ b/projects/plugins/jetpack/tools/webpack.config.masterbar.js
@@ -14,7 +14,7 @@ for ( const file of glob
 
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: false,
+	devtool: jetpackWebpackConfig.devtool,
 	entry: masterbarCssEntries,
 	output: {
 		...jetpackWebpackConfig.output,

--- a/projects/plugins/jetpack/tools/webpack.config.widget-visibility.js
+++ b/projects/plugins/jetpack/tools/webpack.config.widget-visibility.js
@@ -4,7 +4,7 @@ const { definePaletteColorsAsStaticVariables } = require( './webpack.helpers' );
 
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+	devtool: jetpackWebpackConfig.devtool,
 	entry: {
 		index: {
 			import: path.join( __dirname, '../modules/widget-visibility/editor/index.jsx' ),

--- a/projects/plugins/migration/changelog/update-standardize-on-devtool-source-map
+++ b/projects/plugins/migration/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/plugins/migration/webpack.config.js
+++ b/projects/plugins/migration/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = [
 			index: './src/js/index.js',
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),

--- a/projects/plugins/protect/changelog/update-standardize-on-devtool-source-map
+++ b/projects/plugins/protect/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/plugins/protect/webpack.config.js
+++ b/projects/plugins/protect/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = [
 			index: './src/js/index.js',
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),

--- a/projects/plugins/social/changelog/update-standardize-on-devtool-source-map
+++ b/projects/plugins/social/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/plugins/social/webpack.config.js
+++ b/projects/plugins/social/webpack.config.js
@@ -2,7 +2,7 @@ const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 const socialWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
-	devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+	devtool: jetpackWebpackConfig.devtool,
 	output: {
 		...jetpackWebpackConfig.output,
 		path: path.resolve( './build' ),

--- a/projects/plugins/starter-plugin/changelog/update-standardize-on-devtool-source-map
+++ b/projects/plugins/starter-plugin/changelog/update-standardize-on-devtool-source-map
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
+
+

--- a/projects/plugins/starter-plugin/webpack.config.js
+++ b/projects/plugins/starter-plugin/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = [
 			index: './src/js/index.js',
 		},
 		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
 			...jetpackWebpackConfig.output,
 			path: path.resolve( './build' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It seems our developers have spoken: 25 webpack configs in the monorepo have been setting webpack's `devtool` to 'source-map' for development builds, while only 8 have used the default from webpack-config (and 2 are explicitly setting no devtool).

So let's change the default to 'source-map' so everything can be working the same way.

Note this doesn't change anything for production builds, this is only for development.

<details><summary>The 10 webpack configs that will see a change here are</summary>

* projects/packages/action-bar/webpack.config.action-bar.js
* projects/packages/blaze/webpack.config.js
* projects/packages/connection/webpack.config.js
* projects/packages/forms/tools/webpack.config.blocks.js
* projects/packages/image-cdn/webpack.config.js
* projects/packages/lazy-images/webpack.config.js
* projects/packages/yoast-promo/webpack.config.js
* projects/plugins/crm/webpack.config.js
* projects/plugins/jetpack/tools/webpack.config.extensions.js
* projects/plugins/jetpack/tools/webpack.config.masterbar.js

</details>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Production build artifacts should remain unchanged.
* Dev builds should not result in `git status` showing any `.map` files as being untracked (i.e. all should be `.gitignore`d).