### PR TITLE
Google Fonts Module: Cache the response of the remote JSON data

### DIFF
--- a/projects/plugins/jetpack/changelog/feat-google-fonts-cache-json
+++ b/projects/plugins/jetpack/changelog/feat-google-fonts-cache-json
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Cache the remote google fonts JSON data

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -13,15 +13,20 @@
 function jetpack_get_google_fonts_data() {
 	$default_google_fonts_api_url        = 'https://fonts.gstatic.com';
 	$jetpack_google_fonts_collection_url = 'https://s0.wp.com/i/font-collections/jetpack-google-fonts.json';
+	$cache_key                           = 'jetpack_google_fonts_' . md5( $jetpack_google_fonts_collection_url );
+	$data                                = get_transient( $cache_key );
+	if ( $data === false ) {
+		$response = wp_remote_get( $jetpack_google_fonts_collection_url );
+		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
+			return null;
+		}
 
-	$response = wp_remote_get( $jetpack_google_fonts_collection_url );
-	if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
-		return null;
-	}
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( $data === null ) {
+			return null;
+		}
 
-	$data = json_decode( wp_remote_retrieve_body( $response ), true );
-	if ( $data === null ) {
-		return null;
+		set_transient( $cache_key, $data, HOUR_IN_SECONDS );
 	}
 
 	// Replace the google fonts api url if the custom one is provided.

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -26,7 +26,7 @@ function jetpack_get_google_fonts_data() {
 			return null;
 		}
 
-		set_transient( $cache_key, $data, HOUR_IN_SECONDS );
+		set_transient( $cache_key, $data, DAY_IN_SECONDS );
 	}
 
 	// Replace the google fonts api url if the custom one is provided.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p8oabR-1nN-p2#comment-7671

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Cache the remote JSON data to avoid the module re-downloading the file on every request

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a [Jurassic Ninja sandbox](https://jurassic.ninja/create/?jetpack-beta&branch=feat/google-fonts-cache-json) against this PR.
* Install [the latest Gutenberg](https://github.com/WordPress/gutenberg/releases), e.g.: v16.9.0
* Install [Query Monitor](https://href.li/?https://wordpress.org/plugins/query-monitor/), or add some logging around the download.
* Go to `/wp-admin/admin.php?page=jetpack_modules` to activate the “Google Fonts (Beta)” module
* Go to the Site Editor
* See that not every page load will download the JSON file, twice. In Query Monitor, it shows up under “HTTP API Calls”.