### PR TITLE
wp-admin Site Default: respect user's view setting in Classic style

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-respect-user-view-setting
+++ b/projects/plugins/jetpack/changelog/fix-respect-user-view-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Respect the user's view setting when wpcom_admin_interface is wp-admin

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -95,11 +95,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function get_preferred_view( $screen, $fallback_global_preference = true ) {
 
-		// The preferred view will always be wp-admin (classic view) when the wpcom_admin_interface option is set to 'wp-admin'.
-		if ( $this->use_wp_admin_interface( $screen ) ) {
-			return self::CLASSIC_VIEW;
-		}
-
 		// Export on Atomic sites are always managed on WP Admin.
 		if ( in_array( $screen, array( 'export.php' ), true ) ) {
 			return self::CLASSIC_VIEW;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -662,7 +662,9 @@ abstract class Base_Admin_Menu {
 			if ( ! $fallback_global_preference ) {
 				return self::UNKNOWN_VIEW;
 			}
-			return $this->should_link_to_wp_admin() ? self::CLASSIC_VIEW : self::DEFAULT_VIEW;
+
+			$should_link_to_wp_admin = $this->should_link_to_wp_admin( $screen ) || $this->use_wp_admin_interface( $screen );
+			return $should_link_to_wp_admin ? self::CLASSIC_VIEW : self::DEFAULT_VIEW;
 		}
 
 		return $preferred_views[ $screen ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/4455

The user can change the default view via the View menu. When the admin interface style has been set to wp-admin (Classic) all pages will link to wp-admin instead of Calypso. You can still use the 'view' selector but this does not persist beyond the current pageview.

Below, is a screenshot of the View menu that allows you to set which style to use on a per-page level.
![CleanShot 2566-11-03 at 14 30 33@2x](https://github.com/Automattic/jetpack/assets/10244734/6cbd3b9b-5b19-4e6d-9faf-037feaf72507)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We check if we need to load wp-admin based on the `wpcom_admin_interface` setting **after** we check for the preferred style selected by the user on the page level.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using a WoA site, apply this PR. You can do this via the Jetpack Beta Tester plugin OR by rsyncing the Jetpack plugin to a WoA Dev blog.
* Via the hosting configuration page, select the Classic admin interface style.
* Go to a wp-admin page on your WoA site.
* Check that all links point to wp-admin except the ones that should link to Calypso.
* Change the view option of any wp-admin page to Default.
* Ensure you are correctly redirected to the Calypso version of the page.
* Ensure that the link in the menu also points to the Calypso version of the page, while all other links still point to wp-admin.

For this test, it is important that you have not set any view preference yet, otherwise, the results might be confusing. You can remove the `user option` `jetpack_admin_menu_preferred_views` (this is where we store the preferences for which view to use per page).

