### PR TITLE
Subscribe block: allow setting blog ID from attributes

### DIFF
--- a/projects/plugins/jetpack/changelog/updaet-subscribe-blog-id
+++ b/projects/plugins/jetpack/changelog/updaet-subscribe-blog-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe block: allow setting site ID from attributes

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/attributes.js
@@ -1,6 +1,9 @@
 import { __ } from '@wordpress/i18n';
 
 export default {
+	blogId: {
+		type: 'number',
+	},
 	subscribePlaceholder: {
 		type: 'string',
 		default: __( 'Type your email…', 'jetpack' ),

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/block.json
@@ -28,6 +28,9 @@
 		}
 	],
 	"attributes": {
+		"blogId": {
+			"type": "number"
+		},
 		"subscribePlaceholder": {
 			"type": "string",
 			"default": "Type your email…"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -552,7 +552,11 @@ function render_block( $attributes ) {
 	$include_social_followers = isset( $attributes['includeSocialFollowers'] ) ? (bool) get_attribute( $attributes, 'includeSocialFollowers' ) : true;
 	$is_paid_subscriber       = get_attribute( $attributes, 'isPaidSubscriber', false );
 
+	$blog_id_attribute = get_attribute( $attributes, 'blogId' );
+	$blog_id           = ! empty( $blog_id_attribute ) ? $blog_id_attribute : \Jetpack_Options::get_option( 'id' );
+
 	$data = array(
+		'blog_id'                => (int) $blog_id,
 		'widget_id'              => Jetpack_Subscriptions_Widget::$instance_count,
 		'subscribe_email'        => $subscribe_email,
 
@@ -608,7 +612,6 @@ function get_post_access_level_for_current_post() {
  * @return string
  */
 function render_for_website( $data, $classes, $styles ) {
-	$blog_id            = \Jetpack_Options::get_option( 'id' );
 	$widget_id_suffix   = Jetpack_Subscriptions_Widget::$instance_count > 1 ? '-' . Jetpack_Subscriptions_Widget::$instance_count : '';
 	$form_id            = 'subscribe-blog' . $widget_id_suffix;
 	$form_url           = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '#';
@@ -632,7 +635,7 @@ function render_for_website( $data, $classes, $styles ) {
 					action="<?php echo esc_url( $form_url ); ?>"
 					method="post"
 					accept-charset="utf-8"
-					data-blog="<?php echo esc_attr( $blog_id ); ?>"
+					data-blog="<?php echo esc_attr( $data['blog_id'] ); ?>"
 					data-post_access_level="<?php echo esc_attr( $post_access_level ); ?>"
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
@@ -678,12 +681,12 @@ function render_for_website( $data, $classes, $styles ) {
 							<?php endif; ?>
 						>
 							<input type="hidden" name="action" value="subscribe"/>
-							<input type="hidden" name="blog_id" value="<?php echo (int) $blog_id; ?>"/>
+							<input type="hidden" name="blog_id" value="<?php echo (int) $data['blog_id']; ?>"/>
 							<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
 							<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
 							<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 							<?php
-							wp_nonce_field( 'blogsub_subscribe_' . $blog_id, '_wpnonce', false );
+							wp_nonce_field( 'blogsub_subscribe_' . $data['blog_id'], '_wpnonce', false );
 
 							if ( ! empty( $post_id ) ) {
 								echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

To render subscribe blocks for different sites (in context of blogroll blog for example) we need to be able to set the "target site" of subscribe form dynamically.

We don't need editor UI for the setting, but can allow setting the ID via block attributes otherwise. 

### Questions:

- Should we check for remote's `Jetpack::is_module_active( 'subscriptions' )` before we allow subscribing? Or we just _always_ allow subscribing, much like RSS cannot be disabled or Subscribing via Reader and Apps is always possible?
- When site ID is some other site than host site:
    - don't capture post ID,
    - don't capture logged in subscriber's current level (Free/paid/tier) or current post access level,
    - don't capture tier ID.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allow setting blog ID from attributes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

