### PR TITLE
AI Assistant: Remove TOS notice from interstitial page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -66,6 +66,7 @@ function Price( { value, currency, isOld } ) {
  * @param {boolean} props.preferProductName      - Use product name instead of title
  * @param {React.ReactNode} props.supportingInfo - Complementary links or support/legal text
  * @param {string} [props.ctaButtonLabel]        - The label for the Call To Action button
+ * @param {boolean} [props.hideTOS]              - Whether to hide the Terms of Service text
  * @returns {object}                               ProductDetailCard react component.
  */
 const ProductDetailCard = ( {
@@ -76,6 +77,7 @@ const ProductDetailCard = ( {
 	preferProductName,
 	supportingInfo,
 	ctaButtonLabel = null,
+	hideTOS = false,
 } ) => {
 	const { fileSystemWriteAccess, siteSuffix, adminUrl, myJetpackUrl } =
 		window?.myJetpackInitialState ?? {};
@@ -299,19 +301,21 @@ const ProductDetailCard = ( {
 					</Alert>
 				) }
 
-				<div className={ styles[ 'tos-container' ] }>
-					<TermsOfService
-						agreeButtonLabel={
-							hasTrialButton
-								? sprintf(
-										/* translators: placeholder is cta label. */
-										__( '%s or Start for free', 'jetpack-my-jetpack' ),
-										ctaLabel
-								  )
-								: ctaLabel
-						}
-					/>
-				</div>
+				{ ! hideTOS && (
+					<div className={ styles[ 'tos-container' ] }>
+						<TermsOfService
+							agreeButtonLabel={
+								hasTrialButton
+									? sprintf(
+											/* translators: placeholder is cta label. */
+											__( '%s or Start for free', 'jetpack-my-jetpack' ),
+											ctaLabel
+									  )
+									: ctaLabel
+							}
+						/>
+					</div>
+				) }
 
 				{ ( ! isBundle || ( isBundle && ! hasRequiredPlan ) ) && (
 					<Text

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -37,7 +37,8 @@ import videoPressImage from './videopress.png';
  * @param {React.ReactNode} props.supportingInfo - Complementary links or support/legal text
  * @param {boolean} props.preferProductName      - Use product name instead of title
  * @param {string} props.imageContainerClassName - Append a class to the image container
- * @param {string} [props.ctaButtonLabel]          - The label for the Call To Action button
+ * @param {string} [props.ctaButtonLabel]        - The label for the Call To Action button
+ * @param {boolean} [props.hideTOS]              - Whether to hide the Terms of Service text
  * @returns {object}                               ProductInterstitial react component.
  */
 export default function ProductInterstitial( {
@@ -50,6 +51,7 @@ export default function ProductInterstitial( {
 	children = null,
 	imageContainerClassName = '',
 	ctaButtonLabel = null,
+	hideTOS = false,
 } ) {
 	const { activate, detail } = useProduct( slug );
 	const { isUpgradableByBundle, tiers } = detail;
@@ -163,6 +165,7 @@ export default function ProductInterstitial( {
 									supportingInfo={ supportingInfo }
 									preferProductName={ preferProductName }
 									ctaButtonLabel={ ctaButtonLabel }
+									hideTOS={ hideTOS }
 								/>
 							</Col>
 							<Col
@@ -285,6 +288,7 @@ export function JetpackAIInterstitial() {
 			installsPlugin={ true }
 			imageContainerClassName={ styles.aiImageContainer }
 			ctaButtonLabel={ ctaLabel }
+			hideTOS={ true }
 		>
 			<img src={ jetpackAiImage } alt="Jetpack AI" />
 		</ProductInterstitial>

--- a/projects/packages/my-jetpack/changelog/update-ai-assistant-intertitial-remove-tos
+++ b/projects/packages/my-jetpack/changelog/update-ai-assistant-intertitial-remove-tos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Assistant: Remove TOS notice from interstitial page


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #https://github.com/Automattic/jetpack/issues/33358

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Does not render the TOS component on the AI Interstitial, as the user has already agreed when installing Jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Jq2UFBOjX0U5fYmAoCrwaV-fi-4076_10201
p1698351897047139/1698351395.318789-slack-C054LN8RNVA


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to to the interstitial page of Jetpack AI on My Jetpack
* Check that the TOS is not displayed
* Go to other products' interstitial pages
* Check that the TOS is displayed as before

![2023-11-10_15-20-43](https://github.com/Automattic/jetpack/assets/8486249/b01feae2-c98f-4e07-a854-66bbf77e1ed7)
