### PR TITLE
wp-admin Site Default: Add login type selection for classic interface

### DIFF
--- a/projects/plugins/jetpack/changelog/add-login-type-selection-for-classic-interface
+++ b/projects/plugins/jetpack/changelog/add-login-type-selection-for-classic-interface
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Display SSO form for user who has wpcom-admin-interface setting set to wp-admin (fall back to the original WordPress menu)

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -400,6 +400,13 @@ class Jetpack_SSO {
 	}
 
 	/**
+	 * Checks to determine if the user has indicated they want to use the wp-admin interface.
+	 */
+	private function use_wp_admin_interface() {
+		return 'wp-admin' === get_option( 'wpcom_admin_interface' );
+	}
+
+	/**
 	 * Initialization for a SSO request.
 	 */
 	public function login_init() {
@@ -456,7 +463,7 @@ class Jetpack_SSO {
 			 * to the WordPress.com login page AND  that the request to wp-login.php
 			 * is not something other than login (Like logout!)
 			 */
-			if ( Jetpack_SSO_Helpers::bypass_login_forward_wpcom() && $this->wants_to_login() ) {
+			if ( ! $this->use_wp_admin_interface() && Jetpack_SSO_Helpers::bypass_login_forward_wpcom() && $this->wants_to_login() ) {
 				add_filter( 'allowed_redirect_hosts', array( 'Jetpack_SSO_Helpers', 'allowed_redirect_hosts' ) );
 				$reauth  = ! empty( $_GET['force_reauth'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$sso_url = $this->get_sso_url_or_die( $reauth );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/4443

When the "Classic" interface is selected and SSO is enabled, we should present the option of signing in via WordPress or WordPress.com, instead of redirecting wp-login.php to WordPress.com. This is a problematic and confusing user experience for users created directly on the WordPress site.

![image](https://github.com/Automattic/jetpack/assets/36432/6a8cefba-0c5a-4c49-9ed0-5e01b165bab9)


## Proposed changes:
<!--- Explain what functional changes your PR includes -->

In this PR, I propose to skip the redirection if the user chooses to use the `wp-admin` interface instead of `calypso`. In such a case, the default SSO form will be displayed, allowing the user to either log in using a WordPress account or navigate to WordPress.com to sign in there. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create an Atomic site
2. Install [Jetpack beta tester](https://jetpack.com/download-jetpack-beta/) plugin
3. Via the Jetpack menu on your Atomic site, go to the Jetpack beta tester page, select Jetpack (manage)
4. Search for the feature branch `add/login-type-selection-for-classic-interface` and activate that branch. 
5. Using a private browser tab, open a `/wp-admin/` for the site, e.g., `https://SITE_SLUG.wpcomstaging.com/wp-admin/`
6. Confirm it redirects to the 'Log in to your account' page on wordpress.com
7. Now, logged as a site owner, navigate to the Hosting Configuration page on the wpcalypso environment (https://wpcalypso.wordpress.com/hosting-config/), scroll to the bottom, and change the Admin interface style to "Classic style"
8. Using the private browser tab, refresh `https://SITE_SLUG.wpcomstaging.com/wp-admin/`
9. Confirm that it shows the SSO login page at `wp-login.php`, which allows logging in using a WordPress username and password or navigating to the 'Log in to your account' page on wordpress.com