### PR TITLE
General: update WP version requirements to WordPress 6.3.

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -40,7 +40,7 @@ case "$WP_BRANCH" in
 	previous)
 		# We hard-code the version here because there's a time near WP releases where
 		# we've dropped the old 'previous' but WP hasn't actually released the new 'latest'
-		TAG=6.2
+		TAG=6.3
 		;;
 	*)
 		echo "Unrecognized value for WP_BRANCH: $WP_BRANCH" >&2

--- a/.phpcs.config.xml
+++ b/.phpcs.config.xml
@@ -2,8 +2,8 @@
 <!-- This file configures everything except the list of rules. -->
 <!-- The separation is so .github/files/phpcompatibility-dev-phpcs.xml can use the same config with a different rule set. -->
 <ruleset>
-	<config name="minimum_supported_wp_version" value="6.2" />
-	<config name="testVersion" value="5.6-"/>
+	<config name="minimum_supported_wp_version" value="6.3" />
+	<config name="testVersion" value="7.0-"/>
 
 	<!-- Use our custom filter for `.phpcsignore` and `.phpcs.dir.xml` support. -->
 	<arg name="filter" value="vendor/automattic/jetpack-phpcs-filter/src/PhpcsFilter.php" />

--- a/projects/plugins/backup/changelog/update-wp-requirements-63
+++ b/projects/plugins/backup/changelog/update-wp-requirements-63
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack VaultPress Backup ===
 Contributors: automattic, bjorsch, fgiannar, initsogar, jeherve, jwebbdev, kraftbj, macbre, samiff, sermitr, williamvianas
 Tags: jetpack, backup, restore
-Requires at least: 6.2
+Requires at least: 6.3
 Requires PHP: 5.6
 Tested up to: 6.4
 Stable tag: 2.2

--- a/projects/plugins/inspect/changelog/update-wp-requirements-63
+++ b/projects/plugins/inspect/changelog/update-wp-requirements-63
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/inspect/readme.txt
+++ b/projects/plugins/inspect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack inspect ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.2
+Requires at least: 6.3
 Requires PHP: 5.6
 Tested up to: 6.4
 Stable tag: 1.0.0-alpha

--- a/projects/plugins/jetpack/changelog/update-wp-requirements-63
+++ b/projects/plugins/jetpack/changelog/update-wp-requirements-63
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -8,7 +8,7 @@
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
- * Requires at least: 6.2
+ * Requires at least: 6.3
  * Requires PHP: 5.6
  *
  * @package automattic/jetpack
@@ -32,7 +32,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
 define( 'JETPACK__VERSION', '12.9-a.4' );
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, barry, batmoo, beaulebens, bindlegirl, biskobe, bjorsch, blobaugh, brbrr, cainm, cena, cfinke, cgastrell, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, daniloercoli, davoraltman, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jasmussen, jblz, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lhkowalski, lschuyler, macmanx, martinremy, matt, mattwiebe, matveb, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, nunyvega, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, renatoagds, retrofox, richardmtl, richardmuscat, robertbpugh, roccotripaldi, ryancowles, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, thehenridev, tmoorewp, tyxla, Viper007Bond, westi, williamvianas, wpkaren, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, spam, CDN, search, social
 Stable tag: 12.7
-Requires at least: 6.2
+Requires at least: 6.3
 Requires PHP: 5.6
 Tested up to: 6.4
 License: GPLv2 or later

--- a/projects/plugins/migration/changelog/update-wp-requirements-63
+++ b/projects/plugins/migration/changelog/update-wp-requirements-63
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/migration/readme.txt
+++ b/projects/plugins/migration/readme.txt
@@ -1,7 +1,7 @@
 === Move to WordPress.com ===
 Contributors: automattic
 Tags: migrate, migration, backup, restore, transfer, move, copy, wordpress.com, automattic, import, importer, hosting
-Requires at least: 6.2
+Requires at least: 6.3
 Requires PHP: 5.6
 Tested up to: 6.4
 Stable tag: 1.0.0

--- a/projects/plugins/protect/changelog/update-wp-requirements-63
+++ b/projects/plugins/protect/changelog/update-wp-requirements-63
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/protect/readme.txt
+++ b/projects/plugins/protect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Protect ===
 Contributors: automattic, retrofox, leogermani, renatoagds, bjorsch, ebinnion, fgiannar, zinigor, miguelxavierpenha, dsmart, jeherve, manzoorwanijk, njweller, oskosk, samiff, siddarthan, wpkaren, arsihasi, kraftbj, kev, sermitr, kangzj, pabline, dkmyta
 Tags: jetpack, protect, security, malware, scan
-Requires at least: 6.2
+Requires at least: 6.3
 Requires PHP: 5.6
 Tested up to: 6.4
 Stable tag: 1.4.1

--- a/projects/plugins/search/changelog/update-wp-requirements-63
+++ b/projects/plugins/search/changelog/update-wp-requirements-63
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Search ===
 Contributors: automattic, annamcphee, bluefuton, kangzj, jsnmoon, robfelty, gibrown, trakos, dognose24, a8ck3n
 Tags: search, filter, woocommerce search, ajax search, product search, free cloud-based search
-Requires at least: 6.2
+Requires at least: 6.3
 Requires PHP: 5.6
 Tested up to: 6.4
 Stable tag: 1.4.0

--- a/projects/plugins/social/changelog/update-wp-requirements-63
+++ b/projects/plugins/social/changelog/update-wp-requirements-63
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Social  ===
 Contributors: automattic, pabline, siddarthan, gmjuhasz, manzoorwanijk, danielpost
 Tags: social-media, publicize, social-media-manager, social-networking, social marketing, social, social share,  social media scheduling, social media automation, auto post, auto- publish, social share
-Requires at least: 6.2
+Requires at least: 6.3
 Requires PHP: 5.6
 Tested up to: 6.4
 Stable tag: 2.3.0

--- a/projects/plugins/starter-plugin/changelog/update-wp-requirements-63
+++ b/projects/plugins/starter-plugin/changelog/update-wp-requirements-63
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/starter-plugin/readme.txt
+++ b/projects/plugins/starter-plugin/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Starter Plugin ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.2
+Requires at least: 6.3
 Requires PHP: 5.6
 Tested up to: 6.4
 Stable tag: 0.1.0-alpha

--- a/projects/plugins/super-cache/changelog/update-wp-requirements-63
+++ b/projects/plugins/super-cache/changelog/update-wp-requirements-63
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -1,7 +1,7 @@
 === WP Super Cache ===
 Contributors: donncha, automattic, adnan007, dilirity, mikemayhem3030, pyronaur, thingalon
 Tags: performance, caching, wp-cache, wp-super-cache, cache
-Requires at least: 6.2
+Requires at least: 6.3
 Requires PHP: 5.6
 Tested up to: 6.4
 Stable tag: 1.10.0

--- a/projects/plugins/videopress/changelog/update-wp-requirements-63
+++ b/projects/plugins/videopress/changelog/update-wp-requirements-63
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, retrofox, oskosk, thehenridev, renatoagds, lhkowalski, nunyvega, leogermani, cgastrell
 Tags: video, video-hosting, video-player, cdn, vimeo, youtube, video-streaming, mobile-video, jetpack
 
-Requires at least: 6.2
+Requires at least: 6.3
 Tested up to: 6.4
 Stable tag: 1.5
 Requires PHP: 5.6

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -750,7 +750,7 @@ function createReadMeTxt( answers ) {
 		`=== Jetpack ${ answers.name } ===\n` +
 		'Contributors: automattic,\n' +
 		'Tags: jetpack, stuff\n' +
-		'Requires at least: 6.2\n' +
+		'Requires at least: 6.3\n' +
 		'Requires PHP: 5.6\n' +
 		'Tested up to: 6.4\n' +
 		`Stable tag: ${ answers.version }\n` +


### PR DESCRIPTION

## Proposed changes:

WordPress 6.4 is out, we can now require WP-1, i.e. WP 6.3.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Primary issue: #32865

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Is CI happy?
