### PR TITLE
Jetpack: Fix VaultPress submenu not being registered when the standalone plugin is inactive

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-vaultpress-submenu
+++ b/projects/plugins/jetpack/changelog/fix-vaultpress-submenu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix Vaulthe issue where the VaultPress submenu is not visible when the standalone plugin is inactive

--- a/projects/plugins/jetpack/changelog/fix-vaultpress-submenu
+++ b/projects/plugins/jetpack/changelog/fix-vaultpress-submenu
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Fix Vaulthe issue where the VaultPress submenu is not visible when the standalone plugin is inactive
+Fix the issue where the VaultPress submenu is not being registered when the standalone plugin is inactive and the product is active

--- a/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
@@ -200,7 +200,7 @@ class Admin_Sidebar_Link {
 	 * @return boolean
 	 */
 	private function has_backup_plugin() {
-		return Backup::is_active();
+		return Backup::is_standalone_plugin_active();
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Validate if the standalone plugin is active using `Backup::is_standalone_plugin_active()`.

| Backup standalone plugin active | Backup standalone plugin inactive |
|---|---|
| ![CleanShot 2023-11-03 at 10 46 41](https://github.com/Automattic/jetpack/assets/1488641/a73d802a-bffe-4c9c-93e0-5f3886914b05) | ![CleanShot 2023-11-03 at 10 46 53](https://github.com/Automattic/jetpack/assets/1488641/90d696c0-7a70-4e50-b09c-51c18f08443f) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1699013697609709-slack-CS8UYNPEE

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Jetpack Beta on a site that has a VaultPress Backup plan and checkout to this branch.
* If you don't have the Jetpack VaultPress Backup plugin, you should see the `VaultPress` submenu (it should have a external link icon at the end).
* If you have the Jetpack VaultPress Backup plugin active, you should see `VaultPress Backup` submenu (without a external link icon).