### PR TITLE
CRM: Port back 6.3.0 release changelog, readme, and package updates

### DIFF
--- a/projects/plugins/crm/CHANGELOG.md
+++ b/projects/plugins/crm/CHANGELOG.md
@@ -5,6 +5,29 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.0] - 2023-11-15
+### Added
+- API: Add support for creating transactions with custom fields. [#33645]
+
+### Changed
+- Requires PHP 7.4 or higher. [#33806]
+- Requires WordPress 6.0 or higher. [#33805]
+
+### Fixed
+- API: Allow events endpoint to be filtered by owner. [#33789]
+- API: The `create_event` endpoint no longer throws a 100 error. [#33712]
+- API: Restrict what owner data is returned with events endpoint. [#33736]
+- Backend: Prevent error if OpenSSL functions aren't available in PHP. [#33605]
+- Backend: Changing how styles are added to the page on several stand-alone pages to prevent WordPress 6.4 compatibility issues. [#33678]
+- Client Portal: Better PHP 8.2 support. [#33740]
+- Contacts: Fixed display issues on the Add and Edit pages that occurred when moving fields. [#33762]
+- Listviews: Remove legacy code. [#33718]
+- Mail Delivery: Removed usage of deprecated function utf8_encode. [#33777]
+- Quote Templates: Fix issue with notes field rendering HTML entities in some cases. [#33614]
+- Quote Templates: Make sure quote titles with apostrophes do not have backslashes added when rendered. [#33596]
+- WooSync: Catch PHP error in Client Portal invoice if WooCommerce is disabled. [#33759]
+- WooSync: Contacts can now be assigned to existing companies. [#33711]
+
 ## [6.2.0] - 2023-10-11
 ### Added
 - Tests: Add mock globals for testing. [#32755]
@@ -229,6 +252,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved: Added a migration to remove outdated AKA lines
 
 [5.5.4-a.1]: https://github.com/Automattic/jetpack-crm/compare/v5.5.3...v5.5.4-a.1
+[6.3.0]: https://github.com/Automattic/jetpack-crm/compare/6.2.0...6.3.0
 [6.2.0]: https://github.com/Automattic/jetpack-crm/compare/6.1.0...6.2.0
 [6.1.0]: https://github.com/Automattic/jetpack-crm/compare/6.0.0...6.1.0
 [6.0.0]: https://github.com/Automattic/jetpack-crm/compare/5.8.0...6.0.0

--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 6.3.0-alpha
+ * Version: 6.3.0
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/add-crm-3367-api-create-transaction-with-custom-fields
+++ b/projects/plugins/crm/changelog/add-crm-3367-api-create-transaction-with-custom-fields
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add support to the API for creating transactions with custom fields

--- a/projects/plugins/crm/changelog/fix-crm-3319-address-columns-bug-when-odd-fields-above
+++ b/projects/plugins/crm/changelog/fix-crm-3319-address-columns-bug-when-odd-fields-above
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed display issues on the Add and Edit pages that occurred when moving fields

--- a/projects/plugins/crm/changelog/fix-crm-3362-code_modernisation
+++ b/projects/plugins/crm/changelog/fix-crm-3362-code_modernisation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update string functions to use PHP8 or polyfills
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3365-catch_fatal_if_openssl_unavailable
+++ b/projects/plugins/crm/changelog/fix-crm-3365-catch_fatal_if_openssl_unavailable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Prevent error if OpenSSL functions aren't available in PHP.

--- a/projects/plugins/crm/changelog/fix-crm-3369-assign_customer_to_existing_company
+++ b/projects/plugins/crm/changelog/fix-crm-3369-assign_customer_to_existing_company
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-WooSync: contacts can now be assigned to existing companies

--- a/projects/plugins/crm/changelog/fix-crm-3370-remove_unused_woo_welcome_wizard
+++ b/projects/plugins/crm/changelog/fix-crm-3370-remove_unused_woo_welcome_wizard
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Removed WooSync welcome wizard code
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3371-remove_buggy_unused_code
+++ b/projects/plugins/crm/changelog/fix-crm-3371-remove_buggy_unused_code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Listview: remove legacy code

--- a/projects/plugins/crm/changelog/fix-crm-3373-deprecation_notices_in_Client_Portal
+++ b/projects/plugins/crm/changelog/fix-crm-3373-deprecation_notices_in_Client_Portal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Client Portal: Better PHP 8.2 support.

--- a/projects/plugins/crm/changelog/fix-crm-3374-allow_events_API_filter_by_owner
+++ b/projects/plugins/crm/changelog/fix-crm-3374-allow_events_API_filter_by_owner
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-API: allow events endpoint to be filtered by owner

--- a/projects/plugins/crm/changelog/fix-crm-3375-evaluate_zeroBS_getOwner
+++ b/projects/plugins/crm/changelog/fix-crm-3375-evaluate_zeroBS_getOwner
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Limit use of full WP user details

--- a/projects/plugins/crm/changelog/fix-crm-3377-php_fatal_on_invoice_from_woo
+++ b/projects/plugins/crm/changelog/fix-crm-3377-php_fatal_on_invoice_from_woo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-WooSync: catch PHP error in Client Portal invoice if WooCommerce is disabled

--- a/projects/plugins/crm/changelog/fix-crm-3379-bump_minimum_wp_to_6.0
+++ b/projects/plugins/crm/changelog/fix-crm-3379-bump_minimum_wp_to_6.0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Requires WordPress 6.0 or higher.

--- a/projects/plugins/crm/changelog/fix-crm-3380-bump_min_php_to_7.4
+++ b/projects/plugins/crm/changelog/fix-crm-3380-bump_min_php_to_7.4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Requires PHP 7.4 or higher.

--- a/projects/plugins/crm/changelog/fix-crm-3381-replace_deprecated_constants
+++ b/projects/plugins/crm/changelog/fix-crm-3381-replace_deprecated_constants
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Removed deprecated constants for better WP 6.4 compatibility
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3382-php_notice_when_contact_has_assignee
+++ b/projects/plugins/crm/changelog/fix-crm-3382-php_notice_when_contact_has_assignee
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix PHP notice (unreleased regression from 33736)
-
-

--- a/projects/plugins/crm/changelog/fix-crm-deprecated-inline-styles
+++ b/projects/plugins/crm/changelog/fix-crm-deprecated-inline-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Styles: Changing how styles are added to the page on several stand-alone pages to prevent WordPress 6.4 compatibility issues.

--- a/projects/plugins/crm/changelog/fix-crm-quote-template-notes-escaping
+++ b/projects/plugins/crm/changelog/fix-crm-quote-template-notes-escaping
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Quote Templates: Fix issue with notes field rendering HTML entities in some cases

--- a/projects/plugins/crm/changelog/fix-crm-quote-template-title-escaping
+++ b/projects/plugins/crm/changelog/fix-crm-quote-template-title-escaping
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Quote templates: Make sure quote titles with apostrophes do not have backslashes added when rendered.

--- a/projects/plugins/crm/changelog/fix-lock-file
+++ b/projects/plugins/crm/changelog/fix-lock-file
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed lock file

--- a/projects/plugins/crm/changelog/init-release-cycle
+++ b/projects/plugins/crm/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Init 6.2.1-alpha
-
-

--- a/projects/plugins/crm/changelog/patch-1
+++ b/projects/plugins/crm/changelog/patch-1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix Creating Event API Endpoint

--- a/projects/plugins/crm/changelog/remove-crm-utf8_encode-usage
+++ b/projects/plugins/crm/changelog/remove-crm-utf8_encode-usage
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Mail delivery: Removed usage of deprecated function utf8_encode

--- a/projects/plugins/crm/changelog/renovate-babel-monorepo
+++ b/projects/plugins/crm/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-babel-monorepo#2
+++ b/projects/plugins/crm/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-definitelytyped
+++ b/projects/plugins/crm/changelog/renovate-definitelytyped
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/crm/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/crm/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-lock-file-maintenance#4
+++ b/projects/plugins/crm/changelog/renovate-lock-file-maintenance#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-lock-file-maintenance#5
+++ b/projects/plugins/crm/changelog/renovate-lock-file-maintenance#5
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/crm/changelog/renovate-major-codeception-packages
+++ b/projects/plugins/crm/changelog/renovate-major-codeception-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-major-eslint-packages
+++ b/projects/plugins/crm/changelog/renovate-major-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Make new version of prettier happy. No functional change.
-
-

--- a/projects/plugins/crm/changelog/renovate-npm-axios-vulnerability
+++ b/projects/plugins/crm/changelog/renovate-npm-axios-vulnerability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/crm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/crm/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/update-composer-2.6
+++ b/projects/plugins/crm/changelog/update-composer-2.6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/crm/changelog/update-crm-codeception-deps
+++ b/projects/plugins/crm/changelog/update-crm-codeception-deps
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove deps on old codeception versions
-
-

--- a/projects/plugins/crm/changelog/update-node-20
+++ b/projects/plugins/crm/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/plugins/crm/changelog/update-standardize-on-devtool-source-map
+++ b/projects/plugins/crm/changelog/update-standardize-on-devtool-source-map
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use 'source-map' devtool when building in development mode. No change to the production plugin.
-
-

--- a/projects/plugins/crm/changelog/update-tested-up-to-64
+++ b/projects/plugins/crm/changelog/update-tested-up-to-64
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: indicate full compatibility with the latest version of WordPress, 6.4.

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -42,7 +42,7 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_3_0_alpha",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_3_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -24,7 +24,7 @@ final class ZeroBSCRM {
 	 *
 	 * @var string
 	 */
-	public $version = '6.2.0';
+	public $version = '6.3.0';
 
 	/**
 	 * WordPress version tested with.

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "6.3.0-alpha",
+	"version": "6.3.0",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -389,28 +389,26 @@ We offer a full, no-hassle refund within 14 days. You can read more about that, 
 
 
 == Changelog ==
-### 6.2.0 - 2023-10-11
+### 6.3.0 - 2023-11-15
 #### Added
-- Tests: Add mock globals for testing.
-- Automations: Add new backend in preparation for future release.
+- API: Add support for creating transactions with custom fields.
 
 #### Changed
-- Quotes: Allow admin users to accept quotes.
-- Tasks: Use consistent language in code.
-- Increase PHP required version to 7.3.
-- Updated package dependencies.
+- Requires PHP 7.4 or higher.
+- Requires WordPress 6.0 or higher.
 
 #### Fixed
-- API: Rewrite rules are now flushed after enabling module.
-- API: Task reminder param is no longer ignored.
-- Better PHP 8.2 support.
-- CRM Forms: Removed reference to old branding.
-- CSV Importer: Fixed assignment to companies by name.
-- Custom Fields: Corrected bug that prevented new address custom fields from being shown.
-- Invoices: Handle status translations consistently.
-- Segments: Fixed error 219 occurring when using date ranges.
-- Tags: Better slug generation and added tag slug migration.
-- Tags: Prevent duplicate slugs, and adding more robust slug fallback support.
-- Tasks: Corrected placeholders for contacts and companies in the task reminder email.
-- Transactions: Filters now work for custom statuses.
+- API: Allow events endpoint to be filtered by owner.
+- API: The `create_event` endpoint no longer throws a 100 error.
+- API: Restrict what owner data is returned with events endpoint.
+- Backend: Prevent error if OpenSSL functions aren't available in PHP.
+- Backend: Changing how styles are added to the page on several stand-alone pages to prevent WordPress 6.4 compatibility issues.
+- Client Portal: Better PHP 8.2 support.
+- Contacts: Fixed display issues on the Add and Edit pages that occurred when moving fields.
+- Listviews: Remove legacy code.
+- Mail Delivery: Removed usage of deprecated function utf8_encode.
+- Quote Templates: Fix issue with notes field rendering HTML entities in some cases.
+- Quote Templates: Make sure quote titles with apostrophes do not have backslashes added when rendered.
+- WooSync: Catch PHP error in Client Portal invoice if WooCommerce is disabled.
+- WooSync: Contacts can now be assigned to existing companies.
 


### PR DESCRIPTION
## Proposed changes:

* This PR ports the changelog, readme, and package updates for the CRM 6.3.0 release back to trunk

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read - check versions are as expected.