### PR TITLE
AI Assistant: Add tier data shape and types

### DIFF
--- a/projects/plugins/jetpack/changelog/add-current-tier-data-shape
+++ b/projects/plugins/jetpack/changelog/add-current-tier-data-shape
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Introduce tier types and props for current and next tier

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -22,10 +22,8 @@ export const AI_Assistant_Initial_State = {
 		nextStart: aiAssistantFeature?.[ 'usage-period' ]?.[ 'next-start' ],
 		requestsCount: aiAssistantFeature?.[ 'usage-period' ]?.[ 'requests-count' ] || 0,
 	},
-	currentTier: {
-		value: aiAssistantFeature?.[ 'current-tier' ]?.value || 1,
-	},
-	nextTier: aiAssistantFeature?.[ 'next-tier' ] || {},
+	currentTier: aiAssistantFeature?.[ 'current-tier' ],
+	nextTier: aiAssistantFeature?.[ 'next-tier' ] || null,
 };
 
 export default function useAiFeature() {

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/actions.ts
@@ -40,10 +40,8 @@ export function mapAIFeatureResponseToAiFeatureProps(
 			nextStart: response[ 'usage-period' ]?.[ 'next-start' ],
 			requestsCount: response[ 'usage-period' ]?.[ 'requests-count' ] || 0,
 		},
-		currentTier: {
-			value: response[ 'current-tier' ]?.value || 1,
-		},
-		nextTier: response[ 'next-tier' ] || null,
+		currentTier: response[ 'current-tier' ],
+		nextTier: response[ 'next-tier' ],
 	};
 }
 

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -1,6 +1,7 @@
 /**
  * Types & Constants
  */
+import { __ } from '@wordpress/i18n';
 import {
 	ACTION_INCREASE_AI_ASSISTANT_REQUESTS_COUNT,
 	ACTION_REQUEST_AI_ASSISTANT_FEATURE,
@@ -22,7 +23,9 @@ const INITIAL_STATE: PlanStateProps = {
 			errorCode: '',
 			upgradeType: 'default',
 			currentTier: {
-				value: 1,
+				slug: 'ai-assistant-tier-free',
+				value: 0,
+				limit: 20,
 			},
 			usagePeriod: {
 				currentStart: '',
@@ -35,6 +38,8 @@ const INITIAL_STATE: PlanStateProps = {
 			nextTier: {
 				slug: 'ai-assistant-tier-unlimited',
 				value: 1,
+				limit: 922337203685477600,
+				readableLimit: __( 'Unlimited', 'jetpack' ),
 			},
 		},
 	},

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
@@ -8,15 +8,15 @@ export type UpgradeTypeProp = 'vip' | 'default';
 
 export type TierUnlimitedProps = {
 	slug: 'ai-assistant-tier-unlimited';
-	limit: 9223372036854776000n;
+	limit: 922337203685477600;
 	value: 1;
-	readableLimit: 'Unlimited';
+	readableLimit: string;
 };
 
 export type TierFreeProps = {
 	slug: 'ai-assistant-tier-free';
 	limit: 20;
-	value: 20;
+	value: 0;
 };
 
 export type Tier100Props = {
@@ -37,12 +37,27 @@ export type Tier500Props = {
 	value: 500;
 };
 
+export type TierProp = {
+	slug: TierSlugProp;
+	limit: TierLimitProp;
+	value: TierValueProp;
+	readableLimit?: string;
+};
+
+export type TierLimitProp =
+	| TierUnlimitedProps[ 'limit' ]
+	| TierFreeProps[ 'limit' ]
+	| Tier100Props[ 'limit' ]
+	| Tier200Props[ 'limit' ]
+	| Tier500Props[ 'limit' ];
+
 export type TierSlugProp =
 	| TierUnlimitedProps[ 'slug' ]
 	| TierFreeProps[ 'slug' ]
 	| Tier100Props[ 'slug' ]
 	| Tier200Props[ 'slug' ]
 	| Tier500Props[ 'slug' ];
+
 export type TierValueProp =
 	| TierUnlimitedProps[ 'value' ]
 	| TierFreeProps[ 'value' ]
@@ -59,20 +74,13 @@ export type AiFeatureProps = {
 	errorMessage: string;
 	errorCode: string;
 	upgradeType: UpgradeTypeProp;
-	currentTier: {
-		value: TierValueProp;
-	};
+	currentTier: TierFreeProps | Tier100Props | Tier200Props | Tier500Props | TierUnlimitedProps;
 	usagePeriod: {
 		currentStart: string;
 		nextStart: string;
 		requestsCount: number;
 	};
-	nextTier: {
-		slug: TierSlugProp;
-		value: TierValueProp;
-		limit?: number;
-		redeableLimit?: string;
-	};
+	nextTier: TierFreeProps | Tier100Props | Tier200Props | Tier500Props | TierUnlimitedProps;
 };
 
 // Type used in the `wordpress-com/plans` store.

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
@@ -74,13 +74,13 @@ export type AiFeatureProps = {
 	errorMessage: string;
 	errorCode: string;
 	upgradeType: UpgradeTypeProp;
-	currentTier: TierFreeProps | Tier100Props | Tier200Props | Tier500Props | TierUnlimitedProps;
+	currentTier: TierProp;
 	usagePeriod: {
 		currentStart: string;
 		nextStart: string;
 		requestsCount: number;
 	};
-	nextTier: TierFreeProps | Tier100Props | Tier200Props | Tier500Props | TierUnlimitedProps;
+	nextTier: TierProp | null;
 };
 
 // Type used in the `wordpress-com/plans` store.

--- a/projects/plugins/jetpack/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/types.ts
@@ -1,7 +1,15 @@
 /**
  * Types for the AI Assistant feature.
  */
-import type { TierSlugProp, TierValueProp, UpgradeTypeProp } from './store/wordpress-com/types';
+import type {
+	TierProp,
+	TierFreeProps,
+	TierUnlimitedProps,
+	UpgradeTypeProp,
+	Tier100Props,
+	Tier200Props,
+	Tier500Props,
+} from './store/wordpress-com/types';
 
 /*
  * `sites/$site/ai-assistant-feature` endpoint response body props
@@ -21,18 +29,13 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'error-code'?: string;
 	'is-playground-visible'?: boolean;
 	'upgrade-type': UpgradeTypeProp;
-	'current-tier': {
-		value: TierValueProp;
-	};
-	'tier-plans': Array< {
-		slug: TierSlugProp;
-		limit: number;
-		value: TierValueProp;
-	} >;
-	'next-tier'?: {
-		slug: TierSlugProp;
-		value: TierValueProp;
-		limit: number;
-		'redeable-limit': string;
-	};
+	'current-tier': TierFreeProps | TierUnlimitedProps | Tier100Props | Tier200Props | Tier500Props;
+	'tier-plans': Array< TierProp >;
+	'next-tier'?:
+		| TierFreeProps
+		| TierUnlimitedProps
+		| Tier100Props
+		| Tier200Props
+		| Tier500Props
+		| null;
 };

--- a/projects/plugins/jetpack/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/types.ts
@@ -1,15 +1,7 @@
 /**
  * Types for the AI Assistant feature.
  */
-import type {
-	TierProp,
-	TierFreeProps,
-	TierUnlimitedProps,
-	UpgradeTypeProp,
-	Tier100Props,
-	Tier200Props,
-	Tier500Props,
-} from './store/wordpress-com/types';
+import type { TierProp, UpgradeTypeProp } from './store/wordpress-com/types';
 
 /*
  * `sites/$site/ai-assistant-feature` endpoint response body props
@@ -29,13 +21,7 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'error-code'?: string;
 	'is-playground-visible'?: boolean;
 	'upgrade-type': UpgradeTypeProp;
-	'current-tier': TierFreeProps | TierUnlimitedProps | Tier100Props | Tier200Props | Tier500Props;
+	'current-tier': TierProp;
 	'tier-plans': Array< TierProp >;
-	'next-tier'?:
-		| TierFreeProps
-		| TierUnlimitedProps
-		| Tier100Props
-		| Tier200Props
-		| Tier500Props
-		| null;
+	'next-tier'?: TierProp | null;
 };


### PR DESCRIPTION
Add ts types for tiers

Fixes #

## Proposed changes:
This PR adds the definitions for tier types, including the limit prop and the optional readableLimit

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The change should introduce no errors. Keep the console open and use any flow to trigger AI usage:
- open usage panel
- use AI assistant block
- use Form block and ask assistant to build
- use suggestions from AI assistant on paragraphs