### PR TITLE
AI Assistant: set initial state of AI Assistant feature data at store level

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-use-feature-move-initial-state-to-store
+++ b/projects/plugins/jetpack/changelog/update-ai-use-feature-move-initial-state-to-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: set initial state of AI Assistant feature data at store level

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -8,7 +8,6 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import metadata from '../../block.json';
-import { AI_Assistant_Initial_State } from '../../hooks/use-ai-feature';
 import { isUserConnected } from '../../lib/connection';
 
 /*
@@ -55,7 +54,8 @@ export function isPossibleToExtendBlock(): boolean {
 	}
 
 	// Do not extend if there is an error getting the feature.
-	if ( AI_Assistant_Initial_State.errorCode ) {
+	const { errorCode } = select( 'wordpress-com/plans' )?.getAiAssistantFeature?.() || {};
+	if ( errorCode ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/Readme.md
@@ -18,11 +18,3 @@ function UpgradePlan() {
 	);
 }
 ```
-
-# getAIFeature()
-
-Async helper function that performes and returns relevant data about the AI Assistant feature
-
-# AI_Assistant_Initial_State
-
-Constant with the initial state of the AI Assistant feature

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -3,28 +3,6 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 
-const NUM_FREE_REQUESTS_LIMIT = 20;
-
-const aiAssistantFeature = window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ];
-
-export const AI_Assistant_Initial_State = {
-	hasFeature: !! aiAssistantFeature?.[ 'has-feature' ],
-	isOverLimit: !! aiAssistantFeature?.[ 'is-over-limit' ],
-	requestsCount: aiAssistantFeature?.[ 'requests-count' ] || 0,
-	requestsLimit: aiAssistantFeature?.[ 'requests-limit' ] || NUM_FREE_REQUESTS_LIMIT,
-	requireUpgrade: !! aiAssistantFeature?.[ 'site-require-upgrade' ],
-	errorMessage: aiAssistantFeature?.[ 'error-message' ] || '',
-	errorCode: aiAssistantFeature?.[ 'error-code' ],
-	upgradeType: aiAssistantFeature?.[ 'upgrade-type' ] || 'default',
-	usagePeriod: {
-		currentStart: aiAssistantFeature?.[ 'usage-period' ]?.[ 'current-start' ],
-		nextStart: aiAssistantFeature?.[ 'usage-period' ]?.[ 'next-start' ],
-		requestsCount: aiAssistantFeature?.[ 'usage-period' ]?.[ 'requests-count' ] || 0,
-	},
-	currentTier: aiAssistantFeature?.[ 'current-tier' ],
-	nextTier: aiAssistantFeature?.[ 'next-tier' ] || null,
-};
-
 export default function useAiFeature() {
 	const { data, loading } = useSelect( select => {
 		const { getAiAssistantFeature, getIsRequestingAiAssistantFeature } =

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/constants.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/constants.ts
@@ -20,6 +20,7 @@ export const ENDPOINT_AI_ASSISTANT_FEATURE = '/wpcom/v2/jetpack-ai/ai-assistant-
 /**
  * New AI Assistant feature async request
  */
+export const FREE_PLANT_REQUESTS_LIMIT = 20;
 export const ASYNC_REQUEST_COUNTDOWN_INIT_VALUE = 3;
 export const NEW_ASYNC_REQUEST_TIMER_INTERVAL = 5000;
 export const ACTION_DECREASE_NEW_ASYNC_REQUEST_COUNTDOWN = 'DECREASE_NEW_ASYNC_REQUEST_COUNTDOWN';

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/constants.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/constants.ts
@@ -20,7 +20,7 @@ export const ENDPOINT_AI_ASSISTANT_FEATURE = '/wpcom/v2/jetpack-ai/ai-assistant-
 /**
  * New AI Assistant feature async request
  */
-export const FREE_PLANT_REQUESTS_LIMIT = 20;
+export const FREE_PLAN_REQUESTS_LIMIT = 20;
 export const ASYNC_REQUEST_COUNTDOWN_INIT_VALUE = 3;
 export const NEW_ASYNC_REQUEST_TIMER_INTERVAL = 5000;
 export const ACTION_DECREASE_NEW_ASYNC_REQUEST_COUNTDOWN = 'DECREASE_NEW_ASYNC_REQUEST_COUNTDOWN';

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -11,32 +11,36 @@ import {
 	ACTION_SET_AI_ASSISTANT_FEATURE_REQUIRE_UPGRADE,
 	ACTION_STORE_AI_ASSISTANT_FEATURE,
 	ASYNC_REQUEST_COUNTDOWN_INIT_VALUE,
+	FREE_PLANT_REQUESTS_LIMIT,
 } from './constants';
 import type { PlanStateProps } from './types';
+
+const aiAssistantFeature = window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ];
 
 const INITIAL_STATE: PlanStateProps = {
 	plans: [],
 	features: {
 		aiAssistant: {
-			hasFeature: false,
-			isOverLimit: false,
-			requestsCount: 0,
-			requestsLimit: 1000,
-			requireUpgrade: false,
-			errorMessage: '',
-			errorCode: '',
-			upgradeType: 'default',
-			currentTier: {
+			hasFeature: !! aiAssistantFeature?.[ 'has-feature' ],
+			isOverLimit: !! aiAssistantFeature?.[ 'is-over-limit' ],
+			requestsCount: aiAssistantFeature?.[ 'requests-count' ] || 0,
+			requestsLimit: aiAssistantFeature?.[ 'requests-limit' ] || FREE_PLANT_REQUESTS_LIMIT,
+			requireUpgrade: !! aiAssistantFeature?.[ 'site-require-upgrade' ],
+			errorMessage: aiAssistantFeature?.[ 'error-message' ] || '',
+			errorCode: aiAssistantFeature?.[ 'error-code' ],
+			upgradeType: aiAssistantFeature?.[ 'upgrade-type' ] || 'default',
+			currentTier: aiAssistantFeature?.[ 'current-tier' ] || {
 				slug: 'ai-assistant-tier-free',
 				value: 0,
 				limit: 20,
 			},
 			usagePeriod: {
-				currentStart: '',
-				nextStart: '',
-				requestsCount: 0,
+				currentStart:
+					aiAssistantFeature?.[ 'usage-period' ]?.[ 'current-start' ] || 'ai-assistant-tier-free',
+				nextStart: aiAssistantFeature?.[ 'usage-period' ]?.[ 'next-start' ] || '',
+				requestsCount: aiAssistantFeature?.[ 'usage-period' ]?.[ 'requests-count' ] || 0,
 			},
-			nextTier: {
+			nextTier: aiAssistantFeature?.[ 'next-tier' ] || {
 				slug: 'ai-assistant-tier-unlimited',
 				value: 1,
 				limit: 922337203685477600,

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -11,7 +11,7 @@ import {
 	ACTION_SET_AI_ASSISTANT_FEATURE_REQUIRE_UPGRADE,
 	ACTION_STORE_AI_ASSISTANT_FEATURE,
 	ASYNC_REQUEST_COUNTDOWN_INIT_VALUE,
-	FREE_PLANT_REQUESTS_LIMIT,
+	FREE_PLAN_REQUESTS_LIMIT,
 } from './constants';
 import type { PlanStateProps } from './types';
 
@@ -24,7 +24,7 @@ const INITIAL_STATE: PlanStateProps = {
 			hasFeature: !! aiAssistantFeature?.[ 'has-feature' ],
 			isOverLimit: !! aiAssistantFeature?.[ 'is-over-limit' ],
 			requestsCount: aiAssistantFeature?.[ 'requests-count' ] || 0,
-			requestsLimit: aiAssistantFeature?.[ 'requests-limit' ] || FREE_PLANT_REQUESTS_LIMIT,
+			requestsLimit: aiAssistantFeature?.[ 'requests-limit' ] || FREE_PLAN_REQUESTS_LIMIT,
 			requireUpgrade: !! aiAssistantFeature?.[ 'site-require-upgrade' ],
 			errorMessage: aiAssistantFeature?.[ 'error-message' ] || '',
 			errorCode: aiAssistantFeature?.[ 'error-code' ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This moves the initial state from the `useAiFeature()` hook to the `wordpress-com/plans` store. Also, the global store is not exposed anymore, and the way to pick the state is by using the store.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: set initial state of AI Assistant feature data at store level


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the Network and Redux dev tabs
* Confirm the client performs only one `ai-assistant-feature` request 
* Confirm the data is propagated properly, populating the store sub-tree
* Confirm the AI Extension works as usual because this is the only AI implementation that requires data from the global state


https://github.com/Automattic/jetpack/assets/77539/12c6b7e6-eb80-4bb5-9199-e0e966c12355


