### PR TITLE
Launchpad: Add `new_prompt` query param to Write first post task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-query-param-to-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-query-param-to-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: Add query parameter to write three posts prompt

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "4.18.x-dev"
+			"dev-trunk": "4.19.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.18.1-alpha",
+	"version": "4.19.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.18.1-alpha';
+	const PACKAGE_VERSION = '4.19.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -444,7 +444,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'repetition_count_callback' => 'wpcom_launchpad_get_write_3_posts_repetition_count',
 			'target_repetitions'        => 3,
 			'get_calypso_path'          => function ( $task, $default, $data ) {
-				return '/post/' . $data['site_slug_encoded'];
+				return '/post/' . $data['site_slug_encoded'] . '/?answer_prompt=true';
 			},
 		),
 		'manage_subscribers'              => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -84,7 +84,7 @@ function wpcom_launchpad_get_task_definitions() {
 
 				// Add a new_prompt query param for Write sites.
 				if ( 'write' === get_option( 'site_intent' ) ) {
-					return add_query_arg( 'new_prompt', true, $base_path );
+					return add_query_arg( 'new_prompt', 'true', $base_path );
 				}
 
 				return $base_path;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -81,7 +81,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
 				// Add an answer_prompt query param for Write sites.
-				if ( 'write' === get_option( 'site-intent' ) ) {
+				if ( 'write' === get_option( 'site_intent' ) ) {
 					return '/post/' . $data['site_slug_encoded'] . '/?answer_prompt=true';
 				};
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -82,7 +82,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_calypso_path'      => function ( $task, $default, $data ) {
 				$base_path = '/post/' . $data['site_slug_encoded'];
 
-				// Add an answer_prompt query param for Write sites.
+				// Add a new_prompt query param for Write sites.
 				if ( 'write' === get_option( 'site_intent' ) ) {
 					return $base_path . '/?new_prompt=true';
 				}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -80,12 +80,14 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'publish_post', 'wpcom_launchpad_track_publish_first_post_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
+				$base_path = '/post/' . $data['site_slug_encoded'];
+
 				// Add an answer_prompt query param for Write sites.
 				if ( 'write' === get_option( 'site_intent' ) ) {
-					return '/post/' . $data['site_slug_encoded'] . '/?answer_prompt=true';
+					return $base_path . '/?answer_prompt=true';
 				};
 
-				return '/post/' . $data['site_slug_encoded'];
+				return $base_path;
 			},
 		),
 		'plan_completed'                  => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -85,7 +85,7 @@ function wpcom_launchpad_get_task_definitions() {
 				// Add an answer_prompt query param for Write sites.
 				if ( 'write' === get_option( 'site_intent' ) ) {
 					return $base_path . '/?new_prompt=true';
-				};
+				}
 
 				return $base_path;
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -84,7 +84,7 @@ function wpcom_launchpad_get_task_definitions() {
 
 				// Add an answer_prompt query param for Write sites.
 				if ( 'write' === get_option( 'site_intent' ) ) {
-					return $base_path . '/?answer_prompt=true';
+					return $base_path . '/?new_prompt=true';
 				};
 
 				return $base_path;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -80,6 +80,11 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'publish_post', 'wpcom_launchpad_track_publish_first_post_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
+				// Add an answer_prompt query param for Write sites.
+				if ( 'write' === get_option( 'site-intent' ) ) {
+					return '/post/' . $data['site_slug_encoded'] . '/?answer_prompt=true';
+				};
+
 				return '/post/' . $data['site_slug_encoded'];
 			},
 		),
@@ -444,7 +449,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'repetition_count_callback' => 'wpcom_launchpad_get_write_3_posts_repetition_count',
 			'target_repetitions'        => 3,
 			'get_calypso_path'          => function ( $task, $default, $data ) {
-				return '/post/' . $data['site_slug_encoded'] . '/?answer_prompt=true';
+				return '/post/' . $data['site_slug_encoded'];
 			},
 		),
 		'manage_subscribers'              => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -84,7 +84,7 @@ function wpcom_launchpad_get_task_definitions() {
 
 				// Add a new_prompt query param for Write sites.
 				if ( 'write' === get_option( 'site_intent' ) ) {
-					return $base_path . '/?new_prompt=true';
+					return add_query_arg( 'new_prompt', true, $base_path );
 				}
 
 				return $base_path;

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-query-param-to-task
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-query-param-to-task
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "0a697ff704b95d96f5c2587ef72d4a64fecdd8ad"
+                "reference": "36a72b04dabeae38a9d02f35e1ba4e79b5c19377"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.18.x-dev"
+                    "dev-trunk": "4.19.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is part of the Hack Day meetup project adding blogging prompts to the editor.  Our hypothesis is that users who have *not* launched their site and are in the `write` site intent may appreciate having a prompt rather than a blank slate to start with.

Related to https://github.com/Automattic/dotcom-forge/issues/4204

Designed to support work in https://github.com/Automattic/wp-calypso/pull/84219

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the `new_prompt` query param (set to `true`) to the "Write your first post" task if the site intent is `write`
* This will integrate with additional logic in Jetpack to insert the blogging prompt block into the editor and add post meta/tags.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox the API
* Create a new site with the `write` intent from `/start` (choose "Write and publish")
* Skip to dashboard
* Note the "Write your first post" prompt should have a `?new_prompt=true` query param
* Perform the same check for a site that does not have the write intent.
* The query param should not appear.

