### PR TITLE
Subscriber page: add Launchpad tasks & task list

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-subscriber-launchpad-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-subscriber-launchpad-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added Subscriber page Launchpad tasks

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-subscriber-launchpad-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-subscriber-launchpad-tasks
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Added Subscriber page Launchpad tasks
+Added Subscribers page Launchpad tasks

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "4.16.x-dev"
+			"dev-trunk": "4.17.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.16.2",
+	"version": "4.17.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.16.2';
+	const PACKAGE_VERSION = '4.17.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1797,7 +1797,7 @@ add_action( 'post_updated', 'wpcom_launchpad_edit_page_check', 10, 3 );
  * @return bool True if we should show the task, false otherwise.
  */
 function wpcom_launchpad_is_add_subscribe_block_visible() {
-	return Blocks::is_fse_theme();
+	return is_callable( array( '\Automattic\Jetpack\Blocks', 'is_fse_theme' ) ) && \Automattic\Jetpack\Blocks::is_fse_theme();
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Blocks;
+
 /**
  * Get the task definitions for the Launchpad.
  *
@@ -568,7 +570,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Add the Subscribe Block to your theme', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'is_visible_callback'  => '__return_true',
+			'is_visible_callback'  => 'wpcom_launchpad_is_add_subscribe_block_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/site-editor/' . $data['site_slug_encoded'];
 			},
@@ -1788,6 +1790,15 @@ function wpcom_launchpad_edit_page_check( $post_id, $post ) {
 	wpcom_mark_launchpad_task_complete( 'edit_page' );
 }
 add_action( 'post_updated', 'wpcom_launchpad_edit_page_check', 10, 3 );
+
+/**
+ * Determine `add_subscribe_block` task visibility. The task is visible if using a FSE theme.
+ *
+ * @return bool True if we should show the task, false otherwise.
+ */
+function wpcom_launchpad_is_add_subscribe_block_visible() {
+	return Blocks::is_fse_theme();
+}
 
 /**
  * When a template or template part is saved, check if the subscribe block is in the content.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -5,8 +5,6 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-use Automattic\Jetpack\Blocks;
-
 /**
  * Get the task definitions for the Launchpad.
  *
@@ -567,7 +565,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 		'add_subscribe_block'             => array(
 			'get_title'            => function () {
-				return __( 'Add the Subscribe Block to your theme', 'jetpack-mu-wpcom' );
+				return __( 'Add the Subscribe Block to your site', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_add_subscribe_block_visible',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -552,6 +552,27 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/site-monitoring/' . $data['site_slug_encoded'];
 			},
 		),
+		'import_subscribers'              => array(
+			'get_title'            => function () {
+				return __( 'Import existing subscribers', 'jetpack-mu-wpcom' );
+			},
+			'id_map'               => 'subscribers_added',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => '__return_true',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
+			},
+		),
+		'add_subscribe_block'             => array(
+			'get_title'            => function () {
+				return __( 'Add the Subscribe Block to your theme', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => '__return_true',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/site-editor/' . $data['site_slug_encoded'];
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );
@@ -1767,6 +1788,35 @@ function wpcom_launchpad_edit_page_check( $post_id, $post ) {
 	wpcom_mark_launchpad_task_complete( 'edit_page' );
 }
 add_action( 'post_updated', 'wpcom_launchpad_edit_page_check', 10, 3 );
+
+/**
+ * When a template part is saved, make sure the subscribe block is in the content.
+ *
+ * @param int     $post_id The ID of the post being updated.
+ * @param WP_Post $post The post object.
+ *
+ * @return bool True if the task is completed, false otherwise.
+ */
+function wpcom_launchpad_add_subscribe_block_check( $post_id, $post ) {
+	// If this is just a revision, don't proceed.
+	if ( wp_is_post_revision( $post_id ) ) {
+		return;
+	}
+
+	// Check if it's a published template part.
+	if ( $post->post_type !== 'wp_template_part' || $post->post_status !== 'publish' ) {
+		return;
+	}
+
+	// Check if our subscribe block is in the template part content.
+	if ( has_block( 'jetpack/subscriptions', $post->post_content ) ) {
+		// Run your specific function if the subscribe block is found.
+		wpcom_mark_launchpad_task_complete( 'subscriber_block_added' );
+	}
+}
+
+// Hook the above function to the save_post action, specifically for 'wp_template_part' post type.
+add_action( 'save_post_wp_template_part', 'wpcom_launchpad_add_subscribe_block_check', 10, 3 );
 
 /**
  * Returns if the site has domain or bundle purchases.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1790,7 +1790,7 @@ function wpcom_launchpad_edit_page_check( $post_id, $post ) {
 add_action( 'post_updated', 'wpcom_launchpad_edit_page_check', 10, 3 );
 
 /**
- * When a template part is saved, make sure the subscribe block is in the content.
+ * When a template or template part is saved, check if the subscribe block is in the content.
  *
  * @param int     $post_id The ID of the post being updated.
  * @param WP_Post $post The post object.
@@ -1803,20 +1803,20 @@ function wpcom_launchpad_add_subscribe_block_check( $post_id, $post ) {
 		return;
 	}
 
-	// Check if it's a published template part.
-	if ( $post->post_type !== 'wp_template_part' || $post->post_status !== 'publish' ) {
+	// Check if it's a published template or template part.
+	if ( $post->post_status !== 'publish' || ( $post->post_type !== 'wp_template' && $post->post_type !== 'wp_template_part' ) ) {
 		return;
 	}
 
-	// Check if our subscribe block is in the template part content.
+	// Check if our subscribe block is in the template or template part content.
 	if ( has_block( 'jetpack/subscriptions', $post->post_content ) ) {
 		// Run your specific function if the subscribe block is found.
-		wpcom_mark_launchpad_task_complete( 'subscriber_block_added' );
+		wpcom_mark_launchpad_task_complete( 'add_subscribe_block' );
 	}
 }
 
-// Hook the above function to the save_post action, specifically for 'wp_template_part' post type.
-add_action( 'save_post_wp_template_part', 'wpcom_launchpad_add_subscribe_block_check', 10, 3 );
+// Hook the function to the save_post action for all post types.
+add_action( 'save_post', 'wpcom_launchpad_add_subscribe_block_check', 10, 2 );
 
 /**
  * Returns if the site has domain or bundle purchases.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -215,8 +215,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'title'    => 'Subscribers',
 			'task_ids' => array(
 				'import_subscribers',
-				'share_site',
 				'add_subscribe_block',
+				'share_site',
 			),
 		),
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -211,6 +211,14 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_hosting_flow_enabled',
 		),
+		'subscribers'            => array(
+			'title'    => 'Subscribers',
+			'task_ids' => array(
+				'import_subscribers',
+				'share_site',
+				'add_subscribe_block',
+			),
+		),
 	);
 
 	$extended_task_list_definitions = apply_filters( 'wpcom_launchpad_extended_task_list_definitions', array() );

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-subscriber-launchpad-tasks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-subscriber-launchpad-tasks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_7_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_8_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_7"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_7_7_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "511f9873d0b3a20719658d10d690e2b948760187"
+                "reference": "1641dab1f811519e702d3a9479fd947688e0a6bc"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.16.x-dev"
+                    "dev-trunk": "4.17.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.7.7
+ * Version: 1.7.7-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.7.7-alpha
+ * Version: 1.7.8-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.7.6",
+	"version": "1.7.8-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.7.7",
+	"version": "1.7.6",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83846
Fixes https://github.com/Automattic/wp-calypso/issues/83847
Fixes https://github.com/Automattic/wp-calypso/issues/83848
Fixes https://github.com/Automattic/wp-calypso/issues/83849

## Proposed changes:
- This adds the needed tasks for the Launchpad for Subscriber Page.
- It also adds a check that triggers the `subscriber_block_added` task as complete, when a template part is saved with a jetpack:subscribe block in it.
- It will hide the Add subscriber block task when not using an FSE theme

This PR does not:
- Open a modal when clicking Import subscribers
- Complete the Import subscribers task when clicking it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pdDOJh-2Ee-p2

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:

- Apply this PR to your sandbox by following the instructions below
- Open Calypso in your IDE and add a launchpad component somewhere to `client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx`. Make sure to replace the siteSlug to that of the site you're testing with.

```js
import { Launchpad } from '@automattic/launchpad'
---
<Launchpad
siteSlug={ "broddinsandbox.wordpress.com" }
checklistSlug={ "subscribers" }
launchpadContext='my-app-context'

/>
```

![CleanShot 2023-11-03 at 13 20 07@2x](https://github.com/Automattic/jetpack/assets/528287/ac16549d-b2ce-487e-9a7f-a0dcae159f7d)

Check that:
- Clicking `Import subscribers` adds `#add-subscribers` to the page url
- Clicking `Share your site` opens a share box, clicking copy marks the task as complete
- Clicking `Add a subscriber block` takes you to the site editor, adding a subscriber block to a template or template part marks this task as complete.
- Choosing a non-block editor theme (such as Twenty Twenty Five) hides the `Add a subscriber block` task

Also test on Jetpack/Atomic using the instructions below.

