### PR TITLE
Update gravatar profile shortcode

### DIFF
--- a/projects/plugins/jetpack/changelog/update-gravatar-profile-shortcode
+++ b/projects/plugins/jetpack/changelog/update-gravatar-profile-shortcode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Use the same retrieval process as the gravatar widget by requesting the json from Gravatar

--- a/projects/plugins/jetpack/changelog/update-gravatar-profile-shortcode
+++ b/projects/plugins/jetpack/changelog/update-gravatar-profile-shortcode
@@ -1,4 +1,4 @@
-Significance: minor
-Type: enhancement
+Significance: patch
+Type: bugfix
 
-Use the same retrieval process as the gravatar widget by requesting the json from Gravatar
+Shortcode embeds: fix and refactor the display of Gravatars and Gravatar profiless.

--- a/projects/plugins/jetpack/modules/shortcodes/gravatar.php
+++ b/projects/plugins/jetpack/modules/shortcodes/gravatar.php
@@ -79,7 +79,12 @@ function jetpack_gravatar_profile_shortcode( $atts ) {
 
 	// Can specify username, user ID, or email address.
 	if ( is_numeric( $atts['who'] ) ) {
-		$user = get_user_by( 'id', (int) $atts['who'] );
+		$user_id = (int) $atts['who'];
+		if ( ! is_user_member_of_blog( $user_id, get_current_blog_id() ) ) {
+			// Bail if the user id is not a member of this site.
+			return false;
+		}
+		$user = get_user_by( 'id', $user_id );
 	} elseif ( is_email( $atts['who'] ) ) {
 		$user = get_user_by( 'email', sanitize_email( $atts['who'] ) );
 	} elseif ( is_string( $atts['who'] ) ) {
@@ -93,16 +98,60 @@ function jetpack_gravatar_profile_shortcode( $atts ) {
 		return false;
 	}
 
+	$hashed_email = hash( 'sha256', strtolower( trim( $user->user_email ) ) );
+	$cache_key    = 'grofile-' . $hashed_email;
+	$profile      = get_transient( $cache_key );
+
+	if ( empty( $profile ) ) {
+		$profile_url = sprintf(
+			'https://secure.gravatar.com/%s.json',
+			$hashed_email
+		);
+
+		$expire        = 300;
+		$response      = wp_remote_get(
+			esc_url_raw( $profile_url ),
+			array( 'User-Agent' => 'WordPress.com Gravatar Profile Widget' )
+		);
+		$response_code = wp_remote_retrieve_response_code( $response );
+
+		if ( $response_code === 200 ) {
+			$profile = wp_remote_retrieve_body( $response );
+			$profile = json_decode( $profile, true );
+
+			if ( is_array( $profile ) && ! empty( $profile['entry'] ) && is_array( $profile['entry'] ) ) {
+				// Cache for 15 minutes.
+				$expire  = 900;
+				$profile = $profile['entry'][0];
+			} else {
+				// Something strange happened.  Cache for 5 minutes.
+				$profile = array();
+			}
+		} else {
+			// Cache for 15 minutes.
+			$expire  = 900;
+			$profile = array();
+		}
+
+		set_transient( $cache_key, $profile, $expire );
+	}
+
+	if ( empty( $profile ) ) {
+		return false;
+	}
+
 	// Render the shortcode.
-	$gravatar_url = 'https://gravatar.com/' . $user->user_login;
+	$gravatar_url     = 'https://gravatar.com/' . $hashed_email;
+	$user_location    = ! empty( $profile['currentLocation'] ) ? $profile['currentLocation'] : '';
+	$display_name     = ! empty( $profile['displayName'] ) ? $profile['displayName'] : '';
+	$user_description = ! empty( $profile['aboutMe'] ) ? $profile['aboutMe'] : '';
 
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$avatar_url    = wpcom_get_avatar_url( $user->ID, 96 );
-		$avatar_url    = $avatar_url[0];
-		$user_location = get_user_attribute( $user->ID, 'location' );
+		$gravatar_url = 'https://gravatar.com/' . $user->user_login;
+		$avatar_url   = wpcom_get_avatar_url( $user->ID, 96 );
+		$avatar_url   = $avatar_url[0];
 	} else {
-		$avatar_url    = get_avatar_url( $user->user_email, array( 'size' => 96 ) );
-		$user_location = get_user_meta( $user->ID, 'location', true );
+		$avatar_url = get_avatar_url( $user->user_email, array( 'size' => 96 ) );
 	}
 
 	ob_start();
@@ -146,13 +195,15 @@ function jetpack_gravatar_profile_shortcode( $atts ) {
 			</div>
 			<div class="grofile-right">
 				<p class="grofile-name fn">
-					<strong><?php echo esc_html( $user->display_name ); ?></strong>
+					<strong><?php echo esc_html( $display_name ); ?></strong>
 					<?php
 					if ( ! empty( $user_location ) ) :
 						?>
 						<br><span class="grofile-location adr"><?php echo esc_html( $user_location ); ?></span><?php endif; ?>
 				</p>
-				<p class="grofile-bio"><strong><?php esc_html_e( 'Bio:', 'jetpack' ); ?></strong> <?php echo wp_kses_post( $user->description ); ?></p>
+				<p class="grofile-bio">
+					<strong><?php esc_html_e( 'Bio:', 'jetpack' ); ?></strong> <?php echo wp_kses_post( $user_description ); ?>
+				</p>
 				<p class="grofile-view">
 					<a href="<?php echo esc_url( $gravatar_url ); ?>"><?php esc_html_e( 'View complete profile', 'jetpack' ); ?></a>
 				</p>

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.gravatar.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.gravatar.php
@@ -56,8 +56,82 @@ class WP_Test_Jetpack_Shortcodes_Gravatar extends WP_UnitTestCase {
 		);
 		wp_set_current_user( $user->ID );
 
+		$http_request_filter = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode(
+					array(
+						'entry' => array(
+							array(
+								'currentLocation' => 'San Francisco',
+								'displayName'     => 'Gravatar',
+								'aboutMe'         => 'Gravatar is a free service for providing globally-unique avatars.',
+							),
+						),
+					)
+				),
+			);
+		};
+
+		add_filter( 'pre_http_request', $http_request_filter, 10, 1 );
+
 		$shortcode_content = do_shortcode( $content );
 		$this->assertStringContainsString( '<div class="grofile vcard" id="grofile-embed-0">', $shortcode_content );
 		$this->assertStringContainsString( '<img src="http://2.gravatar.com/avatar/572c3489ea700045927076136a969e27?s=96&#038;d=mm&#038;r=g" width="96" height="96" class="no-grav gravatar photo"', $shortcode_content );
+
+		remove_filter( 'pre_http_request', $http_request_filter, 10, 1 );
+	}
+
+	/**
+	 * Verify that rendering the Gravatar profile shortcode returns a profile using user id
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_gravatar_user_id() {
+		$user    = self::factory()->user->create_and_get( array( 'user_email' => 'user@example.org' ) );
+		$content = "[gravatar_profile who='$user->ID']";
+		wp_set_current_user( $user->ID );
+
+		$http_request_filter = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode(
+					array(
+						'entry' => array( array( 'displayName' => 'Gravatar' ) ),
+					)
+				),
+			);
+		};
+
+		add_filter( 'pre_http_request', $http_request_filter, 10, 1 );
+
+		$shortcode_content = do_shortcode( $content );
+		$this->assertStringContainsString( '<img src="http://2.gravatar.com/avatar/572c3489ea700045927076136a969e27?s=96&#038;d=mm&#038;r=g" width="96" height="96" class="no-grav gravatar photo"', $shortcode_content );
+
+		remove_filter( 'pre_http_request', $http_request_filter, 10, 1 );
+	}
+
+	/**
+	 * Verify that rendering the Gravatar profile shortcode returns a profile using user id
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_gravatar_no_profile() {
+		$user    = self::factory()->user->create_and_get( array( 'user_email' => 'user@example.org' ) );
+		$content = "[gravatar_profile who='$user->ID']";
+		wp_set_current_user( $user->ID );
+
+		$http_request_filter = function () {
+			return array(
+				'response' => array( 'code' => 404 ),
+			);
+		};
+
+		add_filter( 'pre_http_request', $http_request_filter, 10, 1 );
+
+		$shortcode_content = do_shortcode( $content );
+		$this->assertSame( '', $shortcode_content );
+
+		remove_filter( 'pre_http_request', $http_request_filter, 10, 1 );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p3btAN-2wb-p2 (GHE Gravatar 106081 issue)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Limit usage of gravatar profile shortcode to users in current blog when used with `who=<user_id>` attribute.
* Retrieving Gravatar user profile has been update to request the data from Gravatar similar to the [Widget](https://github.com/Automattic/jetpack/blob/455da7c1400b07696f566513da104fc5006320a0/projects/plugins/jetpack/modules/widgets/gravatar-profile.php#L443)
* Gravatar url was based on username but that will not be correct for non wpcom scenarios, it will now be based on the hashed email address

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Both on Dotcom or Dotorg simple/multisite
* Make sure regular `[gravatar_profile who="email"]` works as expected
* `[gravatar_profile who="user-id"]` works only for users of that blog