### PR TITLE
Subscribe block: return to correct page after subscribing even when not in a post

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriptions-post-id
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-post-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe block: return to correct page even when not subscribing from a post

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -615,11 +615,14 @@ function render_for_website( $data, $classes, $styles ) {
 	$form_url          = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '#';
 	$post_access_level = get_post_access_level_for_current_post();
 
+	// Post ID is used for pulling post-specific paid status, and returning to the right post after confirming subscription
 	$post_id = null;
 	if ( in_the_loop() ) {
 		$post_id = get_the_ID();
-	} elseif ( is_singular( 'post' ) ) {
+	} elseif ( is_singular( 'post' ) || is_page() ) {
 		$post_id = get_queried_object_id();
+	} else {
+		$post_id = get_option( 'page_on_front' );
 	}
 
 	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to https://github.com/Automattic/jetpack/pull/33932/files#r1384990526

Improves redirection to correct place which happens after confirming subscription.

Previously we easily sent users to subscription management, which isn't great if they started from the site:

<img width="1496" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/234a3669-4cfc-407d-a0a1-0bde5ffb998b">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds individual page IDs to subscription modal, and defaults to "page on front" id (static homepage or "blog" page) if none is found.

The ID will be used to pull paid status of the post object (which of course is available for blog posts only), but also to pull "redirect URL" which we send reader to after they confirm subscription. Otherwise they end up in Calypso subscription management. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create free and paid posts, test subscribing to those. After confirming subscription, you should land at the post.
* Subscribe from subscription block outside the posts loop, e.g. on homepage header/footer (Use Lettre theme for example) — land at homepage after confirming subscription.
* Subscribe from a page — land at the page after confirming subscription.

