### PR TITLE
Connection: Add "source" as a query param to the Jetpack connect URL

### DIFF
--- a/projects/packages/connection/changelog/add-souce-to-jetpack-connect-url
+++ b/projects/packages/connection/changelog/add-souce-to-jetpack-connect-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added source as query param to the Jetpack connect url

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -65,7 +65,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.59.x-dev"
+			"dev-trunk": "1.60.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1916,8 +1916,7 @@ class Manager {
 				'site_created'          => $this->get_assumed_site_creation_date(),
 				'allow_site_connection' => ! $this->has_connected_owner(),
 				'calypso_env'           => ( new Host() )->get_calypso_env(),
-				// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				'source'                => isset( $_GET['source'] ) ? wp_unslash( $_GET['source'] ) : '',
+				'source'                => ( new Host() )->get_source_query(),
 			)
 		);
 

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1917,7 +1917,7 @@ class Manager {
 				'allow_site_connection' => ! $this->has_connected_owner(),
 				'calypso_env'           => ( new Host() )->get_calypso_env(),
 				// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				'source'                => isset( $_GET['source'] ) ? wp_unslash( $_GET['source'] ) : null,
+				'source'                => isset( $_GET['source'] ) ? wp_unslash( $_GET['source'] ) : '',
 			)
 		);
 

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1916,6 +1916,8 @@ class Manager {
 				'site_created'          => $this->get_assumed_site_creation_date(),
 				'allow_site_connection' => ! $this->has_connected_owner(),
 				'calypso_env'           => ( new Host() )->get_calypso_env(),
+				// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				'source'                => isset( $_GET['source'] ) ? wp_unslash( $_GET['source'] ) : null,
 			)
 		);
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.59.0';
+	const PACKAGE_VERSION = '1.60.0-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/status/changelog/add-method-to-return-source-query
+++ b/projects/packages/status/changelog/add-method-to-return-source-query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a new method that returns "source" query param from the URL

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -46,7 +46,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.18.x-dev"
+			"dev-trunk": "1.19.x-dev"
 		}
 	}
 }

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -119,4 +119,19 @@ class Host {
 
 		return '';
 	}
+
+	/**
+	 * Return source query param value from the URL if exists in the allowed sources list.
+	 *
+	 * @return string "source" query param value
+	 */
+	public function get_source_query() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$allowed_sources = array( 'jetpack-manage' );
+		if ( isset( $_GET['source'] ) && in_array( $_GET['source'], $allowed_sources, true ) ) {
+			return sanitize_key( $_GET['source'] );
+		}
+
+		return '';
+	}
 }

--- a/projects/packages/status/tests/php/test-host.php
+++ b/projects/packages/status/tests/php/test-host.php
@@ -145,4 +145,32 @@ class Test_Host extends TestCase {
 			'default'     => array( '' ),
 		);
 	}
+
+	/**
+	 * Test adding a source parameter to the Calypso URL.
+	 *
+	 * @covers Automattic\Jetpack\Status\Host::get_source_query
+	 * @dataProvider get_source_query_params
+	 *
+	 * @param string $source Source parameter.
+	 * @param string $expected Expected query string.
+	 */
+	public function test_get_source_query( $source, $expected ) {
+		$_GET['source'] = $source;
+		$this->assertEquals( $expected, $this->host_obj->get_source_query( $source ) );
+		unset( $_GET['source'] );
+	}
+
+	/**
+	 * Data provider for `test_get_source_query()` test method.
+	 *
+	 * @return array
+	 */
+	public function get_source_query_params() {
+			return array(
+				'empty'   => array( '', '' ),
+				'valid'   => array( 'jetpack-manage', 'jetpack-manage' ),
+				'invalid' => array( 'invalid-param', '' ),
+			);
+	}
 }

--- a/projects/plugins/backup/changelog/add-source-to-jetpack-connect-url
+++ b/projects/plugins/backup/changelog/add-source-to-jetpack-connect-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -425,7 +425,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "33fa9d546d5a36d1c046e23d71488fb10d0356b3"
+                "reference": "77832a49749a4587e9eb6793a058ab360c83930c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -456,7 +456,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1315,7 +1315,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f7cb46ce4ddb975b79fd27163da1a908888322d6"
+                "reference": "cdefb1a0342cba4a8368ecc6278f5d85aeab8197"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1337,7 +1337,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "1.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/add-source-to-jetpack-connect-url
+++ b/projects/plugins/boost/changelog/add-source-to-jetpack-connect-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -473,7 +473,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "33fa9d546d5a36d1c046e23d71488fb10d0356b3"
+                "reference": "77832a49749a4587e9eb6793a058ab360c83930c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -504,7 +504,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1379,7 +1379,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f7cb46ce4ddb975b79fd27163da1a908888322d6"
+                "reference": "cdefb1a0342cba4a8368ecc6278f5d85aeab8197"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1401,7 +1401,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "1.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/inspect/changelog/add-source-to-jetpack-connect-url
+++ b/projects/plugins/inspect/changelog/add-source-to-jetpack-connect-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -340,7 +340,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "33fa9d546d5a36d1c046e23d71488fb10d0356b3"
+                "reference": "77832a49749a4587e9eb6793a058ab360c83930c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -371,7 +371,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -562,7 +562,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f7cb46ce4ddb975b79fd27163da1a908888322d6"
+                "reference": "cdefb1a0342cba4a8368ecc6278f5d85aeab8197"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -584,7 +584,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "1.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-source-to-jetpack-connect-url
+++ b/projects/plugins/jetpack/changelog/add-source-to-jetpack-connect-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2404,7 +2404,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f7cb46ce4ddb975b79fd27163da1a908888322d6"
+                "reference": "cdefb1a0342cba4a8368ecc6278f5d85aeab8197"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -2426,7 +2426,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "1.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -858,7 +858,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "33fa9d546d5a36d1c046e23d71488fb10d0356b3"
+                "reference": "77832a49749a4587e9eb6793a058ab360c83930c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -889,7 +889,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/migration/changelog/add-source-to-jetpack-connect-url
+++ b/projects/plugins/migration/changelog/add-source-to-jetpack-connect-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -425,7 +425,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "33fa9d546d5a36d1c046e23d71488fb10d0356b3"
+                "reference": "77832a49749a4587e9eb6793a058ab360c83930c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -456,7 +456,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1315,7 +1315,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f7cb46ce4ddb975b79fd27163da1a908888322d6"
+                "reference": "cdefb1a0342cba4a8368ecc6278f5d85aeab8197"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1337,7 +1337,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "1.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/add-source-to-jetpack-connect-url
+++ b/projects/plugins/protect/changelog/add-source-to-jetpack-connect-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -340,7 +340,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "33fa9d546d5a36d1c046e23d71488fb10d0356b3"
+                "reference": "77832a49749a4587e9eb6793a058ab360c83930c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -371,7 +371,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1230,7 +1230,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f7cb46ce4ddb975b79fd27163da1a908888322d6"
+                "reference": "cdefb1a0342cba4a8368ecc6278f5d85aeab8197"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1252,7 +1252,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "1.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-source-to-jetpack-connect-url
+++ b/projects/plugins/search/changelog/add-source-to-jetpack-connect-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1374,7 +1374,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f7cb46ce4ddb975b79fd27163da1a908888322d6"
+                "reference": "cdefb1a0342cba4a8368ecc6278f5d85aeab8197"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1396,7 +1396,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "1.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -340,7 +340,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "33fa9d546d5a36d1c046e23d71488fb10d0356b3"
+                "reference": "77832a49749a4587e9eb6793a058ab360c83930c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -371,7 +371,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-source-to-jetpack-connect-url
+++ b/projects/plugins/social/changelog/add-source-to-jetpack-connect-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -340,7 +340,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "33fa9d546d5a36d1c046e23d71488fb10d0356b3"
+                "reference": "77832a49749a4587e9eb6793a058ab360c83930c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -371,7 +371,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1306,7 +1306,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f7cb46ce4ddb975b79fd27163da1a908888322d6"
+                "reference": "cdefb1a0342cba4a8368ecc6278f5d85aeab8197"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1328,7 +1328,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "1.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/add-source-to-jetpack-connect-url
+++ b/projects/plugins/starter-plugin/changelog/add-source-to-jetpack-connect-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -340,7 +340,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "33fa9d546d5a36d1c046e23d71488fb10d0356b3"
+                "reference": "77832a49749a4587e9eb6793a058ab360c83930c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -371,7 +371,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1230,7 +1230,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f7cb46ce4ddb975b79fd27163da1a908888322d6"
+                "reference": "cdefb1a0342cba4a8368ecc6278f5d85aeab8197"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1252,7 +1252,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "1.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/add-source-to-jetpack-connect-url
+++ b/projects/plugins/videopress/changelog/add-source-to-jetpack-connect-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -340,7 +340,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "33fa9d546d5a36d1c046e23d71488fb10d0356b3"
+                "reference": "77832a49749a4587e9eb6793a058ab360c83930c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -371,7 +371,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1230,7 +1230,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f7cb46ce4ddb975b79fd27163da1a908888322d6"
+                "reference": "cdefb1a0342cba4a8368ecc6278f5d85aeab8197"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1252,7 +1252,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "1.19.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/34

## Proposed Changes

This PR adds "source" as a query param to the Jetpack connect URL.



### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Go to Jetpack Live Branch with Jetpack
* Append the URL with `wp-admin/admin.php?page=jetpack&connect_url_redirect=true&jetpack_connect_login_redirect=true&source=jetpack-manage`
* Verify the link you are redirected(/jetpack/connect/authorize) to has source=jetpack-manage in it.

