### PR TITLE
Add accessible name to Contact Form dropdown

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-dropdown-label-accessible-name
+++ b/projects/packages/forms/changelog/fix-contact-form-dropdown-label-accessible-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add an accessible name to the Contact Form dropdown rendered in the front-end

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -715,8 +715,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		$field  = $this->render_label( 'select', $id, $label, $required, $required_field_text );
-		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . ">\n";
+		$label_ns     = 'contact-form-label';
+		$label_id_key = "$label_ns-id";
+		$label_id_val = "$label_ns-$id";
+
+		$field  = $this->render_label( 'select', $id, $label, $required, $required_field_text, array( 'id' => $label_id_val ) );
+		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . "data-$label_id_key='" . esc_attr( $label_id_val ) . "'>\n";
 
 		if ( $this->get_attribute( 'togglelabel' ) ) {
 			$field .= "\t\t<option value=''>" . $this->get_attribute( 'togglelabel' ) . "</option>\n";

--- a/projects/packages/forms/src/contact-form/js/dropdown.js
+++ b/projects/packages/forms/src/contact-form/js/dropdown.js
@@ -13,14 +13,21 @@ jQuery( function ( $ ) {
 	} );
 
 	function initializeSelectMenu() {
-		$( '.contact-form .contact-form-dropdown' )
-			.selectmenu( {
-				classes: {
-					'ui-selectmenu-button': 'contact-form-dropdown__button',
-					'ui-selectmenu-menu': 'contact-form-dropdown__menu',
-				},
-			} )
-			.attr( 'aria-hidden', true )
-			.prop( 'tabindex', -1 );
+		$( '.contact-form .contact-form-dropdown' ).each( function () {
+			const $select = $( this );
+			const labelId = $select.data( 'contact-form-label-id' );
+
+			$select
+				.selectmenu( {
+					classes: {
+						'ui-selectmenu-button': 'contact-form-dropdown__button',
+						'ui-selectmenu-menu': 'contact-form-dropdown__menu',
+					},
+				} )
+				.attr( 'aria-hidden', true )
+				.prop( 'tabindex', -1 )
+				.selectmenu( 'widget' )
+				.attr( 'aria-labelledby', labelId );
+		} );
 	}
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/30762

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the front-end of a site, the dropdown from _Contact Form_ doesn't have an accessible name. It makes it hard for screen reader users to know the purpose of the input.

Using a native `select` tag, the association with a `label` is done by adding the `for` attribute to the latter. However, Contact Form uses `jquery-ui-selectmenu`, which makes the `select` component invisible to assistive technologies and replaces it with a custom dropdown of which the root is a `span`. The association made with the `label` `for` attribute is lost.

The fastest solution to reestablish this association is to add the `aria-labelled-by` attribute to the aforementioned `span` and set the `label` `id` as its value.

Concretely, what's done in this PR is:
- Add an `id` to the `label` rendered just before the dropdown
- Reference that id on the `select` tag via a `data-` attribute, so that we can get it back later
- When initializing a jQuery UI select menu, retrieve that id
- Set that id to an `aria-labelled-by` attribute on the custom dropdown created by jQuery UI

_Note: the safest strategy to keep components accessible is usually to follow standards and use native solutions when available. In this case, we should consider getting rid of jQuery UI in favor of a native `select` and try to style that tag instead._

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Create a new post: visit `/wp-admin/post-new.php`
- Add the _Contact Form_ block to the page
<img width="346" alt="Screenshot 2023-11-15 at 10 20 30 AM" src="https://github.com/Automattic/jetpack/assets/1620183/60e74081-ab82-4141-8771-1c16543defb0">


- Add a dropdown
<img width="659" alt="Screenshot 2023-11-15 at 10 21 29 AM" src="https://github.com/Automattic/jetpack/assets/1620183/c8cf8e47-f54b-429d-9cbd-f7d08b7874fc">


- Open the page preview
- Inspect the dropdown and select the `span` jQuery UI created just after the `select` tag
- You should be able to find an _Accessibility_ panel (screenshots from Chrome)
<img width="293" alt="Screenshot 2023-11-15 at 10 14 54 AM" src="https://github.com/Automattic/jetpack/assets/1620183/23c8cca9-c02b-4341-9b9e-4889131d0c4f">


- Notice the `span` has an accessible name (the _Name_ property in the _Computed properties_ panel below)
<img width="987" alt="Screenshot 2023-11-15 at 10 15 26 AM" src="https://github.com/Automattic/jetpack/assets/1620183/132a8314-a296-49db-aff6-f4b9d0abe7de">

