### PR TITLE
Update Users menu for consistency on Jetpack sites.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribers-menu-for-jetpack
+++ b/projects/plugins/jetpack/changelog/update-subscribers-menu-for-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Calypso for Jetpack: add "Subscribers" and "My profile" under Users menu

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -231,8 +231,11 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		if ( current_user_can( 'list_users' ) ) {
 			$users_url = 'https://wordpress.com/people/team/' . $this->domain;
 			add_menu_page( esc_attr__( 'Users', 'jetpack' ), __( 'Users', 'jetpack' ), 'list_users', $users_url, null, 'dashicons-admin-users', 70 );
-			add_submenu_page( $users_url, esc_attr__( 'Subscribers', 'jetpack' ), __( 'Subscribers', 'jetpack' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null, 1 );
-			add_submenu_page( $users_url, esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', 'https://wordpress.com/me', null, 2 );
+			add_submenu_page( $users_url, esc_attr__( 'All Users', 'jetpack' ), __( 'All Users', 'jetpack' ), 'list_users', $users_url, null, 10 );
+			add_submenu_page( $users_url, esc_attr__( 'Add New User', 'jetpack' ), __( 'Add New User', 'jetpack' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 20 );
+			add_submenu_page( $users_url, esc_attr__( 'Subscribers', 'jetpack' ), __( 'Subscribers', 'jetpack' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null, 30 );
+			add_submenu_page( $users_url, esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', 'https://wordpress.com/me', null, 40 );
+			add_submenu_page( $users_url, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account', null, 50 );
 		} else {
 			add_menu_page( esc_attr__( 'My Profile', 'jetpack' ), __( 'Profile', 'jetpack' ), 'read', 'https://wordpress.com/me', null, 'dashicons-admin-users', 70 );
 		}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -193,7 +193,6 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 			}
 		}
 		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack' ), __( 'Scan', 'jetpack' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $position );
-		add_submenu_page( 'jetpack', esc_attr__( 'Subscribers', 'jetpack' ), __( 'Subscribers', 'jetpack' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null, 3 );
 	}
 
 	/**
@@ -230,7 +229,10 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_users_menu() {
 		if ( current_user_can( 'list_users' ) ) {
-			add_menu_page( esc_attr__( 'Users', 'jetpack' ), __( 'Users', 'jetpack' ), 'list_users', 'https://wordpress.com/people/team/' . $this->domain, null, 'dashicons-admin-users', 70 );
+			$users_url = 'https://wordpress.com/people/team/' . $this->domain;
+			add_menu_page( esc_attr__( 'Users', 'jetpack' ), __( 'Users', 'jetpack' ), 'list_users', $users_url, null, 'dashicons-admin-users', 70 );
+			add_submenu_page( $users_url, esc_attr__( 'Subscribers', 'jetpack' ), __( 'Subscribers', 'jetpack' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null, 1 );
+			add_submenu_page( $users_url, esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', 'https://wordpress.com/me', null, 2 );
 		} else {
 			add_menu_page( esc_attr__( 'My Profile', 'jetpack' ), __( 'Profile', 'jetpack' ), 'read', 'https://wordpress.com/me', null, 'dashicons-admin-users', 70 );
 		}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -99,7 +99,6 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_jetpack_menu();
 		$this->assertSame( 'https://wordpress.com/scan/' . static::$domain, $submenu['jetpack'][2][2] );
-		$this->assertSame( 'https://wordpress.com/subscribers/' . static::$domain, $submenu['jetpack'][3][2] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Updates to Calypso sidebar for Jetpack sites.

**Before**
![image](https://github.com/Automattic/jetpack/assets/87168/f598a98b-fa83-42e0-ba2e-ca1c839eb4a2)

## Proposed changes:
* Move "Subscribers" from under "Jetpack" menu to under "Users", making it identical with how it's for .com sites.
* Set the "Users" menu structure to:
  * Users
    * All Users
    * Add New User
    * Subscribers
    * My Profile
    * Account settings

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1699458787077189/1695900277.676929-slack-C02TCEHP3HA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

**Check the menu structure:**
* Have Jurassic Tube up & running (PCYsg-snO-p2).
* Go to `wordpress.com/people/team/<your_jurassic_tube_site>.jurassic.tube`.
* You should see the following menu structure:
  * Users
    * All Users
    * Add New User
    * Subscribers
    * My Profile
    * Account settings

**Test the unit test:**
- Run `jetpack docker phpunit -- --filter=Test_Jetpack_Admin_Menu`.
- Run `jetpack docker phpunit-multisite -- --filter=Test_Jetpack_Admin_Menu`.
- Test should pass.

## Screenshots

<img width="1081" alt="image" src="https://github.com/Automattic/jetpack/assets/1287077/e627fb0e-1f95-4992-8039-496bf283143a">
