### PR TITLE
Add two bots signature to device detection

### DIFF
--- a/projects/packages/device-detection/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/packages/device-detection/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow cookieinformationscanner and facebookexternalhit to be detected as bots

--- a/projects/packages/device-detection/composer.json
+++ b/projects/packages/device-detection/composer.json
@@ -42,7 +42,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.4.x-dev"
+			"dev-trunk": "1.5.x-dev"
 		}
 	}
 }

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -1559,6 +1559,8 @@ class User_Agent_Info {
 			'domaintunocrawler',
 			'grapeshotcrawler',
 			'cloudflare-alwaysonline',
+			'cookieinformationscanner', // p1699315886066389-slack-C0438NHCLSY
+			'facebookexternalhit', // https://www.facebook.com/externalhit_uatext.php
 		);
 
 		foreach ( $bot_agents as $bot_agent ) {

--- a/projects/plugins/backup/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/plugins/backup/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -548,7 +548,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "fef1f53b844143c5358061d969d7472bb321af18"
+                "reference": "fd0107efb4a3e0f3c2d37c6955a1c83b172e1499"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -565,7 +565,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/plugins/boost/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -596,7 +596,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "fef1f53b844143c5358061d969d7472bb321af18"
+                "reference": "fd0107efb4a3e0f3c2d37c6955a1c83b172e1499"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -613,7 +613,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/plugins/jetpack/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -981,7 +981,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "fef1f53b844143c5358061d969d7472bb321af18"
+                "reference": "fd0107efb4a3e0f3c2d37c6955a1c83b172e1499"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -998,7 +998,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/migration/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/plugins/migration/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -548,7 +548,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "fef1f53b844143c5358061d969d7472bb321af18"
+                "reference": "fd0107efb4a3e0f3c2d37c6955a1c83b172e1499"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -565,7 +565,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/plugins/protect/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -463,7 +463,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "fef1f53b844143c5358061d969d7472bb321af18"
+                "reference": "fd0107efb4a3e0f3c2d37c6955a1c83b172e1499"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -480,7 +480,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/plugins/search/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -463,7 +463,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "fef1f53b844143c5358061d969d7472bb321af18"
+                "reference": "fd0107efb4a3e0f3c2d37c6955a1c83b172e1499"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -480,7 +480,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/plugins/social/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -463,7 +463,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "fef1f53b844143c5358061d969d7472bb321af18"
+                "reference": "fd0107efb4a3e0f3c2d37c6955a1c83b172e1499"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -480,7 +480,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/plugins/starter-plugin/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -463,7 +463,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "fef1f53b844143c5358061d969d7472bb321af18"
+                "reference": "fd0107efb4a3e0f3c2d37c6955a1c83b172e1499"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -480,7 +480,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/super-cache/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/plugins/super-cache/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/super-cache/composer.json
+++ b/projects/plugins/super-cache/composer.json
@@ -51,6 +51,6 @@
 		"wp-svn-autopublish": true
 	},
 	"config": {
-		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_11_0"
+		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_11_1_alpha"
 	}
 }

--- a/projects/plugins/super-cache/composer.lock
+++ b/projects/plugins/super-cache/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "fef1f53b844143c5358061d969d7472bb321af18"
+                "reference": "fd0107efb4a3e0f3c2d37c6955a1c83b172e1499"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -29,7 +29,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/super-cache/package.json
+++ b/projects/plugins/super-cache/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-super-cache",
-	"version": "1.11.0",
+	"version": "1.11.1-alpha",
 	"description": "A very fast caching engine for WordPress that produces static html files.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Super Cache
  * Plugin URI: https://wordpress.org/plugins/wp-super-cache/
  * Description: Very fast caching plugin for WordPress.
- * Version: 1.11.0
+ * Version: 1.11.1-alpha
  * Author: Automattic
  * Author URI: https://automattic.com/
  * License: GPL2+

--- a/projects/plugins/videopress/changelog/update-add-bots-sig-to-ua-detection
+++ b/projects/plugins/videopress/changelog/update-add-bots-sig-to-ua-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -463,7 +463,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "fef1f53b844143c5358061d969d7472bb321af18"
+                "reference": "fd0107efb4a3e0f3c2d37c6955a1c83b172e1499"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -480,7 +480,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Fixes #33460

## Proposed changes:

Allow `cookieinformationscanner` and `facebookexternalhit` to be detected as bots, so that parse-logs.php on wpcom and other consumer would be able to filter traffic with the `is_bot` function provided by the package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1699315886066389-slack-C0438NHCLSY

## Does this pull request change what data or activity we track or use?
Yes but we don't need to change anything

## Testing instructions:
* Install the change on wpcom sandbox following instructions at https://github.com/Automattic/jetpack/pull/34026#issuecomment-1802723111
* Add the following lines to ` bin/stats/parsing/test.log`
```
Blacklisted user agents
1.2.3.4 NL - [01/Nov/2023:16:34:06 +0000] "GET /g.gif?v=ext&blog=88888888&post=0&tz=-7&srv=phenomenex.blog&hp=atomic&ac=2&amp=0&j=1%3A12.8-a.11&host=adfadf.blog&ref=&fcp=2379&rand=0.5537117580377822 HTTP/2.0" "https://phenomenex.blog/tag/mass-spectrometry/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36(KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36 CookieInformationScanner"
1.2.3.4 US - [01/Nov/2023:16:34:06 +0000] "GET /g.gif?v=ext&blog=88888888&post=0&tz=-7&srv=adfadf.blog&hp=atomic&ac=2&amp=0&j=1%3A12.8-a.11&host=phenomenex.blog&ref=&fcp=2379&rand=0.5537117580377822 HTTP/2.0" "https://phenomenex.blog/tag/mass-spectrometry/" "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"

```
* Run `php ./bin/stats/parsing/parse-logs.php`
* Open `bin/stats/parsing/test.sql`
* Ensure you do not see any SQL with blog id `88888888`