### PR TITLE
Subscribe Block: Always show email input if not subscribed

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-always-show-input
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-always-show-input
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+rollback change

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -145,10 +145,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	/**
 	 * Retrieves the email of the currently authenticated subscriber.
 	 *
-	 * This function checks if the current user has an active subscription. If the user is subscribed,
-	 * their email is returned. Otherwise, it returns an empty string to indicate no active subscription.
-	 *
-	 * @return string The email address of the subscribed user or an empty string if not subscribed.
+	 * @return string The email address of the current user.
 	 */
 	public function get_subscriber_email() {
 		$email = $this->get_token_property( 'blog_subscriber' );
@@ -156,6 +153,15 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 			return '';
 		}
 		return $email;
+	}
+
+	/**
+	 * Returns true if the current authenticated user is subscribed to the current site.
+	 *
+	 * @return boolean
+	 */
+	public function is_current_user_subscribed() {
+		return (bool) $this->get_token_property( 'blog_sub' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -161,7 +161,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	 * @return boolean
 	 */
 	public function is_current_user_subscribed() {
-		return (bool) $this->get_token_property( 'blog_sub' );
+		return $this->get_token_property( 'blog_sub' ) === 'active';
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
@@ -56,19 +56,31 @@ class WPCOM_Online_Subscription_Service extends WPCOM_Token_Subscription_Service
 	 * @return string The email address of the subscribed user or an empty string if not subscribed.
 	 */
 	public function get_subscriber_email() {
+		if ( ! is_user_logged_in() ) {
+			return '';
+		}
+		return wp_get_current_user()->user_email;
+	}
+
+	/**
+	 * Returns true if the current authenticated user is subscribed to the current site.
+	 *
+	 * @return boolean
+	 */
+	public function is_current_user_subscribed() {
 		include_once WP_CONTENT_DIR . '/mu-plugins/email-subscriptions/subscriptions.php';
 		$email             = wp_get_current_user()->user_email;
 		$subscriber_object = \Blog_Subscriber::get( $email );
 
 		if ( empty( $subscriber_object ) ) {
-			return '';
+			return false;
 		}
 		$blog_id             = $this->get_site_id();
 		$subscription_status = \Blog_Subscription::get_subscription_status_for_blog( $subscriber_object, $blog_id );
 		if ( 'active' !== $subscription_status ) {
-			return '';
+			return false;
 		}
-		return $email;
+		return true;
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
@@ -71,7 +71,6 @@ class WPCOM_Online_Subscription_Service extends WPCOM_Token_Subscription_Service
 		include_once WP_CONTENT_DIR . '/mu-plugins/email-subscriptions/subscriptions.php';
 		$email             = wp_get_current_user()->user_email;
 		$subscriber_object = \Blog_Subscriber::get( $email );
-
 		if ( empty( $subscriber_object ) ) {
 			return false;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -643,7 +643,7 @@ function render_for_website( $data, $classes, $styles ) {
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
 					<div class="wp-block-jetpack-subscriptions__form-elements">
-						<?php if ( empty( Jetpack_Memberships::is_current_user_subscribed() ) ) : ?>
+						<?php if ( ! Jetpack_Memberships::is_current_user_subscribed() ) : ?>
 						<p id="subscribe-email">
 							<label
 								id="<?php echo esc_attr( $subscribe_field_id . '-label' ); ?>"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -535,7 +535,7 @@ function render_block( $attributes ) {
 		Jetpack_Gutenberg::load_styles_as_required( FEATURE_NAME );
 	}
 
-	$subscribe_email = Jetpack_Memberships::get_current_user_subscriber_email();
+	$subscribe_email = Jetpack_Memberships::get_current_user_email();
 
 	/** This filter is documented in modules/contact-form/grunion-contact-form.php */
 	if ( is_wpcom() || false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
@@ -618,7 +618,7 @@ function render_for_website( $data, $classes, $styles ) {
 	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );
 	$tier_id            = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
 	$button_text        = wp_kses(
-		html_entity_decode( Jetpack_Memberships::get_current_user_subscriber_email() ? ( '✓ ' . $data['submit_button_text_subscribed'] ) : $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+		html_entity_decode( Jetpack_Memberships::is_current_user_subscribed() ? ( '✓ ' . $data['submit_button_text_subscribed'] ) : $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 		Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
 	);
 
@@ -639,11 +639,11 @@ function render_for_website( $data, $classes, $styles ) {
 					accept-charset="utf-8"
 					data-blog="<?php echo esc_attr( $blog_id ); ?>"
 					data-post_access_level="<?php echo esc_attr( $post_access_level ); ?>"
-					data-subscriber_email="<?php echo esc_attr( Jetpack_Memberships::get_current_user_subscriber_email() ); ?>"
+					data-subscriber_email="<?php echo esc_attr( $data['subscribe_email'] ); ?>"
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
 					<div class="wp-block-jetpack-subscriptions__form-elements">
-						<?php if ( empty( Jetpack_Memberships::get_current_user_subscriber_email() ) ) : ?>
+						<?php if ( empty( Jetpack_Memberships::is_current_user_subscribed() ) ) : ?>
 						<p id="subscribe-email">
 							<label
 								id="<?php echo esc_attr( $subscribe_field_id . '-label' ); ?>"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -643,7 +643,7 @@ function render_for_website( $data, $classes, $styles ) {
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
 					<div class="wp-block-jetpack-subscriptions__form-elements">
-						<?php if ( empty( $data['subscribe_email'] ) ) : ?>
+						<?php if ( empty( Jetpack_Memberships::get_current_user_subscriber_email() ) ) : ?>
 						<p id="subscribe-email">
 							<label
 								id="<?php echo esc_attr( $subscribe_field_id . '-label' ); ?>"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -617,8 +617,9 @@ function render_for_website( $data, $classes, $styles ) {
 	$post_id            = get_the_ID();
 	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );
 	$tier_id            = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
+	$is_subscribed      = Jetpack_Memberships::is_current_user_subscribed();
 	$button_text        = wp_kses(
-		html_entity_decode( Jetpack_Memberships::is_current_user_subscribed() ? ( '✓ ' . $data['submit_button_text_subscribed'] ) : $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+		html_entity_decode( $is_subscribed ? ( '✓ ' . $data['submit_button_text_subscribed'] ) : $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 		Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
 	);
 
@@ -631,7 +632,7 @@ function render_for_website( $data, $classes, $styles ) {
 	);
 	?>
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
-		<div class="jetpack_subscription_widget">
+		<div class="jetpack_subscription_widget<?php echo ! $is_subscribed ? ' is-not-subscriber' : ''; ?>">
 			<div class="wp-block-jetpack-subscriptions__container">
 				<form
 					action="<?php echo esc_url( $form_url ); ?>"
@@ -643,7 +644,7 @@ function render_for_website( $data, $classes, $styles ) {
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
 					<div class="wp-block-jetpack-subscriptions__form-elements">
-						<?php if ( ! Jetpack_Memberships::is_current_user_subscribed() ) : ?>
+						<?php if ( ! $is_subscribed ) : ?>
 						<p id="subscribe-email">
 							<label
 								id="<?php echo esc_attr( $subscribe_field_id . '-label' ); ?>"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -4,24 +4,25 @@
 	@return unquote("var(#{$var-name}, #{$fallback})");
 }
 
+
 .is-style-compact {
-	&:has(input[type="email"]) {
+	.is-not-subscriber {
 		.wp-block-jetpack-subscriptions__button,
 		.wp-block-button__link {
 			margin-inline-start: 0 !important;
 			border-start-start-radius: 0 !important;
 			border-end-start-radius: 0 !important;
 		}
-	}
 
-	.components-text-control__input,
-	p#subscribe-email input[type=email] {
-		border-top-right-radius: 0 !important;
-		border-bottom-right-radius: 0 !important;
-	}
+		.components-text-control__input,
+		p#subscribe-email input[type=email] {
+			border-top-right-radius: 0 !important;
+			border-bottom-right-radius: 0 !important;
+		}
 
-	&:not(.wp-block-jetpack-subscriptions__use-newline) .components-text-control__input {
-		border-right-width: 0 !important;
+		&:not(.wp-block-jetpack-subscriptions__use-newline) .components-text-control__input {
+			border-right-width: 0 !important;
+		}
 	}
 }
 
@@ -32,15 +33,17 @@
 		flex-direction: column;
 	}
 
-	.wp-block-jetpack-subscriptions__form,
+	.is-not-subscriber {
+		.wp-block-jetpack-subscriptions__form,
 	form  {
-		&:has(input[type="email"]) {
 			.wp-block-jetpack-subscriptions__form-elements {
 				display: flex;
 				align-items: flex-start;
 			}
 		}
-
+	}
+	.wp-block-jetpack-subscriptions__form,
+	form  {
 		.wp-block-jetpack-subscriptions__textfield .components-text-control__input,
 		.wp-block-jetpack-subscriptions__button,
 		input[type="email"],

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -794,14 +794,25 @@ class Jetpack_Memberships {
 	}
 
 	/**
+	 * Returns the email of the current user.
+	 *
+	 * @return string
+	 */
+	public static function get_current_user_email() {
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
+		return $subscription_service->get_subscriber_email();
+	}
+
+	/**
 	 * Returns if the current user is subscribed or not.
 	 *
 	 * @return boolean
 	 */
-	public static function get_current_user_subscriber_email() {
+	public static function is_current_user_subscribed() {
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
-		return $subscription_service->get_subscriber_email();
+		return $subscription_service->is_current_user_subscribed();
 	}
 }
 Jetpack_Memberships::get_instance();


### PR DESCRIPTION
Fixes #33964

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Always Display the email input if the user is not subscribed, even when the user is logged in to WPCOM or has the subscription token on Jetpack sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Follow up to #33961

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try to reproduce #33964.
* TLDR: If you are not a subscriber you should always see the email input and a "Subscribe" button.
* Confirm that when subscribing you get a "✓Subscribed" button without email input.
* Please test both in Jetpack and in WPCOM.