### PR TITLE
Plans: introduce `plans` prop to plans store

### DIFF
--- a/projects/plugins/jetpack/changelog/update-introduce-plans-prop-to-the-store
+++ b/projects/plugins/jetpack/changelog/update-introduce-plans-prop-to-the-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Plans: introduce `plans` prop to plans store

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -1,16 +1,35 @@
+/**
+ * External dependencies
+ */
 import { createReduxStore, register } from '@wordpress/data';
+/**
+ * Types & Constants
+ */
+type Plan = {
+	product_id: number;
+	product_name: string;
+	product_slug: string;
+};
+
+type PlanStateProps = {
+	plans: Array< Plan >;
+};
 
 const store = 'wordpress-com/plans';
 
+const INITIAL_STATE: PlanStateProps = {
+	plans: [],
+};
+
 const actions = {
-	setPlans( plans ) {
+	setPlans( plans: Array< Plan > ) {
 		return {
 			type: 'SET_PLANS',
 			plans,
 		};
 	},
 
-	fetchFromAPI( url ) {
+	fetchFromAPI( url: string ) {
 		return {
 			type: 'FETCH_FROM_API',
 			url,
@@ -19,10 +38,13 @@ const actions = {
 };
 
 const wordpressPlansStore = createReduxStore( store, {
-	reducer( state = [], action ) {
+	reducer( state = INITIAL_STATE, action ) {
 		switch ( action.type ) {
 			case 'SET_PLANS':
-				return action.plans;
+				return {
+					...state,
+					plans: action.plans,
+				};
 		}
 
 		return state;
@@ -31,8 +53,15 @@ const wordpressPlansStore = createReduxStore( store, {
 	actions,
 
 	selectors: {
-		getPlan( state, planSlug: string ) {
-			return state.find( plan => plan.product_slug === planSlug );
+		/*
+		 * Return the plan with the given slug.
+		 *
+		 * @param {Object} state    - The Plans state tree.
+		 * @param {string} planSlug - The plan slug to find.
+		 * @return {Object}           The plan.
+		 */
+		getPlan( state: PlanStateProps, planSlug: string ) {
+			return state.plans.find( plan => plan.product_slug === planSlug );
 		},
 	},
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR:

* Plans: introduce `plans` prop to plans store. This is the first step to reorganize the tree to add a new `features` prop (follow-up)
* Address some TypeScript issues
* Minor doc improvement.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Plans: introduce `plans` prop to plans store


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Testing instructions are the same that https://github.com/Automattic/jetpack/pull/33919

* Test in Simple and Atomic site
* Ensure the site doesn't have a paid plan
* Go to the block editor
* Use the Redux tool
* Filter the stores by `wordpress-com/plans`
* Create a paid block instance, for instance, Calendly.
* Confirm store action traces

<img width="842" alt="Screenshot 2023-11-06 at 06 50 41" src="https://github.com/Automattic/jetpack/assets/77539/f15a2ec5-396e-48cc-8d17-a11df419b2c9">

* Confirm the store is populated with the product list
* Similarly, use the Network tab to check the request from the client

<img width="841" alt="Screenshot 2023-11-06 at 06 51 09" src="https://github.com/Automattic/jetpack/assets/77539/e7fb825a-ec11-43f6-a385-95027b8732dc">

Additionally, you can us the console dev tool to test the implementation, getting some plan data. For instance:


```js
wp.data.select( 'wordpress-com/plans' ).getPlan( 'jetpack_free' )
```

<img width="900" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/d1c5bb8f-ae3d-45c3-ada9-2e724a9f83b2">


