### PR TITLE
AI Assistant: introduce action to increase requests counter

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-reduce-requests
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-reduce-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: introduce action to increase requests counter

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
@@ -3,8 +3,9 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 /**
- * Types
+ * Types & Constants
  */
+import { AI_ASSISTANT_FEATURE_ENDPOINT } from './constants';
 import type { Plan } from './types';
 import type { AiFeatureProps } from './types';
 import type { SiteAIAssistantFeatureEndpointResponseProps } from '../../types';
@@ -72,7 +73,7 @@ const actions = {
 
 			try {
 				const response: SiteAIAssistantFeatureEndpointResponseProps = await apiFetch( {
-					path: '/wpcom/v2/jetpack-ai/ai-assistant-feature',
+					path: AI_ASSISTANT_FEATURE_ENDPOINT,
 				} );
 
 				// Store the feature in the store.

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
@@ -5,7 +5,14 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Types & Constants
  */
-import { AI_ASSISTANT_FEATURE_ENDPOINT } from './constants';
+import {
+	ACTION_FETCH_FROM_API,
+	ACTION_INCREASE_AI_ASSISTANT_REQUESTS_COUNT,
+	ACTION_REQUEST_AI_ASSISTANT_FEATURE,
+	ACTION_SET_PLANS,
+	ACTION_STORE_AI_ASSISTANT_FEATURE,
+	ENDPOINT_AI_ASSISTANT_FEATURE,
+} from './constants';
 import type { Plan } from './types';
 import type { AiFeatureProps } from './types';
 import type { SiteAIAssistantFeatureEndpointResponseProps } from '../../types';
@@ -42,21 +49,21 @@ export function mapAIFeatureResponseToAiFeatureProps(
 const actions = {
 	setPlans( plans: Array< Plan > ) {
 		return {
-			type: 'SET_PLANS',
+			type: ACTION_SET_PLANS,
 			plans,
 		};
 	},
 
 	fetchFromAPI( url: string ) {
 		return {
-			type: 'FETCH_FROM_API',
+			type: ACTION_FETCH_FROM_API,
 			url,
 		};
 	},
 
 	storeAiAssistantFeature( feature: AiFeatureProps ) {
 		return {
-			type: 'STORE_AI_ASSISTANT_FEATURE',
+			type: ACTION_STORE_AI_ASSISTANT_FEATURE,
 			feature,
 		};
 	},
@@ -69,11 +76,11 @@ const actions = {
 	fetchAiAssistantFeature() {
 		return async ( { dispatch } ) => {
 			// Dispatch isFetching action.
-			dispatch( { type: 'REQUEST_AI_ASSISTANT_FEATURE' } );
+			dispatch( { type: ACTION_REQUEST_AI_ASSISTANT_FEATURE } );
 
 			try {
 				const response: SiteAIAssistantFeatureEndpointResponseProps = await apiFetch( {
-					path: AI_ASSISTANT_FEATURE_ENDPOINT,
+					path: ENDPOINT_AI_ASSISTANT_FEATURE,
 				} );
 
 				// Store the feature in the store.
@@ -84,6 +91,13 @@ const actions = {
 				// @todo: Handle error.
 				console.error( err ); // eslint-disable-line no-console
 			}
+		};
+	},
+
+	increaseAiAssistantRequestsCount( count = 1 ) {
+		return {
+			type: ACTION_INCREASE_AI_ASSISTANT_REQUESTS_COUNT,
+			count,
 		};
 	},
 };

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/constants.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/constants.ts
@@ -1,0 +1,1 @@
+export const AI_ASSISTANT_FEATURE_ENDPOINT = '/wpcom/v2/jetpack-ai/ai-assistant-feature';

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/constants.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/constants.ts
@@ -1,1 +1,12 @@
-export const AI_ASSISTANT_FEATURE_ENDPOINT = '/wpcom/v2/jetpack-ai/ai-assistant-feature';
+/**
+ * Actions
+ */
+export const ACTION_SET_PLANS = 'SET_PLANS';
+export const ACTION_FETCH_FROM_API = 'FETCH_FROM_API';
+export const ACTION_STORE_AI_ASSISTANT_FEATURE = 'STORE_AI_ASSISTANT_FEATURE';
+export const ACTION_REQUEST_AI_ASSISTANT_FEATURE = 'REQUEST_AI_ASSISTANT_FEATURE';
+export const ACTION_INCREASE_AI_ASSISTANT_REQUESTS_COUNT = 'INCREASE_AI_ASSISTANT_REQUESTS_COUNT';
+/**
+ * Endpoints
+ */
+export const ENDPOINT_AI_ASSISTANT_FEATURE = '/wpcom/v2/jetpack-ai/ai-assistant-feature';

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -6,6 +6,7 @@ import { createReduxStore, register } from '@wordpress/data';
  * Internal dependencies
  */
 import actions from './actions';
+import reducer from './reducer';
 /**
  * Types
  */
@@ -13,80 +14,12 @@ import type { PlanStateProps } from './types';
 
 const store = 'wordpress-com/plans';
 
-const INITIAL_STATE: PlanStateProps = {
-	plans: [],
-	features: {
-		aiAssistant: {
-			hasFeature: false,
-			isOverLimit: false,
-			requestsCount: 0,
-			requestsLimit: 0,
-			requireUpgrade: false,
-			errorMessage: '',
-			errorCode: '',
-			upgradeType: 'default',
-			currentTier: {
-				value: 1,
-			},
-			usagePeriod: {
-				currentStart: '',
-				nextStart: '',
-				requestsCount: 0,
-			},
-			_meta: {
-				isRequesting: false,
-			},
-		},
-	},
-};
-
 const wordpressPlansStore = createReduxStore( store, {
 	__experimentalUseThunks: true,
 
-	reducer( state = INITIAL_STATE, action ) {
-		switch ( action.type ) {
-			case 'SET_PLANS':
-				return {
-					...state,
-					plans: action.plans,
-				};
-
-			case 'REQUEST_AI_ASSISTANT_FEATURE':
-				return {
-					...state,
-					features: {
-						...state.features,
-						aiAssistant: {
-							...state.features.aiAssistant,
-							_meta: {
-								...state.features.aiAssistant._meta,
-								isRequesting: true,
-							},
-						},
-					},
-				};
-
-			case 'STORE_AI_ASSISTANT_FEATURE': {
-				return {
-					...state,
-					features: {
-						...state.features,
-						aiAssistant: {
-							...action.feature,
-							_meta: {
-								...state.features.aiAssistant._meta,
-								isRequesting: false,
-							},
-						},
-					},
-				};
-			}
-		}
-
-		return state;
-	},
-
 	actions,
+
+	reducer,
 
 	selectors: {
 		/*

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -2,6 +2,7 @@
  * Types
  */
 import {
+	ACTION_INCREASE_AI_ASSISTANT_REQUESTS_COUNT,
 	ACTION_REQUEST_AI_ASSISTANT_FEATURE,
 	ACTION_SET_PLANS,
 	ACTION_STORE_AI_ASSISTANT_FEATURE,
@@ -69,6 +70,19 @@ export default function reducer( state = INITIAL_STATE, action ) {
 							...state.features.aiAssistant._meta,
 							isRequesting: false,
 						},
+					},
+				},
+			};
+		}
+
+		case ACTION_INCREASE_AI_ASSISTANT_REQUESTS_COUNT: {
+			return {
+				...state,
+				features: {
+					...state.features,
+					aiAssistant: {
+						...state.features.aiAssistant,
+						requestsCount: state.features.aiAssistant.requestsCount + action.count,
 					},
 				},
 			};

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -1,0 +1,79 @@
+/**
+ * Types
+ */
+import {
+	ACTION_REQUEST_AI_ASSISTANT_FEATURE,
+	ACTION_SET_PLANS,
+	ACTION_STORE_AI_ASSISTANT_FEATURE,
+} from './constants';
+import type { PlanStateProps } from './types';
+
+const INITIAL_STATE: PlanStateProps = {
+	plans: [],
+	features: {
+		aiAssistant: {
+			hasFeature: false,
+			isOverLimit: false,
+			requestsCount: 0,
+			requestsLimit: 0,
+			requireUpgrade: false,
+			errorMessage: '',
+			errorCode: '',
+			upgradeType: 'default',
+			currentTier: {
+				value: 1,
+			},
+			usagePeriod: {
+				currentStart: '',
+				nextStart: '',
+				requestsCount: 0,
+			},
+			_meta: {
+				isRequesting: false,
+			},
+		},
+	},
+};
+
+export default function reducer( state = INITIAL_STATE, action ) {
+	switch ( action.type ) {
+		case ACTION_SET_PLANS:
+			return {
+				...state,
+				plans: action.plans,
+			};
+
+		case ACTION_REQUEST_AI_ASSISTANT_FEATURE:
+			return {
+				...state,
+				features: {
+					...state.features,
+					aiAssistant: {
+						...state.features.aiAssistant,
+						_meta: {
+							...state.features.aiAssistant._meta,
+							isRequesting: true,
+						},
+					},
+				},
+			};
+
+		case ACTION_STORE_AI_ASSISTANT_FEATURE: {
+			return {
+				...state,
+				features: {
+					...state.features,
+					aiAssistant: {
+						...action.feature,
+						_meta: {
+							...state.features.aiAssistant._meta,
+							isRequesting: false,
+						},
+					},
+				},
+			};
+		}
+	}
+
+	return state;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In order to make the app optimistic when computing the AI requests count, this PR introduces a new action to deal with it.
It isn't used yet.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: introduce action to increase requests counter


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the dev console
* Open the Redux tool
* Filter the `wordpress-com/plans` store
* Populate the store by getting the AI Assistant feature data

https://github.com/Automattic/jetpack/assets/77539/a40fa1f7-a2bb-4217-ad54-266683ea9915

