### PR TITLE
Prevent PHP Warning by checking for undefined font name

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-font-name-undefined
+++ b/projects/plugins/jetpack/changelog/fix-font-name-undefined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix the PHP warning that happens when the font name is not defined.

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -92,7 +92,9 @@ function jetpack_get_theme_fonts_map() {
 
 	$theme_fonts_map = array();
 	foreach ( $raw_data['settings']['typography']['fontFamilies'] as $font_family ) {
-		$theme_fonts_map[ $font_family['name'] ] = true;
+		if ( isset( $font_family['name'] ) ) {
+			$theme_fonts_map[ $font_family['name'] ] = true;
+		}
 	}
 
 	return $theme_fonts_map;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: p1699390137684919-slack-CBG1CP4EN

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR prevents PHP Warning (`PHP Warning: Undefined array key "name" in /wordpress/plugins/jetpack/12.8-beta/modules/google-fonts/current/load-google-fonts.php on line 95 `) by checking if the font name is set. 

- This warning occurs when the `name` property within `settings.typography.fontFamilies.<font-object>` in your active theme's `theme.json` is undefined. 
- The `name` property is used to exclude certain fonts already provided by the theme. So, fonts lacking the `name` property were not filtered before. This PR does not alter that original behavior.

Related: https://github.com/Automattic/jetpack/pull/33203

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a [Jurassic Ninja sandbox](https://jurassic.ninja/create/?jetpack-beta&branch=fix/font-name-undefined) against this PR.
* Install Gutenberg
* Go to `/wp-admin/admin.php?page=jetpack_modules` to activate the “Google Fonts (Beta)” module
* Verify the Font Library works
	* Go to the Site Editor
	* Select Styles > Typography > Text > Font
	* Ensure you're able to see all Google Fonts in the list
	* See https://jetpack.com/support/google-fonts/ for more info
* Verify it prevents PHP Warning
	* In the `theme.json` of your active theme, remove `settings.typography.fontFamilies.<font-object>.name` with `vi apps/<user-name>/public/wp-content/themes/twentytwentyfour/theme.json`
	* See no PHP Warning with `tail -f apps/<user-name>/public/wp-content/debug.log`