### PR TITLE
Remove/unneeded condition from product data api

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
@@ -118,6 +118,10 @@ const WithBackupsValueSection = ( { lastUndoableEvent } ) => {
 	}
 	const { last_rewindable_event: lastRewindableEvent = {} } = lastUndoableEvent.data;
 
+	if ( ! lastRewindableEvent ) {
+		return null;
+	}
+
 	return (
 		<div className={ styles.activity }>
 			<Gridicon icon={ lastRewindableEvent.gridicon } size={ 24 } />
@@ -189,7 +193,7 @@ const BackupCard = ( { admin, productData, fetchingProductData } ) => {
 		productData || {};
 
 	const lastRewindableEventTime = lastUndoableEvent?.data?.last_rewindable_event?.published;
-	const hasRewindableEvent = hasBackups && lastUndoableEvent?.data;
+	const hasRewindableEvent = hasBackups && lastUndoableEvent?.data?.last_rewindable_event;
 	const undoBackupId = lastUndoableEvent?.data?.undo_backup_id;
 
 	const handleUndoClick = () => {

--- a/projects/packages/my-jetpack/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/packages/my-jetpack/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remove condition from the backup undoable event call, this datapoint will be removed

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -75,7 +75,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.12.x-dev"
+			"dev-trunk": "3.13.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.12.3-alpha",
+	"version": "3.13.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.12.3-alpha';
+	const PACKAGE_VERSION = '3.13.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -64,7 +64,6 @@ class REST_Product_Data {
 
 		// If site has backups and the realtime backup capability, add latest undo event
 		if (
-			$body->backups->last_finished_backup_time &&
 			in_array( 'backup-realtime', $capabilities->data['capabilities'], true )
 		) {
 			$body->backups->last_undoable_event = self::get_site_backup_undo_event();

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -62,15 +62,15 @@ class REST_Product_Data {
 
 		$capabilities = self::get_backup_capabilities();
 
+		if ( is_wp_error( $response ) || empty( $response['body'] ) || 200 !== $response_code ) {
+			return new WP_Error( 'site_products_data_fetch_failed', 'Site products data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
+		}
+
 		// If site has backups and the realtime backup capability, add latest undo event
 		if (
 			in_array( 'backup-realtime', $capabilities->data['capabilities'], true )
 		) {
 			$body->backups->last_undoable_event = self::get_site_backup_undo_event();
-		}
-
-		if ( is_wp_error( $response ) || empty( $response['body'] ) || 200 !== $response_code ) {
-			return new WP_Error( 'site_products_data_fetch_failed', 'Site products data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
 		}
 
 		return rest_ensure_response( $body, 200 );
@@ -112,24 +112,13 @@ class REST_Product_Data {
 	 * This will fetch the last rewindable event from the Activity Log and
 	 * the last rewind_id prior to that.
 	 *
-	 * @param int $page - numbered page of activity logs to fetch.
-	 *
 	 * @return array|WP_Error|null
 	 */
-	public static function get_site_backup_undo_event( $page = null ) {
-		if ( ! $page ) {
-			$page = 1;
-		}
-
-		// Cap out at checking 10 pages of activity log
-		if ( $page >= 10 ) {
-			return null;
-		}
-
+	public static function get_site_backup_undo_event() {
 		$blog_id = \Jetpack_Options::get_option( 'id' );
 
 		$response = Client::wpcom_json_api_request_as_user(
-			'/sites/' . $blog_id . '/activity?force=wpcom&page=' . $page,
+			'/sites/' . $blog_id . '/activity/rewindable?force=wpcom',
 			'v2',
 			array(),
 			null,
@@ -143,11 +132,6 @@ class REST_Product_Data {
 		$body = json_decode( $response['body'], true );
 
 		if ( ! isset( $body['current'] ) ) {
-			return null;
-		}
-
-		// If page has no item, we have reached the end of the activity log.
-		if ( ! isset( $body['current']['orderedItems'] ) || count( $body['current']['orderedItems'] ) === 0 ) {
 			return null;
 		}
 
@@ -182,12 +166,6 @@ class REST_Product_Data {
 					break;
 				}
 			}
-		}
-
-		// Keep checking for rewindable event until one is found.
-		if ( $undo_event['last_rewindable_event'] === null || $undo_event['undo_backup_id'] === null ) {
-			$new_page = $page + 1;
-			return self::get_site_backup_undo_event( $new_page );
 		}
 
 		return rest_ensure_response( $undo_event, 200 );

--- a/projects/plugins/backup/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/plugins/backup/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just updating lockfile
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -899,7 +899,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -930,7 +930,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/plugins/boost/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just updating lockfile
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -954,7 +954,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -985,7 +985,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/plugins/jetpack/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Just updating lockfile
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1638,7 +1638,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1669,7 +1669,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/plugins/migration/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just updating lockfile
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -899,7 +899,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -930,7 +930,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/plugins/protect/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just updating lockfile
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -845,7 +845,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/plugins/search/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just updating lockfile
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -845,7 +845,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/plugins/social/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just updating lockfile
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -845,7 +845,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/plugins/starter-plugin/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just updating lockfile
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -845,7 +845,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/plugins/videopress/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just updating lockfile
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -814,7 +814,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -845,7 +845,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
## Proposed changes:

The backend of the product data is being stripped a bit since we are not pulling live activity log data from that endpoint. The last_finished_backup_time datapoint is being removed, and this is not used in any previous version of the plugin since that change has not yet been released in a Jetpack version, so we should be good to remove it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a P2 generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-pn9-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch
2. Get your local docker environement up and running
3. Point your local environment to your sandbox ( I have to enable global-http to get this working sometimes)
4. Patch D127975-code to your sandbox
5. Without VaultPress backup being installed, go to My Jetpack
6. You should see the unpurchased state of the card with a summary of what can be backed up on the site (if you had vaultpress backup and just cancelled it, I had some caching issues with it still returning as "active" on the backend, wasn't able to track down where that cache is set yet)
![image](https://github.com/Automattic/jetpack/assets/65001528/e5b1f694-949d-4309-8030-bf62ca313276)
7. Purchase a VaultPress backup subscription and wait for there to be a backup. Add an asset like an image or video and wait for a realtime backup to be created.
8. Head back to My Jetpack and you should see the purchased state of the card
![image](https://github.com/Automattic/jetpack/assets/65001528/65fa245b-bac7-4b4d-90d1-720df9671e2d)
