### PR TITLE
Jetpack: reduxify AI Assistant feature

### DIFF
--- a/projects/plugins/jetpack/changelog/update-reduxify-ai-assistant-to-plans-store
+++ b/projects/plugins/jetpack/changelog/update-reduxify-ai-assistant-to-plans-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: reduxify AI Assistant feature

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -12,7 +12,7 @@ type Plan = {
 };
 
 type Feature = {
-	feature_id: number;
+	feature_slug: 'AI_ASSISTANT' | string;
 };
 
 type PlanStateProps = {
@@ -44,6 +44,8 @@ const actions = {
 };
 
 const wordpressPlansStore = createReduxStore( store, {
+	__experimentalUseThunks: true,
+
 	reducer( state = INITIAL_STATE, action ) {
 		switch ( action.type ) {
 			case 'SET_PLANS':
@@ -68,6 +70,16 @@ const wordpressPlansStore = createReduxStore( store, {
 		 */
 		getPlan( state: PlanStateProps, planSlug: string ) {
 			return state.plans.find( plan => plan.product_slug === planSlug );
+		},
+
+		/**
+		 * Return the AI Assistant feature.
+		 *
+		 * @param {object} state - The Plans state tree.
+		 * @returns {object}       The AI Assistant feature data.
+		 */
+		getAiAssistantFeature( state: PlanStateProps ) {
+			return state.features.find( feature => feature.feature_slug === 'AI_ASSISTANT' );
 		},
 	},
 

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -24,7 +24,7 @@ type Feature = AIFeatureProps & {
 type PlanStateProps = {
 	plans: Array< Plan >;
 	features: {
-		aiAssistantFeature?: Feature;
+		aiAssistant?: Feature;
 	};
 };
 
@@ -104,7 +104,7 @@ const wordpressPlansStore = createReduxStore( store, {
 		 * @returns {object}       The AI Assistant feature data.
 		 */
 		getAiAssistantFeature( state: PlanStateProps ): object {
-			return state.features.aiAssistantFeature;
+			return state.features.aiAssistant;
 		},
 	},
 

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { createReduxStore, register } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { AIFeatureProps } from '../../blocks/ai-assistant/hooks/use-ai-feature';
+import { SiteAIAssistantFeatureEndpointResponseProps } from '../../types';
 /**
  * Types & Constants
  */
@@ -11,20 +17,22 @@ type Plan = {
 	product_slug: string;
 };
 
-type Feature = {
+type Feature = AIFeatureProps & {
 	feature_slug: 'AI_ASSISTANT' | string;
 };
 
 type PlanStateProps = {
 	plans: Array< Plan >;
-	features: Array< Feature >;
+	features: {
+		aiAssistantFeature?: Feature;
+	};
 };
 
 const store = 'wordpress-com/plans';
 
 const INITIAL_STATE: PlanStateProps = {
 	plans: [],
-	features: [],
+	features: {},
 };
 
 const actions = {
@@ -41,6 +49,13 @@ const actions = {
 			url,
 		};
 	},
+
+	storeAiAssistantFeature( feature: Feature ) {
+		return {
+			type: 'STORE_AI_ASSISTANT_FEATURE',
+			feature,
+		};
+	},
 };
 
 const wordpressPlansStore = createReduxStore( store, {
@@ -53,6 +68,16 @@ const wordpressPlansStore = createReduxStore( store, {
 					...state,
 					plans: action.plans,
 				};
+
+			case 'STORE_AI_ASSISTANT_FEATURE': {
+				return {
+					...state,
+					features: {
+						...state.features,
+						aiAssistant: action.feature,
+					},
+				};
+			}
 		}
 
 		return state;
@@ -78,8 +103,8 @@ const wordpressPlansStore = createReduxStore( store, {
 		 * @param {object} state - The Plans state tree.
 		 * @returns {object}       The AI Assistant feature data.
 		 */
-		getAiAssistantFeature( state: PlanStateProps ) {
-			return state.features.find( feature => feature.feature_slug === 'AI_ASSISTANT' );
+		getAiAssistantFeature( state: PlanStateProps ): object {
+			return state.features.aiAssistantFeature;
 		},
 	},
 
@@ -100,6 +125,17 @@ const wordpressPlansStore = createReduxStore( store, {
 			const plans = yield actions.fetchFromAPI( url );
 			return actions.setPlans( plans );
 		},
+
+		getAiAssistantFeature:
+			() =>
+			async ( { dispatch } ) => {
+				const response: SiteAIAssistantFeatureEndpointResponseProps = await apiFetch( {
+					path: '/wpcom/v2/jetpack-ai/ai-assistant-feature',
+				} );
+
+				// Store the feature in the store.
+				dispatch( actions.storeAiAssistantFeature( response ) );
+			},
 	},
 } );
 

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -11,14 +11,20 @@ type Plan = {
 	product_slug: string;
 };
 
+type Feature = {
+	feature_id: number;
+};
+
 type PlanStateProps = {
 	plans: Array< Plan >;
+	features: Array< Feature >;
 };
 
 const store = 'wordpress-com/plans';
 
 const INITIAL_STATE: PlanStateProps = {
 	plans: [],
+	features: [],
 };
 
 const actions = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements the data handling to get the AI Assistant feature data through the `wordpress-com/plans` store.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: reduxify AI Assistant feature

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the Redux dev tool
* Identify the `wordpress-com/plans`
* Confirm the `features` prop key is part of the subtree root:
<img width="896" alt="Screenshot 2023-11-07 at 05 29 21" src="https://github.com/Automattic/jetpack/assets/77539/f2845f5b-edeb-43b7-9a94-0f9620fa8fc5">
* Open the dev console
* Get the AI Assistant feature data by using the `getAiAssistantFeature()` selector of the `wordpress-com/store`

```js
wp.data.select( 'wordpress-com/plans' ).getAiAssistantFeature();
```

* Confirm the app pulls and fills the subtree

<img width="900" alt="Screenshot 2023-11-07 at 05 32 46" src="https://github.com/Automattic/jetpack/assets/77539/2406146c-63b2-4047-ad22-8899ae5b5128">


* Hard refresh 
* Open the Network tab
* Get the data again

```js
wp.data.select( 'wordpress-com/plans' ).getAiAssistantFeature();
```

* Confirm the client performs the request to get the AI Assistant Feature data
* Get the data again
* Confirm the client does not perform a new request 

<img width="899" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/4addc174-244e-4ac3-9c6d-3649c7c4541d">

