### PR TITLE
 Media: Prevent fatals in HEIC/HEIF Support

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-prevent-fatal-error-for-heif-to-jpg
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-prevent-fatal-error-for-heif-to-jpg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent fatal errors when filename is empty in the heif support feature

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.0.0",
+	"version": "5.0.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.0.0';
+	const PACKAGE_VERSION = '5.0.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
@@ -17,14 +17,12 @@ function jetpack_wpcom_maybe_convert_heif_to_jpg( $filename ) {
 	}
 
 	if ( empty( $filename ) ) {
-
 		jetpack_wpcom_maybe_log_heif_to_jpg(
 			array(
 				'message'  => 'file path is empty',
 				'severity' => 'error',
 			)
 		);
-
 		return false;
 	}
 
@@ -35,7 +33,6 @@ function jetpack_wpcom_maybe_convert_heif_to_jpg( $filename ) {
 				'severity' => 'error',
 			)
 		);
-
 		return false;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
@@ -15,6 +15,19 @@ function jetpack_wpcom_maybe_convert_heif_to_jpg( $filename ) {
 	if ( ! class_exists( 'Photon_OpenCV' ) ) {
 		return false;
 	}
+
+	if ( empty( $filename ) || ! file_exists( $filename ) ) {
+
+		jetpack_wpcom_maybe_log_heif_to_jpg(
+			array(
+				'message'  => sprintf( 'file does not exist: %s', $filename ),
+				'severity' => 'error',
+			)
+		);
+
+		return false;
+	}
+
 	$valid_magic_bytes = array(
 		'ftypheic',
 		'ftypheix',
@@ -34,6 +47,14 @@ function jetpack_wpcom_maybe_convert_heif_to_jpg( $filename ) {
 		return false;
 	}
 
+	// Log that we found a HEIF image.
+	jetpack_wpcom_maybe_log_heif_to_jpg(
+		array(
+			'message'  => sprintf( 'Found HEIF image with magic bytes: %s', $magic_bytes ),
+			'severity' => 'info',
+		)
+	);
+
 	$img = new Photon_OpenCV();
 	try {
 		$img->readimage( $filename );
@@ -41,6 +62,13 @@ function jetpack_wpcom_maybe_convert_heif_to_jpg( $filename ) {
 		// Bad detection or malformed image
 		/** This action is documented in modules/widgets/social-media-icons.php */
 		do_action( 'jetpack_bump_stats_extras', 'heif2jpg', 'failed-to-read' );
+		jetpack_wpcom_maybe_log_heif_to_jpg(
+			array(
+				'message'    => sprintf( 'failed to read image: %s', $e->getMessage() ),
+				'error_code' => $e->getCode(),
+				'severity'   => 'error',
+			)
+		);
 		return false;
 	}
 
@@ -52,13 +80,34 @@ function jetpack_wpcom_maybe_convert_heif_to_jpg( $filename ) {
 }
 
 /**
+ * Log information about HEIF/HEIC conversions.
+ *
+ * @param array $params The parameters to log.
+ *
+ * @return void
+ */
+function jetpack_wpcom_maybe_log_heif_to_jpg( $params = array() ) {
+	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+		return;
+	}
+
+	require_once WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+
+	$default = array(
+		'feature' => 'heif2jpg',
+		'blog_id' => get_current_blog_id(),
+	);
+
+	log2logstash( wp_parse_args( $params, $default ) );
+}
+
+/**
  * Attempts to convert HEIF/HEIC uploads to JPEG.
  *
  * @param array $file The file array.
  * @return array The file array.
  */
 function jetpack_wpcom_transparently_convert_heif_upload_to_jpg( $file ) {
-
 	if ( ! class_exists( 'Photon_OpenCV' ) ) {
 		return $file;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
@@ -95,7 +95,8 @@ function jetpack_wpcom_maybe_convert_heif_to_jpg( $filename ) {
  * @return void
  */
 function jetpack_wpcom_maybe_log_heif_to_jpg( $params = array() ) {
-	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+
+	if ( ! file_exists( WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php' ) ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
@@ -50,7 +50,7 @@ function jetpack_wpcom_maybe_convert_heif_to_jpg( $filename ) {
 	// Log that we found a HEIF image.
 	jetpack_wpcom_maybe_log_heif_to_jpg(
 		array(
-			'message'  => sprintf( 'Found HEIF image with magic bytes: %s', $magic_bytes ),
+			'message'  => sprintf( 'Found HEIF image: %s with magic bytes: %s', $filename, $magic_bytes ),
 			'severity' => 'info',
 		)
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
@@ -16,8 +16,19 @@ function jetpack_wpcom_maybe_convert_heif_to_jpg( $filename ) {
 		return false;
 	}
 
-	if ( empty( $filename ) || ! file_exists( $filename ) ) {
+	if ( empty( $filename ) ) {
 
+		jetpack_wpcom_maybe_log_heif_to_jpg(
+			array(
+				'message'  => 'file path is empty',
+				'severity' => 'error',
+			)
+		);
+
+		return false;
+	}
+
+	if ( ! file_exists( $filename ) ) {
 		jetpack_wpcom_maybe_log_heif_to_jpg(
 			array(
 				'message'  => sprintf( 'file does not exist: %s', $filename ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/4095

It is possible that the filename is empty when triggering the `jetpack_wpcom_transparently_convert_heif_upload_to_jpg` function via the `wp_handle_upload_prefilter` and  `wp_handle_sideload_prefilter` hooks. This function will detect a HEIC/HEIF image and try to convert it into a jpg image. 

We have received fatal errors in cases where the filename is empty or does not exist:
`PHP Fatal error:  Uncaught ValueError: Path cannot be empty in /.../jetpack-mu-wpcom/src/features/media/heif-support.php:32`

It is likely caused by the interaction with other plugins and I was not able to reproduce the problem without adding a little plugin that deliberately empties the filename.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that we detect empty filenames or files that do not exist and exit early - this will prevent fatal errors
* Log errors and information to logstash if we are in a WPCOM context

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I am unsure as to how the errors happened and was not able to reproduce them. This test will focus on ensuring that the conversion still works properly and that we are logging information in the context of WPCOM

**Simple**

* Apply this patch to a simple site by following the instructions in the jetpack-mu-wpcom docs: PCYsg-Osp-p2
* Go to the media uploader and upload a HEIC/HEIF file
* Ensure that the file is uploaded successfully as a JPG
* In logstash, you should see an info entry for your upload in the log2logstash index. It should show you the filename and the magic bytes that appear at the beginning of the image file that indicate the type of HEIC/HEIF. You can use `feature:heif2jpg` to find the log entry.
* You can try uploading a corrupted HEIC image. Doing this should trigger an error that will be logged in Logstash. You can use `feature:heif2jpg` to find the log entry.

Download a corrupted HEIC file that I provided in the original issue.

**Atomic**

Logging is disabled on Atomic sites.

* Apply this patch to your Atomic site by following the instructions in the jetpack-mu-wpcom docs: PCYsg-Osp-p2
* Go to the media uploader and upload a HEIC/HEIF file
* Ensure that the file is uploaded successfully as a JPG

**Simulate empty file on Atomic**
Because the fatal error is caused by receiving an empty filename, we want to verify that this no longer triggers a fatal error. Add in `wp-content/plugins` a file name `empty-file-uploader.php`with the following code:

```
<?php
/**
 * Plugin Name: Empty Filename Uploader
 * Description: A plugin to simulate an empty filename during upload for testing purposes.
 * Version: 1.0
 * Author: Test
 */

// Hook into the filters for handling file uploads and side loads.
add_filter('wp_handle_upload_prefilter', 'empty_filename_prefilter', 1);
add_filter('wp_handle_sideload_prefilter', 'empty_filename_prefilter', 1);

// Function to modify the filename to be empty.
function empty_filename_prefilter($file) {
    $file['tmp_name'] = '';
    return $file;
}
```

Activate the plugin and try to upload a valid HEIC file. The easiest way to observe that the fatal error is no longer happening is by inspecting the network tab in the browser and looking for the `async-upload.php` request. This request should return a JSON error: `Specified file failed upload test.`. Doing the same without this PR applied should cause a fatal error ( an error page will be returned AND an error `PHP Fatal error:  Uncaught ValueError: Path cannot be empty` will be displayed in the site monitoring php log)