### PR TITLE
Jetpack: add license information to the readme

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-readme-license
+++ b/projects/plugins/jetpack/changelog/update-jetpack-readme-license
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Readme: add license information.
+
+

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -5,6 +5,8 @@ Stable tag: 12.7
 Requires at least: 6.2
 Requires PHP: 5.6
 Tested up to: 6.4
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Improve your WP security with powerful one-click tools like backup, WAF, and malware scan. Get essential free tools including stats, CDN and social sharing.
 


### PR DESCRIPTION
See #34097

## Proposed changes:

That information is already added to all other plugins in the repo, and in the starter-plugin. It's only natural that it be added to the Jetpack plugin as well.

> **Note**
> We already ship a `LICENSE.txt` file in all plugins as well, since #19801.

> **Note**
> For past discussions on the topic of Jetpack's licensing (and a confirmation that the plugin is indeed licensed as "GPLv2 or later", view the discussions in p1HpG7-3SA-p2, #6609, #7879.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Check that the plugin header matches the other plugins in the repo.
