### PR TITLE
Launchpad: Take id_map into consideration when checking wpcom_launchpad_is_task_option_completed

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad_is_task_complete_id_map
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad_is_task_complete_id_map
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Take id_map in consideration when checking if a task is completed inside wpcom_launchpad_is_task_option_completed.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1071,6 +1071,9 @@ function wpcom_launchpad_is_task_option_completed( $task ) {
 	if ( ! empty( $checklist[ $task['id'] ] ) ) {
 		return true;
 	}
+	if ( isset( $task['id_map'] ) && ! empty( $checklist[ $task['id_map'] ] ) ) {
+		return true;
+	}
 	return false;
 }
 


### PR DESCRIPTION
## Proposed changes:
- This adds a check for the task's id_map inside wpcom_launchpad_is_task_option_completed

We were marking a task as complete in Calypso with 

```
				updateLaunchpadSettings( site?.slug , {
					checklist_statuses: { import_subscribers: false },
				} );
```

However, since `import_subscribers` had its id_map set to subscribers_added, the `wpcom_launchpad_is_task_option_completed` call returned false.

@daledupreez this is how id_map should work right? 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Code review should be fine. If you want to do otherwise, apply this PR to your environment. Add the Subscriber Launchpad PR (https://github.com/Automattic/wp-calypso/pull/83996), and then add some links to enable/disable the task:

```
			<a href="#" onClick={e => {
				e.preventDefault();
				updateLaunchpadSettings( site?.slug , {
					checklist_statuses: { import_subscribers: true },
				} );
				queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );

			}}>Mark as complete</a> - 
			<a href="#" onClick={e => {
				e.preventDefault();
				updateLaunchpadSettings( site?.slug , {
					checklist_statuses: { import_subscribers: false },
				} );
				queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );

			}}>Mark as incomplete</a>
```

But really, code review should be fine 😀