### PR TITLE
wp-admin Site Default: Add notice banner for wp-admin users

### DIFF
--- a/projects/plugins/jetpack/changelog/add-wp-admin-notice-banner
+++ b/projects/plugins/jetpack/changelog/add-wp-admin-notice-banner
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added a notice for wp-admin settings pages when the wpcom_admin_interface option is set to wp-admin

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -501,7 +501,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Close over the $switch_url variable.
 		$admin_notices = function() use ( $switch_url ) {
 			// translators: %s is a link to the Calypso settings page.
-			$notice = __( 'You are currently using the Classic view, which doesn\'t offer the same set of features as the Default view. To Access additional settings and features, <a href="%s">switch to the Default view</a>. ', 'jetpack' );
+			$notice = __( 'You are currently using the Classic view, which doesn\'t offer the same set of features as the Default view. To access additional settings and features, <a href="%s">switch to the Default view</a>. ', 'jetpack' );
 			?>
 			<div class="notice notice-warning">
 				<p><?php echo wp_kses( sprintf( $notice, esc_url( $switch_url ) ), array( 'a' => array( 'href' => array() ) ) ); ?></p>

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -482,7 +482,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		$current_screen = get_current_screen();
 
-		if ( ! $current_screen ) {
+		if ( ! $current_screen instanceof \WP_Screen ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -505,7 +505,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$switch_url = sprintf( 'https://wordpress.com/settings/%s/%s', $mapped_screen, $this->domain );
 
 		// Close over the $switch_url variable.
-		$admin_notices = function() use ( $switch_url ) {
+		$admin_notices = function () use ( $switch_url ) {
 			// translators: %s is a link to the Calypso settings page.
 			$notice = __( 'You are currently using the Classic view, which doesn\'t offer the same set of features as the Default view. To access additional settings and features, <a href="%s">switch to the Default view</a>. ', 'jetpack' );
 			?>

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -480,6 +480,12 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			return;
 		}
 
+		$current_screen = get_current_screen();
+
+		if ( ! $current_screen ) {
+			return;
+		}
+
 		// Show the notice for the following screens and map them to the Calypso page.
 		$screen_map = array(
 			'options-general'    => 'general',
@@ -488,8 +494,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			'options-discussion' => 'discussion',
 		);
 
-		$mapped_screen = isset( $screen_map[ get_current_screen()->id ] )
-			? $screen_map[ get_current_screen()->id ]
+		$mapped_screen = isset( $screen_map[ $current_screen->id ] )
+			? $screen_map[ $current_screen->id ]
 			: false;
 
 		if ( ! $mapped_screen ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -41,6 +41,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			},
 			0
 		);
+
+		// Add notices to the settings pages when there is a Calypso page available.
+		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+			add_action( 'current_screen', array( $this, 'add_settings_page_notice' ) );
+		}
 	}
 
 	/**
@@ -462,5 +467,48 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$jitm->dismiss( sanitize_text_field( wp_unslash( $_REQUEST['id'] ) ), sanitize_text_field( wp_unslash( $_REQUEST['feature_class'] ) ) );
 		}
 		wp_die();
+	}
+
+	/**
+	 * Adds a notice above each settings page while using the Classic view to indicate
+	 * that the Default view offers more features. Links to the default view.
+	 *
+	 * @return void
+	 */
+	public function add_settings_page_notice() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		// Show the notice for the following screens and map them to the Calypso page.
+		$screen_map = array(
+			'options-general'    => 'general',
+			'options-writing'    => 'writing',
+			'options-reading'    => 'reading',
+			'options-discussion' => 'discussion',
+		);
+
+		$mapped_screen = isset( $screen_map[ get_current_screen()->id ] )
+			? $screen_map[ get_current_screen()->id ]
+			: false;
+
+		if ( ! $mapped_screen ) {
+			return;
+		}
+
+		$switch_url = sprintf( 'https://wordpress.com/settings/%s/%s', $mapped_screen, $this->domain );
+
+		// Close over the $switch_url variable.
+		$admin_notices = function() use ( $switch_url ) {
+			// translators: %s is a link to the Calypso settings page.
+			$notice = __( 'You are currently using the Classic view, which doesn\'t offer the same set of features as the Default view. To Access additional settings and features, <a href="%s">switch to the Default view</a>. ', 'jetpack' );
+			?>
+			<div class="notice notice-warning">
+				<p><?php echo wp_kses( sprintf( $notice, esc_url( $switch_url ) ), array( 'a' => array( 'href' => array() ) ) ); ?></p>
+			</div>
+			<?php
+		};
+
+		add_action( 'admin_notices', $admin_notices );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/4335

> The settings pages in the Classic wp-admin view have fewer options than their counterparts in Calypso. We should notify users about this fact so they understand that additional settings are available. We should also let them switch to the other version easily.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* For a selected number of settings pages, we add a notice element via the `admin_notices` action hook.
* The notice will inform the user more settings are available via the default view.
* The notice will have a link that directs the user to the relevant Calypso page
* The notice is added to the: General, Writing, Reading and Discussion settings pages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this PR onto a WoA site - you can use the Jetpack Beta Tester plugin or rsync the plugin to a WoA dev blog
* Via wpcalypso.wordpress.com, change the admin interface style setting to Classic
* Go to one of the applicable settings pages ( General, Writing, Reading, Discussion ) and observe that there is a notice informing the user of the Calypso view.
* Ensure that other wp-admin pages do not display this notice.
* Ensure that the links in the notice bring you to the appropriate page in the Calypso UI.