### PR TITLE
AI Assistant: add next-tier prop

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -400,6 +400,7 @@ class Jetpack_AI_Helper {
 				'site-require-upgrade' => $require_upgrade,
 				'upgrade-type'         => $upgrade_type,
 				'current-tier'         => WPCOM\Jetpack_AI\Usage\Helper::get_current_tier( $blog_id ),
+				'next-tier'            => WPCOM\Jetpack_AI\Usage\Helper::get_next_tier( $blog_id ),
 				'tier-plans'           => WPCOM\Jetpack_AI\Usage\Helper::get_tier_plans_list(),
 			);
 		}

--- a/projects/plugins/jetpack/changelog/add-jp-helper-next-tier
+++ b/projects/plugins/jetpack/changelog/add-jp-helper-next-tier
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add next-tier prop to the AI assistant feature endpoint response. Add the prop to hooks and statee

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -25,6 +25,7 @@ export const AI_Assistant_Initial_State = {
 	currentTier: {
 		value: aiAssistantFeature?.[ 'current-tier' ]?.value || 1,
 	},
+	nextTier: aiAssistantFeature?.[ 'next-tier' ] || null,
 };
 
 export default function useAiFeature() {

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
@@ -43,6 +43,7 @@ export function mapAIFeatureResponseToAiFeatureProps(
 		currentTier: {
 			value: response[ 'current-tier' ]?.value || 1,
 		},
+		nextTier: null,
 	};
 }
 

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
@@ -43,7 +43,7 @@ export function mapAIFeatureResponseToAiFeatureProps(
 		currentTier: {
 			value: response[ 'current-tier' ]?.value || 1,
 		},
-		nextTier: null,
+		nextTier: response[ 'next-tier' ] || null,
 	};
 }
 

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -32,6 +32,7 @@ const INITIAL_STATE: PlanStateProps = {
 			_meta: {
 				isRequesting: false,
 			},
+			nextTier: null,
 		},
 	},
 };

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
@@ -31,11 +31,11 @@ export type AiFeatureProps = {
 		nextStart: string;
 		requestsCount: number;
 	};
+	nextTier: null;
 };
 
 export type AiFeatureStateProps = AiFeatureProps & {
 	_meta?: {
 		isRequesting: boolean;
 	};
-	nextTier: null;
 };

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
@@ -37,4 +37,5 @@ export type AiFeatureStateProps = AiFeatureProps & {
 	_meta?: {
 		isRequesting: boolean;
 	};
+	nextTier: null;
 };

--- a/projects/plugins/jetpack/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/types.ts
@@ -29,4 +29,5 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 		limit: number;
 		value: TierValueProp;
 	} >;
+	'next-tier'?: null;
 };


### PR DESCRIPTION
Add `next-tier` prop to the AI assistant feature endpoint response

Fixes #

## Proposed changes:
This PR adds `next-tier` prop as part of the response from the AI assistant feature. It is provided with the same data shape as `current-tier` since they both come from the same collection. 

The PR also adds the prop to the frontend hooks and store, but it doesn't enforce the data shape yet.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Checkout and go to the editor, use the console to force the AI assistant feature fetch, see that the returned value includes `nextTier` as `null`
<img width="737" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/54905df1-037b-4c27-80cf-ae8c94894998">


Apply the patch on your sandbox, enable the filter by adding this line:
```php
add_filter( 'jetpack_ai_tier_plans_enabled', '__return_true' );
```

then look at the ai-assistant-feature response:
<img width="785" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/c5d656da-8e2b-4f3d-8096-4d3b3332a9fd">

<img width="594" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/a9c96b45-4f4f-4966-aa8e-ff4a4a6d7d96">

NOTE: without the filter enabled, you'll get default value `null` on `next-tier`