### PR TITLE
Subscribe Block: Fix regression in the editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-editor
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribe Block: Fix display in the editor.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -286,29 +286,31 @@ export function SubscriptionEdit( props ) {
 			) }
 
 			<div className={ getBlockClassName() } style={ cssVars }>
-				<div className="wp-block-jetpack-subscriptions__form" role="form">
-					<div className="wp-block-jetpack-subscriptions__form-elements">
-						<TextControl
-							placeholder={ subscribePlaceholder }
-							disabled={ true }
-							className={ classnames(
-								emailFieldClasses,
-								'wp-block-jetpack-subscriptions__textfield'
-							) }
-							style={ emailFieldStyles }
-						/>
-						<RichText
-							className={ classnames(
-								buttonClasses,
-								'wp-block-jetpack-subscriptions__button',
-								'wp-block-button__link'
-							) }
-							onChange={ value => setAttributes( { submitButtonText: value } ) }
-							style={ buttonStyles }
-							value={ submitButtonText }
-							withoutInteractiveFormatting
-							allowedFormats={ [ 'core/bold', 'core/italic', 'core/strikethrough' ] }
-						/>
+				<div className="jetpack_subscription_widget is-not-subscriber">
+					<div className="wp-block-jetpack-subscriptions__form" role="form">
+						<div className="wp-block-jetpack-subscriptions__form-elements">
+							<TextControl
+								placeholder={ subscribePlaceholder }
+								disabled={ true }
+								className={ classnames(
+									emailFieldClasses,
+									'wp-block-jetpack-subscriptions__textfield'
+								) }
+								style={ emailFieldStyles }
+							/>
+							<RichText
+								className={ classnames(
+									buttonClasses,
+									'wp-block-jetpack-subscriptions__button',
+									'wp-block-button__link'
+								) }
+								onChange={ value => setAttributes( { submitButtonText: value } ) }
+								style={ buttonStyles }
+								value={ submitButtonText }
+								withoutInteractiveFormatting
+								allowedFormats={ [ 'core/bold', 'core/italic', 'core/strikethrough' ] }
+							/>
+						</div>
 					</div>
 				</div>
 				{ showSubscribersTotal && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34043

Needs a follow up investigation to make sure changing display settings works well.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
After:
<img width="645" alt="Screenshot 2023-11-08 at 16 10 42" src="https://github.com/Automattic/jetpack/assets/104869/b421244f-a136-49a0-9db5-5d78f3cc1ccc">

Before:
<img width="663" alt="Screenshot 2023-11-08 at 15 53 12" src="https://github.com/Automattic/jetpack/assets/104869/83e4a1c6-94d2-4b64-8437-e748935b3267">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a subscribe block in the editor

