### PR TITLE
Fix/subscribe modal showing to subscribers

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-modal-showing-to-subscribers
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-modal-showing-to-subscribers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribe Modal: don't show to subscribers

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -197,26 +197,10 @@ HTML;
 
 		// Don't show if user is subscribed to blog.
 		require_once __DIR__ . '/../views.php';
-		if ( $this->has_subscription_cookie() || Jetpack_Subscriptions_Widget::is_current_user_subscribed() ) {
+		if ( Jetpack_Memberships::is_current_user_subscribed() ) {
 			return false;
 		}
 		return true;
-	}
-
-	/**
-	 * Returns true if site visitor has subscribed
-	 * to the blog and has a subscription cookie.
-	 *
-	 * @return bool
-	 */
-	public function has_subscription_cookie() {
-		$cookies = $_COOKIE;
-		foreach ( $cookies as $name => $value ) {
-			if ( strpos( $name, 'jetpack_blog_subscribe_' ) !== false ) {
-				return true;
-			}
-		}
-		return false;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use new Jetpack_Memberships::is_current_user_subscribed in order to decide if we show the modal or not. The new method handles subscribers for Jetpack and WPCOM better.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Jetpack site make sure the subscribe modal doesn't show up if you are a subscriber

