### PR TITLE
Update/vaultpress backup card purchased state

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1873,6 +1873,9 @@ importers:
       classnames:
         specifier: 2.3.2
         version: 2.3.2
+      gridicons:
+        specifier: 3.4.1
+        version: 3.4.1(react@18.2.0)
       prop-types:
         specifier: 15.8.1
         version: 15.8.1

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Text } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
@@ -17,6 +18,8 @@ const ConnectedProductCard = ( {
 	children,
 	isDataLoading,
 	showMenu = false,
+	Description = null,
+	additionalActions = null,
 	menuItems = [],
 } ) => {
 	const { isRegistered, isUserConnected } = useConnection();
@@ -29,7 +32,13 @@ const ConnectedProductCard = ( {
 		installStandalonePlugin,
 		deactivateStandalonePlugin,
 	} = useProduct( slug );
-	const { name, description, requiresUserConnection, standalonePluginInfo, status } = detail;
+	const {
+		name,
+		description: defaultDescription,
+		requiresUserConnection,
+		standalonePluginInfo,
+		status,
+	} = detail;
 	const [ installingStandalone, setInstallingStandalone ] = useState( false );
 	const [ deactivatingStandalone, setDeactivatingStandalone ] = useState( false );
 
@@ -99,10 +108,16 @@ const ConnectedProductCard = ( {
 			} );
 	}, [ deactivateStandalonePlugin ] );
 
+	const DefaultDescription = () => (
+		<Text variant="body-small" style={ { flexGrow: 1 } }>
+			{ defaultDescription }
+		</Text>
+	);
+
 	return (
 		<ProductCard
 			name={ name }
-			description={ description }
+			Description={ Description ? Description : DefaultDescription }
 			status={ status }
 			admin={ admin }
 			isFetching={ isFetching }
@@ -110,6 +125,7 @@ const ConnectedProductCard = ( {
 			isInstallingStandalone={ installingStandalone }
 			isDeactivatingStandalone={ deactivatingStandalone }
 			onDeactivate={ deactivate }
+			additionalActions={ additionalActions }
 			slug={ slug }
 			onActivate={ handleActivate }
 			showMenu={ menuIsActive }
@@ -130,6 +146,10 @@ ConnectedProductCard.propTypes = {
 	children: PropTypes.node,
 	admin: PropTypes.bool.isRequired,
 	slug: PropTypes.string.isRequired,
+	isDataLoading: PropTypes.bool,
+	showMenu: PropTypes.bool,
+	additionalActions: PropTypes.array,
+	menuItems: PropTypes.array,
 };
 
 export default ConnectedProductCard;

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -1,7 +1,10 @@
 import { Button } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
-import React from 'react';
+import { Icon, chevronDown, external, check } from '@wordpress/icons';
+import cs from 'classnames';
+import React, { useCallback, useState, useEffect, useMemo } from 'react';
 import { useProduct } from '../../hooks/use-product';
+import styles from './style.module.scss';
 
 export const PRODUCT_STATUSES = {
 	ACTIVE: 'active',
@@ -20,6 +23,7 @@ const ActionButton = ( {
 	name,
 	slug,
 	onActivate,
+	additionalActions,
 	onManage,
 	onFixConnection,
 	isFetching,
@@ -28,17 +32,147 @@ const ActionButton = ( {
 	className,
 	onAdd,
 } ) => {
+	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
+	const [ currentAction, setCurrentAction ] = useState( {} );
 	const { detail } = useProduct( slug );
 	const { manageUrl, purchaseUrl } = detail;
 	const isManageDisabled = ! manageUrl;
 
 	const isBusy = isFetching || isInstallingStandalone || isDeactivatingStandalone;
+	const hasAdditionalActions = additionalActions?.length > 0;
 
-	const buttonState = {
-		variant: ! isBusy ? 'primary' : undefined,
-		disabled: isBusy,
-		className,
-	};
+	const buttonState = useMemo( () => {
+		return {
+			variant: ! isBusy ? 'primary' : undefined,
+			disabled: isBusy,
+			className,
+		};
+	}, [ isBusy, className ] );
+
+	const getStatusAction = useCallback( () => {
+		switch ( status ) {
+			case PRODUCT_STATUSES.ABSENT:
+			case PRODUCT_STATUSES.ABSENT_WITH_PLAN: {
+				const buttonText =
+					status === PRODUCT_STATUSES.ABSENT
+						? sprintf(
+								/* translators: placeholder is product name. */
+								__( 'Get %s', 'jetpack-my-jetpack' ),
+								name
+						  )
+						: sprintf(
+								/* translators: placeholder is product name. */
+								__( 'Install %s', 'jetpack-my-jetpack' ),
+								name
+						  );
+				return {
+					...buttonState,
+					href: `#/add-${ slug }`,
+					size: 'small',
+					variant: 'link',
+					weight: 'regular',
+					label: buttonText,
+					onClick: null,
+				};
+			}
+			case PRODUCT_STATUSES.NEEDS_PURCHASE:
+			case PRODUCT_STATUSES.CAN_UPGRADE: {
+				const upgradeText = __( 'Upgrade', 'jetpack-my-jetpack' );
+				const purchaseText = __( 'Purchase', 'jetpack-my-jetpack' );
+				const buttonText = purchaseUrl ? upgradeText : purchaseText;
+
+				return {
+					...buttonState,
+					href: purchaseUrl || `#/add-${ slug }`,
+					size: 'small',
+					variant: 'primary',
+					weight: 'regular',
+					label: buttonText,
+					onClick: onAdd,
+				};
+			}
+			case PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE:
+				return {
+					...buttonState,
+					href: `#/add-${ slug }`,
+					size: 'small',
+					variant: 'primary',
+					weight: 'regular',
+					label: __( 'Start for free', 'jetpack-my-jetpack' ),
+					onClick: onAdd,
+				};
+			case PRODUCT_STATUSES.ACTIVE: {
+				const viewText = __( 'View', 'jetpack-my-jetpack' );
+				const manageText = __( 'Manage', 'jetpack-my-jetpack' );
+				const buttonText = purchaseUrl ? viewText : manageText;
+
+				return {
+					...buttonState,
+					disabled: isManageDisabled || buttonState?.disabled,
+					href: manageUrl,
+					size: 'small',
+					variant: 'secondary',
+					weight: 'regular',
+					label: buttonText,
+					onClick: onManage,
+				};
+			}
+			case PRODUCT_STATUSES.ERROR:
+				return {
+					...buttonState,
+					href: '#/connection',
+					size: 'small',
+					variant: 'primary',
+					weight: 'regular',
+					label: __( 'Fix connection', 'jetpack-my-jetpack' ),
+					onClick: onFixConnection,
+				};
+			case PRODUCT_STATUSES.INACTIVE:
+				return {
+					...buttonState,
+					href: '',
+					size: 'small',
+					variant: 'secondary',
+					weight: 'regular',
+					label: __( 'Activate', 'jetpack-my-jetpack' ),
+					onClick: onActivate,
+				};
+			default:
+				return null;
+		}
+	}, [
+		buttonState,
+		isManageDisabled,
+		manageUrl,
+		name,
+		onActivate,
+		onAdd,
+		onFixConnection,
+		onManage,
+		purchaseUrl,
+		slug,
+		status,
+	] );
+
+	const allActions = useMemo(
+		() =>
+			hasAdditionalActions ? [ ...additionalActions, getStatusAction() ] : [ getStatusAction() ],
+		[ additionalActions, getStatusAction, hasAdditionalActions ]
+	);
+
+	const onChevronClick = useCallback( () => {
+		setIsDropdownOpen( ! isDropdownOpen );
+	}, [ isDropdownOpen ] );
+
+	// By default, we set the first "addition action" as the current action shown on the card.
+	// If there are none, set it to the status action.
+	useEffect( () => {
+		if ( hasAdditionalActions ) {
+			setCurrentAction( allActions[ 0 ] );
+		} else {
+			setCurrentAction( getStatusAction() );
+		}
+	}, [ additionalActions, getStatusAction, hasAdditionalActions, allActions ] );
 
 	if ( ! admin ) {
 		return (
@@ -51,106 +185,67 @@ const ActionButton = ( {
 		);
 	}
 
-	switch ( status ) {
-		case PRODUCT_STATUSES.ABSENT:
-		case PRODUCT_STATUSES.ABSENT_WITH_PLAN:
-			return (
-				<Button
-					{ ...buttonState }
-					href={ `#/add-${ slug }` }
-					size="small"
-					variant="link"
-					weight="regular"
-				>
-					{ status === PRODUCT_STATUSES.ABSENT &&
-						sprintf(
-							/* translators: placeholder is product name. */
-							__( 'Get %s', 'jetpack-my-jetpack' ),
-							name
-						) }
-					{ status === PRODUCT_STATUSES.ABSENT_WITH_PLAN &&
-						sprintf(
-							/* translators: placeholder is product name. */
-							__( 'Install %s', 'jetpack-my-jetpack' ),
-							name
-						) }
-				</Button>
-			);
-		case PRODUCT_STATUSES.NEEDS_PURCHASE:
-		case PRODUCT_STATUSES.CAN_UPGRADE: {
-			const upgradeText = __( 'Upgrade', 'jetpack-my-jetpack' );
-			const purchaseText = __( 'Purchase', 'jetpack-my-jetpack' );
-			const buttonText = purchaseUrl ? upgradeText : purchaseText;
-			return (
-				<Button
-					{ ...buttonState }
-					href={ purchaseUrl || `#/add-${ slug }` }
-					size="small"
-					weight="regular"
-					onClick={ onAdd }
-				>
-					{ buttonText }
-				</Button>
-			);
-		}
-		case PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE:
-			return (
-				<Button
-					{ ...buttonState }
-					href={ `#/add-${ slug }` }
-					size="small"
-					weight="regular"
-					onClick={ onAdd }
-				>
-					{ __( 'Start for free', 'jetpack-my-jetpack' ) }
-				</Button>
-			);
-		case PRODUCT_STATUSES.ACTIVE: {
-			const viewText = __( 'View', 'jetpack-my-jetpack' );
-			const manageText = __( 'Manage', 'jetpack-my-jetpack' );
-			const buttonText = purchaseUrl ? viewText : manageText;
-			return (
-				<Button
-					{ ...buttonState }
-					disabled={ isManageDisabled || buttonState?.disabled }
-					size="small"
-					weight="regular"
-					variant="secondary"
-					href={ manageUrl }
-					onClick={ onManage }
-				>
-					{ buttonText }
-				</Button>
-			);
-		}
-		case PRODUCT_STATUSES.ERROR:
-			return (
-				<Button
-					{ ...buttonState }
-					href="#/connection"
-					size="small"
-					weight="regular"
-					onClick={ onFixConnection }
-				>
-					{ __( 'Fix connection', 'jetpack-my-jetpack' ) }
-				</Button>
-			);
-		case PRODUCT_STATUSES.INACTIVE:
-			return (
-				<Button
-					{ ...buttonState }
-					size="small"
-					weight="regular"
-					variant="secondary"
-					onClick={ onActivate }
-				>
-					{ __( 'Activate', 'jetpack-my-jetpack' ) }
-				</Button>
-			);
+	const dropdown = hasAdditionalActions && (
+		<div className={ styles.dropdown }>
+			<ul className={ styles.dropdownMenu }>
+				{ [ ...additionalActions, getStatusAction() ].map( ( { label, isExternalLink }, index ) => {
+					const onDropdownMenuItemClick = () => {
+						setCurrentAction( allActions[ index ] );
+						setIsDropdownOpen( false );
+					};
 
-		default:
-			return null;
-	}
+					return (
+						<li key={ index }>
+							{ /* eslint-disable-next-line react/jsx-no-bind */ }
+							<button onClick={ onDropdownMenuItemClick } className={ styles.dropdownItem }>
+								<div className={ styles.dropdownItemLabel }>
+									{ label }
+									{ isExternalLink && <Icon icon={ external } size={ 16 } /> }
+								</div>
+
+								{ label === currentAction.label && (
+									<div className={ styles.activeActionCheckmark }>
+										<Icon icon={ check } size={ 24 } fill="white" />
+									</div>
+								) }
+							</button>
+						</li>
+					);
+				} ) }
+			</ul>
+		</div>
+	);
+
+	return (
+		<>
+			<div
+				className={ cs(
+					styles.actionButton,
+					hasAdditionalActions ? styles.hasAdditionalActions : null
+				) }
+			>
+				<Button { ...buttonState } { ...currentAction }>
+					{ currentAction.label }
+				</Button>
+				{ hasAdditionalActions && (
+					<button
+						className={ cs(
+							styles.dropdownChevron,
+							currentAction.variant === 'primary' ? styles.primary : styles.secondary
+						) }
+						onClick={ onChevronClick }
+					>
+						<Icon
+							icon={ chevronDown }
+							size={ 24 }
+							fill={ currentAction.variant === 'primary' ? 'white' : 'black' }
+						/>
+					</button>
+				) }
+				{ isDropdownOpen && dropdown }
+			</div>
+		</>
+	);
 };
 
 export default ActionButton;

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -167,12 +167,8 @@ const ActionButton = ( {
 	// By default, we set the first "addition action" as the current action shown on the card.
 	// If there are none, set it to the status action.
 	useEffect( () => {
-		if ( hasAdditionalActions ) {
-			setCurrentAction( allActions[ 0 ] );
-		} else {
-			setCurrentAction( getStatusAction() );
-		}
-	}, [ additionalActions, getStatusAction, hasAdditionalActions, allActions ] );
+		setCurrentAction( allActions[ 0 ] );
+	}, [ allActions ] );
 
 	if ( ! admin ) {
 		return (

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -1,4 +1,4 @@
-import { Button, Text } from '@automattic/jetpack-components';
+import { Button } from '@automattic/jetpack-components';
 import { Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical, download } from '@wordpress/icons';
@@ -132,7 +132,7 @@ Menu.defaultProps = {
 const ProductCard = props => {
 	const {
 		name,
-		description,
+		Description,
 		status,
 		onActivate,
 		isFetching,
@@ -140,6 +140,7 @@ const ProductCard = props => {
 		isInstallingStandalone,
 		isDeactivatingStandalone,
 		slug,
+		additionalActions,
 		children,
 		// Menu Related
 		showMenu = false,
@@ -253,9 +254,7 @@ const ProductCard = props => {
 				)
 			}
 		>
-			<Text variant="body-small" className={ styles.description }>
-				{ description }
-			</Text>
+			<Description />
 
 			{ isDataLoading ? (
 				<span className={ styles.loading }>{ __( 'Loading…', 'jetpack-my-jetpack' ) }</span>
@@ -271,6 +270,7 @@ const ProductCard = props => {
 					onManage={ manageHandler }
 					onAdd={ addHandler }
 					className={ styles.button }
+					additionalActions={ additionalActions }
 				/>
 				{ ! isAbsent && (
 					<Status
@@ -288,7 +288,7 @@ const ProductCard = props => {
 ProductCard.propTypes = {
 	children: PropTypes.node,
 	name: PropTypes.string.isRequired,
-	description: PropTypes.string.isRequired,
+	Description: PropTypes.func.isRequired,
 	admin: PropTypes.bool.isRequired,
 	isFetching: PropTypes.bool,
 	isInstallingStandalone: PropTypes.bool,
@@ -307,6 +307,7 @@ ProductCard.propTypes = {
 			onClick: PropTypes.func,
 		} )
 	),
+	additionalActions: PropTypes.array,
 	onInstallStandalone: PropTypes.func,
 	onActivateStandalone: PropTypes.func,
 	onDeactivateStandalone: PropTypes.func,

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -1,5 +1,6 @@
 $actions-size: 28px;
 $status-size: 8px;
+$box-shadow-color: rgba( 0, 0, 0, 0.1 );
 
 .container {
 	min-height: 200px;
@@ -30,6 +31,83 @@ $status-size: 8px;
 	h3 {
 		font-weight: 700;
 		line-height: 28px;
+	}
+}
+
+.actionButton {
+	position: relative;
+	display: flex;
+
+	.dropdownChevron {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		border: 0.5px solid var( --jp-black );
+		box-shadow: inset 0 0 0 1px var(--jp-black);
+		border-top-right-radius: var( --jp-border-radius );
+		border-bottom-right-radius: var( --jp-border-radius );
+		cursor: pointer;
+
+		padding: 0;
+	}
+
+	.primary {
+		background-color: var( --jp-black );
+		margin-left: 0.5px;
+	}
+
+	.secondary {
+		background-color: var( --jp-white );
+		border-left-width: 0;
+		margin-left: -0.5px;
+	}
+}
+
+.dropdown {
+	position: absolute;
+	top: calc( 100% + var(--spacing-base) );
+	left: 0;
+	background: var( --jp-white );
+	border-radius: calc( var( --jp-border-radius ) / 2 );
+	box-shadow: 0px 1px 1px 0px $box-shadow-color, 0px 1px 1.5px 0px $box-shadow-color, 0px 2px 3px -0.5px $box-shadow-color;
+	padding: var(--spacing-base);
+
+	.dropdownItem {
+		display: flex;
+		align-items: center;
+		gap: calc( var(--spacing-base) * 7 ); // 56px
+		background-color: var( --jp-white );
+		border: none;
+
+		padding: var(--spacing-base);
+		cursor: pointer;
+		width: 100%;
+
+		&:hover {
+			background-color: var( --jp-gray-0 );
+		}
+	}
+	
+	.dropdownItemLabel {
+		display: flex;
+		align-items: center;
+		gap: calc( var(--spacing-base) * 0.5 );
+
+		font-size: var( --font-label );
+	}
+
+	.activeActionCheckmark {
+		background-color: var( --jp-green-50 );
+		height: 25px;
+		width: 25px;
+	}
+}
+
+.hasAdditionalActions {
+	a, button {
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
 	}
 }
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
@@ -195,7 +195,7 @@ const BackupCard = ( { admin, productData, fetchingProductData } ) => {
 	const handleUndoClick = () => {
 		recordEvent( 'jetpack_myjetpack_backup_card_undo_click', {
 			product: slug,
-			undoBackupId,
+			undo_backup_id: undoBackupId,
 		} );
 	};
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
@@ -202,6 +202,7 @@ const BackupCard = ( { admin, productData, fetchingProductData } ) => {
 	const undoAction = {
 		href: getRedirectUrl( 'jetpack-backup-undo-cta', {
 			path: undoBackupId,
+			site: window?.myJetpackInitialState?.siteSuffix,
 		} ),
 		size: 'small',
 		variant: 'primary',

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
@@ -1,9 +1,10 @@
-import { numberFormat } from '@automattic/jetpack-components';
-import { __, sprintf } from '@wordpress/i18n';
-import { Icon, commentContent, post, page, image, video, audio } from '@wordpress/icons';
+import { numberFormat, Text, getRedirectUrl } from '@automattic/jetpack-components';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import { useEffect, useState, useMemo } from 'react';
+import useAnalytics from '../../../hooks/use-analytics';
 import { useProduct } from '../../../hooks/use-product';
 import ProductCard from '../../connected-product-card';
 import { PRODUCT_STATUSES } from '../../product-card/action-button';
@@ -11,20 +12,12 @@ import styles from './style.module.scss';
 
 const getIcon = slug => {
 	switch ( slug ) {
-		case 'comment':
-			return <Icon icon={ commentContent } size={ 24 } />;
 		case 'post':
-			return <Icon icon={ post } size={ 24 } />;
+			return <Gridicon icon="posts" size={ 24 } />;
 		case 'page':
-			return <Icon icon={ page } size={ 24 } />;
-		case 'image':
-			return <Icon icon={ image } size={ 24 } />;
-		case 'video':
-			return <Icon icon={ video } size={ 24 } />;
-		case 'audio':
-			return <Icon icon={ audio } size={ 24 } />;
+			return <Gridicon icon="pages" size={ 24 } />;
 		default:
-			return null;
+			return <Gridicon icon={ slug } size={ 24 } />;
 	}
 };
 
@@ -43,7 +36,7 @@ const getTitle = slug => {
 		case 'audio':
 			return 'Audio Files';
 		default:
-			return '';
+			return slug;
 	}
 };
 
@@ -119,20 +112,128 @@ const NoBackupsValueSection = ( { siteData } ) => {
 	);
 };
 
-// eslint-disable-next-line no-unused-vars
+const WithBackupsValueSection = ( { lastUndoableEvent } ) => {
+	if ( ! lastUndoableEvent || ! lastUndoableEvent.data ) {
+		return null;
+	}
+	const { last_rewindable_event: lastRewindableEvent = {} } = lastUndoableEvent.data;
+
+	return (
+		<div className={ styles.activity }>
+			<Gridicon icon={ lastRewindableEvent.gridicon } size={ 24 } />
+			<p className={ styles.summary }>{ lastRewindableEvent.summary }</p>
+		</div>
+	);
+};
+
+const getTimeSinceLastRenewableEvent = lastRewindableEventTime => {
+	if ( ! lastRewindableEventTime ) {
+		return '';
+	}
+
+	const now = new Date();
+	const lastRewindableEventDate = new Date( lastRewindableEventTime );
+	const timeSinceLastRenewableEvent = now - lastRewindableEventDate;
+
+	if ( timeSinceLastRenewableEvent > 0 ) {
+		const days = Math.floor( timeSinceLastRenewableEvent / ( 1000 * 60 * 60 * 24 ) );
+		const hours = Math.floor(
+			( timeSinceLastRenewableEvent % ( 1000 * 60 * 60 * 24 ) ) / ( 1000 * 60 * 60 )
+		);
+		const minutes = Math.floor(
+			( timeSinceLastRenewableEvent % ( 1000 * 60 * 60 ) ) / ( 1000 * 60 )
+		);
+		const seconds = Math.floor( ( timeSinceLastRenewableEvent % ( 1000 * 60 ) ) / 1000 );
+
+		if ( days > 0 ) {
+			return sprintf(
+				// translators: %s is the number of days since the last backup
+				_n( '%s day ago', '%s days ago', days, 'jetpack-my-jetpack' ),
+				days
+			);
+		}
+
+		if ( hours > 0 ) {
+			return sprintf(
+				// translators: %s is the number of hours since the last backup
+				_n( '%s hour ago', '%s hours ago', hours, 'jetpack-my-jetpack' ),
+				hours
+			);
+		}
+
+		if ( minutes > 0 ) {
+			return sprintf(
+				// translators: %s is the number of minutes since the last backup
+				_n( '%s minute ago', '%s minutes ago', minutes, 'jetpack-my-jetpack' ),
+				minutes
+			);
+		}
+
+		return sprintf(
+			// translators: %s is the number of seconds since the last backup
+			_n( '%s second ago', '%s seconds ago', seconds, 'jetpack-my-jetpack' ),
+			seconds
+		);
+	}
+};
+
 const BackupCard = ( { admin, productData, fetchingProductData } ) => {
 	const slug = 'backup';
 
+	const { recordEvent } = useAnalytics();
 	const { detail } = useProduct( slug );
 	const { status } = detail;
 	const hasBackups = status === PRODUCT_STATUSES.ACTIVE || status === PRODUCT_STATUSES.CAN_UPGRADE;
 
-	const { site_data: siteData = {} } = productData || {};
+	const { site_data: siteData = {}, last_undoable_event: lastUndoableEvent = {} } =
+		productData || {};
+
+	const lastRewindableEventTime = lastUndoableEvent?.data?.last_rewindable_event?.published;
+	const hasRewindableEvent = hasBackups && lastUndoableEvent?.data;
+	const undoBackupId = lastUndoableEvent?.data?.undo_backup_id;
+
+	const handleUndoClick = () => {
+		recordEvent( 'jetpack_myjetpack_backup_card_undo_click', {
+			product: slug,
+			undoBackupId,
+		} );
+	};
+
+	const undoAction = {
+		href: getRedirectUrl( 'jetpack-backup-undo-cta', {
+			path: undoBackupId,
+		} ),
+		size: 'small',
+		variant: 'primary',
+		weight: 'regular',
+		label: __( 'Undo', 'jetpack-my-jetpack' ),
+		onClick: handleUndoClick,
+		isExternalLink: true,
+	};
+
+	const WithBackupsDescription = () => (
+		<Text variant="body-small" className={ styles.description }>
+			<span>{ __( 'Activity Detected', 'jetpack-my-jetpack' ) }</span>
+			<span className={ styles.time }>
+				{ getTimeSinceLastRenewableEvent( lastRewindableEventTime ) }
+			</span>
+		</Text>
+	);
 
 	return (
-		<ProductCard admin={ admin } slug={ slug } showMenu isDataLoading={ fetchingProductData }>
-			{ /* todo: Add component for when users do have backups and an activity log */ }
-			{ hasBackups ? <></> : <NoBackupsValueSection siteData={ siteData } /> }
+		<ProductCard
+			admin={ admin }
+			slug={ slug }
+			showMenu
+			isDataLoading={ fetchingProductData }
+			Description={ hasRewindableEvent ? WithBackupsDescription : null }
+			additionalActions={ hasRewindableEvent ? [ undoAction ] : null }
+		>
+			{ hasBackups ? (
+				<WithBackupsValueSection lastUndoableEvent={ lastUndoableEvent } />
+			) : (
+				<NoBackupsValueSection siteData={ siteData } />
+			) }
 		</ProductCard>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/style.module.scss
@@ -3,6 +3,7 @@
     align-items: center;
     justify-content: space-between;
     margin-top: 1rem;
+    color: var( --jp-black );
 
     .main-stats {
         display: flex;
@@ -22,4 +23,29 @@
 
         font-size: var(--font-body-small);
     }
+}
+
+.activity {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-top: 1rem;
+    color: var( --jp-black );
+
+    .summary {
+        font-size: var(--font-body-small);
+        margin: 0;
+    }
+}
+
+.description {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    flex-grow: 1;
+}
+
+.time {
+    color: var( --jp-gray-40 );
 }

--- a/projects/packages/my-jetpack/changelog/update-vaultpress-backup-card-purchased-state
+++ b/projects/packages/my-jetpack/changelog/update-vaultpress-backup-card-purchased-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Update purchased state for VaultPress backup card on My Jetpack

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -75,7 +75,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.11.x-dev"
+			"dev-trunk": "3.12.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/element": "5.21.0",
 		"@wordpress/i18n": "4.44.0",
 		"@wordpress/icons": "9.35.0",
+		"gridicons": "3.4.1",
 		"classnames": "2.3.2",
 		"prop-types": "15.8.1",
 		"react-router-dom": "6.6.2"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.11.1",
+	"version": "3.12.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.11.1';
+	const PACKAGE_VERSION = '3.12.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -27,6 +27,17 @@ class REST_Product_Data {
 				'permission_callback' => __CLASS__ . '::permissions_callback',
 			)
 		);
+
+		// Get backup undo event
+		register_rest_route(
+			'my-jetpack/v1',
+			'/site/backup/undo-event',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::get_site_backup_undo_event',
+				'permission_callback' => __CLASS__ . '::permissions_callback',
+			)
+		);
 	}
 
 	/**
@@ -49,10 +60,90 @@ class REST_Product_Data {
 		$response_code  = wp_remote_retrieve_response_code( $response );
 		$body           = json_decode( wp_remote_retrieve_body( $response ) );
 
+		// If site has backups, add latest undo event
+		if ( $body->backups->last_finished_backup_time ) {
+			$body->backups->last_undoable_event = self::get_site_backup_undo_event();
+		}
+
 		if ( is_wp_error( $response ) || empty( $response['body'] ) || 200 !== $response_code ) {
 			return new WP_Error( 'site_products_data_fetch_failed', 'Site products data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
 		}
 
 		return rest_ensure_response( $body, 200 );
+	}
+
+	/**
+	 * This will fetch the last rewindable event from the Activity Log and
+	 * the last rewind_id prior to that.
+	 *
+	 * @param int $page - numbered page of activity logs to fetch.
+	 *
+	 * @return array|WP_Error
+	 */
+	public static function get_site_backup_undo_event( int $page = 1 ) {
+		$blog_id = \Jetpack_Options::get_option( 'id' );
+
+		$response = Client::wpcom_json_api_request_as_user(
+			'/sites/' . $blog_id . '/activity?force=wpcom&page=' . $page,
+			'v2',
+			array(),
+			null,
+			'wpcom'
+		);
+
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$body = json_decode( $response['body'], true );
+
+		if ( ! isset( $body['current'] ) ) {
+			return null;
+		}
+
+		if ( ! isset( $body['current']['orderedItems'] ) || count( $body['current']['orderedItems'] ) === 0 ) {
+			return null;
+		}
+
+		// Preparing the response structure
+		$undo_event = array(
+			'last_rewindable_event' => null,
+			'undo_backup_id'        => null,
+		);
+
+		// List of events that will not be considered to be undo.
+		// Basically we should not `undo` a full backup event, but we could
+		// use them to undo any other action like plugin updates.
+		$last_event_exceptions = array(
+			'rewind__backup_only_complete_full',
+			'rewind__backup_only_complete_initial',
+			'rewind__backup_only_complete',
+			'rewind__backup_complete_full',
+			'rewind__backup_complete_initial',
+			'rewind__backup_complete',
+		);
+
+		// Looping through the events to find the last rewindable event and the last backup_id.
+		// The idea is to find the last rewindable event and then the last rewind_id before that.
+		$found_last_event = false;
+		foreach ( $body['current']['orderedItems'] as $event ) {
+			if ( $event['is_rewindable'] ) {
+				if ( ! $found_last_event && ! in_array( $event['name'], $last_event_exceptions, true ) ) {
+					$undo_event['last_rewindable_event'] = $event;
+					$found_last_event                    = true;
+				} elseif ( $found_last_event ) {
+					$undo_event['undo_backup_id'] = $event['rewind_id'];
+					break;
+				}
+			}
+		}
+
+		// Keep checking for rewindable event until one is found.
+		if ( $undo_event['last_rewindable_event'] === null || $undo_event['undo_backup_id'] === null ) {
+			$new_page = $page + 1;
+			return self::get_site_backup_undo_event( $new_page );
+		}
+
+		return rest_ensure_response( $undo_event, 200 );
 	}
 }

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -76,11 +76,11 @@ class REST_Product_Data {
 	 * This will fetch the last rewindable event from the Activity Log and
 	 * the last rewind_id prior to that.
 	 *
-	 * @param mixed $page - numbered page of activity logs to fetch.
+	 * @param int $page - numbered page of activity logs to fetch.
 	 *
 	 * @return array|WP_Error
 	 */
-	public static function get_site_backup_undo_event( mixed $page = null ) {
+	public static function get_site_backup_undo_event( $page = null ) {
 		if ( ! $page ) {
 			$page = 1;
 		}

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -76,11 +76,15 @@ class REST_Product_Data {
 	 * This will fetch the last rewindable event from the Activity Log and
 	 * the last rewind_id prior to that.
 	 *
-	 * @param int $page - numbered page of activity logs to fetch.
+	 * @param mixed $page - numbered page of activity logs to fetch.
 	 *
 	 * @return array|WP_Error
 	 */
-	public static function get_site_backup_undo_event( int $page = 1 ) {
+	public static function get_site_backup_undo_event( mixed $page = null ) {
+		if ( ! $page ) {
+			$page = 1;
+		}
+
 		$blog_id = \Jetpack_Options::get_option( 'id' );
 
 		$response = Client::wpcom_json_api_request_as_user(

--- a/projects/plugins/backup/changelog/update-vaultpress-backup-card-purchased-state
+++ b/projects/plugins/backup/changelog/update-vaultpress-backup-card-purchased-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a lockfile update
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -899,7 +899,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "37745817c3f9d2f02365b23178a405b8aa47125e"
+                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -930,7 +930,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.11.x-dev"
+                    "dev-trunk": "3.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/update-vaultpress-backup-card-purchased-state
+++ b/projects/plugins/boost/changelog/update-vaultpress-backup-card-purchased-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a lockfile update
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -954,7 +954,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "37745817c3f9d2f02365b23178a405b8aa47125e"
+                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -985,7 +985,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.11.x-dev"
+                    "dev-trunk": "3.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/update-vaultpress-backup-card-purchased-state
+++ b/projects/plugins/jetpack/changelog/update-vaultpress-backup-card-purchased-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Just a lockfile update
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1638,7 +1638,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "37745817c3f9d2f02365b23178a405b8aa47125e"
+                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1669,7 +1669,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.11.x-dev"
+                    "dev-trunk": "3.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/update-vaultpress-backup-card-purchased-state
+++ b/projects/plugins/migration/changelog/update-vaultpress-backup-card-purchased-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a lockfile update
+
+

--- a/projects/plugins/migration/composer.json
+++ b/projects/plugins/migration/composer.json
@@ -72,6 +72,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_migrationⓥ1_0_1"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_migrationⓥ1_0_2_alpha"
 	}
 }

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -899,7 +899,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "37745817c3f9d2f02365b23178a405b8aa47125e"
+                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -930,7 +930,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.11.x-dev"
+                    "dev-trunk": "3.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/wpcom-migration.php
+++ b/projects/plugins/migration/wpcom-migration.php
@@ -4,7 +4,7 @@
  * Plugin Name: Move to WordPress.com
  * Plugin URI: https://wordpress.org/plugins/wpcom-migration
  * Description: A WordPress plugin that helps users to migrate their sites to WordPress.com.
- * Version: 1.0.1
+ * Version: 1.0.2-alpha
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * License: GPLv2 or later

--- a/projects/plugins/protect/changelog/update-vaultpress-backup-card-purchased-state
+++ b/projects/plugins/protect/changelog/update-vaultpress-backup-card-purchased-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a lockfile update
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "37745817c3f9d2f02365b23178a405b8aa47125e"
+                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -845,7 +845,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.11.x-dev"
+                    "dev-trunk": "3.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/update-vaultpress-backup-card-purchased-state
+++ b/projects/plugins/search/changelog/update-vaultpress-backup-card-purchased-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a lockfile update
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "37745817c3f9d2f02365b23178a405b8aa47125e"
+                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -845,7 +845,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.11.x-dev"
+                    "dev-trunk": "3.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/update-vaultpress-backup-card-purchased-state
+++ b/projects/plugins/social/changelog/update-vaultpress-backup-card-purchased-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a lockfile update
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "37745817c3f9d2f02365b23178a405b8aa47125e"
+                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -845,7 +845,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.11.x-dev"
+                    "dev-trunk": "3.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/update-vaultpress-backup-card-purchased-state
+++ b/projects/plugins/starter-plugin/changelog/update-vaultpress-backup-card-purchased-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a lockfile update
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "37745817c3f9d2f02365b23178a405b8aa47125e"
+                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -845,7 +845,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.11.x-dev"
+                    "dev-trunk": "3.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/update-vaultpress-backup-card-purchased-state
+++ b/projects/plugins/videopress/changelog/update-vaultpress-backup-card-purchased-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a lockfile update
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "37745817c3f9d2f02365b23178a405b8aa47125e"
+                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -845,7 +845,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.11.x-dev"
+                    "dev-trunk": "3.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
## Proposed changes:

* Add most recent undoable activity log item to purchased state of VaultPress backup card
* Add undo button
* Add ability to add additional actions to the My Jetpack cards (such as the Undo action) in a dropdown
* Show when activity was last detected

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-pn9-p2

## Does this pull request change what data or activity we track or use?

Yes, we will be tracking when users click the Undo button and will track the Undo ID within that event

## Testing instructions:

1. Create an Ephemeral site with the Jetpack beta plugin and checkout this branch
2. Connect your site to Jepack, but do not purchase a Backup plan yet
3. Head to `/wp-admin/admin.php?page=my-jetpack` and you should see something like this depending the assets your site has
![image](https://github.com/Automattic/jetpack/assets/65001528/53ff9fb4-a6e7-4632-9268-e6730bd0b222)
4. Go to the Store Admin and assign a VaultPress Backup (daily) deprecated plan to your site. This is to make sure we don't see anything weird if the site doesn't have realtime backup capabilities
5. Go back to My Jetpack and you should see this
![image](https://github.com/Automattic/jetpack/assets/65001528/015bd186-5c73-408a-ae39-9ba1b7de36e9)
6. Make sure your site runs a daily backup and make sure you still don't see anything on the card
7. Next, remove the VaultPress Backup (daily) subscription and purchase a current VaultPress Backup plan
8. Add an asset or two and make sure a realtime backup is created for that event
9. Head over to My Jetpack and you should see the most recent event backed up along with the Undo button
![image](https://github.com/Automattic/jetpack/assets/65001528/45743e7f-1ffe-42f8-a074-102bd89d50b4)
10. Make sure the Manage CTA still works by selecting the dropdown and choosing Manage, and then clicking the CTA
![image](https://github.com/Automattic/jetpack/assets/65001528/474a96f2-b0a6-4074-8d92-fd2ef1b6f80b)
11. Now click the Undo CTA and make sure you are taken to the cloud with the correct realtime backup to restore to
