### PR TITLE
AI Assistant: ensure the client performs AI data feature request at least once

### DIFF
--- a/projects/plugins/jetpack/changelog/y
+++ b/projects/plugins/jetpack/changelog/y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: ensure the client performs AI data feature request at least once

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -688,6 +688,9 @@ class Jetpack_Gutenberg {
 			$ai_assistant_state['is-playground-visible'] = Constants::is_true( 'JETPACK_AI_ASSISTANT_PLAYGROUND' );
 		}
 
+		// Jetpack AI enabled
+		$ai_assistant_state['is-enabled'] = apply_filters( 'jetpack_ai_enabled', true );
+
 		$screen_base = null;
 		if ( function_exists( 'get_current_screen' ) ) {
 			$screen_base = get_current_screen()->base;

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
@@ -95,3 +95,9 @@ const wordpressPlansStore = createReduxStore( store, {
 } );
 
 register( wordpressPlansStore );
+
+/*
+ * Ensure to request the AI Assistant feature data
+ * by calling the selector. Resolver will take care.
+ */
+select( store ).getAiAssistantFeature();

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -100,4 +100,6 @@ register( wordpressPlansStore );
  * Ensure to request the AI Assistant feature data
  * by calling the selector. Resolver will take care.
  */
-select( store ).getAiAssistantFeature();
+if ( window.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-enabled' ] ) {
+	select( store ).getAiAssistantFeature();
+}

--- a/projects/plugins/jetpack/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/types.ts
@@ -7,6 +7,7 @@ import type { TierProp, UpgradeTypeProp } from './store/wordpress-com/types';
  * `sites/$site/ai-assistant-feature` endpoint response body props
  */
 export type SiteAIAssistantFeatureEndpointResponseProps = {
+	'is-enabled': boolean;
 	'has-feature': boolean;
 	'is-over-limit': boolean;
 	'requests-count': number;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR ensures to request of the AI Assistant feature data when it's enabled. Currently, the requests arr performed at the components level. Although it works, it would be better to ensure the request at the app level.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: ensure the client performs AI data feature request at least once

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disable the AI Assistant feature by using a filter

```php
add_filter( 'jetpack_ai_enabled', '__return_false' );
```

* Go to the block editor
* Open the Network tab
* Filter the request by `ai-assistant-feature`
* Confirm there is not any request for the AI Assistant feature data

<img width="572" alt="Screenshot 2023-11-14 at 20 27 20" src="https://github.com/Automattic/jetpack/assets/77539/da081a67-e1e2-4a04-90db-6eb2f3aa9564">

* enable the AI Assistant feature (remove the filter line or return `__return_true` );
* Hard refresh
* Network tab
* Confirm there is only one request to get the AI Assistant feature data:

<img width="901" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/4227cf1d-3ed1-4fa6-857a-447673483a6f">

