### PR TITLE
get_author: wpcom: Add a new wpcom_pre_get_active_blog_for_user filter

### DIFF
--- a/projects/plugins/jetpack/changelog/get_author-add-wpcom-filter
+++ b/projects/plugins/jetpack/changelog/get_author-add-wpcom-filter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-get_author: wpcom: Add a new wpcom_pre_get_active_blog_for_user filter
+get_author: wpcom: Add a new wpcom_api_pre_get_active_blog_author filter

--- a/projects/plugins/jetpack/changelog/get_author-add-wpcom-filter
+++ b/projects/plugins/jetpack/changelog/get_author-add-wpcom-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+get_author: wpcom: Add a new wpcom_pre_get_active_blog_for_user filter

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1455,7 +1455,9 @@ abstract class WPCOM_JSON_API_Endpoint {
 				if ( false === $active_blog ) {
 					$active_blog = get_active_blog_for_user( $id );
 				}
-				$site_id = $active_blog->blog_id;
+				if ( ! empty( $active_blog ) ) {
+					$site_id = $active_blog->blog_id;
+				}
 				if ( $site_id > -1 ) {
 					$site_visible = (
 						-1 !== (int) $active_blog->public ||

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1451,6 +1451,16 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$nice       = $user->user_nicename;
 			}
 			if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! $is_jetpack ) {
+				/**
+				 * Allow customizing the blog ID returned with the author in WordPress.com REST API queries.
+				 *
+				 * @since $$next-version$$
+				 *
+				 * @module json-api
+				 *
+				 * @param bool|int $active_blog  Blog ID, or false by default.
+				 * @param int      $id           User ID.
+				 */
 				$active_blog = apply_filters( 'wpcom_pre_get_active_blog_for_user', false, $id );
 				if ( false === $active_blog ) {
 					$active_blog = get_active_blog_for_user( $id );

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1451,6 +1451,8 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$nice       = $user->user_nicename;
 			}
 			if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! $is_jetpack ) {
+				$site_id = -1;
+
 				/**
 				 * Allow customizing the blog ID returned with the author in WordPress.com REST API queries.
 				 *
@@ -1461,8 +1463,6 @@ abstract class WPCOM_JSON_API_Endpoint {
 				 * @param bool|int $active_blog  Blog ID, or false by default.
 				 * @param int      $id           User ID.
 				 */
-				$site_id = -1;
-
 				$active_blog = apply_filters( 'wpcom_pre_get_active_blog_for_user', false, $id );
 				if ( false === $active_blog ) {
 					$active_blog = get_active_blog_for_user( $id );

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1451,8 +1451,11 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$nice       = $user->user_nicename;
 			}
 			if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! $is_jetpack ) {
-				$active_blog = get_active_blog_for_user( $id );
-				$site_id     = $active_blog->blog_id;
+				$active_blog = apply_filters( 'wpcom_pre_get_active_blog_for_user', false, $id );
+				if ( false === $active_blog ) {
+					$active_blog = get_active_blog_for_user( $id );
+				}
+				$site_id = $active_blog->blog_id;
 				if ( $site_id > -1 ) {
 					$site_visible = (
 						-1 !== (int) $active_blog->public ||

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1463,7 +1463,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				 * @param bool|int $active_blog  Blog ID, or false by default.
 				 * @param int      $id           User ID.
 				 */
-				$active_blog = apply_filters( 'wpcom_pre_get_active_blog_for_user', false, $id );
+				$active_blog = apply_filters( 'wpcom_api_pre_get_active_blog_author', false, $id );
 				if ( false === $active_blog ) {
 					$active_blog = get_active_blog_for_user( $id );
 				}

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1461,6 +1461,8 @@ abstract class WPCOM_JSON_API_Endpoint {
 				 * @param bool|int $active_blog  Blog ID, or false by default.
 				 * @param int      $id           User ID.
 				 */
+				$site_id = -1;
+
 				$active_blog = apply_filters( 'wpcom_pre_get_active_blog_for_user', false, $id );
 				if ( false === $active_blog ) {
 					$active_blog = get_active_blog_for_user( $id );


### PR DESCRIPTION
## Proposed changes:

* Inside the WPCOM only section of `get_author()`, add a new filter called `wpcom_pre_get_active_blog_for_user` which can optionally bypass the call to `get_active_blog_for_user()`.
  * WPCOM has some special users with over 50,000 blogs that this can help out with. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Unit tests + Manual inspection. 
  * If JP is not running on WPCOM, this patch should have no change in behavior. 
  * If JP is running on WPCOM but there is no filter attached, there should be no change in behavior.

```
scp projects/plugins/jetpack/class.json-api-endpoints.php wpcom-sandbox:./public_html/wp-content/mu-plugins/jetpack-plugin/sun/class.json-api-endpoints.php
scp projects/plugins/jetpack/class.json-api-endpoints.php wpcom-sandbox:./public_html/wp-content/mu-plugins/jetpack-plugin/moon/class.json-api-endpoints.php
```
API Console: GET 1.2 `/read/following?locale=en&meta=site%2Cfeed&number=40&order=DESC`

Should continue to see author information

