### PR TITLE
Subscribe modal: fix lack of spacing in some themes 

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-modal-spacing
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-modal-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribe modal: fix lack of spacing in some themes

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -136,8 +136,8 @@ class Jetpack_Subscribe_Modal {
 		$subscribe_text     = __( 'Subscribe now to keep reading and get access to the full archive.', 'jetpack' );
 
 		return <<<HTML
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|70","right":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
-	<div class="wp-block-group has-border-color" style="border-color:#dddddd;border-width:1px;margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)">
+	<!-- wp:group {"style":{"spacing":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
+	<div class="wp-block-group has-border-color" style="border-color:#dddddd;border-width:1px;margin-top:0;margin-bottom:0;padding-top:32px;padding-right:32px;padding-bottom:32px;padding-left:32px">
 
 	<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"600","fontSize":"26px"},"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"4px","bottom":"10px"}}}} -->
 		<h2 class="wp-block-heading has-text-align-center" style="margin-top:4px;margin-bottom:10px;font-size:26px;font-style:normal;font-weight:600">$discover_more_from</h2>

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
@@ -28,6 +28,7 @@
 	border-radius: 10px;
 	box-sizing: border-box;
 	transition: all 0.4s;
+	text-wrap: balance;
 }
 
 .jetpack-subscribe-modal.open .jetpack-subscribe-modal__modal-content {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34034

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Switch using theme presets for spacing into fixed pixel values.
* Add "balance" text-wrap rule.

### Padding explained

I had hopend that presets would be similar across themes (they mostly are when I tested) but there are themes where spacing values are wildly different, and presets don't go up to 7 always. E.g. in TT4 they end up at 6:

<img src="https://github.com/Automattic/jetpack/assets/87168/9dc622ab-0b43-4996-8958-8f89e9c30d30" width="250" />


Now that we have fixed pixel values, we cannot rely theme setting different spacing for different screen sizes. We need to use the same value for mobile and wide screen.

**TT4 theme Before**

![image](https://github.com/Automattic/jetpack/assets/87168/c47cce91-191e-42cb-89c6-25bdc0f62935)

**TT4 theme After**

<img width="812" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/8b26f02b-6a53-4726-9beb-fb0f47855108">

### Text wrap explained

To help text flow better in mobile version, I'm also adding "balance" text-wrap rule.

Without the rule:

<img width="407" alt="Screenshot 2023-11-09 at 11 41 18" src="https://github.com/Automattic/jetpack/assets/87168/be1ab99c-e70e-4e33-b3bf-b973f4364ba9">

With the rule:
<img width="407" alt="Screenshot 2023-11-09 at 11 41 13" src="https://github.com/Automattic/jetpack/assets/87168/68cc734e-9bfb-4647-bb85-30b78a8e8289">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable subscribe modal from Newsletter settings. 
* Ensure you haven't modified the modal template locally; if you have, you must copy the group block's HTML from this PR into block editor's code view and save the markup. Or delete the template.
* Use the new [Twenty Twenty Four theme](https://wordpress.org/themes/twentytwentyfour/) ([Github](https://wordpress.org/themes/twentytwentyfour/))
* In incognito, go to a blog post and scroll down, see the modal
* Test how spacing works in different screen sizes.
* Test different themes, e.g. Lettre.
