### PR TITLE
Social: Fix store/initial-state out of sync issue

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-store-refresh-issue
+++ b/projects/js-packages/publicize-components/changelog/fix-social-store-refresh-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue where initial state is not in sync

--- a/projects/js-packages/publicize-components/src/components/auto-conversion/toggle/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/auto-conversion/toggle/index.tsx
@@ -1,6 +1,7 @@
 import { ToggleControl } from '@automattic/jetpack-components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import React from 'react';
 import { SOCIAL_STORE_ID } from '../../../social-store';
 import { SocialStoreSelectors } from '../../../types/types';
@@ -15,6 +16,11 @@ type AutoConversionToggleProps = {
 	 * The class name to add to the toggle.
 	 */
 	toggleClass?: string;
+
+	/**
+	 * Whether or not to refresh the settings.
+	 */
+	shouldRefresh?: boolean;
 };
 
 /**
@@ -23,7 +29,17 @@ type AutoConversionToggleProps = {
  * @param {AutoConversionToggleProps} props - Component props.
  * @returns {React.ReactElement} - JSX.Element
  */
-const AutoConversionToggle: React.FC< AutoConversionToggleProps > = props => {
+const AutoConversionToggle: React.FC< AutoConversionToggleProps > = ( {
+	shouldRefresh = false,
+	toggleClass,
+	children,
+} ) => {
+	const refreshSettings = useDispatch( SOCIAL_STORE_ID ).refreshAutoConversionSettings;
+
+	useEffect( () => {
+		shouldRefresh && refreshSettings();
+	}, [ shouldRefresh, refreshSettings ] );
+
 	const { isEnabled, isUpdating } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
 		return {
@@ -43,11 +59,11 @@ const AutoConversionToggle: React.FC< AutoConversionToggleProps > = props => {
 
 	return (
 		<ToggleControl
-			className={ props.toggleClass }
+			className={ toggleClass }
 			disabled={ isUpdating }
 			checked={ isEnabled }
 			onChange={ toggleStatus }
-			label={ props.children }
+			label={ children }
 		/>
 	);
 };

--- a/projects/js-packages/publicize-components/src/components/social-image-generator/toggle/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-image-generator/toggle/index.tsx
@@ -1,6 +1,7 @@
 import { ToggleControl } from '@automattic/jetpack-components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import React from 'react';
 import { SOCIAL_STORE_ID } from '../../../social-store';
 import { SocialStoreSelectors } from '../../../types/types';
@@ -15,6 +16,11 @@ type SocialImageGeneratorToggleProps = {
 	 * The class name to add to the toggle.
 	 */
 	toggleClass?: string;
+
+	/**
+	 * Whether or not to refresh the settings.
+	 */
+	shouldRefresh?: boolean;
 };
 
 /**
@@ -23,7 +29,17 @@ type SocialImageGeneratorToggleProps = {
  * @param {SocialImageGeneratorToggleProps} props - Component props.
  * @returns {React.ReactElement} - JSX.Element
  */
-const SocialImageGeneratorToggle: React.FC< SocialImageGeneratorToggleProps > = props => {
+const SocialImageGeneratorToggle: React.FC< SocialImageGeneratorToggleProps > = ( {
+	toggleClass,
+	children,
+	shouldRefresh = false,
+} ) => {
+	const refreshSettings = useDispatch( SOCIAL_STORE_ID ).refreshSocialImageGeneratorSettings;
+
+	useEffect( () => {
+		shouldRefresh && refreshSettings();
+	}, [ refreshSettings, shouldRefresh ] );
+
 	const { isEnabled, isUpdating } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
 		return {
@@ -43,11 +59,11 @@ const SocialImageGeneratorToggle: React.FC< SocialImageGeneratorToggleProps > = 
 
 	return (
 		<ToggleControl
-			className={ props.toggleClass }
+			className={ toggleClass }
 			disabled={ isUpdating }
 			checked={ isEnabled }
 			onChange={ toggleStatus }
-			label={ props.children }
+			label={ children }
 		/>
 	);
 };

--- a/projects/js-packages/publicize-components/src/social-store/actions/auto-conversion-settings.js
+++ b/projects/js-packages/publicize-components/src/social-store/actions/auto-conversion-settings.js
@@ -39,11 +39,14 @@ export function* updateAutoConversionSettings( settings ) {
  */
 export function* refreshAutoConversionSettings() {
 	try {
+		yield setUpdatingAutoConversionSettings();
 		const updatedSettings = yield fetchAutoConversionSettings();
 		yield setAutoConversionSettings( updatedSettings );
 		return true;
 	} catch ( e ) {
 		return false;
+	} finally {
+		yield setUpdatingAutoConversionSettingsDone();
 	}
 }
 

--- a/projects/js-packages/publicize-components/src/social-store/actions/social-image-generator-settings.js
+++ b/projects/js-packages/publicize-components/src/social-store/actions/social-image-generator-settings.js
@@ -59,4 +59,27 @@ export function setSocialImageGeneratorSettings( options ) {
 	return { type: SET_SOCIAL_IMAGE_GENERATOR_SETTINGS, options };
 }
 
-export default { updateSocialImageGeneratorSettings, setSocialImageGeneratorSettings };
+/**
+ * Yield actions to refresh settings
+ *
+ * @yields {object} - an action object.
+ * @returns {object} - an action object.
+ */
+export function* refreshSocialImageGeneratorSettings() {
+	try {
+		yield setUpdatingSocialImageGeneratorSettings();
+		const updatedSettings = yield fetchSocialImageGeneratorSettings();
+		yield setSocialImageGeneratorSettings( updatedSettings );
+		return true;
+	} catch ( e ) {
+		return false;
+	} finally {
+		yield setUpdatingSocialImageGeneratorSettingsDone();
+	}
+}
+
+export default {
+	updateSocialImageGeneratorSettings,
+	setSocialImageGeneratorSettings,
+	refreshSocialImageGeneratorSettings,
+};

--- a/projects/plugins/jetpack/_inc/client/sharing/features/auto-conversion-section.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/features/auto-conversion-section.jsx
@@ -9,7 +9,7 @@ import { FormFieldset } from '../../components/forms';
 const AutoConversionSection = () => {
 	return (
 		<FormFieldset>
-			<AutoConversionToggle toggleClass="jp-settings-sharing__sig-toggle">
+			<AutoConversionToggle shouldRefresh toggleClass="jp-settings-sharing__sig-toggle">
 				<div>
 					<div>
 						<Text>

--- a/projects/plugins/jetpack/_inc/client/sharing/features/social-image-generator-section.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/features/social-image-generator-section.jsx
@@ -10,7 +10,7 @@ import './style.scss';
 const SocialImageGeneratorSection = () => {
 	return (
 		<FormFieldset>
-			<SocialImageGeneratorToggle toggleClass="jp-settings-sharing__sig-toggle">
+			<SocialImageGeneratorToggle shouldRefresh toggleClass="jp-settings-sharing__sig-toggle">
 				<div>
 					<Text>
 						<strong>{ __( 'Enable Social Image Generator', 'jetpack' ) }</strong>

--- a/projects/plugins/jetpack/changelog/fix-social-store-refresh-issue
+++ b/projects/plugins/jetpack/changelog/fix-social-store-refresh-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed an issue where initial state is not in sync

--- a/projects/plugins/social/changelog/fix-social-store-refresh-issue
+++ b/projects/plugins/social/changelog/fix-social-store-refresh-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue where initial state is not in sync

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -40,6 +40,7 @@ const Admin = () => {
 		isSocialImageGeneratorAvailable,
 		isAutoConversionAvailable,
 		shouldShowAdvancedPlanNudge,
+		isUpdatingJetpackSettings,
 	} = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID );
 		return {
@@ -51,6 +52,7 @@ const Admin = () => {
 			isSocialImageGeneratorAvailable: store.isSocialImageGeneratorAvailable(),
 			isAutoConversionAvailable: store.isAutoConversionAvailable(),
 			shouldShowAdvancedPlanNudge: store.shouldShowAdvancedPlanNudge(),
+			isUpdatingJetpackSettings: store.isUpdatingJetpackSettings(),
 		};
 	} );
 
@@ -87,8 +89,12 @@ const Admin = () => {
 						{ shouldShowAdvancedPlanNudge && <AdvancedUpsellNotice /> }
 						<InstagramNotice onUpgrade={ onUpgradeToggle } />
 						<SocialModuleToggle />
-						{ isModuleEnabled && isAutoConversionAvailable && <AutoConversionToggle /> }
-						{ isModuleEnabled && isSocialImageGeneratorAvailable && <SocialImageGeneratorToggle /> }
+						{ ! isUpdatingJetpackSettings && isModuleEnabled && isAutoConversionAvailable && (
+							<AutoConversionToggle shouldRefresh />
+						) }
+						{ ! isUpdatingJetpackSettings && isModuleEnabled && isSocialImageGeneratorAvailable && (
+							<SocialImageGeneratorToggle shouldRefresh />
+						) }
 					</AdminSection>
 					<AdminSectionHero>
 						<InfoSection />

--- a/projects/plugins/social/src/js/components/auto-conversion-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/auto-conversion-toggle/index.tsx
@@ -3,13 +3,29 @@ import { SOCIAL_STORE_ID } from '@automattic/jetpack-publicize-components';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import ToggleSection from '../toggle-section';
 import { SocialStoreSelectors } from '../types/types';
 import styles from './styles.module.scss';
 
-const AutoConversionToggle: React.FC = () => {
+type AutoConversionToggleProps = {
+	/**
+	 * Whether or not to refresh the settings.
+	 */
+	shouldRefresh?: boolean;
+};
+
+const AutoConversionToggle: React.FC< AutoConversionToggleProps > = ( {
+	shouldRefresh = false,
+} ) => {
+	const refreshSettings = useDispatch( SOCIAL_STORE_ID ).refreshAutoConversionSettings;
+
+	useEffect( () => {
+		shouldRefresh && refreshSettings();
+	}, [ shouldRefresh, refreshSettings ] );
+
 	const { isEnabled, isUpdating } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
 		return {

--- a/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
@@ -9,8 +9,23 @@ import ToggleSection from '../toggle-section';
 import { SocialStoreSelectors } from '../types/types';
 import styles from './styles.module.scss';
 
-const SocialImageGeneratorToggle: React.FC = () => {
-	const [ currentTemplate, setCurrentTemplate ] = useState( null );
+interface SocialImageGeneratorToggleProps {
+	/**
+	 * Whether or not to refresh the settings.
+	 */
+	shouldRefresh: boolean;
+}
+
+const SocialImageGeneratorToggle: React.FC< SocialImageGeneratorToggleProps > = ( {
+	shouldRefresh,
+} ) => {
+	const refreshSettings = useDispatch( SOCIAL_STORE_ID ).refreshSocialImageGeneratorSettings;
+
+	useEffect( () => {
+		shouldRefresh && refreshSettings();
+	}, [ shouldRefresh, refreshSettings ] );
+
+	const [ currentTemplate, setCurrentTemplate ] = useState< string | null >( null );
 	const { isEnabled, isUpdating, defaultTemplate } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
 		return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In our store, a feature is available if the main Jetpack Social toggle is on. Right now if you have Jetpack Social off, and go to the settings page, turning Jetpack Social on will show SIG and auto conversion off even if they are on in the settings, as the initial state was loaded with Jetpack Social off

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refresh the store from the blog options when we turn Jetpack Social on

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/orgs/Automattic/projects/733/views/2?pane=issue&itemId=43051048
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open up your site and turn off Jetpack Social off on the admin page. Refresh the page and turn it on.
* After loading the features should be on if they were on before turning the feature off
* Without this change following these steps will show the features being off.

