### PR TITLE
AI Asistant: expose tier plans on feature endpoint payload

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -424,6 +424,7 @@ class Jetpack_AI_Helper {
 				'current-tier'         => array(
 					'value' => $current_tier_value,
 				),
+				'tier-plans'           => WPCOM\Jetpack_AI\Usage\Helper::get_tier_plans_list(),
 			);
 		}
 

--- a/projects/plugins/jetpack/changelog/add-tier-plans-on-ai-feature
+++ b/projects/plugins/jetpack/changelog/add-tier-plans-on-ai-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add tier-plans on ai-assistant-feature endpoint payload containing the collection of available tiered plans


### PR DESCRIPTION
Add tier-plans as new prop on the ai-assistant-feature endpoint

Fixes #33361 

## Proposed changes:
This PR uses the newly introduced helper method (D127450-code) to expose the tiered plans collection on the assistant feature endpoint. This is part of our ongoing effort to bring all we need from backend to further construct all the UI flows and processes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1698848974635889-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Wait until the build is ready, apply on your sandbox. Then use a JN/local pointing to your sandbox. Start a new post and open the AI panel on the JP menu. You should see the request triggering and the response include the new prop. The new prop should be an empty array.

You can also use the https://developer.wordpress.com/docs/api/console/ pointing public-api to your sandbox and check on any site making a request to /sites/[site ID]/jetpack-ai/ai-assistant-feature
<img width="676" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/d6f8b476-e68c-40ef-b9e9-e1908e14828e">

If you enable the filter flag on your instance, you should get the actual collection of tiered plans.