### PR TITLE
Fix accept header check and add new wpsc_accept_list filter for sites to modify that list

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-accept_list_check
+++ b/projects/plugins/super-cache/changelog/fix-accept_list_check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Super Cache: fix "accept header" check, and add new "wpsc_accept_list" filter on JSON accept list

--- a/projects/plugins/super-cache/composer.json
+++ b/projects/plugins/super-cache/composer.json
@@ -51,6 +51,6 @@
 		"wp-svn-autopublish": true
 	},
 	"config": {
-		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_10_1_alpha"
+		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_11_0_alpha"
 	}
 }

--- a/projects/plugins/super-cache/package.json
+++ b/projects/plugins/super-cache/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-super-cache",
-	"version": "1.10.1-alpha",
+	"version": "1.11.0-alpha",
 	"description": "A very fast caching engine for WordPress that produces static html files.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -510,6 +510,7 @@ function wpsc_get_accept_header() {
 
 	if ( $accept === 'N/A' ) {
 		$json_list = apply_filters( 'wpsc_accept_list', array( 'application/json', 'application/activity+json', 'application/ld+json' ) );
+		$json_list = array_map( 'strtolower', $json_list );
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- $accept is checked and set below.
 		$accept = isset( $_SERVER['HTTP_ACCEPT'] ) ? strtolower( filter_var( $_SERVER['HTTP_ACCEPT'] ) ) : '';

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -509,13 +509,13 @@ function wpsc_get_accept_header() {
 	static $accept = 'N/A';
 
 	if ( $accept === 'N/A' ) {
-		$json_list = apply_filters( 'wpsc_accept_list', array( 'application/json', 'application/activity+json', 'application/ld+json' ) );
-		$json_list = array_map( 'strtolower', $json_list );
+		$accept_headers = apply_filters( 'wpsc_accept_headers', array( 'application/json', 'application/activity+json', 'application/ld+json' ) );
+		$accept_headers = array_map( 'strtolower', $accept_headers );
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- $accept is checked and set below.
 		$accept = isset( $_SERVER['HTTP_ACCEPT'] ) ? strtolower( filter_var( $_SERVER['HTTP_ACCEPT'] ) ) : '';
 
-		foreach ( $json_list as $header ) {
+		foreach ( $accept_headers as $header ) {
 			if ( strpos( $accept, $header ) !== false ) {
 				$accept = 'application/json';
 			}

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -509,7 +509,7 @@ function wpsc_get_accept_header() {
 	static $accept = 'N/A';
 
 	if ( $accept === 'N/A' ) {
-		$json_list = array( 'application/json', 'application/activity+json', 'application/ld+json' );
+		$json_list = apply_filters( 'wpsc_accept_list', array( 'application/json', 'application/activity+json', 'application/ld+json' ) );
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- $accept is checked and set below.
 		$accept = isset( $_SERVER['HTTP_ACCEPT'] ) ? strtolower( filter_var( $_SERVER['HTTP_ACCEPT'] ) ) : '';

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -515,7 +515,7 @@ function wpsc_get_accept_header() {
 		$accept = isset( $_SERVER['HTTP_ACCEPT'] ) ? strtolower( filter_var( $_SERVER['HTTP_ACCEPT'] ) ) : '';
 
 		foreach ( $json_list as $header ) {
-			if ( strpos( $accept, $header ) ) {
+			if ( strpos( $accept, $header ) !== false ) {
 				$accept = 'application/json';
 			}
 		}

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Super Cache
  * Plugin URI: https://wordpress.org/plugins/wp-super-cache/
  * Description: Very fast caching plugin for WordPress.
- * Version: 1.10.1-alpha
+ * Version: 1.11.0-alpha
  * Author: Automattic
  * Author URI: https://automattic.com/
  * License: GPL2+


### PR DESCRIPTION
As reported [here](https://wordpress.org/support/topic/wp-supercache-seems-to-ignore-non-default-accept-header/), the author page sometimes shows HTML to Fediverse clients using ActivityPub.

If the /author/username page is cached already, then it is delivered to the client.
This PR fixes a check of the Accept header, so it recognises those clients correctly. The plugin already had code that checks the Accept header is "text/html" and refuses to serve a cached file if it's not. That check was getting an incorrect Accept header so the cached file was served, regardless.

It also adds a filter, wpsc_accept_list, so the list of Accept headers can be modified by the site owner.

Fixes #33968

## Proposed changes:
* In wpsc_get_accept_header() fix the strpos() that checks the Accept header, so it detects if the header is found in position 0 of the list item.
* In that same function add a filter, wpsc_accept_list, around the list of non text/html Accept headers so the site owner can modify it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Install this plugin and activate caching.
2. Go to /author/username on your site using a private/incognito browser to prime the cache. Confirm that the page is cached by examining the bottom of the source.
3. At a terminal, use this to test with an ActivityPub Accept header. Replace URL with your own test site: `curl -v -sS -H 'Accept: application/activity+json' https://example.com/author/username/`
4. HTML should be shown if the page is cached already.
5. Apply this PR.
6. Rerun the `curl` command, and it should show a JSON array with author information.
7. Reload the browser window and confirm again that the page is cached.