### PR TITLE
Proofread: compute AI requests counter from here too

### DIFF
--- a/projects/plugins/jetpack/changelog/update-increases-ai-requests-counter-from-proofread
+++ b/projects/plugins/jetpack/changelog/update-increases-ai-requests-counter-from-proofread
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Proofread: compute AI requests counter from here too

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
@@ -5,8 +5,8 @@ import { AiStatusIndicator, useAiSuggestions } from '@automattic/jetpack-ai-clie
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { serialize } from '@wordpress/blocks';
 import { Modal, Button } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import TurndownService from 'turndown';
@@ -55,6 +55,8 @@ export default function Proofread( {
 		setIsProofreadModalVisible( ! isProofreadModalVisible );
 	};
 
+	const { increaseAiAssistantRequestsCount } = useDispatch( 'wordpress-com/plans' );
+
 	const handleSuggestion = ( content: string ) => {
 		const text = content.split( '\n' ).map( ( line, idx ) => {
 			return line?.length ? <p key={ `line-${ idx }` }>{ line }</p> : null;
@@ -67,9 +69,9 @@ export default function Proofread( {
 		/// TODO: Handle Error
 	};
 
-	const handleDone = () => {
-		// TODO: Handle Done
-	};
+	const handleDone = useCallback( () => {
+		increaseAiAssistantRequestsCount();
+	}, [ increaseAiAssistantRequestsCount ] );
 
 	const { request, requestingState } = useAiSuggestions( {
 		askQuestionOptions: {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
@@ -55,7 +55,8 @@ export default function Proofread( {
 		setIsProofreadModalVisible( ! isProofreadModalVisible );
 	};
 
-	const { increaseAiAssistantRequestsCount } = useDispatch( 'wordpress-com/plans' );
+	const { increaseAiAssistantRequestsCount, dequeueAiAssistantFeatureAyncRequest } =
+		useDispatch( 'wordpress-com/plans' );
 
 	const handleSuggestion = ( content: string ) => {
 		const text = content.split( '\n' ).map( ( line, idx ) => {
@@ -93,6 +94,13 @@ export default function Proofread( {
 				},
 			},
 		];
+
+		/*
+		 * Always dequeue/cancel the AI Assistant feature async request,
+		 * in case there is one pending,
+		 * when performing a new AI suggestion request.
+		 */
+		dequeueAiAssistantFeatureAyncRequest();
 
 		request( messages );
 		toggleProofreadModal();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Continuing with the AI requests counter optimistically, and AI Assistant plan availability depending on it, this PR does the implementation for the Proofread feature.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Proofread: compute AI requests counter from here too


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the Jetapack AI sidebar
* Open the Redux dev tool
* Request a `AI FEEDBACK ON POST`
* Confirm the app performs the request
* Confirm it increases the requests counter

https://github.com/Automattic/jetpack/assets/77539/91918667-1211-4d8a-9009-22e640f20160


