### PR TITLE
AI Assistant: show upgrade banner only when the AI Assistant block is selected

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-block-show-benner-only-when-selected
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-block-show-benner-only-when-selected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: show upgrade banner only when the AI Assistant block is selected

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -48,7 +48,7 @@ const isInBlockEditor = window?.Jetpack_Editor_Initial_State?.screenBase === 'po
 const isPlaygroundVisible =
 	window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-playground-visible' ];
 
-export default function AIAssistantEdit( { attributes, setAttributes, clientId } ) {
+export default function AIAssistantEdit( { attributes, setAttributes, clientId, isSelected } ) {
 	const [ userPrompt, setUserPrompt ] = useState();
 	const [ errorData, setError ] = useState( {} );
 	const [ loadingImages, setLoadingImages ] = useState( false );
@@ -505,7 +505,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 					</InspectorControls>
 				) }
 
-				{ requireUpgrade && <UpgradePrompt /> }
+				{ requireUpgrade && isSelected && <UpgradePrompt /> }
 				{ ! connected && <ConnectPrompt /> }
 				{ ! isWaitingState && connected && ! requireUpgrade && (
 					<ToolbarControls


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR shows the upgrade banner when the site requires it only when the block is selected.

Fixes https://github.com/Automattic/jetpack/issues/34071

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: show upgrade banner only when the AI Assistant block is selected

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a few instances of the AI Assistant block
* Open the dev console
* Dispatch the action to set the site requires an upgrade
```
wp.data.dispatch( 'wordpress-com/plans' ).setAiAssistantFeatureRequireUpgrade()
```

**Before (trunk)**

Confirm the editor shows the banner in all AI Assistant block instances:

<img width="942" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/dcd74a46-1750-45d8-976b-7183531a6aa8">


**After (this PR)**

The app shows the banner only when the block is selected

https://github.com/Automattic/jetpack/assets/77539/b1307781-b656-4a97-bf25-b5ba7de4bc78





