### PR TITLE
WIP - Use register_settings for Social options

### DIFF
--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -43,7 +43,7 @@ class Publicize_Setup {
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 		add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
 		// add_action( 'rest_api_init', array( new Auto_Conversion\REST_Settings_Controller(), 'register_routes' ) );
-		add_action( 'rest_api_init', array( new Jetpack_Social_Settings\REST_Settings_Controller(), 'register_routes' ) );
+		add_action( 'rest_api_init', array( new Jetpack_Social_Settings\Settings(), 'register_settings' ) );
 
 		( new Social_Image_Generator\Setup() )->init();
 	}

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -47,7 +47,7 @@ class Settings {
 			return;
 		}
 
-		$this->update_auto_conversion_settings( $auto_conversion_settings['image'] );
+		update_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES, $auto_conversion_settings['image'] );
 		delete_option( 'jetpack_social_settings' );
 	}
 
@@ -106,7 +106,7 @@ class Settings {
 
 	public function update_settings( $updated, $name, $value ) {
 		if ( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES === $name ) {
-			return $this->update_auto_conversion_settings( $value );
+			return $this->update_auto_conversion_setting( $value );
 		}
 
 		if ( self::OPTION_PREFIX . self::IMAGE_GENERATOR_SETTINGS === $name ) {
@@ -117,7 +117,7 @@ class Settings {
 
 	public function update_auto_conversion_setting( $new_setting ) {
 		$this->migrate_old_option();
-		return update_option( self::OPTION_PREFIX . self::IMAGE_GENERATOR_SETTINGS, $new_setting );
+		return update_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES, $new_setting );
 	}
 
 	public function update_social_image_generator_settings( $new_settings ) {


### PR DESCRIPTION


## Proposed changes:
This is on experiment to see if we can use register_setting in order to utilise the core functions and rest endpoints.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

