### PR TITLE
Nextdoor: Fix the embed resizing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nextdoor-embed-sizing
+++ b/projects/plugins/jetpack/changelog/fix-nextdoor-embed-sizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Nextdoor: Fix the embed resizing

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/edit.js
@@ -128,8 +128,8 @@ const BlockPreview = ( { defaultClassName, iframeUrl } ) => {
 
 	return (
 		<>
-			<SandBox html={ html } />
 			<div className={ `${ defaultClassName }-overlay` }></div>
+			<SandBox html={ html } />
 		</>
 	);
 };

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/edit.js
@@ -14,6 +14,7 @@ const icon = getBlockIconComponent( metadata );
 
 export function NextdoorEdit( {
 	attributes,
+	clientId,
 	className,
 	name,
 	noticeOperations,
@@ -99,7 +100,11 @@ export function NextdoorEdit( {
 				{ ...{ defaultClassName, nextdoorShareUrl, onFormSubmit, setNextdoorShareUrl } }
 			/>
 			{ iframeUrl ? (
-				<BlockPreview defaultClassName={ defaultClassName } iframeUrl={ iframeUrl } />
+				<BlockPreview
+					defaultClassName={ defaultClassName }
+					iframeUrl={ iframeUrl }
+					clientId={ clientId }
+				/>
 			) : (
 				blockPlaceholder
 			) }
@@ -107,14 +112,14 @@ export function NextdoorEdit( {
 	);
 }
 
-const BlockPreview = ( { defaultClassName, iframeUrl } ) => {
+const BlockPreview = ( { defaultClassName, iframeUrl, clientId } ) => {
 	const html = `
 		<script>
 			window.addEventListener( 'message', function ( event ) {
 				if ( ! event.origin.startsWith( 'https://nextdoor' ) ) {
 					return;
 				}
-				var iframe = document.getElementById( 'nextdoor-embed' );
+				var iframe = document.getElementById( 'nextdoor-embed-${ clientId }' );
 				if ( event.source !== iframe.contentWindow ) {
 					return;
 				}
@@ -123,7 +128,7 @@ const BlockPreview = ( { defaultClassName, iframeUrl } ) => {
 				window.parent.postMessage( { action: 'resize', width: clientBoundingRect.width, height: clientBoundingRect.height }, '*' );
 			} );
 		</script>
-		<iframe id="nextdoor-embed" width="100%" height="200" frameBorder="0" src="${ iframeUrl }" title="Nextdoor" />
+		<iframe id="nextdoor-embed-${ clientId }" width="100%" height="200" frameBorder="0" src="${ iframeUrl }" title="Nextdoor" />
 		`;
 
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/edit.js
@@ -128,7 +128,10 @@ const BlockPreview = ( { defaultClassName, iframeUrl, clientId } ) => {
 				window.parent.postMessage( { action: 'resize', width: clientBoundingRect.width, height: clientBoundingRect.height }, '*' );
 			} );
 		</script>
-		<iframe id="nextdoor-embed-${ clientId }" width="100%" height="200" frameBorder="0" src="${ iframeUrl }" title="Nextdoor" />
+		<iframe id="nextdoor-embed-${ clientId }" width="100%" height="200" frameBorder="0" src="${ iframeUrl }" title="${ __(
+			'Nextdoor',
+			'jetpack'
+		) }" />
 		`;
 
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/nextdoor.php
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/nextdoor.php
@@ -51,9 +51,10 @@ function load_assets( $attr ) {
 	 */
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
-	$iframe_markup = '<iframe src="' . esc_url( $url ) . '" frameborder="0" title="' . esc_html__( 'Nextdoor embed', 'jetpack' ) . '" height="200" width="100%"></iframe>';
+	$block_id      = wp_unique_id( 'nextdoor-block-' );
+	$iframe_markup = '<iframe id="' . esc_attr( $block_id ) . '" src="' . esc_url( $url ) . '" frameborder="0" title="' . esc_html__( 'Nextdoor embed', 'jetpack' ) . '" height="400" width="100%"></iframe>';
 
-	$block_classes = Blocks::classes( __DIR__, $attr );
+	$block_classes = Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr );
 
 	$html =
 		'<figure class="' . esc_attr( $block_classes ) . '">' .

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/nextdoor.php
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/nextdoor.php
@@ -46,19 +46,21 @@ function load_assets( $attr ) {
 		return;
 	}
 
+	$url = preg_replace( '#/embed/#', '/p/', $url );
+
 	/*
 	 * Enqueue necessary scripts and styles.
 	 */
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
-	$block_id      = wp_unique_id( 'nextdoor-block-' );
-	$iframe_markup = '<iframe id="' . esc_attr( $block_id ) . '" src="' . esc_url( $url ) . '" frameborder="0" title="' . esc_html__( 'Nextdoor embed', 'jetpack' ) . '" height="400" width="100%"></iframe>';
+	$block_id    = wp_unique_id( 'nextdoor-block-' );
+	$link_markup = '<a href="' . esc_url( $url ) . '" title="' . esc_html__( 'Nextdoor embed', 'jetpack' ) . '">' . esc_html( $url ) . '</a>';
 
 	$block_classes = Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr );
 
 	$html =
-		'<figure class="' . esc_attr( $block_classes ) . '">' .
-			$iframe_markup .
+		'<figure id="' . esc_attr( $block_id ) . '" class="' . esc_attr( $block_classes ) . '">' .
+			$link_markup .
 		'</figure>';
 
 	return $html;

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/test/edit.js
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { SandBox } from '@wordpress/components';
 import { NextdoorEdit } from '../edit';
 import { parseUrl } from '../utils';
 
@@ -11,9 +12,18 @@ jest.mock( '../utils.js', () => {
 	};
 } );
 
+jest.mock( '@wordpress/components', () => {
+	const originalComponents = jest.requireActual( '@wordpress/components' );
+	return {
+		...originalComponents,
+		SandBox: jest.fn(),
+	};
+} );
+
 jest.mock( '../utils.js', () => ( {
 	__esModule: true,
 	parseUrl: jest.fn(),
+	resizeIframeOnMessage: jest.fn(),
 } ) );
 
 describe( 'NextdoorEdit', () => {
@@ -70,11 +80,11 @@ describe( 'NextdoorEdit', () => {
 
 		render( <NextdoorEdit { ...{ ...defaultProps, attributes } } /> );
 
-		let iframe;
-		await waitFor( () => ( iframe = screen.getByTitle( 'Nextdoor' ) ) );
+		expect( SandBox ).toHaveBeenCalled();
 
-		expect( iframe ).toBeInTheDocument();
-		// eslint-disable-next-line testing-library/no-node-access
-		expect( iframe.previousElementSibling ).toHaveClass( 'wp-block-jetpack-nextdoor-overlay' );
+		const callDetails = SandBox.mock.calls[ 0 ][ 0 ];
+
+		expect( callDetails ).toHaveProperty( 'html' );
+		expect( callDetails.html ).toContain( 'src="https://nextdoor.com/embed/valid-url"' );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/utils.js
@@ -33,8 +33,17 @@ export const parseUrl = postUrl => {
 };
 
 export const resizeIframeOnMessage = id => {
-	const iframe = document.getElementById( id );
-	let firstCall = true;
+	const figure = document.getElementById( id );
+	const link = figure.querySelector( 'a' );
+	const attributes = {
+		width: '100%',
+		height: '200',
+		frameborder: '0',
+		title: link.getAttribute( 'title' ),
+		src: getEmbedUrlFromPostUrl( link.href ),
+	};
+
+	const iframe = document.createElement( 'iframe' );
 	window.addEventListener( 'message', event => {
 		if ( ! event.origin.startsWith( 'https://nextdoor' ) ) {
 			return;
@@ -42,14 +51,10 @@ export const resizeIframeOnMessage = id => {
 		if ( event.source !== iframe.contentWindow ) {
 			return;
 		}
-		if ( firstCall ) {
-			firstCall = false;
-			iframe.setAttribute( 'width', '99%' );
-		} else {
-			setTimeout( () => {
-				iframe.setAttribute( 'width', '100%' );
-				iframe.setAttribute( 'height', event.data.height + 'px' );
-			}, 500 );
-		}
+		iframe.setAttribute( 'height', event.data.height + 'px' );
 	} );
+	Object.keys( attributes ).forEach( attribute =>
+		iframe.setAttribute( attribute, attributes[ attribute ] )
+	);
+	figure.replaceChild( iframe, link );
 };

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/utils.js
@@ -31,3 +31,25 @@ export const parseUrl = postUrl => {
 
 	return newUrl;
 };
+
+export const resizeIframeOnMessage = id => {
+	const iframe = document.getElementById( id );
+	let firstCall = true;
+	window.addEventListener( 'message', event => {
+		if ( ! event.origin.startsWith( 'https://nextdoor' ) ) {
+			return;
+		}
+		if ( event.source !== iframe.contentWindow ) {
+			return;
+		}
+		if ( firstCall ) {
+			firstCall = false;
+			iframe.setAttribute( 'width', '99%' );
+		} else {
+			setTimeout( () => {
+				iframe.setAttribute( 'width', '100%' );
+				iframe.setAttribute( 'height', event.data.height + 'px' );
+			}, 500 );
+		}
+	} );
+};

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/view.js
@@ -1,10 +1,10 @@
 import { resizeIframeOnMessage } from './utils';
 
 document.addEventListener( 'DOMContentLoaded', () => {
-	const iframes = document.querySelectorAll( 'iframe' );
-	iframes.forEach( iframe => {
-		if ( iframe.id.startsWith( 'nextdoor-block' ) ) {
-			resizeIframeOnMessage( iframe.id );
+	const embeds = document.querySelectorAll( 'figure' );
+	embeds.forEach( embed => {
+		if ( embed.id.startsWith( 'nextdoor-block' ) ) {
+			resizeIframeOnMessage( embed.id );
 		}
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/view.js
@@ -1,0 +1,10 @@
+import { resizeIframeOnMessage } from './utils';
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	const iframes = document.querySelectorAll( 'iframe' );
+	iframes.forEach( iframe => {
+		if ( iframe.id.startsWith( 'nextdoor-block' ) ) {
+			resizeIframeOnMessage( iframe.id );
+		}
+	} );
+} );


### PR DESCRIPTION
Nextdoor are now sending us the height of the embed using postMessage, so we need to react to that.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This patch needs to be tested on Jetpack and WPCOM sites too.

For Jetpack sites:

1. Add `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` to your site so your see the beta blocks.
2. Create a new post, and try adding a Nextdoor block with pasting the link into the body, or searching for the block then pasting the URL to the post
3. The block should appear with the right height after loading in the editor. Create at least 2 blocks to test the unique ids, then publish the post.
4. Check the published post, the blocks should be there with the right size too
5. Repeat steps 1-4 with and without the Gutenberg plugin activated, to test if it works with nested iframes.

For WPCOM sites:

1. Use `bin/jetpack-downloader` following the instructions below to test the changes on your wpcom site.
2. After sandboxing the site follow steps 2-4 above and make sure everything works fine

