### PR TITLE
Fixed subscribe block redirect issue on non-post pages

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-form-redirect-to-post-bug
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-form-redirect-to-post-bug
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Subscribe block: only redirect to post when inside a post context

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -609,12 +609,19 @@ function get_post_access_level_for_current_post() {
  * @return string
  */
 function render_for_website( $data, $classes, $styles ) {
-	$blog_id            = \Jetpack_Options::get_option( 'id' );
-	$widget_id_suffix   = Jetpack_Subscriptions_Widget::$instance_count > 1 ? '-' . Jetpack_Subscriptions_Widget::$instance_count : '';
-	$form_id            = 'subscribe-blog' . $widget_id_suffix;
-	$form_url           = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '#';
-	$post_access_level  = get_post_access_level_for_current_post();
-	$post_id            = get_the_ID();
+	$blog_id           = \Jetpack_Options::get_option( 'id' );
+	$widget_id_suffix  = Jetpack_Subscriptions_Widget::$instance_count > 1 ? '-' . Jetpack_Subscriptions_Widget::$instance_count : '';
+	$form_id           = 'subscribe-blog' . $widget_id_suffix;
+	$form_url          = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '#';
+	$post_access_level = get_post_access_level_for_current_post();
+
+	$post_id = null;
+	if ( in_the_loop() ) {
+		$post_id = get_the_ID();
+	} elseif ( is_singular( 'post' ) ) {
+		$post_id = get_queried_object_id();
+	}
+
 	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );
 	$tier_id            = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
 	$is_subscribed      = Jetpack_Memberships::is_current_user_subscribed();

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -55,39 +55,38 @@ domReady( function () {
 		} );
 	}
 
-	const form = document.querySelector( '.wp-block-jetpack-subscriptions__container form' );
-	if ( ! form ) {
-		return;
-	}
-	if ( ! form.payments_attached ) {
-		form.payments_attached = true;
-		form.addEventListener( 'submit', function ( event ) {
-			if ( form.resubmitted ) {
-				return;
-			}
+	const forms = document.querySelectorAll( '.wp-block-jetpack-subscriptions__container form' );
+	forms.forEach( form => {
+		if ( ! form.payments_attached ) {
+			form.payments_attached = true;
+			form.addEventListener( 'submit', function ( event ) {
+				if ( form.resubmitted ) {
+					return;
+				}
 
-			const emailInput = form.querySelector( 'input[type=email]' );
-			const email = emailInput ? emailInput.value : form.dataset.subscriber_email;
+				const emailInput = form.querySelector( 'input[type=email]' );
+				const email = emailInput ? emailInput.value : form.dataset.subscriber_email;
 
-			if ( ! email ) {
-				return;
-			}
+				if ( ! email ) {
+					return;
+				}
 
-			event.preventDefault();
+				event.preventDefault();
 
-			const post_id = form.querySelector( 'input[name=post_id]' )?.value ?? '';
-			const tier_id = form.querySelector( 'input[name=tier_id]' )?.value ?? '';
+				const post_id = form.querySelector( 'input[name=post_id]' )?.value ?? '';
+				const tier_id = form.querySelector( 'input[name=tier_id]' )?.value ?? '';
 
-			show_iframe( {
-				email,
-				post_id,
-				tier_id,
-				blog: form.dataset.blog,
-				plan: 'newsletter',
-				source: 'jetpack_subscribe',
-				post_access_level: form.dataset.post_access_level,
-				display: 'alternate',
+				show_iframe( {
+					email,
+					post_id,
+					tier_id,
+					blog: form.dataset.blog,
+					plan: 'newsletter',
+					source: 'jetpack_subscribe',
+					post_access_level: form.dataset.post_access_level,
+					display: 'alternate',
+				} );
 			} );
-		} );
-	}
+		}
+	} );
 } );


### PR DESCRIPTION
## Proposed changes:
The subscribe block was incorrectly redirecting to the post from `get_the_ID()` when used on the homepage and archive pages.

This PR also contains a small fix to bind the showing of the subscribe modal to all subscribe forms on the page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply this PR
- Change the design of your blog: 
   - Add a subscribe block to the footer
   - Show post content inside the post loop for the homepage
- Create a post with a subscribe block 
- Inspect the subscribe blocks using developer tools:
   - When on the home page the footer subscribe block shouldn't contain a hidden `post_id` field
   - The subscribe block inside the post loop should contain a hidden `post_id` field containing the post_id of the post being shown
   - Both subscribe blocks on the post detail (single) page should contain a hidden `post_id` field containing the post_id of the post being shown

You can also try subscribing using the different blocks, the one in the footer on the home page should redirect to `Reader > Manage Subscriptions` while the other ones should redirect to the post.
