### PR TITLE
Activity Log: add link to Activity Log to Jetpack menu

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-activitylog-menu
+++ b/projects/packages/my-jetpack/changelog/add-activitylog-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Display an "Activity Log" menu item to connected users.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -75,7 +75,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.12.x-dev"
+			"dev-trunk": "3.13.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.12.3-alpha",
+	"version": "3.13.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-activitylog.php
+++ b/projects/packages/my-jetpack/src/class-activitylog.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Manage the display of an "Activity Log" menu item.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Redirect;
+
+/**
+ * Activity Log features in My Jetpack.
+ */
+class Activitylog {
+	/**
+	 * Initialize the class and hooks needed.
+	 */
+	public static function init() {
+		add_action( 'admin_menu', array( self::class, 'add_submenu_jetpack' ) );
+	}
+
+	/**
+	 * The page to be added to submenu
+	 *
+	 * @return void|null|string The resulting page's hook_suffix
+	 */
+	public static function add_submenu_jetpack() {
+		// Only proceed if the site is connected to WordPress.com.
+		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
+			return;
+		}
+
+		// Do not display the menu on Multisite.
+		if ( is_multisite() ) {
+			return;
+		}
+
+		return Admin_Menu::add_menu(
+			__( 'Activity Log', 'jetpack-my-jetpack' ),
+			_x( 'Activity Log', 'product name shown in menu', 'jetpack-my-jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
+			'manage_options',
+			esc_url( Redirect::get_url( 'cloud-activity-log-wp-menu' ) ),
+			null,
+			1
+		);
+	}
+}

--- a/projects/packages/my-jetpack/src/class-activitylog.php
+++ b/projects/packages/my-jetpack/src/class-activitylog.php
@@ -28,7 +28,7 @@ class Activitylog {
 	 * @return void|null|string The resulting page's hook_suffix
 	 */
 	public static function add_submenu_jetpack() {
-		// Only proceed if the site is connected to WordPress.com.
+		// Only proceed if the user is connected to WordPress.com.
 		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
 			return;
 		}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.12.3-alpha';
+	const PACKAGE_VERSION = '3.13.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.
@@ -75,6 +75,9 @@ class Initializer {
 
 		// Sets up JITMS.
 		JITM::configure();
+
+		// Add "Activity Log" menu item.
+		Activitylog::init();
 
 		/**
 		 * Fires after the My Jetpack package is initialized

--- a/projects/packages/my-jetpack/tests/php/test-activitylog.php
+++ b/projects/packages/my-jetpack/tests/php/test-activitylog.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Test the Activity Log features in My Jetpack.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use WorDBless\BaseTestCase;
+
+class Test_Activitylog extends BaseTestCase {
+	/**
+	 * Admin user id
+	 *
+	 * @var int
+	 */
+	protected $admin_id;
+
+	/**
+	 * Editor user id
+	 *
+	 * @var int
+	 */
+	protected $editor_id;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		$this->admin_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_user',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+
+		$this->editor_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_user_2',
+				'user_pass'  => 'dummy_pass_2',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test that the menu is not added when on multisite.
+	 */
+	public function test_add_submenu_jetpack_multisite() {
+		if ( is_multisite() ) {
+			$this->assertFalse( Activitylog::add_submenu_jetpack() );
+		}
+
+		$this->assertNotFalse( Activitylog::add_submenu_jetpack() );
+	}
+
+	/**
+	 * Test that the menu doesn't appear for non-admins.
+	 */
+	public function test_add_submenu_jetpack_editor() {
+		wp_set_current_user( $this->editor_id );
+
+		$this->assertNull( Activitylog::add_submenu_jetpack() );
+	}
+
+	/**
+	 * Test that the menu appears for admins.
+	 */
+	public function test_add_submenu_jetpack_admin() {
+		wp_set_current_user( $this->admin_id );
+
+		$this->assertNotFalse( Activitylog::add_submenu_jetpack() );
+	}
+}

--- a/projects/plugins/backup/changelog/add-activitylog-menu
+++ b/projects/plugins/backup/changelog/add-activitylog-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -898,7 +898,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -929,7 +929,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/add-activitylog-menu
+++ b/projects/plugins/boost/changelog/add-activitylog-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -953,7 +953,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -984,7 +984,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -974,7 +974,9 @@ export default connect(
  *
  * @param pageOrder
  */
-window.wpNavMenuClassChange = function ( pageOrder = { myJetpack: 1, dashboard: 2, settings: 3 } ) {
+window.wpNavMenuClassChange = function (
+	pageOrder = { myJetpack: 1, activityLog: 2, dashboard: 3, settings: 4 }
+) {
 	let hash = window.location.hash;
 	let page = new URLSearchParams( window.location.search );
 

--- a/projects/plugins/jetpack/changelog/add-activitylog-menu
+++ b/projects/plugins/jetpack/changelog/add-activitylog-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/add-activitylog-menu-react-ffocus
+++ b/projects/plugins/jetpack/changelog/add-activitylog-menu-react-ffocus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: ensure the menu item focus supports the new "activity log" menu item.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1637,7 +1637,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1668,7 +1668,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/add-activitylog-menu
+++ b/projects/plugins/migration/changelog/add-activitylog-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -898,7 +898,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -929,7 +929,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/add-activitylog-menu
+++ b/projects/plugins/protect/changelog/add-activitylog-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -813,7 +813,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -844,7 +844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/add-activitylog-menu
+++ b/projects/plugins/search/changelog/add-activitylog-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -813,7 +813,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -844,7 +844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/add-activitylog-menu
+++ b/projects/plugins/social/changelog/add-activitylog-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -813,7 +813,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -844,7 +844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/add-activitylog-menu
+++ b/projects/plugins/starter-plugin/changelog/add-activitylog-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -813,7 +813,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -844,7 +844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/add-activitylog-menu
+++ b/projects/plugins/videopress/changelog/add-activitylog-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -813,7 +813,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e57d5539d4458fa476194c0364c59df998a5b383"
+                "reference": "3eb2f21243cf091284e6a9f9819be6a62230057a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -844,7 +844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.12.x-dev"
+                    "dev-trunk": "3.13.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
## Proposed changes:

The Activity Log is a feature that can be very useful for site owners, but that we typically haven't shown a lot until now. This commit has an "Activity Log" menu item to the Jetpack menu, for all Jetpack plugins using "My Jetpack", as soon as the user is connected to WordPress.com.

Just like for the "My Jetpack" menu, we do not show it on Multisite sites since Jetpack Cloud isn't fully compatible with Multisite yet.

<img width="179" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/c12cc50b-25f7-4c2f-b111-a16f9a1d6f63">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 668-gh-jetpack-roadmap
* p1HpG7-po1-p2

## Does this pull request change what data or activity we track or use?

* Yes, clicks on the link are tracked (see PCYsg-pY7-p2#monitoring )

## Testing instructions:

* Start with a brand new site, using one of the plugins (either Jetpack or
 standalone)
* You should not see any "Activity Log" menu item by default.
* Connect your site to WordPress.com.
* When you come back to wp-admin, you should notice an "Activity Log" link with an external icon next to it, right below "My Jetpack".
* When clicking on the link, you should be redirected to https://cloud.jetpack/activity-log/yoursite.com
* You can try installing an additional Jetpack plugin, and the link position should not change.
* You can also try to launch a Multisite network; you should not see the "Activity Log" menu item there.
