### PR TITLE
AI Client: do not dispatch `done` event when JETPACK_AI_ERROR

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-client-prevent-unclear-error-message-on-done
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-prevent-unclear-error-message-on-done
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: do not dispatch `done` event when JETPACK_AI_ERROR

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -296,6 +296,14 @@ export default class SuggestionsEventSource extends EventTarget {
 
 	processEvent( e: EventSourceMessage ) {
 		if ( e.data === '[DONE]' ) {
+			/*
+			 * Check if the unclear prompt event was already dispatched,
+			 * to ensure that it is dispatched only once per request.
+			 */
+			if ( this.errorUnclearPromptTriggered ) {
+				return;
+			}
+
 			if ( this.fullMessage.length ) {
 				// Dispatch an event with the full content
 				this.dispatchEvent( new CustomEvent( 'done', { detail: this.fullMessage } ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up of https://github.com/Automattic/jetpack/pull/34025

In the same way that a double `error` event was dispatched, fixed in https://github.com/Automattic/jetpack/pull/34025, this PR fixes the issue that happens sometimes when the prompt is unclear but in the `done` event. Visually, the editor shows the undesired `JETPACK_AI_ERROR`:

<img width="526" alt="Screenshot 2023-11-09 at 12 25 36" src="https://github.com/Automattic/jetpack/assets/77539/7958dbb4-89d7-41aa-a25d-db9b763bd108">


Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: do not dispatch `done` event when JETPACK_AI_ERROR


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create an AI Assistant block instance 
* Set an unclear prompt message
* Send the request

**BEFORE (trunk)**
* Confirm that, sometimes, the app renders the `JETPACK_AI_ERROR`:
![image](https://github.com/Automattic/jetpack/assets/77539/a0e1e476-eb82-4641-baae-a888c7a46677)

**AFTER (this PR)**
* Confirm that the app never renders the error message


