### PR TITLE
Blocks: update support from __experimentalLayout to layout

### DIFF
--- a/projects/plugins/jetpack/changelog/update-block-layout-support
+++ b/projects/plugins/jetpack/changelog/update-block-layout-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: update block support from __experimentalLayout to layout.

--- a/projects/plugins/jetpack/extensions/blocks/payment-buttons/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/payment-buttons/block.json
@@ -48,7 +48,7 @@
 				"blockGap": true
 			}
 		},
-		"__experimentalLayout": {
+		"layout": {
 			"allowSwitching": false,
 			"allowInheriting": false,
 			"default": {

--- a/projects/plugins/jetpack/extensions/blocks/payment-buttons/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/payment-buttons/edit.js
@@ -64,7 +64,7 @@ function PaymentButtonsEdit( { clientId, attributes } ) {
 		orientation: 'horizontal',
 		template: [ [ 'jetpack/recurring-payments' ] ],
 		templateInsertUpdatesSelection: true,
-		__experimentalLayout: layout,
+		layout,
 	} );
 
 	// The ID needs to be just on the outermost wrapper - the toolbar and wpcom upgrade nudge

--- a/projects/plugins/jetpack/extensions/blocks/payment-buttons/payment-buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/payment-buttons/payment-buttons.php
@@ -28,7 +28,7 @@ function register_block() {
 			array(
 				'render_callback' => __NAMESPACE__ . '\render_block',
 				'supports'        => array(
-					'__experimentalLayout' => array(
+					'layout' => array(
 						'allowSwitching'  => false,
 						'allowInheriting' => false,
 						'default'         => array(

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
@@ -94,7 +94,7 @@ function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 				allowedBlocks={ ALLOWED_BLOCKS }
 				template={ isPreview ? previewTemplate : template }
 				templateInsertUpdatesSelection={ false }
-				__experimentalLayout={ { type: 'default', alignments: [] } }
+				layout={ { type: 'default', alignments: [] } }
 				__experimentalMoverDirection="horizontal"
 			/>
 		</div>

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
@@ -135,7 +135,7 @@ const TiledGalleryEdit = props => {
 			numColumns: displayedColumns,
 			marginHorizontal: TILE_SPACING,
 			marginVertical: TILE_SPACING,
-			__experimentalLayout: { type: 'default', alignments: [] },
+			layout: { type: 'default', alignments: [] },
 			gridProperties: {
 				numColumns: displayedColumns,
 			},


### PR DESCRIPTION
Fixes #32853

## Proposed changes:

Related PR where the changes were introduced to Gutenberg:
https://github.com/WordPress/gutenberg/pull/51434

> Marks __experimentalLayout, __experimentalLayoutStyle, __experimentalUseLayoutClasses and __experimentalUseLayoutStyles stable.

Block support for layout has now graduated from experimental to stable. Everything works the same; the only difference is that when adding block support for layout in block.json, its name is now layout instead of __experimentalLayout.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Primary issue: #32865

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Test the impacted blocks and ensure they continue to work as expected.
