### PR TITLE
Subscribe Block: Ignore token on simple sites if logged out

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-logged-out-on-simple
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-logged-out-on-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+improve subscribe block on simple sites

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-token-subscription-service.php
@@ -43,4 +43,13 @@ class WPCOM_Token_Subscription_Service extends Token_Subscription_Service {
 	 // phpcs:ignore ImportDetection.Imports.RequireImports.Symbol
 		return defined( 'EARN_JWT_SIGNING_KEY' ) ? EARN_JWT_SIGNING_KEY : false;
 	}
+
+	/**
+	 * Returns true if the current authenticated user is subscribed to the current site.
+	 *
+	 * @return boolean
+	 */
+	public function is_current_user_subscribed() {
+		return false;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1699619742836339-slack-C02TCEHP3HA

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When checking subscribe status ignore token from cookie on simple sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*