### PR TITLE
General: do not ship development config files in production build

### DIFF
--- a/projects/packages/admin-ui/.gitattributes
+++ b/projects/packages/admin-ui/.gitattributes
@@ -10,6 +10,7 @@ package.json      export-ignore
 # Files to exclude from the mirror repo, but included in the monorepo.
 # Remember to end all directories with `/**` to properly tag every file.
 .gitignore        production-exclude
+.phpcs.dir.xml    production-exclude
 changelog/**      production-exclude
 phpunit.xml.dist  production-exclude
 tests/**          production-exclude

--- a/projects/packages/admin-ui/changelog/update-ignore-dev-files-production
+++ b/projects/packages/admin-ui/changelog/update-ignore-dev-files-production
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Do not ship development tooling config files in production build.
+
+

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.2.24",
+	"version": "0.2.25-alpha",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.2.24';
+	const PACKAGE_VERSION = '0.2.25-alpha';
 
 	/**
 	 * Whether this class has been initialized

--- a/projects/packages/backup/.gitattributes
+++ b/projects/packages/backup/.gitattributes
@@ -1,4 +1,5 @@
 # Files not needed to be distributed.
+.babelrc         export-ignore
 .gitattributes   export-ignore
 .github/         export-ignore
 .gitignore       export-ignore

--- a/projects/packages/backup/changelog/update-ignore-dev-files-production
+++ b/projects/packages/backup/changelog/update-ignore-dev-files-production
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Do not ship development tooling config files in production build.
+
+

--- a/projects/packages/compat/.gitattributes
+++ b/projects/packages/compat/.gitattributes
@@ -3,4 +3,5 @@
 .github/         export-ignore
 
 # Files not needed in the production build.
+.phpcs.dir.xml   production-exclude
 /changelog/**    production-exclude

--- a/projects/packages/compat/changelog/update-ignore-dev-files-production
+++ b/projects/packages/compat/changelog/update-ignore-dev-files-production
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Do not ship development tooling config files in production build.
+
+

--- a/projects/packages/my-jetpack/.gitattributes
+++ b/projects/packages/my-jetpack/.gitattributes
@@ -1,4 +1,5 @@
 # Files not needed to be distributed in the package.
+.babelrc          export-ignore
 .gitattributes    export-ignore
 .github/          export-ignore
 package.json      export-ignore

--- a/projects/packages/my-jetpack/changelog/update-ignore-dev-files-production
+++ b/projects/packages/my-jetpack/changelog/update-ignore-dev-files-production
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Do not ship development tooling config files in production build.
+
+

--- a/projects/packages/plugins-installer/.gitattributes
+++ b/projects/packages/plugins-installer/.gitattributes
@@ -9,6 +9,7 @@ package.json      export-ignore
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # Remember to end all directories with `/**` to properly tag every file.
+.phpcs.dir.xml    production-exclude
 .gitignore        production-exclude
 changelog/**      production-exclude
 phpunit.xml.dist  production-exclude

--- a/projects/packages/plugins-installer/changelog/update-ignore-dev-files-production
+++ b/projects/packages/plugins-installer/changelog/update-ignore-dev-files-production
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Do not ship development tooling config files in production build.
+
+

--- a/projects/packages/waf/.gitattributes
+++ b/projects/packages/waf/.gitattributes
@@ -9,8 +9,10 @@ package.json      export-ignore
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # Remember to end all directories with `/**` to properly tag every file.
-.gitignore        production-exclude
-changelog/**      production-exclude
-phpunit.xml.dist  production-exclude
-.phpcs.dir.xml    production-exclude
-tests/**          production-exclude
+.phpcs.dir.phpcompatibility.xml production-exclude
+.phpcsignore                    production-exclude
+.gitignore                      production-exclude
+changelog/**                    production-exclude
+phpunit.xml.dist                production-exclude
+.phpcs.dir.xml                  production-exclude
+tests/**                        production-exclude

--- a/projects/packages/waf/changelog/update-ignore-dev-files-production
+++ b/projects/packages/waf/changelog/update-ignore-dev-files-production
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Do not ship development tooling config files in production build.
+
+


### PR DESCRIPTION
See #34097

## Proposed changes:

A few of our config files were still shipped with the production version of our packages. This should fix that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here; check that the added files are indeed not needed in production builds of the packages.
