### PR TITLE
Prevent PHP warnings by adding `isset` and `is_array` checks to inner block loop in WooCommerce Analytics module

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-woo-analytics-warnings
+++ b/projects/plugins/jetpack/changelog/fix-woo-analytics-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Prevent a PHP Warning when accessing inner blocks on cart and checkout pages.

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -470,7 +470,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 */
 	private function get_inner_blocks( $inner_blocks ) {
 		$block_names = array();
-		if ( isset( $inner_blocks['blockName'] ) && $inner_blocks['blockName'] ) {
+		if ( ! empty( $inner_blocks['blockName'] ) ) {
 			$block_names[] = $inner_blocks['blockName'];
 		}
 		if ( isset( $inner_blocks['innerBlocks'] ) && is_array( $inner_blocks['innerBlocks'] ) ) {

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -523,7 +523,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		foreach ( $other_blocks as $block ) {
 
 			// This check is necessary because sometimes this is null when using templates.
-			if ( isset( $block['blockName'] ) && $block['blockName'] ) {
+			if ( ! empty( $block['blockName'] ) ) {
 				$all_inner_blocks[] = $block['blockName'];
 			}
 

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -504,10 +504,10 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		$other_blocks  = array_filter(
 			$parsed_blocks,
 			function ( $block ) {
-				if ( is_checkout() && isset( $block['blockName'] ) && $block['blockName'] !== 'woocommerce/checkout' ) {
+				if ( is_checkout() && isset( $block['blockName'] ) && 'woocommerce/checkout' !== $block['blockName'] ) {
 					return true;
 				}
-				if ( is_cart() && isset( $block['blockName'] ) && $block['blockName'] !== 'woocommerce/cart' ) {
+				if ( is_cart() && isset( $block['blockName'] ) && 'woocommerce/cart' !== $block['blockName'] ) {
 					return true;
 				}
 				return false;
@@ -524,7 +524,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				$all_inner_blocks[] = $block['blockName'];
 			}
 
-			if ( ! isset( $block['innerBlocks'] ) || ! is_array( $block['innerBlocks'] ) || count( $block['innerBlocks'] ) === 0 ) {
+			if ( ! isset( $block['innerBlocks'] ) || ! is_array( $block['innerBlocks'] ) || 0 === count( $block['innerBlocks'] ) ) {
 				continue;
 			}
 

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -504,10 +504,13 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		$other_blocks  = array_filter(
 			$parsed_blocks,
 			function ( $block ) {
-				if ( is_checkout() && isset( $block['blockName'] ) && 'woocommerce/checkout' !== $block['blockName'] ) {
+				if ( ! isset( $block['blockName'] ) ) {
+					return false;
+				}
+				if ( is_checkout() && 'woocommerce/checkout' !== $block['blockName'] ) {
 					return true;
 				}
-				if ( is_cart() && isset( $block['blockName'] ) && 'woocommerce/cart' !== $block['blockName'] ) {
+				if ( is_cart() && 'woocommerce/cart' !== $block['blockName'] ) {
 					return true;
 				}
 				return false;

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -470,10 +470,10 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 */
 	private function get_inner_blocks( $inner_blocks ) {
 		$block_names = array();
-		if ( $inner_blocks['blockName'] ) {
+		if ( isset( $inner_blocks['blockName'] ) && $inner_blocks['blockName'] ) {
 			$block_names[] = $inner_blocks['blockName'];
 		}
-		if ( $inner_blocks['innerBlocks'] ) {
+		if ( isset( $inner_blocks['innerBlocks'] ) && is_array( $inner_blocks['innerBlocks'] ) ) {
 			$block_names = array_merge( $block_names, $this->get_inner_blocks( $inner_blocks['innerBlocks'] ) );
 		}
 		return $block_names;
@@ -504,10 +504,10 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		$other_blocks  = array_filter(
 			$parsed_blocks,
 			function ( $block ) {
-				if ( is_checkout() && $block['blockName'] !== 'woocommerce/checkout' ) {
+				if ( is_checkout() && isset( $block['blockName'] ) && $block['blockName'] !== 'woocommerce/checkout' ) {
 					return true;
 				}
-				if ( is_cart() && $block['blockName'] !== 'woocommerce/cart' ) {
+				if ( is_cart() && isset( $block['blockName'] ) && $block['blockName'] !== 'woocommerce/cart' ) {
 					return true;
 				}
 				return false;
@@ -520,11 +520,11 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		foreach ( $other_blocks as $block ) {
 
 			// This check is necessary because sometimes this is null when using templates.
-			if ( $block['blockName'] ) {
+			if ( isset( $block['blockName'] ) && $block['blockName'] ) {
 				$all_inner_blocks[] = $block['blockName'];
 			}
 
-			if ( ! is_array( $block['innerBlocks'] ) || count( $block['innerBlocks'] ) === 0 ) {
+			if ( ! isset( $block['innerBlocks'] ) || ! is_array( $block['innerBlocks'] ) || count( $block['innerBlocks'] ) === 0 ) {
 				continue;
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hardens the code to prevent PHP warnings when accessing undefined array members.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1698931821469179-slack-C011ENB20Q1

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Ensure the WooCommerce analytics module is enabled
- Set up your site so the WooCommerce Blocks `Cart` block is enabled on the Cart page, and the `Checkout` block is enabled on the Checkout page.
- Go to the Cart page and then proceed to the Checkout page.
- Ensure no PHP warnings are shown.