### PR TITLE
Social: Move Nextdoor block to production

### DIFF
--- a/projects/plugins/jetpack/changelog/update-move-nextdoor-block-production
+++ b/projects/plugins/jetpack/changelog/update-move-nextdoor-block-production
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added nextdoor block to production blocks

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -55,7 +55,8 @@
 		"paywall",
 		"ai-content-lens",
 		"blogroll",
-		"blogroll-item"
+		"blogroll-item",
+		"nextdoor"
 	],
 	"beta": [
 		"amazon",
@@ -66,8 +67,7 @@
 		"videopress/video-chapters",
 		"create-with-voice",
 		"ai-assistant-backend-prompts",
-		"ai-assistant-usage-panel",
-		"nextdoor"
+		"ai-assistant-usage-panel"
 	],
 	"experimental": [ "ai-image", "ai-paragraph" ],
 	"no-post-editor": [


### PR DESCRIPTION
This change moves our Nextdoor embed block to production after merging https://github.com/Automattic/jetpack/pull/33931

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Remove `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` from your `wp-config.php` file
* Check out this PR
* Make sure you still see the Nextdoor block in the editor and on published posts, and the beta flair should not appear

