### PR TITLE
Add/bloganuary add tags to bloganuary posts

### DIFF
--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -48,7 +48,7 @@ function jetpack_setup_blogging_prompt_response( $post_id ) {
 	if ( $prompt ) {
 		update_post_meta( $post_id, '_jetpack_blogging_prompt_key', $prompt_id );
 		wp_add_post_tags( $post_id, array( 'dailyprompt', "dailyprompt-$prompt_id" ) );
-		if ( ! empty( $prompt['bloganuary_id'] ) ) {
+		if ( array_key_exists( 'bloganuary_id', $prompt ) ) {
 			wp_add_post_tags( $post_id, array( 'bloganuary', $prompt['bloganuary_id'] ) );
 		}
 	}

--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -48,6 +48,9 @@ function jetpack_setup_blogging_prompt_response( $post_id ) {
 	if ( $prompt ) {
 		update_post_meta( $post_id, '_jetpack_blogging_prompt_key', $prompt_id );
 		wp_add_post_tags( $post_id, array( 'dailyprompt', "dailyprompt-$prompt_id" ) );
+		if ( ! empty( $prompt['bloganuary_id'] ) ) {
+			wp_add_post_tags( $post_id, array( 'bloganuary', $prompt['bloganuary_id'] ) );
+		}
 	}
 }
 
@@ -118,6 +121,8 @@ function jetpack_get_blogging_prompt_by_id( $prompt_id ) {
 
 	$request = new WP_REST_Request( 'GET', $route );
 	$request->set_param( '_locale', $locale );
+	$request->set_param( 'force_year', gmdate( 'Y' ) );
+
 	$response = rest_do_request( $request );
 
 	if ( $response->is_error() || WP_Http::OK !== $response->get_status() ) {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -128,6 +128,10 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 			return $this->proxy_request_to_wpcom( $request, $request->get_param( 'id' ) );
 		}
 
+		if ( $request->get_param( 'force_year' ) ) {
+			$this->force_year = $request->get_param( 'force_year' );
+		}
+
 		switch_to_blog( self::TEMPLATE_BLOG_ID );
 		$item = parent::get_item( $request );
 		restore_current_blog();

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -537,11 +537,11 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 		}
 
 		$response_status = wp_remote_retrieve_response_code( $response );
-		$response_body   = json_decode( wp_remote_retrieve_body( $response ) );
+		$response_body   = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		if ( $response_status >= 400 ) {
-			$code    = isset( $response_body->code ) ? $response_body->code : 'unknown_error';
-			$message = isset( $response_body->message ) ? $response_body->message : __( 'An unknown error occurred.', 'jetpack' );
+			$code    = isset( $response_body['code'] ) ? $response_body['code'] : 'unknown_error';
+			$message = isset( $response_body['message'] ) ? $response_body['message'] : __( 'An unknown error occurred.', 'jetpack' );
 			return new WP_Error( $code, $message, array( 'status' => $response_status ) );
 		}
 

--- a/projects/plugins/jetpack/changelog/add-bloganuary-add-tags
+++ b/projects/plugins/jetpack/changelog/add-bloganuary-add-tags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+add force_year param to individual get for blogging prompt. Add bloganuary tags for prompts in january.


### PR DESCRIPTION
Adds bloganuary tags as specified in pe7F0s-1iI-p2. Builds on https://github.com/Automattic/jetpack/pull/33852

When a prompt is created in January it now gets a `bloganuary_id` such as `bloganuary-2024-01` for the first prompt of January.

This PR adds tags `bloganuary` and `bloganuary-2024-01` to newly created posts created in January.


## Proposed changes:

I had to extend the blogging-prompts v3 api slightly so that the single GET for a prompt can take a `force_year` parameter. I then passed in `force_year` to the current year when adding tags. Otherwise the dates would be the original date which would be in 2020. I think it would have been possible to design this in a more robust way, but at this point I just want to get it all connected and working.
<img width="275" alt="Screen Shot 2023-11-09 at 11 46 10 pm" src="https://github.com/Automattic/jetpack/assets/22446385/84dc0e7f-fc5f-419a-888b-4452b2783af5">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ x ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
 pe7F0s-1iI-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply this diff to my wpcom sandbox.
Open the editor for a prompt in January e.g. 
`/post/$site_slug?answer_prompt=1812`
Edit the post.
Expand the post settings "tags" section as shown in screenshot above.
You should see the blogging prompt tags and also two bloganuary tags.
This should only happen for blogging prompts in January

It can also be tested in calypso along with https://github.com/Automattic/wp-calypso/pull/83696