### PR TITLE
Subscribe modal: don't show when previewing post or theme

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-disable-in-preview
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-disable-in-preview
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe modal: don't show when previewing post or theme

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -169,6 +169,12 @@ HTML;
 			return false;
 		}
 
+		// Don't show when previewing blog posts or site's theme
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['preview'] ) || isset( $_GET['theme_preview'] ) || isset( $_GET['customize_preview'] ) || isset( $_GET['hide_banners'] ) ) {
+			return false;
+		}
+
 		// Don't show if one of subscribe query params is set.
 		// They are set when user submits the subscribe form.
 		// The nonce is checked elsewhere before redirect back to this page with query params.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Feedback via slack p1699147934734569-slack-CTG7Q97G8 shared that when previewing blog posts, they might see subscribe banner.

<img width="1009" alt="Screenshot 2023-11-06 at 11 16 29" src="https://github.com/Automattic/jetpack/assets/87168/ff4d21ed-db9d-4b32-ab53-50418211af92">


Previously we never showed modal for the logged in admins even if the conditions otherwise were met, but we had lots of feedback that it was hard for people to test & review the modal. We started showing modal to admins, too in https://github.com/Automattic/jetpack/pull/33622. Now we just need to ensure the modal doesn't show in places where they don't expect, because they're reviewing something elese (like the theme or post).

Adding quite a few of the get-params that we use at .com for different preview iframes, just to cover any current unexpected situations as well any future ones.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check for preview get params before deciding to show the modal

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* As logged in admin, enable subscribe modal
* Have a free blog post
* Ensure you haven't dismissed banner by removing cookie `jetpack_subscribe_modal_dismissed`
* Load the post and see the banner
* Add `?preview` (or other getters added in the PR) to the URL and see modal no more.