### PR TITLE
Add Facebook to Quick Share buttons

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-fb-to-quick-share
+++ b/projects/js-packages/publicize-components/changelog/add-fb-to-quick-share
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added Facebook to Quick Share buttons

--- a/projects/js-packages/publicize-components/src/components/share-buttons/available-networks.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-buttons/available-networks.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 
 type Network = {
 	label: string;
-	networkName: 'x' | 'whatsapp';
+	networkName: 'x' | 'whatsapp' | 'facebook';
 	url: string;
 };
 
@@ -16,5 +16,10 @@ export const availableNetworks: Array< Network > = [
 		label: __( 'WhatsApp', 'jetpack' ),
 		networkName: 'whatsapp',
 		url: 'https://api.whatsapp.com/send?text={{text}}',
+	},
+	{
+		label: __( 'Facebook', 'jetpack' ),
+		networkName: 'facebook',
+		url: 'https://www.facebook.com/sharer/sharer.php?u={{url}}',
 	},
 ];

--- a/projects/js-packages/publicize-components/src/components/share-buttons/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/share-buttons/styles.module.scss
@@ -59,6 +59,12 @@ $whatsapp: #2ab318;
 		background-color: $whatsapp;
 	}
 
+	.facebook {
+		background-color: var( --color-facebook );
+		// I hate !important, but social icon has it, so it needs to be overriden
+		border-radius: var(--jp-border-radius) !important;
+	}
+
 	.clipboard {
 		background-color: #fff;
 		outline: 1px solid var(--jp-gray);


### PR DESCRIPTION
Jetpack Social does not support sharing posts to personal profiles. So, users need an easy way to share to their own accounts.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add Facebook to Quick Share buttons on the post-publish and quick share panels

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Boot up the PR and run `jetpack build plugins/jetpack`
* Create a new post and hit publish or for an existing post, run this in browser console
    - `wp.data.dispatch('core/edit-post').togglePublishSidebar();`
* On the post publish panel, confirm that you see the "Facebook" button
* Confirm that it works as expected
* Open Jetpack sidebar for a published post
* Expand "Share this post", click on the share icon
* Confirm that you see the Facebook button and it works as expected



<img width="290" alt="Screenshot 2023-11-02 at 2 47 27 PM" src="https://github.com/Automattic/jetpack/assets/18226415/8ed420ae-b213-4953-b9af-22e76fb0150b">
<img width="368" alt="Screenshot 2023-11-02 at 2 47 39 PM" src="https://github.com/Automattic/jetpack/assets/18226415/67f04efe-d6dd-4d7e-bd7a-2964bf65d0d3">
<img width="911" alt="Screenshot 2023-11-02 at 2 47 50 PM" src="https://github.com/Automattic/jetpack/assets/18226415/f409bd07-3ce3-4ba5-90d4-8c95f41359f3">
