### PR TITLE
Fix/media endpoint length

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-media-endpoing-length
+++ b/projects/plugins/jetpack/changelog/fix-media-endpoing-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add duration for videopress and media files that might have it set

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1663,6 +1663,14 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$response['length'] = $metadata['length'];
 			}
 
+			if ( empty( $response['length'] ) && isset( $metadata['duration'] ) ) {
+				$response['length'] = (int) $metadata['duration'];
+			}
+
+			if ( empty( $response['length'] ) && isset( $metadata['videopress']['duration'] ) ) {
+				$response['length'] = ceil( $metadata['videopress']['duration'] / 1000 );
+			}
+
 			// add VideoPress info.
 			if ( function_exists( 'video_get_info_by_blogpostid' ) ) {
 				$info = video_get_info_by_blogpostid( $this->api->get_blog_id_for_output(), $media_item->ID );

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -987,6 +987,14 @@ abstract class SAL_Post {
 				$response['length'] = $metadata['length'];
 			}
 
+			if ( empty( $response['length'] ) && isset( $metadata['duration'] ) ) {
+				$response['length'] = (int) $metadata['duration'];
+			}
+
+			if ( empty( $response['length'] ) && isset( $metadata['videopress']['duration'] ) ) {
+				$response['length'] = ceil( $metadata['videopress']['duration'] / 1000 );
+			}
+
 			// add VideoPress info.
 			if ( function_exists( 'video_get_info_by_blogpostid' ) ) {
 				$info = video_get_info_by_blogpostid( $this->site->get_id(), $media_id );


### PR DESCRIPTION
This PR fixes the unavailability of media length for a subset of video. 
For P2 and VideoPress videos. 

## Proposed changes:
This PR makes the duration of a particular videos available on a v1.1/sites/site_id/media/post_id endpoint 
by looking for the media duration on the meta data object in more places. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Upload a videopress file. Notice now that the videopress duration is now visible. 
https://wordpress.com/media/videos/example.com

Load this change on .com and sandbox the public-api.wordpress.com and notice that media on p2s has a duration. 

