### PR TITLE
AI Assistant: use new async data on excerpt panel

### DIFF
--- a/projects/plugins/jetpack/changelog/change-ai-excerpt-use-assistant-data
+++ b/projects/plugins/jetpack/changelog/change-ai-excerpt-use-assistant-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use new async flow to get isOverLimit from useAiFeature. Fix wee typos on excerpt term"

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
@@ -116,7 +116,12 @@ export function AiExcerptControl( {
 						label={ langLabel }
 					/>
 
-					<ToneDropdownMenu label={ toneLabel } value={ tone } onChange={ onToneChange } />
+					<ToneDropdownMenu
+						disabled={ disabled }
+						label={ toneLabel }
+						value={ tone }
+						onChange={ onToneChange }
+					/>
 
 					<AiModelSelectorControl
 						model={ model }

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	AI_MODEL_GPT_4,
-	ERROR_QUOTA_EXCEEDED,
-	useAiSuggestions,
-} from '@automattic/jetpack-ai-client';
+import { AI_MODEL_GPT_4, useAiSuggestions } from '@automattic/jetpack-ai-client';
 import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { TextareaControl, ExternalLink, Button, Notice, BaseControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -18,6 +14,7 @@ import { count } from '@wordpress/wordcount';
  * Internal dependencies
  */
 import UpgradePrompt from '../../../../blocks/ai-assistant/components/upgrade-prompt';
+import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import { isBetaExtension } from '../../../../editor';
 import { AiExcerptControl } from '../../components/ai-excerpt-control';
 /**
@@ -188,7 +185,7 @@ ${ postContent }
 		reset();
 	}
 
-	const isQuotaExceeded = error?.code === ERROR_QUOTA_EXCEEDED;
+	const { requireUpgrade: isQuotaExceeded } = useAiFeature();
 
 	// Set the docs link depending on the site type
 	const docsLink =

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -175,12 +175,12 @@ ${ postContent }
 		request( prompt, { feature: 'jetpack-ai-content-lens', model } );
 	}
 
-	function setExpert() {
+	function setExcerpt() {
 		editPost( { excerpt: suggestion } );
 		reset();
 	}
 
-	function discardExpert() {
+	function discardExcerpt() {
 		editPost( { excerpt: excerpt } );
 		reset();
 	}
@@ -252,7 +252,7 @@ ${ postContent }
 				>
 					<div className="jetpack-generated-excerpt__generate-buttons-container">
 						<Button
-							onClick={ discardExpert }
+							onClick={ discardExcerpt }
 							variant="secondary"
 							isDestructive
 							disabled={ requestingState !== 'done' || isQuotaExceeded }
@@ -260,7 +260,7 @@ ${ postContent }
 							{ __( 'Discard', 'jetpack' ) }
 						</Button>
 						<Button
-							onClick={ setExpert }
+							onClick={ setExcerpt }
 							variant="secondary"
 							disabled={ requestingState !== 'done' || isQuotaExceeded }
 						>

--- a/projects/plugins/jetpack/extensions/shared/components/ai-model-selector-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/shared/components/ai-model-selector-control/index.tsx
@@ -49,6 +49,7 @@ export default function AiModelSelectorControl( {
 				] }
 				onChange={ onModelChange }
 				help={ help }
+				disabled={ disabled }
 			/>
 		);
 	}
@@ -65,6 +66,7 @@ export default function AiModelSelectorControl( {
 			<ToggleGroupControlOption
 				label={ __( 'GTP-3.5 Turbo', 'jetpack' ) }
 				value={ AI_MODEL_GPT_3_5_Turbo_16K }
+				disabled={ disabled }
 			/>
 			<ToggleGroupControlOption label={ __( 'GPT-4', 'jetpack' ) } value={ AI_MODEL_GPT_4 } />
 		</ToggleGroupControl>


### PR DESCRIPTION
Use isOverLimit from data store. Fix wee typos.

Fixes #

## Proposed changes:
This PR addresses a couple of small issues/conveniences:

- get isOverLimit value from the data store instead of waiting for some request/response
- disable all excerpt AI controls when isOverLimit
- fix a couple of typos on excerpt term (expert)

Current:
![excerpt](https://github.com/Automattic/jetpack/assets/157240/83a44ba9-aa49-429e-9524-f7504417d89f)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Checkout/apply and check on a site without being over the plan limit, controls should looks as usual.

Either go over the limit or test on a site which has gone over the limit. Visit the editor, check the excerpt panel, see that it should already be showing the upgrade nudge and all the controls should be disabled.

