### PR TITLE
Memberships: Fix issue with tier resolver

### DIFF
--- a/projects/plugins/jetpack/changelog/add-fix-issue-with-tier-selector
+++ b/projects/plugins/jetpack/changelog/add-fix-issue-with-tier-selector
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Membership products resolver would not filter tiers

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -17,10 +17,10 @@ function PaywallEdit( { className } ) {
 	const accessLevel = useAccessLevel( postType );
 
 	const { stripeConnectUrl, hasNewsletterPlans } = useSelect( select => {
-		const { getNewsletterProducts, getConnectUrl } = select( 'jetpack/membership-products' );
+		const { getNewsletterTierProducts, getConnectUrl } = select( 'jetpack/membership-products' );
 		return {
 			stripeConnectUrl: getConnectUrl(),
-			hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
+			hasNewsletterPlans: getNewsletterTierProducts()?.length !== 0,
 		};
 	} );
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -331,7 +331,7 @@ const withThemeProvider = WrappedComponent => props => (
 
 export default compose( [
 	withSelect( select => {
-		const newsletterPlans = select( 'jetpack/membership-products' )?.getNewsletterProducts();
+		const newsletterPlans = select( 'jetpack/membership-products' )?.getNewsletterTierProducts();
 		return {
 			hasNewsletterPlans: newsletterPlans?.length !== 0,
 		};

--- a/projects/plugins/jetpack/extensions/shared/components/plans-setup-dialog/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/plans-setup-dialog/index.jsx
@@ -9,10 +9,10 @@ import useAutosaveAndRedirect from '../../use-autosave-and-redirect';
 
 export default function PlansSetupDialog( { showDialog, closeDialog } ) {
 	const { hasNewsletterPlans } = useSelect( select => {
-		const { getNewsletterProducts, getConnectUrl } = select( 'jetpack/membership-products' );
+		const { getNewsletterTierProducts, getConnectUrl } = select( 'jetpack/membership-products' );
 		return {
 			stripeConnectUrl: getConnectUrl(),
-			hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
+			hasNewsletterPlans: getNewsletterTierProducts()?.length !== 0,
 		};
 	} );
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -82,7 +82,9 @@ function TierSelector() {
 	// TODO: figure out how to handle different currencies
 	const products = useSelect( select =>
 		select( membershipProductsStore ).getNewsletterTierProducts()
-	).sort( ( p1, p2 ) => Number( p2.price ) - Number( p1.price ) );
+	)
+		.filter( product => product.interval === '1 month' )
+		.sort( ( p1, p2 ) => Number( p2.price ) - Number( p1.price ) );
 
 	// Find the current tier meta
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -80,9 +80,9 @@ export function useSetTier() {
 
 function TierSelector() {
 	// TODO: figure out how to handle different currencies
-	const products = useSelect( select => select( membershipProductsStore ).getProducts() )
-		.filter( product => product.subscribe_as_site_subscriber && product.interval === '1 month' )
-		.sort( ( p1, p2 ) => Number( p2.price ) - Number( p1.price ) );
+	const products = useSelect( select =>
+		select( membershipProductsStore ).getNewsletterTierProducts()
+	).sort( ( p1, p2 ) => Number( p2.price ) - Number( p1.price ) );
 
 	// Find the current tier meta
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
@@ -189,7 +189,7 @@ export function NewsletterAccessRadioButtons( {
 export function NewsletterAccessDocumentSettings( { accessLevel } ) {
 	const { hasNewsletterPlans, stripeConnectUrl, isLoading, foundPaywallBlock } = useSelect(
 		select => {
-			const { getNewsletterProducts, getConnectUrl, isApiStateLoading } = select(
+			const { getNewsletterTierProducts, getConnectUrl, isApiStateLoading } = select(
 				'jetpack/membership-products'
 			);
 			const { getBlocks } = select( 'core/block-editor' );
@@ -197,7 +197,7 @@ export function NewsletterAccessDocumentSettings( { accessLevel } ) {
 			return {
 				isLoading: isApiStateLoading(),
 				stripeConnectUrl: getConnectUrl(),
-				hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
+				hasNewsletterPlans: getNewsletterTierProducts()?.length !== 0,
 				foundPaywallBlock: getBlocks().find( block => block.name === paywallBlockMetadata.name ),
 			};
 		}
@@ -287,7 +287,7 @@ export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
 	const { isLoading, postHasPaywallBlock, newsletterCategories, newsletterCategoriesEnabled } =
 		useSelect( select => {
 			const {
-				getNewsletterProducts,
+				getNewsletterTierProducts,
 				getConnectUrl,
 				isApiStateLoading,
 				getNewsletterCategories,
@@ -298,7 +298,7 @@ export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
 			return {
 				isLoading: isApiStateLoading(),
 				stripeConnectUrl: getConnectUrl(),
-				hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
+				hasNewsletterPlans: getNewsletterTierProducts()?.length !== 0,
 				postHasPaywallBlock: getBlocks().some( block => block.name === paywallBlockMetadata.name ),
 				newsletterCategories: getNewsletterCategories(),
 				newsletterCategoriesEnabled: getNewsletterCategoriesEnabled(),

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -151,7 +151,7 @@ const setDefaultProductIfNeeded = ( selectedProductId, setSelectedProductId, sel
 	}
 };
 
-export const getNewsletterProducts = (
+export const getNewsletterTierProducts = (
 	productType = PRODUCT_TYPE_PAYMENT_PLAN,
 	selectedProductId = 0,
 	setSelectedProductId = () => {}

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -15,7 +15,7 @@ import {
 	setSubscriberCounts,
 	setNewsletterCategories,
 } from './actions';
-import { API_STATE_CONNECTED, API_STATE_NOTCONNECTED } from './constants';
+import { API_STATE_CONNECTED, API_STATE_NOTCONNECTED, TYPE_TIER } from './constants';
 import { onError } from './utils';
 
 const EXECUTION_KEY = 'membership-products-resolver-getProducts';
@@ -157,7 +157,9 @@ export const getNewsletterTierProducts = (
 	setSelectedProductId = () => {}
 ) =>
 	// Returns the products, but silences the snack bar if a default product is created
-	getProducts( productType, selectedProductId, setSelectedProductId, false );
+	getProducts( productType, selectedProductId, setSelectedProductId, false ).filter(
+		product => product.type === TYPE_TIER
+	);
 
 export const getProducts =
 	(

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -15,7 +15,7 @@ import {
 	setSubscriberCounts,
 	setNewsletterCategories,
 } from './actions';
-import { API_STATE_CONNECTED, API_STATE_NOTCONNECTED, TYPE_TIER } from './constants';
+import { API_STATE_CONNECTED, API_STATE_NOTCONNECTED } from './constants';
 import { onError } from './utils';
 
 const EXECUTION_KEY = 'membership-products-resolver-getProducts';
@@ -155,11 +155,7 @@ export const getNewsletterTierProducts = (
 	productType = PRODUCT_TYPE_PAYMENT_PLAN,
 	selectedProductId = 0,
 	setSelectedProductId = () => {}
-) =>
-	// Returns the products, but silences the snack bar if a default product is created
-	getProducts( productType, selectedProductId, setSelectedProductId, false ).filter(
-		product => product.type === TYPE_TIER
-	);
+) => getProducts( productType, selectedProductId, setSelectedProductId, false );
 
 export const getProducts =
 	(

--- a/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
@@ -13,7 +13,7 @@ export const getProductsNoResolver = state => getProducts( state );
 export const getProduct = ( state, productId ) =>
 	getProducts( state ).find( product => product.id === productId );
 
-export const getNewsletterProducts = state =>
+export const getNewsletterTierProducts = state =>
 	state.products.filter( product => product.type === TYPE_TIER );
 
 export const getSiteSlug = state => state.siteSlug;

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/selectors-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/selectors-test.js
@@ -3,7 +3,6 @@ import {
 	getNewsletterCategoriesEnabled,
 	getNewsletterTierProducts,
 	getNewsletterCategoriesSubscriptionsCount,
-	getNewsletterProducts,
 	getProducts,
 } from '../selectors';
 

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/selectors-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/selectors-test.js
@@ -1,12 +1,12 @@
 import {
 	getNewsletterCategories,
 	getNewsletterCategoriesEnabled,
-	getNewsletterProducts,
+	getNewsletterTierProducts,
 	getProducts,
 } from '../selectors';
 
 describe( 'Membership Products Selectors', () => {
-	test( 'GetProducts and getNewsletterProducts works as expected', () => {
+	test( 'GetProducts and getNewsletterTierProducts works as expected', () => {
 		const products = [
 			{
 				id: 1,
@@ -27,7 +27,7 @@ describe( 'Membership Products Selectors', () => {
 		};
 
 		expect( getProducts( state ) ).toStrictEqual( state.products );
-		expect( getNewsletterProducts( state ) ).toStrictEqual( [ newsletter_product ] );
+		expect( getNewsletterTierProducts( state ) ).toStrictEqual( [ newsletter_product ] );
 	} );
 
 	test( 'getNewsletterCategories and getNewsletterCategoriesEnabled works as expected', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See p1699963507382499/1699898012.697669-slack-C052XEUUBL4
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Rename getNewsletterProducts to getNewsletterTierProducts to clear confusion
* Fix resolver, which would not filter the right products

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this on your sandbox
* Sandbox ericktesting1571.wordpress.com
* visit https://ericktesting1571.wordpress.com/ admin
* You should see the right plans in the editor 
And this should NOT happen anymore:
<img width="1372" alt="Screenshot 2023-11-14 at 13 15 15" src="https://github.com/Automattic/jetpack/assets/790558/0164822f-d882-4206-909e-7e19753e577b">
