### PR TITLE
AI Assistant: do not request AI Assistant feature data from the backend

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-do-not-perform-ai-assistant-request-from-backend
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-do-not-perform-ai-assistant-request-from-backend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: do not perform AI Assistant feature request from the backend

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -677,19 +677,10 @@ class Jetpack_Gutenberg {
 		}
 
 		// AI Assistant
-		$ai_assistant_state = Jetpack_AI_Helper::get_ai_assistance_feature();
-
-		if ( is_wp_error( $ai_assistant_state ) ) {
-			$ai_assistant_state = array(
-				'error-message' => $ai_assistant_state->get_error_message(),
-				'error-code'    => $ai_assistant_state->get_error_code(),
-			);
-		} else {
-			$ai_assistant_state['is-playground-visible'] = Constants::is_true( 'JETPACK_AI_ASSISTANT_PLAYGROUND' );
-		}
-
-		// Jetpack AI enabled
-		$ai_assistant_state['is-enabled'] = apply_filters( 'jetpack_ai_enabled', true );
+		$ai_assistant_state = array(
+			'is-enabled'            => apply_filters( 'jetpack_ai_enabled', true ),
+			'is-playground-visible' => Constants::is_true( 'JETPACK_AI_ASSISTANT_PLAYGROUND' ),
+		);
 
 		$screen_base = null;
 		if ( function_exists( 'get_current_screen' ) ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
@@ -25,19 +25,15 @@ const isAiAssistantSupportExtensionEnabled =
  * @returns {object}          Block settings.
  */
 function extendAiContentLensFeatures( settings, name ) {
-	// Do not extend if the site requires an upgrade.
-	const siteRequireUpgrade =
-		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'site-require-upgrade' ];
-	if ( siteRequireUpgrade ) {
-		return settings;
-	}
-
 	// Bail early when the block is not the AI Assistant.
 	if ( name !== metadata.name ) {
 		return settings;
 	}
 
-	// Bail early when the block is not registered.
+	/*
+	 * Bail early when the AI Assistant block is not registered.
+	 * It will handle with the site requires an upgrade.
+	 */
 	if ( ! isPossibleToExtendBlock() ) {
 		return settings;
 	}

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -15,32 +15,29 @@ import {
 } from './constants';
 import type { PlanStateProps } from './types';
 
-const aiAssistantFeature = window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ];
-
 const INITIAL_STATE: PlanStateProps = {
 	plans: [],
 	features: {
 		aiAssistant: {
-			hasFeature: !! aiAssistantFeature?.[ 'has-feature' ],
-			isOverLimit: !! aiAssistantFeature?.[ 'is-over-limit' ],
-			requestsCount: aiAssistantFeature?.[ 'requests-count' ] || 0,
-			requestsLimit: aiAssistantFeature?.[ 'requests-limit' ] || FREE_PLAN_REQUESTS_LIMIT,
-			requireUpgrade: !! aiAssistantFeature?.[ 'site-require-upgrade' ],
-			errorMessage: aiAssistantFeature?.[ 'error-message' ] || '',
-			errorCode: aiAssistantFeature?.[ 'error-code' ],
-			upgradeType: aiAssistantFeature?.[ 'upgrade-type' ] || 'default',
-			currentTier: aiAssistantFeature?.[ 'current-tier' ] || {
+			hasFeature: true,
+			isOverLimit: false,
+			requestsCount: 0,
+			requestsLimit: FREE_PLAN_REQUESTS_LIMIT,
+			requireUpgrade: false,
+			errorMessage: '',
+			errorCode: '',
+			upgradeType: 'default',
+			currentTier: {
 				slug: 'ai-assistant-tier-free',
 				value: 0,
 				limit: 20,
 			},
 			usagePeriod: {
-				currentStart:
-					aiAssistantFeature?.[ 'usage-period' ]?.[ 'current-start' ] || 'ai-assistant-tier-free',
-				nextStart: aiAssistantFeature?.[ 'usage-period' ]?.[ 'next-start' ] || '',
-				requestsCount: aiAssistantFeature?.[ 'usage-period' ]?.[ 'requests-count' ] || 0,
+				currentStart: 'ai-assistant-tier-free',
+				nextStart: '',
+				requestsCount: 0,
 			},
-			nextTier: aiAssistantFeature?.[ 'next-tier' ] || {
+			nextTier: {
 				slug: 'ai-assistant-tier-unlimited',
 				value: 1,
 				limit: 922337203685477600,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR removes the code that performs a request to the AI Assistant Feature data from the backend to improve the first-dendering time. It isn't required anymore since the app already ensures to perform an initial async request to get the same data.

Follow-up https://github.com/Automattic/jetpack/pull/34109

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: do not request AI Assistant feature data from the backend

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Confirm the app works as expected
  * Test the Usage Panel
  * Test the Upgrade banner in the AI Assistant block when request limits are achieved with a site with a Free site
  * etc.

<img width="819" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/907b815d-57ed-4186-9042-e444e1aabe73">

* Confirm the app performs only one async request to get AI Assistant feature data

<img width="585" alt="Screenshot 2023-11-15 at 14 23 38" src="https://github.com/Automattic/jetpack/assets/77539/6388cfbb-e206-467b-b625-86bd0425643d">

