### PR TITLE
Jetpack Plans: address TS issues

### DIFF
--- a/projects/plugins/jetpack/changelog/update-address-ai-assistant-feature-data-types
+++ b/projects/plugins/jetpack/changelog/update-address-ai-assistant-feature-data-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack Plans: address TS issues

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -6,27 +6,8 @@ import { useEffect, useState } from '@wordpress/element';
 /**
  * Types & constants
  */
-export type UpgradeTypeProp = 'vip' | 'default';
+import { AIFeatureProps } from '../../../../store/wordpress-com/types';
 import type { SiteAIAssistantFeatureEndpointResponseProps } from '../../../../types';
-
-export type AIFeatureProps = {
-	hasFeature: boolean;
-	isOverLimit: boolean;
-	requestsCount: number;
-	requestsLimit: number;
-	requireUpgrade: boolean;
-	errorMessage: string;
-	errorCode: string;
-	upgradeType: UpgradeTypeProp;
-	currentTier: {
-		value: 0 | 1 | 100 | 200 | 500;
-	};
-	usagePeriod: {
-		currentStart: string;
-		nextStart: string;
-		requestsCount: number;
-	};
-};
 
 const NUM_FREE_REQUESTS_LIMIT = 20;
 

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -6,23 +6,8 @@ import { createReduxStore, register } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { AIFeatureProps } from '../../blocks/ai-assistant/hooks/use-ai-feature';
-import { SiteAIAssistantFeatureEndpointResponseProps } from '../../types';
-/**
- * Types & Constants
- */
-type Plan = {
-	product_id: number;
-	product_name: string;
-	product_slug: string;
-};
-
-type PlanStateProps = {
-	plans: Array< Plan >;
-	features: {
-		aiAssistant?: AIFeatureProps;
-	};
-};
+import type { AIFeatureProps, Plan, PlanStateProps } from '../../store/wordpress-com/types';
+import type { SiteAIAssistantFeatureEndpointResponseProps } from '../../types';
 
 const store = 'wordpress-com/plans';
 
@@ -46,7 +31,7 @@ const actions = {
 		};
 	},
 
-	storeAiAssistantFeature( feature: Feature ) {
+	storeAiAssistantFeature( feature: AIFeatureProps ) {
 		return {
 			type: 'STORE_AI_ASSISTANT_FEATURE',
 			feature,

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -17,14 +17,10 @@ type Plan = {
 	product_slug: string;
 };
 
-type Feature = AIFeatureProps & {
-	feature_slug: 'AI_ASSISTANT' | string;
-};
-
 type PlanStateProps = {
 	plans: Array< Plan >;
 	features: {
-		aiAssistant?: Feature;
+		aiAssistant?: AIFeatureProps;
 	};
 };
 

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
@@ -1,0 +1,33 @@
+export type Plan = {
+	product_id: number;
+	product_name: string;
+	product_slug: string;
+};
+
+export type PlanStateProps = {
+	plans: Array< Plan >;
+	features: {
+		aiAssistant?: AIFeatureProps;
+	};
+};
+
+// AI Assistant feature props
+export type UpgradeTypeProp = 'vip' | 'default';
+export type AIFeatureProps = {
+	hasFeature: boolean;
+	isOverLimit: boolean;
+	requestsCount: number;
+	requestsLimit: number;
+	requireUpgrade: boolean;
+	errorMessage: string;
+	errorCode: string;
+	upgradeType: UpgradeTypeProp;
+	currentTier: {
+		value: 0 | 1 | 100 | 200 | 500;
+	};
+	usagePeriod: {
+		currentStart: string;
+		nextStart: string;
+		requestsCount: number;
+	};
+};

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
@@ -13,6 +13,7 @@ export type PlanStateProps = {
 
 // AI Assistant feature props
 export type UpgradeTypeProp = 'vip' | 'default';
+export type TierValueProp = 1 | 20 | 100 | 200 | 500;
 export type AIFeatureProps = {
 	hasFeature: boolean;
 	isOverLimit: boolean;
@@ -23,7 +24,7 @@ export type AIFeatureProps = {
 	errorCode: string;
 	upgradeType: UpgradeTypeProp;
 	currentTier: {
-		value: 0 | 1 | 100 | 200 | 500;
+		value: TierValueProp;
 	};
 	usagePeriod: {
 		currentStart: string;

--- a/projects/plugins/jetpack/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/types.ts
@@ -21,7 +21,7 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'error-code'?: string;
 	'is-playground-visible'?: boolean;
 	'upgrade-type': UpgradeTypeProp;
-	'currnet-tier': {
+	'current-tier': {
 		value: TierValueProp;
 	};
 	'tier-plans': Array< {

--- a/projects/plugins/jetpack/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/types.ts
@@ -1,7 +1,7 @@
 /**
  * Types for the AI Assistant feature.
  */
-import { UpgradeTypeProp } from './store/wordpress-com/types';
+import type { TierValueProp, UpgradeTypeProp } from './store/wordpress-com/types';
 
 /*
  * `sites/$site/ai-assistant-feature` endpoint response body props
@@ -22,11 +22,11 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'is-playground-visible'?: boolean;
 	'upgrade-type': UpgradeTypeProp;
 	'currnet-tier': {
-		value: 1 | 20 | 100 | 200 | 500;
+		value: TierValueProp;
 	};
 	'tier-plans': Array< {
 		slug: string;
 		limit: number;
-		value: 1 | 20 | 100 | 200 | 500;
+		value: TierValueProp;
 	} >;
 };

--- a/projects/plugins/jetpack/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/types.ts
@@ -1,7 +1,7 @@
 /**
  * Types for the AI Assistant feature.
  */
-import { UpgradeTypeProp } from './blocks/ai-assistant/hooks/use-ai-feature';
+import { UpgradeTypeProp } from './store/wordpress-com/types';
 
 /*
  * `sites/$site/ai-assistant-feature` endpoint response body props

--- a/projects/plugins/jetpack/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/types.ts
@@ -11,9 +11,22 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'is-over-limit': boolean;
 	'requests-count': number;
 	'requests-limit': number;
+	'usage-period': {
+		'current-start': string;
+		'next-start': string;
+		'requests-count': number;
+	};
 	'site-require-upgrade': boolean;
-	'error-message': string;
-	'error-code': string;
-	'is-playground-visible': boolean;
+	'error-message'?: string;
+	'error-code'?: string;
+	'is-playground-visible'?: boolean;
 	'upgrade-type': UpgradeTypeProp;
+	'currnet-tier': {
+		value: 1 | 20 | 100 | 200 | 500;
+	};
+	'tier-plans': Array< {
+		slug: string;
+		limit: number;
+		value: 1 | 20 | 100 | 200 | 500;
+	} >;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR addresses a few TypeScript issues in the plans and AI Assistant feature data implementation:

* Creates a new `types.ts` file in the `./extensions/store/wordpress-com` folder
* Move TS definitions there
* Update importing TS definitions from there

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack Plans: reorganize and address TS issues

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

No significant changes here in terms of functionality. Anyway, you'll be able to check the store works as usual. Please follow the texting instructions of https://github.com/Automattic/jetpack/pull/33985