### PR TITLE
wp-admin Site Default: Tweak profile menu items

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-wp-admin-profile-links
+++ b/projects/plugins/jetpack/changelog/improve-wp-admin-profile-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Two minor changes to the Profile menu for WoA sites using 'Classic style'

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -404,11 +404,17 @@ class Masterbar {
 
 		foreach ( $nodes as $id => $node ) {
 
-			if ( $id === 'edit-profile' ) {
-				$this->add_wpcom_profile_link( $bar );
-			}
-
 			$bar->add_node( $node );
+			// Add our custom node and change the title of the edit profile node.
+			if ( 'edit-profile' === $id ) {
+				$this->add_wpcom_profile_link( $bar );
+				$bar->add_node(
+					array(
+						'id'    => 'edit-profile',
+						'title' => __( 'Site Profile', 'jetpack' ),
+					)
+				);
+			}
 		}
 
 		// Add a menu item to the user menu


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4343

## Proposed changes:

Makes two changes to the profile menu:
1. Changes 'Edit Profile' to 'Site Profile', to better distinguish between WordPress.com profile.
2. Moves 'Site Profile' above the 'WordPress.com Profile' link

**Before**

<img width="377" alt="CleanShot 2023-11-06 at 13 50 06@2x" src="https://github.com/Automattic/jetpack/assets/36432/a535a4c7-f67f-446b-98fe-939ac63f9574">

**After**

<img width="378" alt="CleanShot 2023-11-06 at 13 48 57@2x" src="https://github.com/Automattic/jetpack/assets/36432/69774312-50aa-4dea-a457-4f779895615c">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Create a new Business site.
2. Register the site in WoA Developer Blog Manager.
3. Take the site Atomic.
4. Install the Jetpack Beta tester plugin.
5. Navigate to Hosting Configuration and switch to "Classic style".
6. Click on General Settings to get a WP-Admin page.
7. Verify the Core Toolbar renders the Profile menu as expected, and that each of the links work.

