### PR TITLE
Jetpack AI: Use the Usage Helper to set ai-assistant-feature endpoint fields

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -343,31 +343,6 @@ class Jetpack_AI_Helper {
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$has_ai_assistant_feature = \wpcom_site_has_feature( 'ai-assistant' );
-			if ( ! class_exists( 'OpenAI' ) ) {
-				\require_lib( 'openai' );
-			}
-
-			if ( ! class_exists( 'OpenAI_Limit_Usage' ) ) {
-				if ( is_readable( WP_CONTENT_DIR . '/lib/openai/openai-limit-usage.php' ) ) {
-					require_once WP_CONTENT_DIR . '/lib/openai/openai-limit-usage.php';
-				} else {
-					return new WP_Error(
-						'openai_limit_usage_not_found',
-						__( 'OpenAI_Limit_Usage class not found.', 'jetpack' )
-					);
-				}
-			}
-
-			if ( ! class_exists( 'OpenAI_Request_Count' ) ) {
-				if ( is_readable( WP_CONTENT_DIR . '/lib/openai/openai-request-count.php' ) ) {
-					require_once WP_CONTENT_DIR . '/lib/openai/openai-request-count.php';
-				} else {
-					return new WP_Error(
-						'openai_request_count_not_found',
-						__( 'OpenAI_Request_Count class not found.', 'jetpack' )
-					);
-				}
-			}
 
 			if ( ! class_exists( 'WPCOM\Jetpack_AI\Usage\Helper' ) ) {
 				if ( is_readable( WP_CONTENT_DIR . '/lib/jetpack-ai/usage/helper.php' ) ) {

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -382,7 +382,7 @@ class Jetpack_AI_Helper {
 
 			$blog_id        = get_current_blog_id();
 			$is_over_limit  = WPCOM\Jetpack_AI\Usage\Helper::is_over_limit( $blog_id );
-			$requests_limit = \OpenAI_Limit_Usage::get_free_requests_limit( $blog_id );
+			$requests_limit = WPCOM\Jetpack_AI\Usage\Helper::get_free_requests_limit( $blog_id );
 			$requests_count = \OpenAI_Request_Count::get_count( $blog_id );
 
 			// Check if the site requires an upgrade.

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -381,7 +381,7 @@ class Jetpack_AI_Helper {
 			}
 
 			$blog_id        = get_current_blog_id();
-			$is_over_limit  = \OpenAI_Limit_Usage::is_blog_over_request_limit( $blog_id );
+			$is_over_limit  = WPCOM\Jetpack_AI\Usage\Helper::is_over_limit( $blog_id );
 			$requests_limit = \OpenAI_Limit_Usage::get_free_requests_limit( $blog_id );
 			$requests_count = \OpenAI_Request_Count::get_count( $blog_id );
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -383,7 +383,7 @@ class Jetpack_AI_Helper {
 			$blog_id        = get_current_blog_id();
 			$is_over_limit  = WPCOM\Jetpack_AI\Usage\Helper::is_over_limit( $blog_id );
 			$requests_limit = WPCOM\Jetpack_AI\Usage\Helper::get_free_requests_limit( $blog_id );
-			$requests_count = \OpenAI_Request_Count::get_count( $blog_id );
+			$requests_count = WPCOM\Jetpack_AI\Usage\Helper::get_all_time_requests_count( $blog_id );
 
 			// Check if the site requires an upgrade.
 			$require_upgrade = $is_over_limit && ! $has_ai_assistant_feature;

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-use-usage-helper-for-fields
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-use-usage-helper-for-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: use the Usage Helper to set fields on the ai-assistant-feature endpoint.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #33824.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use the `WPCOM\Jetpack_AI\Usage\Helper` to set:
   * `is-over-limit` (if the site is over the allowed limit, be it the free or the tiered one)
   * `requests-limit` (the free requests limit for the site type)
   * `requests-count` (the amount of requests since the beggining)
* Remove code that was checking for the OpenAI_* class presence, since they are not in use anymore

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Let's test it comparing the values before and after the change
* Before applying this change to your sandbox, go to the WordPress.com console (https://developer.wordpress.com/docs/api/console/)
* Execute a request to the `wpcom/v2` `/sites/$wpcom_site/jetpack-ai/ai-assistant-feature` endpoint using your test site and note the results:

<img width="600" alt="Screenshot 2023-11-15 at 17 45 35" src="https://github.com/Automattic/jetpack/assets/6760046/1d55e9d4-d9ee-4b67-ad82-81c1688bc06b">

* Apply this change to your sandbox and make sure you are sandboxing the `public-api`  
* Go to the WordPress.com console again
* Execute the same request as before, then compare the results:

<img width="600" alt="Screenshot 2023-11-15 at 17 50 21" src="https://github.com/Automattic/jetpack/assets/6760046/885e75bd-a057-4a39-8510-d17f4e8fdc41">

* The values for `requests-limit` and `requests-count` should be the same as before
* The value for `is-over-limit` may change because now a new rule is applied (the rule from D128826-code):
   * before, the rule was considering if the site was over the free limit of requests (a site with a paid plan could easily be over the 20 requests limit)
   * now, the rule considers if the site is over the limit of requests of the current plan it has (be it free or unlimited, and will also work for tiered plans)
   * confirm the value for `is-over-limit` makes sense by comparing the `requests-count` to the expected limit of the plan active on the site (free or unlimited)
* If possible, test for a Jetpack site and a Simple site