### PR TITLE
AI Assistant: do not fetch AI Assistant feature data from the backend

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-do-not-request-feature-data-in-the-first-rendering
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-do-not-request-feature-data-in-the-first-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: do not fetch AI Assistant feature data from the backend

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -677,7 +677,7 @@ class Jetpack_Gutenberg {
 		}
 
 		// AI Assistant
-		$ai_assistant_state = Jetpack_AI_Helper::get_ai_assistance_feature();
+		$ai_assistant_state = array();
 
 		if ( is_wp_error( $ai_assistant_state ) ) {
 			$ai_assistant_state = array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR removes the code that performs a request to get AI Assistant feature data in the backend.
Since almost the data is always provided by the useAi

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: do not fetch AI Assistant feature data from the backend

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

