### PR TITLE
AI Assistant: register isFetching state in the plans store

### DIFF
--- a/projects/plugins/jetpack/changelog/update-store-wordpress-com-introduce-is-fetching-in-assistant
+++ b/projects/plugins/jetpack/changelog/update-store-wordpress-com-introduce-is-fetching-in-assistant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: register isFetching state in the plans store

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
@@ -1,8 +1,42 @@
 /**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+/**
  * Types
  */
 import type { Plan } from './types';
 import type { AiFeatureProps } from './types';
+import type { SiteAIAssistantFeatureEndpointResponseProps } from '../../types';
+
+/**
+ * Map the response from the `sites/$site/ai-assistant-feature`
+ * endpoint to the AI Assistant feature props.
+ * @param { SiteAIAssistantFeatureEndpointResponseProps } response - The response from the endpoint.
+ * @returns { AiFeatureProps }                                       The AI Assistant feature props.
+ */
+export function mapAIFeatureResponseToAiFeatureProps(
+	response: SiteAIAssistantFeatureEndpointResponseProps
+): AiFeatureProps {
+	return {
+		hasFeature: !! response[ 'has-feature' ],
+		isOverLimit: !! response[ 'is-over-limit' ],
+		requestsCount: response[ 'requests-count' ],
+		requestsLimit: response[ 'requests-limit' ],
+		requireUpgrade: !! response[ 'site-require-upgrade' ],
+		errorMessage: response[ 'error-message' ],
+		errorCode: response[ 'error-code' ],
+		upgradeType: response[ 'upgrade-type' ],
+		usagePeriod: {
+			currentStart: response[ 'usage-period' ]?.[ 'current-start' ],
+			nextStart: response[ 'usage-period' ]?.[ 'next-start' ],
+			requestsCount: response[ 'usage-period' ]?.[ 'requests-count' ] || 0,
+		},
+		currentTier: {
+			value: response[ 'current-tier' ]?.value || 1,
+		},
+	};
+}
 
 const actions = {
 	setPlans( plans: Array< Plan > ) {
@@ -23,6 +57,29 @@ const actions = {
 		return {
 			type: 'STORE_AI_ASSISTANT_FEATURE',
 			feature,
+		};
+	},
+
+	/**
+	 * Thunk action to fetch the AI Assistant feature from the API.
+	 *
+	 * @returns {Function} The thunk action.
+	 */
+	fetchAiAssistantFeature() {
+		return async ( { dispatch } ) => {
+			try {
+				const response: SiteAIAssistantFeatureEndpointResponseProps = await apiFetch( {
+					path: '/wpcom/v2/jetpack-ai/ai-assistant-feature',
+				} );
+
+				// Store the feature in the store.
+				dispatch(
+					actions.storeAiAssistantFeature( mapAIFeatureResponseToAiFeatureProps( response ) )
+				);
+			} catch ( err ) {
+				// @todo: Handle error.
+				console.error( err ); // eslint-disable-line no-console
+			}
 		};
 	},
 };

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
@@ -67,6 +67,9 @@ const actions = {
 	 */
 	fetchAiAssistantFeature() {
 		return async ( { dispatch } ) => {
+			// Dispatch isFetching action.
+			dispatch( { type: 'REQUEST_AI_ASSISTANT_FEATURE' } );
+
 			try {
 				const response: SiteAIAssistantFeatureEndpointResponseProps = await apiFetch( {
 					path: '/wpcom/v2/jetpack-ai/ai-assistant-feature',

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -29,12 +29,27 @@ const wordpressPlansStore = createReduxStore( store, {
 					plans: action.plans,
 				};
 
+			case 'REQUEST_AI_ASSISTANT_FEATURE':
+				return {
+					...state,
+					features: {
+						...state.features,
+						aiAssistant: {
+							...state.features.aiAssistant,
+							isFetching: true,
+						},
+					},
+				};
+
 			case 'STORE_AI_ASSISTANT_FEATURE': {
 				return {
 					...state,
 					features: {
 						...state.features,
-						aiAssistant: action.feature,
+						aiAssistant: {
+							...action.feature,
+							isFetching: false,
+						},
 					},
 				};
 			}

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -15,7 +15,29 @@ const store = 'wordpress-com/plans';
 
 const INITIAL_STATE: PlanStateProps = {
 	plans: [],
-	features: {},
+	features: {
+		aiAssistant: {
+			hasFeature: false,
+			isOverLimit: false,
+			requestsCount: 0,
+			requestsLimit: 0,
+			requireUpgrade: false,
+			errorMessage: '',
+			errorCode: '',
+			upgradeType: 'default',
+			currentTier: {
+				value: 1,
+			},
+			usagePeriod: {
+				currentStart: '',
+				nextStart: '',
+				requestsCount: 0,
+			},
+			_meta: {
+				isRequesting: false,
+			},
+		},
+	},
 };
 
 const wordpressPlansStore = createReduxStore( store, {

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { createReduxStore, register } from '@wordpress/data';
 /**
  * Internal dependencies
@@ -10,8 +9,7 @@ import actions from './actions';
 /**
  * Types
  */
-import type { AiFeatureProps, PlanStateProps } from './types';
-import type { SiteAIAssistantFeatureEndpointResponseProps } from '../../types';
+import type { PlanStateProps } from './types';
 
 const store = 'wordpress-com/plans';
 
@@ -19,35 +17,6 @@ const INITIAL_STATE: PlanStateProps = {
 	plans: [],
 	features: {},
 };
-
-/**
- * Map the response from the `sites/$site/ai-assistant-feature`
- * endpoint to the AI Assistant feature props.
- * @param { SiteAIAssistantFeatureEndpointResponseProps } response - The response from the endpoint.
- * @returns { AiFeatureProps }                                       The AI Assistant feature props.
- */
-function mapAIFeatureResponseToAiFeatureProps(
-	response: SiteAIAssistantFeatureEndpointResponseProps
-): AiFeatureProps {
-	return {
-		hasFeature: !! response[ 'has-feature' ],
-		isOverLimit: !! response[ 'is-over-limit' ],
-		requestsCount: response[ 'requests-count' ],
-		requestsLimit: response[ 'requests-limit' ],
-		requireUpgrade: !! response[ 'site-require-upgrade' ],
-		errorMessage: response[ 'error-message' ],
-		errorCode: response[ 'error-code' ],
-		upgradeType: response[ 'upgrade-type' ],
-		usagePeriod: {
-			currentStart: response[ 'usage-period' ]?.[ 'current-start' ],
-			nextStart: response[ 'usage-period' ]?.[ 'next-start' ],
-			requestsCount: response[ 'usage-period' ]?.[ 'requests-count' ] || 0,
-		},
-		currentTier: {
-			value: response[ 'current-tier' ]?.value || 1,
-		},
-	};
-}
 
 const wordpressPlansStore = createReduxStore( store, {
 	__experimentalUseThunks: true,
@@ -117,18 +86,13 @@ const wordpressPlansStore = createReduxStore( store, {
 			return actions.setPlans( plans );
 		},
 
-		getAiAssistantFeature:
-			() =>
-			async ( { dispatch } ) => {
-				const response: SiteAIAssistantFeatureEndpointResponseProps = await apiFetch( {
-					path: '/wpcom/v2/jetpack-ai/ai-assistant-feature',
-				} );
+		getAiAssistantFeature: ( state: PlanStateProps ) => {
+			if ( state?.features?.aiAssistant ) {
+				return;
+			}
 
-				// Store the feature in the store.
-				dispatch(
-					actions.storeAiAssistantFeature( mapAIFeatureResponseToAiFeatureProps( response ) )
-				);
-			},
+			return actions.fetchAiAssistantFeature();
+		},
 	},
 } );
 

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -36,7 +36,10 @@ const wordpressPlansStore = createReduxStore( store, {
 						...state.features,
 						aiAssistant: {
 							...state.features.aiAssistant,
-							isRequesting: true,
+							_meta: {
+								...state.features.aiAssistant._meta,
+								isRequesting: true,
+							},
 						},
 					},
 				};
@@ -48,7 +51,10 @@ const wordpressPlansStore = createReduxStore( store, {
 						...state.features,
 						aiAssistant: {
 							...action.feature,
-							isRequesting: false,
+							_meta: {
+								...state.features.aiAssistant._meta,
+								isRequesting: false,
+							},
 						},
 					},
 				};

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -36,7 +36,7 @@ const wordpressPlansStore = createReduxStore( store, {
 						...state.features,
 						aiAssistant: {
 							...state.features.aiAssistant,
-							isFetching: true,
+							isRequesting: true,
 						},
 					},
 				};
@@ -48,7 +48,7 @@ const wordpressPlansStore = createReduxStore( store, {
 						...state.features,
 						aiAssistant: {
 							...action.feature,
-							isFetching: false,
+							isRequesting: false,
 						},
 					},
 				};

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
@@ -31,4 +31,7 @@ export type AiFeatureProps = {
 		nextStart: string;
 		requestsCount: number;
 	};
+	_meta?: {
+		isRequesting: boolean;
+	};
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The plan to connect the components with the store is through the [useAIFeature()](https://github.com/Automattic/jetpack/blob/afb03aeefc43aa0041b415975ce2c6cca78801c9/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts#L60) custom hook. For this, we need:

* An action to request the data (this PR)
* Register the requesting state in the store (this PR)
* Store the error when something wrong happens (follow-up)

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: register isFetching state in the plans store

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the Redux tool and the dev console
* Dispatch the `fetchAiAssistantFeature()` action

```js
wp.data.dispatch( 'wordpress-com/plans' ).fetchAiAssistantFeature()
```
* Confirm you see the `isRequesting` state into the proper `_meta` prop:

https://github.com/Automattic/jetpack/assets/77539/f034860a-8110-4a4a-9a36-417d8d5a35b2
