### PR TITLE
AI Client: ensure dispatching unclear error prompt once per request/response

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-client-dispatch-unclear-prompt-once
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-dispatch-unclear-prompt-once
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: ensure dispatching unclear error prompt once per request/response

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.1.14",
+	"version": "0.1.15-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -161,7 +161,7 @@ export default class SuggestionsEventSource extends EventTarget {
 		}
 
 		// Clean the unclear prompt trigger flag
-		this._error_unclear_prompt_triggered = false;
+		this.errorUnclearPromptTriggered = false;
 
 		await fetchEventSource( url, {
 			openWhenHidden: true,
@@ -267,10 +267,10 @@ export default class SuggestionsEventSource extends EventTarget {
 			 * Check if the unclear prompt event was already dispatched,
 			 * to ensure that it is dispatched only once per request.
 			 */
-			if ( this._error_unclear_prompt_triggered ) {
+			if ( this.errorUnclearPromptTriggered ) {
 				return;
 			}
-			this._error_unclear_prompt_triggered = true;
+			this.errorUnclearPromptTriggered = true;
 
 			// The unclear prompt marker was found, so we dispatch an error event
 			this.dispatchEvent( new CustomEvent( ERROR_UNCLEAR_PROMPT ) );

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -264,7 +264,7 @@ export default class SuggestionsEventSource extends EventTarget {
 		const replacedMessage = this.fullMessage.replace( /__|(\*\*)/g, '' );
 		if ( replacedMessage.startsWith( 'JETPACK_AI_ERROR' ) ) {
 			/*
-			 * Check if the unclear prompt even was already dispatched,
+			 * Check if the unclear prompt event was already dispatched,
 			 * to ensure that it is dispatched only once per request.
 			 */
 			if ( this._error_unclear_prompt_triggered ) {

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -73,7 +73,7 @@ export default class SuggestionsEventSource extends EventTarget {
 	controller: AbortController;
 
 	// Flag to detect if the unclear prompt event was already dispatched
-	_error_unclear_prompt_triggered: boolean;
+	errorUnclearPromptTriggered: boolean;
 
 	constructor( data: SuggestionsEventSourceConstructorArgs ) {
 		super();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an issue that happens when detecting the `Unclear prompt error`.
The app tries to catch the error searching by the `JETPACK_AI_ERROR` string in the streaming connection.
Sometimes, and depending on the streaming data, the app dispatches the error twice (or maybe more?) because:

* The method is called twice
* The fullMessage prop contains the `JETPACK_AI_ERROR`

To fix this issue, I've introduced a flag in order to avoid more than one dispatch per request

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: ensure dispatching unclear error prompt once per request/response


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Use the debug() lines
* Create an AI Assistant block instance
* Introduce an unclear prompt
* Request
* Confirm that, always, the app dispatched the event once per request, looking at the debug line:

<img width="566" alt="Screenshot 2023-11-08 at 14 37 09" src="https://github.com/Automattic/jetpack/assets/77539/85fbab7e-c77c-4726-b32d-f61935c669c5">


