### PR TITLE
Repo Gardening: also gather p2 comments as support references

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gather-support-p2s-too
+++ b/projects/github-actions/repo-gardening/changelog/update-gather-support-p2s-too
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Gather Support References: also gather p2 comment references.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -88,7 +88,7 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 
 		// xxx-zen is the preferred format for tickets.
 		// xxx-zd, as well as its uppercase version, is considered an alternate version.
-		const wrongId = supportId.match( /([0-9]*)-zd/i );
+		const wrongId = supportId.match( /^([0-9]*)-zd$/i );
 		if ( wrongId ) {
 			const correctedId = `${ wrongId[ 1 ] }-zen`;
 			correctedSupportIds.add( correctedId );

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -50,7 +50,7 @@ async function getListComment( issueComments ) {
  */
 async function getIssueReferences( octokit, owner, repo, number, issueComments ) {
 	const ticketReferences = [];
-	const referencesRegexP = /([0-9]*-(?:zen|zd)|[a-zA-Z0-9-]+-p2#comment-[0-9]*)/gim;
+	const referencesRegexP = /[0-9]*-(?:zen|zd)|[a-zA-Z0-9-]+-p2#comment-[0-9]*/gim;
 
 	debug( `gather-support-references: Getting references from issue body.` );
 	const {

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -80,12 +80,6 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 	ticketReferences.map( reference => {
 		const supportId = reference[ 0 ];
 
-		// Do not correct p2 comment references.
-		if ( supportId.includes( '-p2#comment-' ) ) {
-			correctedSupportIds.add( supportId );
-			return;
-		}
-
 		// xxx-zen is the preferred format for tickets.
 		// xxx-zd, as well as its uppercase version, is considered an alternate version.
 		const wrongId = supportId.match( /^([0-9]*)-zd$/i );

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -33,7 +33,13 @@ async function getListComment( issueComments ) {
 }
 
 /**
- * Scan the contents of the issue as well as all its comments, get all support references, and add them to an array of references.
+ * Scan the contents of the issue as well as all its comments,
+ * get all support references, and add them to an array of references.
+ *
+ * Support references can be in the following formats:
+ * - xxx-zen
+ * - xxx-zd
+ * - xxxx-xxx-p2#comment-xxx
  *
  * @param {GitHub} octokit      - Initialized Octokit REST client.
  * @param {string} owner        - Repository owner.
@@ -44,7 +50,7 @@ async function getListComment( issueComments ) {
  */
 async function getIssueReferences( octokit, owner, repo, number, issueComments ) {
 	const ticketReferences = [];
-	const referencesRegexP = /[0-9]*-(?:zen|zd)/gim;
+	const referencesRegexP = /([0-9]*-(?:zen|zd)|[a-zA-Z0-9-]+-p2#comment-[0-9]*)/gim;
 
 	debug( `gather-support-references: Getting references from issue body.` );
 	const {
@@ -73,6 +79,12 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 	const correctedSupportIds = new Set();
 	ticketReferences.map( reference => {
 		const supportId = reference[ 0 ];
+
+		// Do not correct p2 comment references.
+		if ( supportId.includes( '-p2#comment-' ) ) {
+			correctedSupportIds.add( supportId );
+			return;
+		}
 
 		// xxx-zen is the preferred format for tickets.
 		// xxx-zd, as well as its uppercase version, is considered an alternate version.


### PR DESCRIPTION
## Proposed changes:

Until now, when collecting support references (and consequently when judging whether an issue should be escalated or not), we looked at the number of tickets that had been posted on the issue.
However, in some cases user feedback may come as links to p2 comments instead of support tickets. Let's count those as support references as well.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related conversation: p1698810312902799-slack-CQD1HH4MA

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This cannot be tested on this repo before merged, but you can test it in a forked repo. Here is an example:
https://github.com/jeherve/jetpack/issues/114#issuecomment-1796001066
