### PR TITLE
VideoPress: enqueue token bridge on shortcode

### DIFF
--- a/projects/packages/videopress/changelog/fix-token-bridge-enqueue-on-shortcode
+++ b/projects/packages/videopress/changelog/fix-token-bridge-enqueue-on-shortcode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Enqueue token-bridge script when processing videopress shortcode

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.20.x-dev"
+			"dev-trunk": "0.21.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.20.3-alpha",
+	"version": "0.21.0-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -129,6 +129,7 @@ class Block_Editor_Content {
 		'</figure>';
 
 		$version = Package_Version::PACKAGE_VERSION;
+		Jwt_Token_Bridge::enqueue_jwt_token_bridge();
 		wp_enqueue_script( 'videopress-iframe', 'https://videopress.com/videopress-iframe.js', array(), $version, true );
 
 		return sprintf( $block_template, $src, $width, $height, $cover );

--- a/projects/packages/videopress/src/class-jwt-token-bridge.php
+++ b/projects/packages/videopress/src/class-jwt-token-bridge.php
@@ -25,7 +25,6 @@ class Jwt_Token_Bridge {
 	 * This method should be called only once by the Initializer class. Do not call this method again.
 	 */
 	public static function init() {
-
 		if ( ! Status::is_active() ) {
 			return;
 		}

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.20.3-alpha';
+	const PACKAGE_VERSION = '0.21.0-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/changelog/fix-token-bridge-enqueue-on-shortcode
+++ b/projects/plugins/jetpack/changelog/fix-token-bridge-enqueue-on-shortcode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2463,7 +2463,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "f7ab9dc67a51d0ee374cd55ef454f3b3a2969b38"
+                "reference": "eb495ee2030ddd15f0d0bb1d424490edc9134112"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2488,7 +2488,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.20.x-dev"
+                    "dev-trunk": "0.21.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/plugins/videopress/changelog/fix-token-bridge-enqueue-on-shortcode
+++ b/projects/plugins/videopress/changelog/fix-token-bridge-enqueue-on-shortcode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1289,7 +1289,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "f7ab9dc67a51d0ee374cd55ef454f3b3a2969b38"
+                "reference": "eb495ee2030ddd15f0d0bb1d424490edc9134112"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1314,7 +1314,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.20.x-dev"
+                    "dev-trunk": "0.21.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"


### PR DESCRIPTION
Enqueue token bridge script for proper functionality when processing VideoPress shortcode

Fixes #33975 
Fixes #33977 

## Proposed changes:
This PR adds a call to the token enqueueing method side by side with the iframe script when the shortcode is being processed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1698873100821409-slack-C03TA48NSUX


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test on JN, do not use the PR link. Instance JN without JP and only JP Beta.

Install only VP plugin using JP Beta, follow the connection process. Upload a video, make it private. Create a subscriber user on the site. Publish 2 posts with the video, use the block on one and the shortcode on the other.

Open an incognito window and visit the posts, none should allow the video to play. Login with the subscriber on that incognito window. Reload the posts and make sure the videos are playable now.

You can also check the token-bridge being loaded on the post with the shortcode. Use the Beta plugin to checkout latest stable VP 1.6, load the shortcode post and see the token-bridge is not loaded and, likely, the video will fail to play (maybe you need to clear site data before this test).

Test the same approach on .com and AT, likely this was not broken on .com, make sure it continues to work.