### PR TITLE
Update WooCommerce Analytics module to check for changed template names

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-template-name-change-warning
+++ b/projects/plugins/jetpack/changelog/fix-template-name-change-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix a PHP Warning when WooCommerce templates were not found due to a name change

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -217,6 +217,16 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 			$checkout_template = get_block_template( $checkout_template_id );
 		}
 
+		// Something failed with the template retrieval, return early with 0 values rather than let a warning appear.
+		if ( ! $cart_template || ! $checkout_template ) {
+			return array(
+				'cart_page_contains_cart_block'         => 0,
+				'cart_page_contains_cart_shortcode'     => 0,
+				'checkout_page_contains_checkout_block' => 0,
+				'checkout_page_contains_checkout_shortcode' => 0,
+			);
+		}
+
 		// Update the info transient with data we got from the templates, if the site isn't using WC Blocks we
 		// won't be doing this so no concern about overwriting.
 		$info = array(

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -194,14 +194,14 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		$cart_template_id     = null;
 		$checkout_template_id = null;
 		$block_controller     = Automattic\WooCommerce\Blocks\Package::container()->get( Automattic\WooCommerce\Blocks\BlockTemplatesController::class );
-		$templates            = $block_controller->get_block_templates( array( 'cart', 'checkout' ) );
+		$templates            = $block_controller->get_block_templates( array( 'cart', 'checkout', 'page-checkout', 'page-cart' ) );
 
 		foreach ( $templates as $template ) {
-			if ( 'cart' === $template->slug ) {
+			if ( 'cart' === $template->slug || 'page-cart' === $template->slug ) {
 				$cart_template_id = ( $template->id );
 				continue;
 			}
-			if ( 'checkout' === $template->slug ) {
+			if ( 'checkout' === $template->slug || 'page-checkout' === $template->slug ) {
 				$checkout_template_id = ( $template->id );
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
There is a PHP Warning when WooCommerce Cart/Checkout templates were not found. The templates are now called `page-checkout` and `page-cart` and the code has been updated to look for them.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Not a product discussion but a Slack comment from Beau - p1699478726251299-slack-C8X6Q7XQU

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure your store is set up to use and record WooCommerce Analytics
* Add items to your cart and go to a page with the Checkout block on
* Ensure no PHP Warnings are logged