### PR TITLE
AI Assistant: Add loading state to usage panel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-loading
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Add loading state to usage panel

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -56,44 +56,40 @@ export async function getAIFeatures(): Promise< AIFeatureProps > {
 		path: '/wpcom/v2/jetpack-ai/ai-assistant-feature',
 	} );
 
-	try {
-		return {
-			hasFeature: !! response[ 'has-feature' ],
-			isOverLimit: !! response[ 'is-over-limit' ],
-			requestsCount: response[ 'requests-count' ],
-			requestsLimit: response[ 'requests-limit' ],
-			requireUpgrade: !! response[ 'site-require-upgrade' ],
-			errorMessage: response[ 'error-message' ],
-			errorCode: response[ 'error-code' ],
-			upgradeType: response[ 'upgrade-type' ],
-			usagePeriod: {
-				currentStart: response[ 'usage-period' ]?.[ 'current-start' ],
-				nextStart: response[ 'usage-period' ]?.[ 'next-start' ],
-				requestsCount: response[ 'usage-period' ]?.[ 'requests-count' ] || 0,
-			},
-			currentTier: {
-				value: response[ 'current-tier' ]?.value || 1,
-			},
-		};
-	} catch ( error ) {
-		console.error( error ); // eslint-disable-line no-console
-	}
+	return {
+		hasFeature: !! response[ 'has-feature' ],
+		isOverLimit: !! response[ 'is-over-limit' ],
+		requestsCount: response[ 'requests-count' ],
+		requestsLimit: response[ 'requests-limit' ],
+		requireUpgrade: !! response[ 'site-require-upgrade' ],
+		errorMessage: response[ 'error-message' ],
+		errorCode: response[ 'error-code' ],
+		upgradeType: response[ 'upgrade-type' ],
+		usagePeriod: {
+			currentStart: response[ 'usage-period' ]?.[ 'current-start' ],
+			nextStart: response[ 'usage-period' ]?.[ 'next-start' ],
+			requestsCount: response[ 'usage-period' ]?.[ 'requests-count' ] || 0,
+		},
+		currentTier: {
+			value: response[ 'current-tier' ]?.value || 1,
+		},
+	};
 }
 
 export default function useAIFeature() {
 	const [ data, setData ] = useState< AIFeatureProps >( AI_Assistant_Initial_State );
 	const [ loading, setLoading ] = useState< boolean >( false );
-	const [ failed, setFailed ] = useState< boolean >( false );
+	const [ error, setError ] = useState< Error >( null );
 
 	const loadFeatures = async () => {
 		setLoading( true );
-		setFailed( false );
+		setError( null );
 
 		try {
 			const aiFeatures = await getAIFeatures();
 			setData( aiFeatures );
-		} catch ( error ) {
-			setFailed( true );
+		} catch ( err ) {
+			setError( err );
 		} finally {
 			setLoading( false );
 		}
@@ -106,7 +102,7 @@ export default function useAIFeature() {
 	return {
 		...data,
 		loading,
-		failed,
+		error,
 		setLoading,
 		refresh: loadFeatures,
 	};

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -82,13 +82,32 @@ export async function getAIFeatures(): Promise< AIFeatureProps > {
 
 export default function useAIFeature() {
 	const [ data, setData ] = useState< AIFeatureProps >( AI_Assistant_Initial_State );
+	const [ loading, setLoading ] = useState< boolean >( false );
+	const [ failed, setFailed ] = useState< boolean >( false );
+
+	const loadFeatures = async () => {
+		setLoading( true );
+		setFailed( false );
+
+		try {
+			const aiFeatures = await getAIFeatures();
+			setData( aiFeatures );
+		} catch ( error ) {
+			setFailed( true );
+		} finally {
+			setLoading( false );
+		}
+	};
 
 	useEffect( () => {
-		getAIFeatures().then( setData );
+		loadFeatures();
 	}, [] );
 
 	return {
 		...data,
-		refresh: () => getAIFeatures().then( setData ),
+		loading,
+		failed,
+		setLoading,
+		refresh: loadFeatures,
 	};
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { ThemeProvider } from '@automattic/jetpack-components';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, PanelBody, PanelRow, BaseControl } from '@wordpress/components';
@@ -75,28 +74,26 @@ export default function AiAssistantPluginSidebar() {
 	return (
 		<>
 			<JetpackPluginSidebar>
-				<ThemeProvider>
-					<PanelBody title={ title } initialOpen={ false }>
+				<PanelBody title={ title } initialOpen={ false }>
+					<PanelRow>
+						<BaseControl
+							className="jetpack-ai-proofread-control__header"
+							label={ __( 'AI feedback on post', 'jetpack' ) }
+						>
+							<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
+						</BaseControl>
+					</PanelRow>
+					{ requireUpgrade && ! isUsagePanelAvailable && (
 						<PanelRow>
-							<BaseControl
-								className="jetpack-ai-proofread-control__header"
-								label={ __( 'AI feedback on post', 'jetpack' ) }
-							>
-								<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
-							</BaseControl>
+							<Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } />
 						</PanelRow>
-						{ requireUpgrade && ! isUsagePanelAvailable && (
-							<PanelRow>
-								<Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } />
-							</PanelRow>
-						) }
-						{ isUsagePanelAvailable && (
-							<PanelRow>
-								<UsagePanel />
-							</PanelRow>
-						) }
-					</PanelBody>
-				</ThemeProvider>
+					) }
+					{ isUsagePanelAvailable && (
+						<PanelRow>
+							<UsagePanel />
+						</PanelRow>
+					) }
+				</PanelBody>
 			</JetpackPluginSidebar>
 
 			<PluginPrePublishPanel
@@ -104,12 +101,10 @@ export default function AiAssistantPluginSidebar() {
 				icon={ <JetpackEditorPanelLogo /> }
 				initialOpen={ false }
 			>
-				<ThemeProvider>
-					<>
-						<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
-						{ requireUpgrade && <Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } /> }
-					</>
-				</ThemeProvider>
+				<>
+					<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
+					{ requireUpgrade && <Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } /> }
+				</>
 			</PluginPrePublishPanel>
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+import { ThemeProvider } from '@automattic/jetpack-components';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, PanelBody, PanelRow, BaseControl } from '@wordpress/components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import React from 'react';
 /**
  * Internal dependencies
  */
@@ -73,34 +75,41 @@ export default function AiAssistantPluginSidebar() {
 	return (
 		<>
 			<JetpackPluginSidebar>
-				<PanelBody title={ title } initialOpen={ false }>
-					<PanelRow>
-						<BaseControl
-							className="jetpack-ai-proofread-control__header"
-							label={ __( 'AI feedback on post', 'jetpack' ) }
-						>
-							<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
-						</BaseControl>
-					</PanelRow>
-					{ requireUpgrade && ! isUsagePanelAvailable && (
+				<ThemeProvider>
+					<PanelBody title={ title } initialOpen={ false }>
 						<PanelRow>
-							<Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } />
+							<BaseControl
+								className="jetpack-ai-proofread-control__header"
+								label={ __( 'AI feedback on post', 'jetpack' ) }
+							>
+								<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
+							</BaseControl>
 						</PanelRow>
-					) }
-					{ isUsagePanelAvailable && (
-						<PanelRow>
-							<UsagePanel />
-						</PanelRow>
-					) }
-				</PanelBody>
+						{ requireUpgrade && ! isUsagePanelAvailable && (
+							<PanelRow>
+								<Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } />
+							</PanelRow>
+						) }
+						{ isUsagePanelAvailable && (
+							<PanelRow>
+								<UsagePanel />
+							</PanelRow>
+						) }
+					</PanelBody>
+				</ThemeProvider>
 			</JetpackPluginSidebar>
+
 			<PluginPrePublishPanel
 				title={ title }
 				icon={ <JetpackEditorPanelLogo /> }
 				initialOpen={ false }
 			>
-				<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
-				{ requireUpgrade && <Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } /> }
+				<ThemeProvider>
+					<>
+						<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
+						{ requireUpgrade && <Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } /> }
+					</>
+				</ThemeProvider>
 			</PluginPrePublishPanel>
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -1,16 +1,18 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
 import { BaseControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
+import React from 'react';
+/**
+ * Internal dependencies
+ */
 import './style.scss';
 /**
  * Types
  */
-import type { UsageBarProps } from './types';
-import type { AIFeatureProps } from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
-import type React from 'react';
+import type { UsageBarProps, UsageControlProps } from './types';
 
 /**
  * UsageBar component
@@ -49,7 +51,7 @@ function UsageControl( {
 	hasFeature,
 	requestsCount,
 	requestsLimit,
-}: Pick< AIFeatureProps, 'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit' > ) {
+}: UsageControlProps ) {
 	let help = __( 'Unlimited requests for your site', 'jetpack' );
 
 	if ( ! hasFeature ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
@@ -1,22 +1,26 @@
-@import '@automattic/jetpack-base-styles/style';
-
-.ai-assistant-usage-bar {
-	&-wrapper {
-		width: 100%;
-		height: 4px;
-		border-radius: 2px;
-		background-color: var(--jp-gray-5);
-		overflow: hidden;
-		margin: 0;
+.jetpack-ai-usage-panel {
+	.jetpack-ai-usage-panel-loading {
+		height: calc( var( --spacing-base ) * 11 + 0.5px );
 	}
 
-	&-usage {
-		height: 100%;
-		border-radius: 2px;
-		background-color: var(--jp-green-40 );
-
-		&.is-limit-reached {
-			background-color: var(--jp-red);
+	.ai-assistant-usage-bar {
+		&-wrapper {
+			width: 100%;
+			height: 4px;
+			border-radius: 2px;
+			background-color: var( --jp-gray-5 );
+			overflow: hidden;
+			margin: 0;
+		}
+	
+		&-usage {
+			height: 100%;
+			border-radius: 2px;
+			background-color: var( --jp-green-40 );
+	
+			&.is-limit-reached {
+				background-color: var( --jp-red );
+			}
 		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
@@ -1,6 +1,11 @@
+@import '@automattic/jetpack-base-styles/style';
+
 .jetpack-ai-usage-panel {
+	--spacing-base: 8px;
+
 	.jetpack-ai-usage-panel-loading {
 		height: calc( var( --spacing-base ) * 11 + 0.5px );
+		background-color: var( --jp-gray );
 	}
 
 	.ai-assistant-usage-bar {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
@@ -1,3 +1,8 @@
+/**
+ * Types
+ */
+import { AIFeatureProps } from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
+
 export type UsageBarProps = {
 	/**
 	 * The current usage, as a percentage represented by a number between 0 and 1.
@@ -9,3 +14,7 @@ export type UsageBarProps = {
 	 */
 	limitReached: boolean;
 };
+export type UsageControlProps = Pick<
+	AIFeatureProps,
+	'isOverLimit' | 'hasFeature' | 'requestsCount' | 'requestsLimit'
+>;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import React from 'react';
 /**
  * Internal dependencies
  */
@@ -46,7 +47,7 @@ export default function UsagePanel() {
 					onClick={ autosaveAndRedirect }
 					disabled={ isRedirecting }
 				>
-					Upgrade
+					{ __( 'Upgrade', 'jetpack' ) }
 				</Button>
 			) }
 		</div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { LoadingPlaceholder } from '@automattic/jetpack-components';
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import React from 'react';
@@ -19,36 +20,42 @@ export default function UsagePanel() {
 	const canUpgrade = canUserPurchasePlan();
 
 	// fetch usage data
-	const { hasFeature, requestsCount, requestsLimit, isOverLimit } = useAIFeature();
+	const { hasFeature, requestsCount, requestsLimit, isOverLimit, loading } = useAIFeature();
 
 	return (
 		<div className="jetpack-ai-usage-panel">
-			<UsageControl
-				isOverLimit={ isOverLimit }
-				hasFeature={ hasFeature }
-				requestsCount={ requestsCount }
-				requestsLimit={ requestsLimit }
-			/>
+			{ loading ? (
+				<LoadingPlaceholder className="jetpack-ai-usage-panel-loading" />
+			) : (
+				<>
+					<UsageControl
+						isOverLimit={ isOverLimit }
+						hasFeature={ hasFeature }
+						requestsCount={ requestsCount }
+						requestsLimit={ requestsLimit }
+					/>
 
-			{ false && (
-				<p className="muted">
-					{
-						// translators: %1$d: number of days until the next usage count reset
-						sprintf( __( 'Requests will reset in %1$d days.', 'jetpack' ), 10 )
-					}
-				</p>
-			) }
+					{ false && (
+						<p className="muted">
+							{
+								// translators: %1$d: number of days until the next usage count reset
+								sprintf( __( 'Requests will reset in %1$d days.', 'jetpack' ), 10 )
+							}
+						</p>
+					) }
 
-			{ ! hasFeature && canUpgrade && (
-				<Button
-					variant="primary"
-					label="Upgrade your Jetpack AI plan"
-					href={ checkoutUrl }
-					onClick={ autosaveAndRedirect }
-					disabled={ isRedirecting }
-				>
-					{ __( 'Upgrade', 'jetpack' ) }
-				</Button>
+					{ ! hasFeature && canUpgrade && (
+						<Button
+							variant="primary"
+							label="Upgrade your Jetpack AI plan"
+							href={ checkoutUrl }
+							onClick={ autosaveAndRedirect }
+							disabled={ isRedirecting }
+						>
+							{ __( 'Upgrade', 'jetpack' ) }
+						</Button>
+					) }
+				</>
 			) }
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/style.scss
@@ -1,9 +1,9 @@
 @import '@automattic/jetpack-base-styles/style';
 
 .jetpack-ai-usage-panel {
-    width: 100%;
+	width: 100%;
 
-    p.muted {
-        color: var(--jp-gray-50 );
-    }
+	p.muted {
+		color: var( --jp-gray-50 );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #33936

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Exposes `loading` on `useAIFeature`
* Adds a `LoadingPlaceholder` component when loading on `UsagePanel`
* Uses `ThemeProvider` to load Jetpack CSS, necessary for the `LoadingPlaceholder` component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open the Jetpack sidebar
* Open the AI Assistant panel
* Check that the placeholder is displayed while loading

Now we are using initial data, but the initial data will be removed. Loading will happen only once after the store is set up.

https://github.com/Automattic/jetpack/assets/8486249/28d056a2-855f-4fe8-814b-89732ed23597
