### PR TITLE
Jetpack form: memoize the onDone and onError callbacks passed to the hook

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-from-ai-assistant-memoize-callbacks
+++ b/projects/plugins/jetpack/changelog/update-jetpack-from-ai-assistant-memoize-callbacks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack form: memoize the onDone and onError callbacks passed to the hook

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -93,26 +93,29 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
 		const { increaseRequestsCount } = useAiFeature();
 
 		const { eventSource } = useAiContext( {
-			onDone: () => {
+			onDone: useCallback( () => {
 				/*
 				 * Increase the AI Suggestion counter.
 				 * @todo: move this at store level.
 				 */
 				increaseRequestsCount();
-			},
-			onError: error => {
-				/*
-				 * Incrses AI Suggestion counter
-				 * only for valid errors.
-				 * @todo: move this at store level.
-				 */
-				if ( error.code === 'error_network' || error.code === 'error_quota_exceeded' ) {
-					return;
-				}
+			}, [ increaseRequestsCount ] ),
+			onError: useCallback(
+				error => {
+					/*
+					 * Incrses AI Suggestion counter
+					 * only for valid errors.
+					 * @todo: move this at store level.
+					 */
+					if ( error.code === 'error_network' || error.code === 'error_quota_exceeded' ) {
+						return;
+					}
 
-				// Increase the AI Suggestion counter.
-				increaseRequestsCount();
-			},
+					// Increase the AI Suggestion counter.
+					increaseRequestsCount();
+				},
+				[ increaseRequestsCount ]
+			),
 		} );
 
 		const stopSuggestion = useCallback( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR slightly improves the app performance by avoiding rendering, memoizing the `onDone` and `onError` callbacks passed to the useAiFeature() hook.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack form: memoize the onDone and onError callbacks passed to the hook

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Confirm the request counter works optimistically 


https://github.com/Automattic/jetpack/assets/77539/34958ec6-34b9-41ab-ae10-d3b701056502



https://github.com/Automattic/jetpack/assets/77539/4a85649c-e54c-4e5a-b3fe-206f90566741
