### PR TITLE
wp-admin Site Default: Keep "Stats" as a prominent menu item when SSO is connected

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-move-stats-to-root-level-menu-item
+++ b/projects/plugins/jetpack/changelog/fix-move-stats-to-root-level-menu-item
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Move the Jetpack stats menu item to the top level of the admin menu

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -362,6 +362,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			return;
 		}
 
+		// Ensure that the required callbacks exist
+		if ( ! function_exists( 'jetpack_admin_ui_stats_report_page_wrapper' ) || ! function_exists( 'stats_reports_load' ) ) {
+			return;
+		}
+
 		// Loop through the Jetpack submenu items and find the stats menu item.
 		foreach ( $submenu['jetpack'] as $menu_item ) {
 			if ( 'stats' !== $menu_item[2] ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/4456

In the Calypso interface, the stats menu is more prominent while in the Jetpack plugin the stats menu item is nested under the Jetpack menu. To align with the Calypso interface, we should move the Stats menu item to the root level of the admin menu.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the stats menu item under the Jetpack menu
* Add the Stats item on the root level of the admin menu
* Ensure that the appropriate callbacks are used to properly load the stats page

Screenshot showing the Stats menu at the top level and no stats menu item under the Jetpack submenu:
<img width="444" alt="CleanShot 2566-11-06 at 15 38 59@2x" src="https://github.com/Automattic/jetpack/assets/10244734/bf911959-e72f-44dd-a6d4-7ef7c7ee8c4e">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load the Jetpack branch on your sandbox and on a WoA site (via the jetpack beta tester plugin or by using Jetpack rsync on a WoA dev blog)
* First, verify that the menu on a simple site is not affected by this change. There should not be a Stats menu under the Jetpack menu and on the top level there should be a stats menu that points to the Calypso stats page.
* Go to a WoA blog with this PR loaded but with the Admin Interface Style option set to default. Ensure that the stats menu appears ONLY under the Jetpack menu.
* Load the stats page and ensure it is still working as expected.
* Now switch the Admin Interface Style of your WoA site (via wpcalypso) to 'Classic'
* Go to your site and verify that a stats menu is added on the top level. Ensure that this menu item links to the stats page in wp-admin (not Calypso).
* Also check pages served via Calypso and verify that the stats menu item links to wp-admin and that it no longer appears under the Jetpack menu.
* Verify that other menu items behave as expected. Particularly the ones under the Jetpack submenu.
* Another thing to double check is that the per-page view setting still correctly applied. Try switching back and forth and ensure that the menu items are pointing to the correct version of the page (either Calypso or wp-admin)

