### PR TITLE
wp-admin Site Default: Ensure settings point to wp-admin when wpcom_admin_interface is 'wp-admin'

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-settings-and-user-menu-incorrect-links
+++ b/projects/plugins/jetpack/changelog/fix-settings-and-user-menu-incorrect-links
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Its a small bugfix
+
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -57,12 +57,13 @@ class Admin_Menu extends Base_Admin_Menu {
 	 * @return string
 	 */
 	public function get_preferred_view( $screen, $fallback_global_preference = true ) {
+		$force_default_view = in_array( $screen, array( 'users.php', 'options-general.php' ), true );
+		$use_wp_admin       = $this->use_wp_admin_interface( $screen );
+
 		// When no preferred view has been set for "Users > All Users" or "Settings > General", keep the previous
 		// behavior that forced the default view regardless of the global preference.
-		if (
-			$fallback_global_preference &&
-			in_array( $screen, array( 'users.php', 'options-general.php' ), true )
-		) {
+		// This behavior is overriden by the wpcom_admin_interface option when it is set to wp-admin.
+		if ( ! $use_wp_admin && $fallback_global_preference && $force_default_view ) {
 			$preferred_view = parent::get_preferred_view( $screen, false );
 			if ( self::UNKNOWN_VIEW === $preferred_view ) {
 				return self::DEFAULT_VIEW;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/4455

There was a bug where the general settings page and users page had a special exception to always point to the default view. This is desired behavior unless the new `wpcom_admin_interface` option is set to wp-admin. The logic to force links to go to wp-admin in response to the `wpcom_admin_interface` option was moved down to a later point after the exception was applied. 

See: https://github.com/Automattic/jetpack/pull/33945 where this bug was introduced

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only apply the settings and user page exception when the `wpcom_admin_interface` option is not `wp-admin`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Atomic site:**

- Using a WoA site, apply this PR. You can do this via the Jetpack Beta Tester plugin OR by rsyncing the Jetpack plugin to a WoA Dev blog.
- Via the hosting configuration page, select the Classic admin interface style.
- Go to a wp-admin page on your WoA site.
- Check that all links point to wp-admin except the ones that should link to Calypso.
- Change the view option of any wp-admin page to Default.
- Ensure you are correctly redirected to the Calypso version of the page.
- Ensure that the link in the menu also points to the Calypso version of the page, while all other links still point to wp-admin.
- Check that the settings page AND users page both point to wp-admin
- Check that you can change the view setting of the settings page and users page to default and that the menu items change accordingly. Also, verify that you can change back to the classic view again.
- Change the admin interface style back to default and check that the links now point to Calypso again and that the view settings on the per-page level are correctly applied. E.g. try to toggle between Default and Classic to verify that per-page level view settings work correctly. 

**Simple site**

- Load this PR on your sandbox `bin/jetpack-downloader test jetpack fix/settings-and-user-menu-incorrect-links`
- Ensure that the menu items are all pointing to Calypso, except for the pages that should always point to wp-admin regardless.