### PR TITLE
Jetpack Form: handle AI requests counter when asking AI suggestions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-from-ai-feature-data-handling
+++ b/projects/plugins/jetpack/changelog/update-jetpack-from-ai-feature-data-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack Form: handle AI requests counter when asking AI suggestions

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -85,6 +85,8 @@ export default function AiAssistantBar( {
 	const { inputValue, setInputValue, isVisible, assistantAnchor } =
 		useContext( AiAssistantUiContext );
 
+	const { dequeueAiAssistantFeatureAyncRequest } = useDispatch( 'wordpress-com/plans' );
+
 	const focusOnPrompt = () => {
 		// Small delay to avoid focus crash
 		setTimeout( () => {
@@ -124,9 +126,22 @@ export default function AiAssistantBar( {
 			content: getSerializedContentFromBlock( clientId ),
 		} );
 
+		/*
+		 * Always dequeue/cancel the AI Assistant feature async request,
+		 * in case there is one pending,
+		 * when performing a new AI suggestion request.
+		 */
+		dequeueAiAssistantFeatureAyncRequest();
+
 		requestSuggestion( prompt, { feature: 'jetpack-form-ai-extension' } );
 		wrapperRef?.current?.focus();
-	}, [ clientId, inputValue, removeNotice, requestSuggestion ] );
+	}, [
+		clientId,
+		dequeueAiAssistantFeatureAyncRequest,
+		inputValue,
+		removeNotice,
+		requestSuggestion,
+	] );
 
 	const handleStopSuggestion = useCallback( () => {
 		stopSuggestion();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -6,14 +6,13 @@ import { JETPACK_MODULES_STORE_ID } from '@automattic/jetpack-shared-extension-u
 import { BlockControls } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { select, useSelect } from '@wordpress/data';
+import { select, useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useCallback } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import React from 'react';
 /*
  * Internal dependencies
  */
-import useAiFeature from '../../hooks/use-ai-feature';
 import AiAssistantBar from './components/ai-assistant-bar';
 import AiAssistantToolbarButton from './components/ai-assistant-toolbar-button';
 import { isJetpackFromBlockAiCompositionAvailable } from './constants';
@@ -104,7 +103,7 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
 			clientId: props.clientId,
 		} );
 
-		const { increaseRequestsCount } = useAiFeature();
+		const { increaseAiAssistantRequestsCount } = useDispatch( 'wordpress-com/plans' );
 
 		const { eventSource } = useAiContext( {
 			onDone: useCallback( () => {
@@ -112,8 +111,8 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
 				 * Increase the AI Suggestion counter.
 				 * @todo: move this at store level.
 				 */
-				increaseRequestsCount();
-			}, [ increaseRequestsCount ] ),
+				increaseAiAssistantRequestsCount();
+			}, [ increaseAiAssistantRequestsCount ] ),
 			onError: useCallback(
 				error => {
 					/*
@@ -126,9 +125,9 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
 					}
 
 					// Increase the AI Suggestion counter.
-					increaseRequestsCount();
+					increaseAiAssistantRequestsCount();
 				},
-				[ increaseRequestsCount ]
+				[ increaseAiAssistantRequestsCount ]
 			),
 		} );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Similar to https://github.com/Automattic/jetpack/pull/34094 but with the Jetpack Form with AI assistant:

This PR continues with the handling of the AI Assistant feature data. In this PR:

Dequeue the AI Assistant Fearture data async request (in case it exists) when asking for a new excerpt
Dispatch the action to increase the requests counter from the store, avoiding to use the useAIFeature() hook

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack Form: handle AI requests counter when asking AI suggestions

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the Redux dev tool
* Create a Jetpack Form instance
* Open the Jetpack AI sidebar. Identify the Usage panel
* Confirm the app increases the counter every time you ask for an AI suggestion to compose the form
* Confirm the app dequeues the async requests right after the user asks for a new change

https://github.com/Automattic/jetpack/assets/77539/5b3d405d-1f67-4467-9ab2-2634df12e93d




