### PR TITLE
AI Excerpt: dequeue AI feature async request when asking a new suggestion

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ensure-dequeue-ai-feature-async-request
+++ b/projects/plugins/jetpack/changelog/update-ensure-dequeue-ai-feature-async-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: dequeue AI feature async request when asking a new suggestion

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -18,7 +18,6 @@ import { count } from '@wordpress/wordcount';
  * Internal dependencies
  */
 import UpgradePrompt from '../../../../blocks/ai-assistant/components/upgrade-prompt';
-import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import { isBetaExtension } from '../../../../editor';
 import { AiExcerptControl } from '../../components/ai-excerpt-control';
 /**
@@ -54,7 +53,8 @@ function AiPostExcerpt() {
 
 	const { editPost } = useDispatch( 'core/editor' );
 
-	const { dequeueAiAssistantFeatureAyncRequest } = useDispatch( 'wordpress-com/plans' );
+	const { dequeueAiAssistantFeatureAyncRequest, increaseAiAssistantRequestsCount } =
+		useDispatch( 'wordpress-com/plans' );
 
 	// Post excerpt words number
 	const [ excerptWordsNumber, setExcerptWordsNumber ] = useState( 50 );
@@ -63,7 +63,6 @@ function AiPostExcerpt() {
 	const [ language, setLanguage ] = useState< LanguageProp >();
 	const [ tone, setTone ] = useState< ToneProp >();
 	const [ model, setModel ] = useState< AiModelTypeProp >( AI_MODEL_GPT_4 );
-	const { increaseRequestsCount } = useAiFeature();
 
 	const { request, stopSuggestion, suggestion, requestingState, error, reset } = useAiSuggestions( {
 		onDone: useCallback( () => {
@@ -71,8 +70,8 @@ function AiPostExcerpt() {
 			 * Increase the AI Suggestion counter.
 			 * @todo: move this at store level.
 			 */
-			increaseRequestsCount();
-		}, [ increaseRequestsCount ] ),
+			increaseAiAssistantRequestsCount();
+		}, [ increaseAiAssistantRequestsCount ] ),
 		onError: useCallback(
 			suggestionError => {
 				/*
@@ -88,9 +87,9 @@ function AiPostExcerpt() {
 				}
 
 				// Increase the AI Suggestion counter.
-				increaseRequestsCount();
+				increaseAiAssistantRequestsCount();
 			},
-			[ increaseRequestsCount ]
+			[ increaseAiAssistantRequestsCount ]
 		),
 	} );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -54,6 +54,8 @@ function AiPostExcerpt() {
 
 	const { editPost } = useDispatch( 'core/editor' );
 
+	const { dequeueAiAssistantFeatureAyncRequest } = useDispatch( 'wordpress-com/plans' );
+
 	// Post excerpt words number
 	const [ excerptWordsNumber, setExcerptWordsNumber ] = useState( 50 );
 
@@ -166,6 +168,13 @@ ${ postContent }
 				context: messageContext,
 			},
 		];
+
+		/*
+		 * Always dequeue/cancel the AI Assistant feature async request,
+		 * in case there is one pending,
+		 * when performing a new AI suggestion request.
+		 */
+		dequeueAiAssistantFeatureAyncRequest();
 
 		request( prompt, { feature: 'jetpack-ai-content-lens', model } );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR continues with the handling of the AI Assistant feature data. In this PR:

* Dequeue the AI Assistant Fearture data async request (in case it exists) when asking for a new excerpt
* Dispatch the action to increases the requests counter from the store, avoiding to use the useAIFeature() hook

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: dequeue AI feature async request when asking a new suggestion


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the Redux dev tool
* Open the Post sidebar 
* Open the AI Expert panel
* Confirm the app increases the counter every time that the AI excerpt suggestion is done
* Confirm the app dequeues the async requests right after the user asks for a new excerpt

https://github.com/Automattic/jetpack/assets/77539/3606e6e9-ca92-4c3a-8331-0dc388d4e26e
