### PR TITLE
AI Assistant: increases the requests count of the usage period of the plans store

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-increase-requests-count-of-usage-period
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-increase-requests-count-of-usage-period
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: increases the requests count of the usage period of the plans store

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -114,6 +114,10 @@ export default function reducer( state = INITIAL_STATE, action ) {
 						isOverLimit,
 						requestsCount,
 						requireUpgrade,
+						currentTier: {
+							...state.features.aiAssistant.currentTier,
+							value: state.features.aiAssistant.currentTier.value + action.count,
+						},
 					},
 				},
 			};

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -105,6 +105,10 @@ export default function reducer( state = INITIAL_STATE, action ) {
 			const isOverLimit = requestsCount >= state.features.aiAssistant.requestsLimit;
 			const requireUpgrade = isOverLimit && ! state.features.aiAssistant.hasFeature;
 
+			// Increase the requests count also fo the Usage Period.
+			const usagePeriod = state.features.aiAssistant.usagePeriod || { requestsCount: 0 };
+			usagePeriod.requestsCount += action.count;
+
 			return {
 				...state,
 				features: {
@@ -114,10 +118,6 @@ export default function reducer( state = INITIAL_STATE, action ) {
 						isOverLimit,
 						requestsCount,
 						requireUpgrade,
-						currentTier: {
-							...state.features.aiAssistant.currentTier,
-							value: state.features.aiAssistant.currentTier.value + action.count,
-						},
 					},
 				},
 			};

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -118,6 +118,7 @@ export default function reducer( state = INITIAL_STATE, action ) {
 						isOverLimit,
 						requestsCount,
 						requireUpgrade,
+						usagePeriod: { ...usagePeriod },
 					},
 				},
 			};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR increases the requests count of the usage period optimistically.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: increases the requests count of the usage period of the plans store

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the Redux dev tool and the dev console
* Dispatch the action to increase the requests counter

```js
wp.data.dispatch( 'wordpress-com/plans' ).increaseAiAssistantRequestsCount()
```

* Confirm both counters increases

https://github.com/Automattic/jetpack/assets/77539/82a19624-2b3a-4072-acc7-d0084d655d1e

