### PR TITLE
Super Cache: Fix null parameter warning when enabling/disabling caching

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-null_parameter_supercachedir
+++ b/projects/plugins/super-cache/changelog/fix-null_parameter_supercachedir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+super-cache: fixed null parameter warning when using $supercachedir

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -1859,6 +1859,10 @@ function wp_super_cache_enable() {
 
 	$super_cache_enabled = true;
 
+	if ( ! $supercachedir ) {
+		$supercachedir = get_supercache_dir();
+	}
+
 	if ( is_dir( $supercachedir . '.disabled' ) ) {
 		if ( is_dir( $supercachedir ) ) {
 			prune_super_cache( $supercachedir . '.disabled', true );
@@ -1881,6 +1885,10 @@ function wp_super_cache_disable() {
 	wp_cache_debug( 'wp_super_cache_disable: disable cache' );
 
 	$super_cache_enabled = false;
+
+	if ( ! $supercachedir ) {
+		$supercachedir = get_supercache_dir();
+	}
 
 	if ( is_dir( $supercachedir ) ) {
 		@rename( $supercachedir, $supercachedir . '.disabled' );


### PR DESCRIPTION
This small fix will fix a PHP warning that the parameter being passed to is_dir() is NULL in the enable/disable caching functions.

## Proposed changes:
* In wp_super_cache_enable() and wp_super_cache_disable() check if $supercachedir is defined and set it if not.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
ref: https://wordpress.org/support/topic/deprecated-is_dir/

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Tail your error_log
* If you have PHP8.2 installed, then you'll see a warning about is_dir() when caching is enabled or disabled from the settings page.
* If you don't have PHP8.2 installed, then error_log $supercachedir in wp_super_cache_enable() and wp_super_cache_disable() and you'll see it's blank when you toggle caching.
* Apply PR and error_log $supercachedir after the changes and it will be set to the path of your super cache directory.
