### PR TITLE
AI Assistant: janitorial code rearrange and site ID retrieval

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -333,7 +333,9 @@ class Jetpack_AI_Helper {
 	 */
 	public static function get_ai_assistance_feature() {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$has_ai_assistant_feature = \wpcom_site_has_feature( 'ai-assistant' );
+			// On WPCOM, we can get the ID from the site.
+			$blog_id                  = get_current_blog_id();
+			$has_ai_assistant_feature = \wpcom_site_has_feature( 'ai-assistant', $blog_id );
 
 			if ( ! class_exists( 'WPCOM\Jetpack_AI\Usage\Helper' ) ) {
 				if ( is_readable( WP_CONTENT_DIR . '/lib/jetpack-ai/usage/helper.php' ) ) {
@@ -346,10 +348,7 @@ class Jetpack_AI_Helper {
 				}
 			}
 
-			$blog_id        = get_current_blog_id();
-			$is_over_limit  = WPCOM\Jetpack_AI\Usage\Helper::is_over_limit( $blog_id );
-			$requests_limit = WPCOM\Jetpack_AI\Usage\Helper::get_free_requests_limit( $blog_id );
-			$requests_count = WPCOM\Jetpack_AI\Usage\Helper::get_all_time_requests_count( $blog_id );
+			$is_over_limit = WPCOM\Jetpack_AI\Usage\Helper::is_over_limit( $blog_id );
 
 			/**
 			 * Check if the site requires an upgrade.
@@ -364,7 +363,8 @@ class Jetpack_AI_Helper {
 			 *
 			 * With tiered plans, we need to check if the
 			 * site is over the limit even when it has the
-			 * feature.
+			 * feature, and this is now handled by Helper::is_over_limit.
+			 * site-require-upgrade/$require_upgrade remains for backward compatibility.
 			 */
 			$require_upgrade = $is_over_limit;
 
@@ -374,8 +374,8 @@ class Jetpack_AI_Helper {
 			return array(
 				'has-feature'          => $has_ai_assistant_feature,
 				'is-over-limit'        => $is_over_limit,
-				'requests-count'       => $requests_count,
-				'requests-limit'       => $requests_limit,
+				'requests-count'       => WPCOM\Jetpack_AI\Usage\Helper::get_all_time_requests_count( $blog_id ),
+				'requests-limit'       => WPCOM\Jetpack_AI\Usage\Helper::get_free_requests_limit( $blog_id ),
 				'usage-period'         => WPCOM\Jetpack_AI\Usage\Helper::get_period_data( $blog_id ),
 				'site-require-upgrade' => $require_upgrade,
 				'upgrade-type'         => $upgrade_type,

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -332,15 +332,6 @@ class Jetpack_AI_Helper {
 	 * @return mixed
 	 */
 	public static function get_ai_assistance_feature() {
-		$blog_id = Jetpack_Options::get_option( 'id' );
-
-		// Try to pick the AI Assistant feature from cache.
-		$transient_name = self::transient_name_for_ai_assistance_feature( $blog_id );
-		$cache          = get_transient( $transient_name );
-		if ( $cache ) {
-			return $cache;
-		}
-
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$has_ai_assistant_feature = \wpcom_site_has_feature( 'ai-assistant' );
 
@@ -392,6 +383,16 @@ class Jetpack_AI_Helper {
 				'next-tier'            => WPCOM\Jetpack_AI\Usage\Helper::get_next_tier( $blog_id ),
 				'tier-plans'           => WPCOM\Jetpack_AI\Usage\Helper::get_tier_plans_list(),
 			);
+		}
+
+		// Outside of WPCOM, we need to fetch the data from the site.
+		$blog_id = Jetpack_Options::get_option( 'id' );
+
+		// Try to pick the AI Assistant feature from cache.
+		$transient_name = self::transient_name_for_ai_assistance_feature( $blog_id );
+		$cache          = get_transient( $transient_name );
+		if ( $cache ) {
+			return $cache;
 		}
 
 		$request_path = sprintf( '/sites/%d/jetpack-ai/ai-assistant-feature', $blog_id );

--- a/projects/plugins/jetpack/changelog/change-jp-ai-helper-code-rearrange
+++ b/projects/plugins/jetpack/changelog/change-jp-ai-helper-code-rearrange
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Rearrange the code for readability and make use of specific calls on different contexts. Leave comments behind for the future


### PR DESCRIPTION
Make for cleaner code and less prone to mishaps on blog ID usage.

## Proposed changes:
This PR carries no functional change, its sole purpose is to make the code more clear and less prone to misbehaves.
- use (and comment) specific calls to get the site ID on different contexts
- provide blog ID on methods that accept it as second param
- group code depending on exec context

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1700146451177769-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test instructions are just to repeat the latest change tests for this file and expect the same output: #34170 & #34171 

* Let's test if the flag is working correctly for the current plan structure (free and unlimited paid)
* Apply this branch change to your sandbox and sandbox the `public-api` endpoint
* Go to the WordPress.com console to execute requests to `wpcom/v2` `/sites/$wpcom_site/jetpack-ai/ai-assistant-feature`
* Check the `site-require-upgrade` field on the response for some test scenarios:
   * Site with free plan and less than 20 requests -> `site-require-upgrade: false`
   * Site with free plan and more than 20 requests -> `site-require-upgrade: true`
   * Site with the paid plan -> `site-require-upgrade: false`
   * Internal P2 -> `site-require-upgrade: false`
   * Simple site with upgrade -> `site-require-upgrade: false`
* If you have a site with a tiered plan attached to it, test using it and confirm the field will be false when you are under the limit, and true when you are over the limit 

* Let's test it comparing the values before and after the change
* Before applying this change to your sandbox, go to the WordPress.com console (https://developer.wordpress.com/docs/api/console/)
* Execute a request to the `wpcom/v2` `/sites/$wpcom_site/jetpack-ai/ai-assistant-feature` endpoint using your test site and note the results:

<img width="600" alt="Screenshot 2023-11-15 at 17 45 35" src="https://github.com/Automattic/jetpack/assets/6760046/1d55e9d4-d9ee-4b67-ad82-81c1688bc06b">

* Apply this change to your sandbox and make sure you are sandboxing the `public-api`  
* Go to the WordPress.com console again
* Execute the same request as before, then compare the results:

<img width="600" alt="Screenshot 2023-11-15 at 17 50 21" src="https://github.com/Automattic/jetpack/assets/6760046/885e75bd-a057-4a39-8510-d17f4e8fdc41">

* The values for `requests-limit` and `requests-count` should be the same as before
* The value for `is-over-limit` may change because now a new rule is applied (the rule from D128826-code):
   * before, the rule was considering if the site was over the free limit of requests (a site with a paid plan could easily be over the 20 requests limit)
   * now, the rule considers if the site is over the limit of requests of the current plan it has (be it free or unlimited, and will also work for tiered plans)
   * confirm the value for `is-over-limit` makes sense by comparing the `requests-count` to the expected limit of the plan active on the site (free or unlimited)
* If possible, test for a Jetpack site and a Simple site
