### PR TITLE
AI Assistant: use new WPCOM helper methods

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -396,7 +396,7 @@ class Jetpack_AI_Helper {
 				'is-over-limit'        => $is_over_limit,
 				'requests-count'       => $requests_count,
 				'requests-limit'       => $requests_limit,
-				'usage-period'         => WPCOM\Jetpack_AI\Usage\Helper::get_usage_period( $blog_id ),
+				'usage-period'         => WPCOM\Jetpack_AI\Usage\Helper::get_period_data( $blog_id ),
 				'site-require-upgrade' => $require_upgrade,
 				'upgrade-type'         => $upgrade_type,
 				'current-tier'         => WPCOM\Jetpack_AI\Usage\Helper::get_current_tier( $blog_id ),

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -385,24 +385,6 @@ class Jetpack_AI_Helper {
 			$requests_limit = \OpenAI_Limit_Usage::get_free_requests_limit( $blog_id );
 			$requests_count = \OpenAI_Request_Count::get_count( $blog_id );
 
-			/*
-			 * Usage since the last plan purchase day
-			 */
-			$usage_period_start          = null;
-			$usage_next_period_start     = null;
-			$usage_period_requests_count = 0;
-
-			/*
-			 * Get current tier value, a number representing
-			 * the current tier of the site.
-			 *
-			 * - 0 represents a site with the free plan.
-			 * - 1 represents a site with the current, unlimited plan.
-			 * - 100, 200, 500 represents a site with the new plans,
-			 * with the respective number of allowed requests.
-			 */
-			$current_tier_value = $has_ai_assistant_feature ? 1 : 0;
-
 			// Check if the site requires an upgrade.
 			$require_upgrade = $is_over_limit && ! $has_ai_assistant_feature;
 
@@ -414,16 +396,10 @@ class Jetpack_AI_Helper {
 				'is-over-limit'        => $is_over_limit,
 				'requests-count'       => $requests_count,
 				'requests-limit'       => $requests_limit,
-				'usage-period'         => array(
-					'current-start'  => $usage_period_start,
-					'next-start'     => $usage_next_period_start,
-					'requests-count' => $usage_period_requests_count,
-				),
+				'usage-period'         => WPCOM\Jetpack_AI\Usage\Helper::get_usage_period( $blog_id ),
 				'site-require-upgrade' => $require_upgrade,
 				'upgrade-type'         => $upgrade_type,
-				'current-tier'         => array(
-					'value' => $current_tier_value,
-				),
+				'current-tier'         => WPCOM\Jetpack_AI\Usage\Helper::get_current_tier( $blog_id ),
 				'tier-plans'           => WPCOM\Jetpack_AI\Usage\Helper::get_tier_plans_list(),
 			);
 		}

--- a/projects/plugins/jetpack/changelog/change-use-wpcom-helpers
+++ b/projects/plugins/jetpack/changelog/change-use-wpcom-helpers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Use the new methods on WPCOM helper to build the AI assistant feature payload


### PR DESCRIPTION
Update our helper lib to use newly introduced methods on WPCOM helper.

Fixes #33937 

Depends on D128110-code

## Proposed changes:
This PR uses the new methods to determine tiered plans information on the AI Asisstant feature endpoint payload.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-1Ty-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use your sandbox with the patch D128110-code applied. Either instruct your local instance of JN to use  your sandbox. Also aim you machine to use the sandbox (as some requests come right out of the browser). Remember to enable global http.

Open the editor and check the value of `Jetpack_Editor_Initial_State['ai-assistant']` in the console.
It should contain a prop `current-tier` holding an object:
```js
current-tier: {
  slug: 'some-slug',
  limit: XXX,
  value: XXX,
}
```