### PR TITLE
My Jetpack: Deal with wp_error responses from the Jetpack AI ai-assistant-feature data request

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-fix-error-on-getting-next-tier-while-disconnected
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-fix-error-on-getting-next-tier-while-disconnected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Fix bug when the Jetpack AI feature information is not available.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.12.1",
+	"version": "3.12.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.12.1';
+	const PACKAGE_VERSION = '3.12.2-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -80,7 +80,13 @@ class Jetpack_Ai extends Product {
 	 * @return int
 	 */
 	public static function get_next_usage_tier() {
-		$info         = self::get_ai_assistant_feature();
+		$info = self::get_ai_assistant_feature();
+
+		// Bail early if it's not possible to fetch the feature data.
+		if ( is_wp_error( $info ) ) {
+			return null;
+		}
+
 		$current_tier = isset( $info['current-tier']['value'] ) ? $info['current-tier']['value'] : null;
 
 		if ( null === $current_tier ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes the fatal error on My Jetpack page when the site is disconnected.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Detect when the request fails and bail early returning `null`, meaning it's not possible to determine the next tier available in this situation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1699903329162289-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a disconnected Jetpack site, visit `Jetpack > My Jetpack`
* Before this fix, the page would be broken:

<img width="600" alt="Screenshot 2023-11-13 at 16 53 21" src="https://github.com/Automattic/jetpack/assets/6760046/4bd67232-df07-4c68-816c-3932d0460b95">

* After this fix, the page should load properly:

<img width="600" alt="Screenshot 2023-11-13 at 17 01 35" src="https://github.com/Automattic/jetpack/assets/6760046/c6215e19-0ccd-483e-955c-776aa4af00d5">