### PR TITLE
wp-admin Site Default: Always links 'My Sites' to the Sites page

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-wp-admin-toolbar-mods
+++ b/projects/plugins/jetpack/changelog/improve-wp-admin-toolbar-mods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Always links 'My Sites' to the Sites page when 'wp-admin' is the admin interface.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -11,6 +11,11 @@
 			return;
 		}
 
+		var adminbarBlogMenuList = adminbar.querySelector( '#wp-admin-bar-blog > .ab-sub-wrapper ul' );
+		if ( ! adminbarBlogMenuList ) {
+			return;
+		}
+
 		function setAriaExpanded( value ) {
 			var anchors = adminbar.querySelectorAll( '#wp-admin-bar-blog a' );
 			for ( var i = 0; i < anchors.length; i++ ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -179,6 +179,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			return;
 		}
 
+		// Unnecessary because "My Sites" always links to the Sites page.
+		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
+			return;
+		}
+
 		// Add the menu item.
 		add_menu_page( __( 'site-switcher', 'jetpack' ), __( 'Browse sites', 'jetpack' ), 'read', 'https://wordpress.com/sites', null, 'dashicons-arrow-left-alt2', 0 );
 		add_filter( 'add_menu_classes', array( $this, 'set_browse_sites_link_class' ) );
@@ -220,6 +225,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds site card component.
 	 */
 	public function add_site_card_menu() {
+		// Unnecessary because core toolbar links to the site.
+		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
+			return;
+		}
+
 		$default        = plugins_url( 'globe-icon.svg', __FILE__ );
 		$icon           = get_site_icon_url( 32, $default );
 		$blog_name      = get_option( 'blogname' ) !== '' ? get_option( 'blogname' ) : $this->domain;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -225,11 +225,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds site card component.
 	 */
 	public function add_site_card_menu() {
-		// Unnecessary because core toolbar links to the site.
-		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
-			return;
-		}
-
 		$default        = plugins_url( 'globe-icon.svg', __FILE__ );
 		$icon           = get_site_icon_url( 32, $default );
 		$blog_name      = get_option( 'blogname' ) !== '' ? get_option( 'blogname' ) : $this->domain;

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -924,12 +924,19 @@ class Masterbar {
 			$blog_name = mb_substr( html_entity_decode( $blog_name, ENT_QUOTES ), 0, 20 ) . '&hellip;';
 		}
 
+		$my_site_url   = 'https://wordpress.com/sites/' . $this->primary_site_url;
+		$my_site_title = _n( 'My Site', 'My Sites', $this->user_site_count, 'jetpack' );
+		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
+			$my_site_url   = 'https://wordpress.com/sites';
+			$my_site_title = esc_html__( 'My Sites', 'jetpack' );
+		}
+
 		$wp_admin_bar->add_menu(
 			array(
 				'parent' => 'root-default',
 				'id'     => 'blog',
-				'title'  => _n( 'My Site', 'My Sites', $this->user_site_count, 'jetpack' ),
-				'href'   => 'https://wordpress.com/sites/' . $this->primary_site_url,
+				'title'  => $my_site_title,
+				'href'   => $my_site_url,
 				'meta'   => array(
 					'class' => 'my-sites mb-trackable',
 				),


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4457

## Proposed changes:

Always links 'My Sites' to the Sites page when 'wp-admin' is the selected admin interface:

<img width="514" alt="CleanShot 2023-11-03 at 05 18 43@2x" src="https://github.com/Automattic/jetpack/assets/36432/78c2a512-9d1b-43d2-8962-a4086080e364">

Because 'My Sites' always links to the Sites page, I'm also removing the 'Browse sites' link:

![CleanShot 2023-11-03 at 05 21 49@2x](https://github.com/Automattic/jetpack/assets/36432/19b3a5ea-181d-42e9-9fe0-b8b31dfc82fe)

Also fixes a leftover issue from https://github.com/Automattic/jetpack/pull/33854 where it wasn't actually possible to click "My Sites".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Atomic Setup:
1. Create a new Business site.
2. Register the site in WoA Developer Blog Manager.
3. Take the site Atomic.
4. Install the Jetpack Beta tester plugin.

With "Default style" selected, verify the WordPress.com masterbar, "Browse sites", and the Site card all appear as expected:

<img width="807" alt="CleanShot 2023-11-03 at 05 30 25@2x" src="https://github.com/Automattic/jetpack/assets/36432/4d556ecd-1bab-4b47-b862-28ae4d269825">

With "Classic style" selected, verify the core toolbar appears as expected, and "Browse sites" no longer appears:

<img width="575" alt="CleanShot 2023-11-03 at 06 33 04@2x" src="https://github.com/Automattic/jetpack/assets/36432/ae5fcdee-b9be-437d-8189-00edac0055ff">


Clicking on "My Sites" should take you to the Sites page.

Lastly, verify the WordPress.com masterbar, "Browse sites", and the Site card all appear as expected on a Simple site.
