### PR TITLE
Jetpack: Fix open ai libs require paths

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -348,8 +348,8 @@ class Jetpack_AI_Helper {
 			}
 
 			if ( ! class_exists( 'OpenAI_Limit_Usage' ) ) {
-				if ( is_readable( WP_PLUGIN_DIR . '/openai/openai-limit-usage.php' ) ) {
-					require_once WP_PLUGIN_DIR . '/openai/openai-limit-usage.php';
+				if ( is_readable( WP_CONTENT_DIR . '/lib/openai/openai-limit-usage.php' ) ) {
+					require_once WP_CONTENT_DIR . '/lib/openai/openai-limit-usage.php';
 				} else {
 					return new WP_Error(
 						'openai_limit_usage_not_found',
@@ -359,8 +359,8 @@ class Jetpack_AI_Helper {
 			}
 
 			if ( ! class_exists( 'OpenAI_Request_Count' ) ) {
-				if ( is_readable( WP_PLUGIN_DIR . '/openai/openai-request-count.php' ) ) {
-					require_once WP_PLUGIN_DIR . '/openai/openai-request-count.php';
+				if ( is_readable( WP_CONTENT_DIR . '/lib/openai/openai-request-count.php' ) ) {
+					require_once WP_CONTENT_DIR . '/lib/openai/openai-request-count.php';
 				} else {
 					return new WP_Error(
 						'openai_request_count_not_found',

--- a/projects/plugins/jetpack/changelog/fix-open-ai-libs-require-paths
+++ b/projects/plugins/jetpack/changelog/fix-open-ai-libs-require-paths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Change the paths used to require OpenAI classes


### PR DESCRIPTION
Fix paths used to require libs and helpers


## Proposed changes:
This PR addresses a bug that never triggered. The paths used to require the classes and libs is wrong, but the condition under which those files should have been required was never met.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1699553597616979-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
There is no testing process that can cover the case, we'll just use the sandbox to try and mimic what was done before and what is done now to require the libs:

```bash
wpsh

# previous to this patch, this is the line that tried to load one of the classes
require_once WP_PLUGIN_DIR . '/openai/openai-request-count.php';
# see that it should trigger an error

# new path
require_once WP_CONTENT_DIR . '/lib/openai/openai-request-count.php';
# should output nothing

# try to run a method from the newly required file
print_r( OpenAI_Request_Count::get_count( 211199336 ) ); # use whatever blog ID here
# should print the requests count for the given blog ID
```