### PR TITLE
Social: Refresh store on Publicize module toggle via 1 call

### DIFF
--- a/projects/js-packages/publicize-components/index.ts
+++ b/projects/js-packages/publicize-components/index.ts
@@ -18,6 +18,7 @@ export { default as PublicizePanel } from './src/components/panel';
 export { default as ReviewPrompt } from './src/components/review-prompt';
 export { default as PostPublishReviewPrompt } from './src/components/post-publish-review-prompt';
 export { default as PostPublishOneClickSharing } from './src/components/post-publish-one-click-sharing';
+export { default as RefreshJetpackSocialSettingsWrapper } from './src/components/refresh-jetpack-settings';
 
 export { default as useSocialMediaConnections } from './src/hooks/use-social-media-connections';
 export { default as useSocialMediaMessage } from './src/hooks/use-social-media-message';

--- a/projects/js-packages/publicize-components/src/components/auto-conversion/toggle/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/auto-conversion/toggle/index.tsx
@@ -1,7 +1,6 @@
 import { ToggleControl } from '@automattic/jetpack-components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { useEffect } from '@wordpress/element';
 import React from 'react';
 import { SOCIAL_STORE_ID } from '../../../social-store';
 import { SocialStoreSelectors } from '../../../types/types';
@@ -16,11 +15,6 @@ type AutoConversionToggleProps = {
 	 * The class name to add to the toggle.
 	 */
 	toggleClass?: string;
-
-	/**
-	 * Whether or not to refresh the settings.
-	 */
-	shouldRefresh?: boolean;
 };
 
 /**
@@ -30,16 +24,9 @@ type AutoConversionToggleProps = {
  * @returns {React.ReactElement} - JSX.Element
  */
 const AutoConversionToggle: React.FC< AutoConversionToggleProps > = ( {
-	shouldRefresh = false,
 	toggleClass,
 	children,
 } ) => {
-	const refreshSettings = useDispatch( SOCIAL_STORE_ID ).refreshAutoConversionSettings;
-
-	useEffect( () => {
-		shouldRefresh && refreshSettings();
-	}, [ shouldRefresh, refreshSettings ] );
-
 	const { isEnabled, isUpdating } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
 		return {

--- a/projects/js-packages/publicize-components/src/components/refresh-jetpack-settings/index.js
+++ b/projects/js-packages/publicize-components/src/components/refresh-jetpack-settings/index.js
@@ -1,5 +1,4 @@
 import { useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
 import { SOCIAL_STORE_ID } from '../../social-store';
 
 /**
@@ -13,11 +12,9 @@ import { SOCIAL_STORE_ID } from '../../social-store';
 export default function RefreshJetpackSocialSettingsWrapper( { shouldRefresh, children } ) {
 	const refreshOptions = useDispatch( SOCIAL_STORE_ID ).refreshJetpackSocialSettings;
 
-	useEffect( () => {
-		if ( shouldRefresh ) {
-			refreshOptions();
-		}
-	} );
+	if ( shouldRefresh ) {
+		refreshOptions();
+	}
 
 	return children;
 }

--- a/projects/js-packages/publicize-components/src/components/refresh-jetpack-settings/index.js
+++ b/projects/js-packages/publicize-components/src/components/refresh-jetpack-settings/index.js
@@ -1,0 +1,23 @@
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { SOCIAL_STORE_ID } from '../../social-store';
+
+/**
+ * HOC that refreshes all of the Jetpack Social settings in the store, to be used in class components.
+ *
+ * @param {object} props - The component props.
+ * @param {boolean} props.shouldRefresh - Whether or not to refresh the settings.
+ * @param {object} props.children - The children to render.
+ * @returns { object } The refreshJetpackSocialSettings function.
+ */
+export default function RefreshJetpackSocialSettingsWrapper( { shouldRefresh, children } ) {
+	const refreshOptions = useDispatch( SOCIAL_STORE_ID ).refreshJetpackSocialSettings;
+
+	useEffect( () => {
+		if ( shouldRefresh ) {
+			refreshOptions();
+		}
+	} );
+
+	return children;
+}

--- a/projects/js-packages/publicize-components/src/components/social-image-generator/toggle/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-image-generator/toggle/index.tsx
@@ -1,7 +1,6 @@
 import { ToggleControl } from '@automattic/jetpack-components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { useEffect } from '@wordpress/element';
 import React from 'react';
 import { SOCIAL_STORE_ID } from '../../../social-store';
 import { SocialStoreSelectors } from '../../../types/types';
@@ -16,11 +15,6 @@ type SocialImageGeneratorToggleProps = {
 	 * The class name to add to the toggle.
 	 */
 	toggleClass?: string;
-
-	/**
-	 * Whether or not to refresh the settings.
-	 */
-	shouldRefresh?: boolean;
 };
 
 /**
@@ -32,14 +26,7 @@ type SocialImageGeneratorToggleProps = {
 const SocialImageGeneratorToggle: React.FC< SocialImageGeneratorToggleProps > = ( {
 	toggleClass,
 	children,
-	shouldRefresh = false,
 } ) => {
-	const refreshSettings = useDispatch( SOCIAL_STORE_ID ).refreshSocialImageGeneratorSettings;
-
-	useEffect( () => {
-		shouldRefresh && refreshSettings();
-	}, [ refreshSettings, shouldRefresh ] );
-
 	const { isEnabled, isUpdating } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
 		return {

--- a/projects/plugins/jetpack/_inc/client/sharing/features/auto-conversion-section.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/features/auto-conversion-section.jsx
@@ -9,7 +9,7 @@ import { FormFieldset } from '../../components/forms';
 const AutoConversionSection = () => {
 	return (
 		<FormFieldset>
-			<AutoConversionToggle shouldRefresh toggleClass="jp-settings-sharing__sig-toggle">
+			<AutoConversionToggle toggleClass="jp-settings-sharing__sig-toggle">
 				<div>
 					<div>
 						<Text>

--- a/projects/plugins/jetpack/_inc/client/sharing/features/social-image-generator-section.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/features/social-image-generator-section.jsx
@@ -10,7 +10,7 @@ import './style.scss';
 const SocialImageGeneratorSection = () => {
 	return (
 		<FormFieldset>
-			<SocialImageGeneratorToggle shouldRefresh toggleClass="jp-settings-sharing__sig-toggle">
+			<SocialImageGeneratorToggle toggleClass="jp-settings-sharing__sig-toggle">
 				<div>
 					<Text>
 						<strong>{ __( 'Enable Social Image Generator', 'jetpack' ) }</strong>

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { RefreshJetpackSocialSettingsWrapper } from '@automattic/jetpack-publicize-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import Card from 'components/card';
@@ -154,10 +155,14 @@ export const Publicize = withModuleSettingsFormHelpers(
 							>
 								{ __( 'Automatically share your posts to social networks', 'jetpack' ) }
 							</ModuleToggle>
-							{ shouldShowChildElements && hasAutoConversion && <AutoConversionSection /> }
-							{ shouldShowChildElements && hasSocialImageGenerator && (
-								<SocialImageGeneratorSection />
-							) }
+							<RefreshJetpackSocialSettingsWrapper
+								shouldRefresh={ ! isActive && this.props.isSavingAnyOption( 'publicize' ) }
+							>
+								{ shouldShowChildElements && hasAutoConversion && <AutoConversionSection /> }
+								{ shouldShowChildElements && hasSocialImageGenerator && (
+									<SocialImageGeneratorSection />
+								) }
+							</RefreshJetpackSocialSettingsWrapper>
 						</SettingsGroup>
 					) }
 

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -30,16 +30,6 @@ const Admin = () => {
 
 	const refreshJetpackSocialSettings = useDispatch( SOCIAL_STORE_ID ).refreshJetpackSocialSettings;
 
-	useEffect( () => {
-		if (
-			isModuleEnabled &&
-			isUpdatingJetpackSettings &&
-			( isAutoConversionAvailable || isSocialImageGeneratorAvailable )
-		) {
-			refreshJetpackSocialSettings();
-		}
-	} );
-
 	const onUpgradeToggle = useCallback( () => setForceDisplayPricingPage( true ), [] );
 	const onPricingPageDismiss = useCallback( () => setForceDisplayPricingPage( false ), [] );
 
@@ -67,6 +57,18 @@ const Admin = () => {
 			isUpdatingJetpackSettings: store.isUpdatingJetpackSettings(),
 		};
 	} );
+
+	useEffect( () => {
+		if (
+			isModuleEnabled &&
+			isUpdatingJetpackSettings &&
+			( isAutoConversionAvailable || isSocialImageGeneratorAvailable )
+		) {
+			refreshJetpackSocialSettings();
+		}
+		// We want this to run only once, when the module is enabled.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isModuleEnabled ] );
 
 	const moduleName = `Jetpack Social ${ pluginVersion }`;
 

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -7,8 +7,8 @@ import {
 } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import { SOCIAL_STORE_ID } from '@automattic/jetpack-publicize-components';
-import { useSelect } from '@wordpress/data';
-import { useState, useCallback } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import React from 'react';
 import AdvancedUpsellNotice from '../advanced-upsell-notice';
 import AutoConversionToggle from '../auto-conversion-toggle';
@@ -27,6 +27,18 @@ const Admin = () => {
 	const { isUserConnected, isRegistered } = useConnection();
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 	const [ forceDisplayPricingPage, setForceDisplayPricingPage ] = useState( false );
+
+	const refreshJetpackSocialSettings = useDispatch( SOCIAL_STORE_ID ).refreshJetpackSocialSettings;
+
+	useEffect( () => {
+		if (
+			isModuleEnabled &&
+			isUpdatingJetpackSettings &&
+			( isAutoConversionAvailable || isSocialImageGeneratorAvailable )
+		) {
+			refreshJetpackSocialSettings();
+		}
+	} );
 
 	const onUpgradeToggle = useCallback( () => setForceDisplayPricingPage( true ), [] );
 	const onPricingPageDismiss = useCallback( () => setForceDisplayPricingPage( false ), [] );
@@ -90,10 +102,10 @@ const Admin = () => {
 						<InstagramNotice onUpgrade={ onUpgradeToggle } />
 						<SocialModuleToggle />
 						{ ! isUpdatingJetpackSettings && isModuleEnabled && isAutoConversionAvailable && (
-							<AutoConversionToggle shouldRefresh />
+							<AutoConversionToggle />
 						) }
 						{ ! isUpdatingJetpackSettings && isModuleEnabled && isSocialImageGeneratorAvailable && (
-							<SocialImageGeneratorToggle shouldRefresh />
+							<SocialImageGeneratorToggle />
 						) }
 					</AdminSection>
 					<AdminSectionHero>

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -8,7 +8,7 @@ import {
 import { useConnection } from '@automattic/jetpack-connection';
 import { SOCIAL_STORE_ID } from '@automattic/jetpack-publicize-components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useState, useCallback, useEffect } from '@wordpress/element';
+import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 import React from 'react';
 import AdvancedUpsellNotice from '../advanced-upsell-notice';
 import AutoConversionToggle from '../auto-conversion-toggle';
@@ -32,6 +32,8 @@ const Admin = () => {
 
 	const onUpgradeToggle = useCallback( () => setForceDisplayPricingPage( true ), [] );
 	const onPricingPageDismiss = useCallback( () => setForceDisplayPricingPage( false ), [] );
+
+	const hasRefreshedSettings = useRef( false );
 
 	const {
 		isModuleEnabled,
@@ -62,8 +64,10 @@ const Admin = () => {
 		if (
 			isModuleEnabled &&
 			isUpdatingJetpackSettings &&
+			! hasRefreshedSettings.current &&
 			( isAutoConversionAvailable || isSocialImageGeneratorAvailable )
 		) {
+			hasRefreshedSettings.current = true;
 			refreshJetpackSocialSettings();
 		}
 		// We want this to run only once, when the module is enabled.
@@ -103,11 +107,11 @@ const Admin = () => {
 						{ shouldShowAdvancedPlanNudge && <AdvancedUpsellNotice /> }
 						<InstagramNotice onUpgrade={ onUpgradeToggle } />
 						<SocialModuleToggle />
-						{ ! isUpdatingJetpackSettings && isModuleEnabled && isAutoConversionAvailable && (
-							<AutoConversionToggle />
+						{ isModuleEnabled && isAutoConversionAvailable && (
+							<AutoConversionToggle disabled={ isUpdatingJetpackSettings } />
 						) }
-						{ ! isUpdatingJetpackSettings && isModuleEnabled && isSocialImageGeneratorAvailable && (
-							<SocialImageGeneratorToggle />
+						{ isModuleEnabled && isSocialImageGeneratorAvailable && (
+							<SocialImageGeneratorToggle disabled={ isUpdatingJetpackSettings } />
 						) }
 					</AdminSection>
 					<AdminSectionHero>

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -33,8 +33,6 @@ const Admin = () => {
 	const onUpgradeToggle = useCallback( () => setForceDisplayPricingPage( true ), [] );
 	const onPricingPageDismiss = useCallback( () => setForceDisplayPricingPage( false ), [] );
 
-	const hasRefreshedSettings = useRef( false );
-
 	const {
 		isModuleEnabled,
 		showPricingPage,
@@ -60,19 +58,23 @@ const Admin = () => {
 		};
 	} );
 
+	const hasEnabledModule = useRef( isModuleEnabled );
+
 	useEffect( () => {
 		if (
 			isModuleEnabled &&
-			isUpdatingJetpackSettings &&
-			! hasRefreshedSettings.current &&
+			! hasEnabledModule.current &&
 			( isAutoConversionAvailable || isSocialImageGeneratorAvailable )
 		) {
-			hasRefreshedSettings.current = true;
+			hasEnabledModule.current = true;
 			refreshJetpackSocialSettings();
 		}
-		// We want this to run only once, when the module is enabled.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isModuleEnabled ] );
+	}, [
+		isAutoConversionAvailable,
+		isModuleEnabled,
+		isSocialImageGeneratorAvailable,
+		refreshJetpackSocialSettings,
+	] );
 
 	const moduleName = `Jetpack Social ${ pluginVersion }`;
 

--- a/projects/plugins/social/src/js/components/auto-conversion-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/auto-conversion-toggle/index.tsx
@@ -9,7 +9,14 @@ import ToggleSection from '../toggle-section';
 import { SocialStoreSelectors } from '../types/types';
 import styles from './styles.module.scss';
 
-const AutoConversionToggle: React.FC = () => {
+type AutoConversionToggleProps = {
+	/**
+	 * If the toggle is disabled.
+	 */
+	disabled?: boolean;
+};
+
+const AutoConversionToggle: React.FC< AutoConversionToggleProps > = ( { disabled } ) => {
 	const { isEnabled, isUpdating } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
 		return {
@@ -30,7 +37,7 @@ const AutoConversionToggle: React.FC = () => {
 	return (
 		<ToggleSection
 			title={ __( 'Automatically convert images for compatibility', 'jetpack-social' ) }
-			disabled={ isUpdating }
+			disabled={ isUpdating || disabled }
 			checked={ isEnabled }
 			onChange={ toggleStatus }
 		>

--- a/projects/plugins/social/src/js/components/auto-conversion-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/auto-conversion-toggle/index.tsx
@@ -3,29 +3,13 @@ import { SOCIAL_STORE_ID } from '@automattic/jetpack-publicize-components';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
-import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import ToggleSection from '../toggle-section';
 import { SocialStoreSelectors } from '../types/types';
 import styles from './styles.module.scss';
 
-type AutoConversionToggleProps = {
-	/**
-	 * Whether or not to refresh the settings.
-	 */
-	shouldRefresh?: boolean;
-};
-
-const AutoConversionToggle: React.FC< AutoConversionToggleProps > = ( {
-	shouldRefresh = false,
-} ) => {
-	const refreshSettings = useDispatch( SOCIAL_STORE_ID ).refreshAutoConversionSettings;
-
-	useEffect( () => {
-		shouldRefresh && refreshSettings();
-	}, [ shouldRefresh, refreshSettings ] );
-
+const AutoConversionToggle: React.FC = () => {
 	const { isEnabled, isUpdating } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
 		return {

--- a/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
@@ -9,7 +9,16 @@ import ToggleSection from '../toggle-section';
 import { SocialStoreSelectors } from '../types/types';
 import styles from './styles.module.scss';
 
-const SocialImageGeneratorToggle: React.FC = () => {
+type SocialImageGeneratorToggleProps = {
+	/**
+	 * If the toggle is disabled.
+	 */
+	disabled?: boolean;
+};
+
+const SocialImageGeneratorToggle: React.FC< SocialImageGeneratorToggleProps > = ( {
+	disabled,
+} ) => {
 	const [ currentTemplate, setCurrentTemplate ] = useState< string | null >( null );
 	const { isEnabled, isUpdating, defaultTemplate } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
@@ -56,7 +65,7 @@ const SocialImageGeneratorToggle: React.FC = () => {
 	return (
 		<ToggleSection
 			title={ __( 'Enable Social Image Generator', 'jetpack-social' ) }
-			disabled={ isUpdating }
+			disabled={ isUpdating || disabled }
 			checked={ isEnabled }
 			onChange={ toggleStatus }
 		>

--- a/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
@@ -9,22 +9,7 @@ import ToggleSection from '../toggle-section';
 import { SocialStoreSelectors } from '../types/types';
 import styles from './styles.module.scss';
 
-interface SocialImageGeneratorToggleProps {
-	/**
-	 * Whether or not to refresh the settings.
-	 */
-	shouldRefresh: boolean;
-}
-
-const SocialImageGeneratorToggle: React.FC< SocialImageGeneratorToggleProps > = ( {
-	shouldRefresh,
-} ) => {
-	const refreshSettings = useDispatch( SOCIAL_STORE_ID ).refreshSocialImageGeneratorSettings;
-
-	useEffect( () => {
-		shouldRefresh && refreshSettings();
-	}, [ shouldRefresh, refreshSettings ] );
-
+const SocialImageGeneratorToggle: React.FC = () => {
 	const [ currentTemplate, setCurrentTemplate ] = useState< string | null >( null );
 	const { isEnabled, isUpdating, defaultTemplate } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This change updates how we refresh our options on the Publicize module change, and will use the common api fetch, so we can decrease the number of API calls.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed the separated refresh from the toggle components 07cf749fca37012a69c0c35dcf5aedbc7c7443dd
* Added a common refresh into the admin page and to Jetpack Dashboard. 61facfa7bbd9a7b492e9d295071314e28a22848a and 1902f5d6d4b1b808169a0acf0f70b4ed0f153bd5

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/orgs/Automattic/projects/733/views/2?pane=issue&itemId=44049666
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Turn SIG and auto conversion on.
* Turn off the main Publicize module.
* Refresh the page
* Turn on the module, the child toggles should reflect their actual state
* There should be only 1 call to the API
