### PR TITLE
Make Contact Form single and multiple choice inputs accessible

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-multiple-options-accessibility
+++ b/projects/packages/forms/changelog/fix-contact-form-multiple-options-accessibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fix Contact Form single and multiple choice inputs markup accessibility

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -123,6 +123,40 @@
 	flex-direction: column;
 	align-items: flex-start;
 	gap: 12px;
+
+	margin: 0;
+	padding: 0;
+
+	border: none;
+}
+
+.contact-form .is-style-outlined .grunion-checkbox-multiple-options,
+.contact-form .is-style-outlined .grunion-radio-options {
+	border: solid 1px var( --jetpack--contact-form--border-color );
+}
+
+.contact-form .grunion-checkbox-multiple-options legend,
+.contact-form .grunion-radio-options legend {
+	margin-bottom: 0.25em;
+	padding: 0;
+
+	font-weight: 700;
+}
+
+.contact-form .is-style-outlined .grunion-checkbox-multiple-options legend,
+.contact-form .is-style-outlined .grunion-radio-options legend {
+	margin: 0 0 -0.75em;
+	padding: 0 0.25em;
+
+	font-size: 0.8em;
+	font-weight: 300;
+}
+
+.contact-form .grunion-checkbox-multiple-options .contact-form-field,
+.contact-form .grunion-radio-options .contact-form-field {
+	display: flex;
+
+	margin: 0;
 }
 
 .contact-form label span.required {
@@ -549,13 +583,6 @@ on production builds, the attributes are being reordered, causing side-effects
 	padding-right: var(--field-padding);
 }
 
-.contact-form .is-style-animated .grunion-field-checkbox-multiple-wrap .grunion-checkbox-multiple-options,
-.contact-form .is-style-animated .grunion-field-radio-wrap .grunion-radio-options {
-	padding-bottom: var(--jetpack--contact-form--input-padding, 16px);
-	padding-top: 1.8em;
-	flex-grow: 1
-}
-
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
 	position: absolute;
 	top: 50%;
@@ -649,7 +676,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form .grunion-field-wrap input.checkbox-multiple:checked::before {
-	content: "✓";
+	content: "\2713";
 }
 
 .contact-form .grunion-field-wrap input.radio:checked::after {

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -1151,10 +1151,10 @@ class WP_Test_Contact_Form extends BaseTestCase {
 			for ( $i = 0; $i < $n; $i++ ) {
 				$item_label = $labels->item( $i );
 				//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$this->assertEquals( $item_label->nodeValue, $attributes['options'][ $i ] ); // extra space added for a padding.
+				$this->assertEquals( $item_label->nodeValue, $attributes['options'][ $i ] );
 
 				//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$input = $item_label->previousElementSibling;
+				$input = $item_label->parentNode->getElementsByTagName( 'input' )->item( 0 );
 				$this->assertEquals( $input->getAttribute( 'type' ), $attributes['input_type'], 'Type doesn\'t match' );
 				if ( 'radio' === $attributes['input_type'] ) {
 					$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/16685

## Proposed changes:
The _Single Choice_ and _Multiple Choice_ inputs in the _Contact Form_ package have inaccessible markup, as reported in the issue above. This PR does the following:
- It wraps the inputs in a `fieldset`
- It replaces the top `label` by a `legend`
- For each option, it associates the `input` and the `label` by specifying a `for` attribute on the latter. It also moves the `input` out of the `label`. [Generally, explicit labels are better supported by assistive technology](https://www.w3.org/WAI/tutorials/forms/labels/).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Create a new post: visit `/wp-admin/post-new.php`
- Add the _Contact Form_ block to the page
<img width="346" alt="Screenshot 2023-11-15 at 10 20 30 AM" src="https://github.com/Automattic/jetpack/assets/1620183/60e74081-ab82-4141-8771-1c16543defb0">

- Add a or transform the existing fields so that you have both a single choice and multiple choice inputs on the page
<img width="212" alt="Screenshot 2023-11-15 at 1 59 49 PM" src="https://github.com/Automattic/jetpack/assets/1620183/56332561-4970-4cf4-bac8-7cae831249db">

- Open the preview
- Check that the inputs work as expected, look like they do on trunk, and have the proper markup as highlighted above
<img width="685" alt="Screenshot 2023-11-15 at 2 02 15 PM" src="https://github.com/Automattic/jetpack/assets/1620183/fa5aed3f-c0ed-4d79-b23c-2f71dea39f73">

- Repeat the above for the `Outlined` style
<img width="328" alt="Screenshot 2023-11-15 at 2 03 42 PM" src="https://github.com/Automattic/jetpack/assets/1620183/c77d5204-595e-46ad-a61b-9e85166f6b9d">
<img width="667" alt="Screenshot 2023-11-15 at 1 31 00 PM" src="https://github.com/Automattic/jetpack/assets/1620183/a99087f9-3e52-4a61-bc99-68c82b7e51b3">


_Note: it seems that the Animated style doesn't change anything for these 2 inputs except adding some odd padding. I've therefore made the Default and Animated styles similar._


