### PR TITLE
Site Favorites: Add 'is_user_favorite' property to sites on WordPress.com 

### DIFF
--- a/projects/plugins/jetpack/changelog/add-site-favorite-option-to-site
+++ b/projects/plugins/jetpack/changelog/add-site-favorite-option-to-site
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Add is_favorite option to sites on WordPress.com
+Add is_user_favorite option to sites on WordPress.com

--- a/projects/plugins/jetpack/changelog/add-site-favorite-option-to-site
+++ b/projects/plugins/jetpack/changelog/add-site-favorite-option-to-site
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add is_favorite option to sites on WordPress.com

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -72,6 +72,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'quota'                       => '(array) An array describing how much space a user has left for uploads',
 		'launch_status'               => '(string) A string describing the launch status of a site',
 		'site_migration'              => '(array) Data about any migration into the site.',
+		'is_favorite'                 => '(bool) If the user marked a site as favorite.',
 		'is_fse_active'               => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'             => '(bool) If the site is capable of Full Site Editing or not',
 		'is_core_site_editor_enabled' => '(bool) If the site has the core site editor enabled.',
@@ -575,6 +576,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'site_migration':
 				$response[ $key ] = $this->site->get_migration_meta();
+				break;
+			case 'is_favorite':
+				$response[ $key ] = $this->site->is_favorite();
 				break;
 			case 'is_fse_active':
 				$response[ $key ] = $this->site->is_fse_active();

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -72,7 +72,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'quota'                       => '(array) An array describing how much space a user has left for uploads',
 		'launch_status'               => '(string) A string describing the launch status of a site',
 		'site_migration'              => '(array) Data about any migration into the site.',
-		'is_favorite'                 => '(bool) If the user marked a site as favorite.',
+		'is_user_favorite'            => '(bool) If the user marked a site as favorite.',
 		'is_fse_active'               => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'             => '(bool) If the site is capable of Full Site Editing or not',
 		'is_core_site_editor_enabled' => '(bool) If the site has the core site editor enabled.',
@@ -577,8 +577,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'site_migration':
 				$response[ $key ] = $this->site->get_migration_meta();
 				break;
-			case 'is_favorite':
-				$response[ $key ] = $this->site->is_favorite();
+			case 'is_user_favorite':
+				$response[ $key ] = $this->site->is_user_favorite();
 				break;
 			case 'is_fse_active':
 				$response[ $key ] = $this->site->is_fse_active();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1553,5 +1553,5 @@ abstract class SAL_Site {
 	 *
 	 * @see class.json-api-site-jetpack.php for implementation.
 	 */
-	abstract public function is_favorite();
+	abstract public function is_user_favorite();
 }

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1547,4 +1547,11 @@ abstract class SAL_Site {
 	public function get_wpcom_admin_interface() {
 		return (string) get_option( 'wpcom_admin_interface' );
 	}
+
+	/**
+	 * Returns whether the user marked the site as favorite. Not used in Jetpack.
+	 *
+	 * @see class.json-api-site-jetpack.php for implementation.
+	 */
+	abstract public function is_favorite();
 }

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
@@ -684,4 +684,15 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	public function get_wpcom_admin_interface() {
 		return null;
 	}
+
+	/**
+	 * Returns whether the user marked the site as favorite. Not used in Jetpack.
+	 *
+	 * @see /wpcom/public.api/rest/sal/trait.json-api-site-wpcom.php.
+	 *
+	 * @return null
+	 */
+	public function is_favorite() {
+		return null;
+	}
 }

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
@@ -692,7 +692,7 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	 *
 	 * @return null
 	 */
-	public function is_favorite() {
+	public function is_user_favorite() {
 		return null;
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4539
Related to D129036-code

## Proposed changes:

This PR adds `is_user_favorite` property to sites to WordPress.com

### Other information:

- [ ] Have you written new tests for your changes, if applicable? N/A
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them? 
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:

1. Apply this diff to your sandbox if not merged yet: D129036-code
2. Run `bin/jetpack-downloader test jetpack add/site-favorite-option-to-site` on your sandbox and apply it on top of the diff mentioned above
3. Navigate to https://developer.wordpress.com/docs/api/console/
4. Select `WP.COM API`, `v1.2.`, `GET`, `/me/sites`
5. Select one of the sites from the list and confirm that you can see the `is_user_favorite` property in the list
6. Navigate to https://developer.wordpress.com/docs/api/console/
7. Select `WP REST API`, `wpcom/v2`, `POST`, /sites/$site/site-favorite` (replace $site with the site ID of the site that you would like to make as favorite)
8. Select `WP.COM API`, `v1.2.`, `GET`, `/me/sites`
9. Confirm that the `is_user_favorite` property is set to `true` for the site that you used in step 7
