### PR TITLE
AI Assistant: simplify how to render the upgrade banner in the AI Assistant block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-block-simply-require-upgrade
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-block-simply-require-upgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: simplify how to render upgrade banner for AI Assistant block

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -73,7 +73,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		};
 	}, [] );
 
-	const { requireUpgrade: requireUpgradeOnStart, increaseRequestsCount } = useAiFeature();
+	const { requireUpgrade, increaseRequestsCount } = useAiFeature();
 
 	const focusOnPrompt = () => {
 		/*
@@ -94,8 +94,6 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	};
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-
-	const requireUpgrade = requireUpgradeOnStart || errorData?.code === 'error_quota_exceeded';
 
 	const {
 		isLoadingCategories,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -73,11 +73,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		};
 	}, [] );
 
-	const {
-		requireUpgrade: requireUpgradeOnStart,
-		refresh: refreshFeatureData,
-		increaseRequestsCount,
-	} = useAiFeature();
+	const { requireUpgrade: requireUpgradeOnStart, increaseRequestsCount } = useAiFeature();
 
 	const focusOnPrompt = () => {
 		/*
@@ -129,7 +125,6 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		setError,
 		tracks,
 		userPrompt,
-		refreshFeatureData,
 		requireUpgrade,
 	} );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -31,7 +31,6 @@ const useSuggestionsFromOpenAI = ( {
 	onSuggestionDone,
 	onUnclearPrompt,
 	onModeration,
-	refreshFeatureData,
 	requireUpgrade,
 } ) => {
 	const [ isLoadingCategories, setIsLoadingCategories ] = useState( false );
@@ -356,8 +355,6 @@ const useSuggestionsFromOpenAI = ( {
 			const blocks = parse( detail );
 			const validBlocks = blocks.filter( block => block.isValid );
 			replaceInnerBlocks( clientId, validBlocks );
-
-			refreshFeatureData();
 		};
 
 		const onErrorUnclearPrompt = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up of https://github.com/Automattic/jetpack/pull/34057

Simplify how the Upgrade banner is rendered in the AI Assistant block, relying only on the custom hook through the data provided by the store.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: simplify how to render the upgrade banner in the AI Assistant block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Go to the block editor
* Create an AI Assistant block instance 
* Confirm that when the site requires an upgrade, the block representation contains the Upgrade banner 

<img width="588" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/f24803ef-d5c0-4a22-b29f-1d1bc4f9e041">


* Confirm that when the site archives the free requests limit, the app shows the banner


