### PR TITLE
Related Posts: define feature name so the block can be displayed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-broken-related-posts-block
+++ b/projects/plugins/jetpack/changelog/fix-broken-related-posts-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Related Posts: ensure the Related Posts Block can be displayed properly.

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/related-posts.php
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/related-posts.php
@@ -44,7 +44,7 @@ function render_block( $attributes, $content ) {
 	// If the Related Posts module is not active, don't render the block.
 	if (
 		! ( new Host() )->is_wpcom_simple()
-		&& ! ( new Modules() )->is_active( FEATURE_NAME )
+		&& ! ( new Modules() )->is_active( 'related-posts' )
 	) {
 		return '';
 	}


### PR DESCRIPTION
Fixes #33958

## Proposed changes:

In #33682, we removed `FEATURE_NAME`, even though we still relied on that constant downer in the file. Let's define `related-posts` so the module check can work and the block can be displayed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Start with a self-hosted site connected to WordPress.com, where you've published more than 10 posts.

* Go to Jetpack > Settings > Traffic
* Enable the Related Posts feature
* Go to Apperance > Themes
* Switch to a classic theme like Twenty Twenty
* Visit one of your posts; you should see 3 related posts at the bottom of the post.
* Go back to Appearance > Themes
* Switch to a block theme like Twenty Twenty Three
* Go to Appearance > Editor > Templates > Single posts
* Edit the template and add a Related Posts block somewhere, in the post meta for example.
* Save your changes.
* Visit that same post on the frontend again
    * You should see the related posts.
