### PR TITLE
AI Assistant: increase the requests counter from the AI Assistant block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-block-increse-requests-counter
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-block-increse-requests-counter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: increase the requests counter from the AI Assistant block

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -118,7 +118,10 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			focusOnPrompt();
 			increaseRequestsCount();
 		}, [ increaseRequestsCount ] ),
-		onUnclearPrompt: focusOnPrompt,
+		onUnclearPrompt: useCallback( () => {
+			focusOnBlock();
+			increaseRequestsCount();
+		}, [ increaseRequestsCount ] ),
 		onModeration: focusOnPrompt,
 		attributes,
 		clientId,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -19,7 +19,7 @@ import {
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { RawHTML, useState } from '@wordpress/element';
+import { RawHTML, useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import MarkdownIt from 'markdown-it';
@@ -73,7 +73,17 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		};
 	}, [] );
 
+	const {
+		requireUpgrade: requireUpgradeOnStart,
+		refresh: refreshFeatureData,
+		increaseRequestsCount,
+	} = useAiFeature();
+
 	const focusOnPrompt = () => {
+		/*
+		 * Increase the AI Suggestion counter.
+		 * @todo: move this at store level.
+		 */
 		// Small delay to avoid focus crash
 		setTimeout( () => {
 			aiControlRef.current?.focus?.();
@@ -88,8 +98,6 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	};
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-
-	const { requireUpgrade: requireUpgradeOnStart, refresh: refreshFeatureData } = useAiFeature();
 
 	const requireUpgrade = requireUpgradeOnStart || errorData?.code === 'error_quota_exceeded';
 
@@ -106,7 +114,10 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		wholeContent,
 		requestingState,
 	} = useSuggestionsFromOpenAI( {
-		onSuggestionDone: focusOnPrompt,
+		onSuggestionDone: useCallback( () => {
+			focusOnPrompt();
+			increaseRequestsCount();
+		}, [ increaseRequestsCount ] ),
 		onUnclearPrompt: focusOnPrompt,
 		onModeration: focusOnPrompt,
 		attributes,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements the needed changes to update the AI requests counter from an AI Assistant block instance

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: increase the requests counter from the AI Assistant block


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the Jetpack AI sidebar
* Identify the Usage panel
* Create an AI Assistant block instance
* Confirm the requests counter increases right after the response comes
* Confirm it increases even when the prompt is unclear 

https://github.com/Automattic/jetpack/assets/77539/7829062e-b833-46df-b321-ffb3589253f4

