### PR TITLE
Subscribe Block: Improves "Subscribed" state in WPCOM

### DIFF
--- a/projects/plugins/jetpack/changelog/2023-11-03-20-11-20-806088
+++ b/projects/plugins/jetpack/changelog/2023-11-03-20-11-20-806088
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: fix not released change
+
+

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -143,6 +143,22 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	}
 
 	/**
+	 * Retrieves the email of the currently authenticated subscriber.
+	 *
+	 * This function checks if the current user has an active subscription. If the user is subscribed,
+	 * their email is returned. Otherwise, it returns an empty string to indicate no active subscription.
+	 *
+	 * @return string The email address of the subscribed user or an empty string if not subscribed.
+	 */
+	public function get_subscriber_email() {
+		$email = $this->get_token_property( 'blog_subscriber' );
+		if ( empty( $email ) ) {
+			return '';
+		}
+		return $email;
+	}
+
+	/**
 	 * Return if the user has access to the content depending on the access level and the user rights
 	 *
 	 * @param string $access_level Post or blog access level.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
@@ -48,6 +48,30 @@ class WPCOM_Online_Subscription_Service extends WPCOM_Token_Subscription_Service
 	}
 
 	/**
+	 * Retrieves the email of the currently authenticated subscriber.
+	 *
+	 * This function checks if the current user has an active subscription. If the user is subscribed,
+	 * their email is returned. Otherwise, it returns an empty string to indicate no active subscription.
+	 *
+	 * @return string The email address of the subscribed user or an empty string if not subscribed.
+	 */
+	public function get_subscriber_email() {
+		include_once WP_CONTENT_DIR . '/mu-plugins/email-subscriptions/subscriptions.php';
+		$email             = wp_get_current_user()->user_email;
+		$subscriber_object = \Blog_Subscriber::get( $email );
+
+		if ( empty( $subscriber_object ) ) {
+			return '';
+		}
+		$blog_id             = $this->get_site_id();
+		$subscription_status = \Blog_Subscription::get_subscription_status_for_blog( $subscriber_object, $blog_id );
+		if ( 'active' !== $subscription_status ) {
+			return '';
+		}
+		return $email;
+	}
+
+	/**
 	 * Lookup users subscriptions for a site and determine if the user has a valid subscription to match the plan ID
 	 *
 	 * @param array  $valid_plan_ids .

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -798,7 +798,7 @@ class Jetpack_Memberships {
 	public static function get_current_user_subscriber_email() {
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
-		return $subscription_service->get_token_property( 'blog_subscriber' );
+		return $subscription_service->get_subscriber_email();
 	}
 }
 Jetpack_Memberships::get_instance();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Improves subscribe button behavior introduced in https://github.com/Automattic/jetpack/pull/33897
* See p1699026721433949-slack-C05PV073SG3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a simple site check the subscribe button while logged in / logged out.