### PR TITLE
Make Subscribe block default texts editable

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-block-input-placeholder
+++ b/projects/plugins/jetpack/changelog/fix-subscription-block-input-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Allow edition of Subscription block placeholder text and button label

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -264,7 +264,7 @@ export default function SubscriptionControls( {
 				<TextareaControl
 					value={ subscribePlaceholder }
 					label={ __( 'Input placeholder text', 'jetpack' ) }
-					help={ __( 'Edit the placeholder text of email address input.', 'jetpack' ) }
+					help={ __( 'Edit the placeholder text of the email address input.', 'jetpack' ) }
 					onChange={ placeholder => setAttributes( { subscribePlaceholder: placeholder } ) }
 				/>
 				<TextareaControl

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -51,6 +51,8 @@ export default function SubscriptionControls( {
 	subscriberCount,
 	textColor,
 	buttonWidth,
+	subscribePlaceholder,
+	submitButtonText,
 	successMessage,
 } ) {
 	const { isPublicizeEnabled } = usePublicizeConfig();
@@ -257,6 +259,19 @@ export default function SubscriptionControls( {
 					onChange={ () => {
 						setAttributes( { buttonOnNewLine: ! buttonOnNewLine } );
 					} }
+				/>
+
+				<TextareaControl
+					value={ subscribePlaceholder }
+					label={ __( 'Input placeholder text', 'jetpack' ) }
+					help={ __( 'Edit the placeholder text of email address input.', 'jetpack' ) }
+					onChange={ placeholder => setAttributes( { subscribePlaceholder: placeholder } ) }
+				/>
+				<TextareaControl
+					value={ submitButtonText }
+					label={ __( 'Submit button label', 'jetpack' ) }
+					help={ __( 'Edit the label of the button a user clicks to subscribe.', 'jetpack' ) }
+					onChange={ text => setAttributes( { submitButtonText: text } ) }
 				/>
 				{ ! isSimpleSite() && (
 					<TextareaControl

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -274,6 +274,8 @@ export function SubscriptionEdit( props ) {
 					subscriberCount={ subscriberCount }
 					textColor={ textColor }
 					buttonWidth={ buttonWidth }
+					subscribePlaceholder={ subscribePlaceholder }
+					submitButtonText={ submitButtonText }
 					successMessage={ successMessage }
 				/>
 			</InspectorControls>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/26377

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The _Subscribe_ block consists of a text input and a button. This PR makes the input placeholder and button label editable.

| Before | After |
|-|-|
|<img width="300" alt="" src="https://github.com/Automattic/jetpack/assets/1620183/8516288b-9b2d-4156-b9bc-7f7a596f2c35">|<img width="300" alt="" src="https://github.com/Automattic/jetpack/assets/1620183/b27a7dec-c583-4e2a-aa7e-20eb26453bb7">|
|<img width="300" alt="" src="https://github.com/Automattic/jetpack/assets/1620183/5ea87cb4-0985-4e24-a7ee-0d1845f6bf0a">|<img width="300" alt="" src="https://github.com/Automattic/jetpack/assets/1620183/cffdb74f-d9a3-4142-9278-7850a02246ce">|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Self-hosted site
- Spin up a test site with this branch
- Visit `/wp-admin/post-new.php`
- Add the `Subscribe` block to the page, and activate subscriptions if they're not already
- Make sure the block is selected
- In the _Block_ panel of the sidebar, expand the _Settings_ section
- Notice you can update the input placeholder and submit label (they should be updated in real-time in the editor)
- Refresh the page and check the updated texts have been saved
- Preview the post and notice that you can see the custom texts
- Optionally, beginning with a version of the plugin that doesn't include these changes, add the `Subscribe` block to the page, update the plugin to use this branch, and reload the page. Notice that upgrading the plugin didn't cause any issue in the existing page.

### Simple site
- Download the branch
- Build the plugin: `jetpack build plugins/jetpack`
- Sync the build with your sandbox site: `jetpack rsync jetpack`
- Visit `<your site>/wp-admin/post-new.php`
- Repeat the above steps

