### PR TITLE
My Jetpack: Add direct checkout support for products with quantity-based plans

### DIFF
--- a/projects/js-packages/connection/changelog/update-ai-assistant-intertitial-checkout-url
+++ b/projects/js-packages/connection/changelog/update-ai-assistant-intertitial-checkout-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Connection: Add optional quantity to product checkout workflow hook

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -21,15 +21,16 @@ const defaultAdminUrl =
  * Custom hook that performs the needed steps
  * to concrete the checkout workflow.
  *
- * @param {object} props              - The props passed to the hook.
- * @param {string} props.productSlug  - The WordPress product slug.
- * @param {string} props.redirectUrl  - The URI to redirect to after checkout.
- * @param {string} [props.siteSuffix] - The site suffix.
- * @param {string} [props.adminUrl]   - The site wp-admin url.
- * @param {boolean} props.connectAfterCheckout - Whether or not to conect after checkout if not connected (default false - connect before).
+ * @param {object} props                                  - The props passed to the hook.
+ * @param {string} props.productSlug                      - The WordPress product slug.
+ * @param {string} props.redirectUrl                      - The URI to redirect to after checkout.
+ * @param {string} [props.siteSuffix]                     - The site suffix.
+ * @param {string} [props.adminUrl]                       - The site wp-admin url.
+ * @param {boolean} props.connectAfterCheckout            - Whether or not to conect after checkout if not connected (default false - connect before).
  * @param {Function} props.siteProductAvailabilityHandler - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
- * @param {Function} props.from       - The plugin slug initiated the flow.
- * @returns {Function}				  - The useEffect hook.
+ * @param {Function} props.from                           - The plugin slug initiated the flow.
+ * @param {number} [props.quantity]                       - The quantity of the product to purchase.
+ * @returns {Function}                                      The useEffect hook.
  */
 export default function useProductCheckoutWorkflow( {
 	productSlug,
@@ -38,6 +39,7 @@ export default function useProductCheckoutWorkflow( {
 	adminUrl = defaultAdminUrl,
 	connectAfterCheckout = false,
 	siteProductAvailabilityHandler = null,
+	quantity = null,
 	from,
 } = {} ) {
 	debug( 'productSlug is %s', productSlug );
@@ -61,7 +63,11 @@ export default function useProductCheckoutWorkflow( {
 			? 'checkout/jetpack/'
 			: `checkout/${ siteSuffix }/`;
 
-		const productCheckoutUrl = new URL( `${ origin }${ checkoutPath }${ productSlug }` );
+		const quantitySuffix = quantity != null ? `:-q-${ quantity }` : '';
+
+		const productCheckoutUrl = new URL(
+			`${ origin }${ checkoutPath }${ productSlug }${ quantitySuffix }`
+		);
 
 		if ( shouldConnectAfterCheckout ) {
 			productCheckoutUrl.searchParams.set( 'connect_after_checkout', true );
@@ -87,14 +93,15 @@ export default function useProductCheckoutWorkflow( {
 
 		return productCheckoutUrl;
 	}, [
-		connectAfterCheckout,
 		isRegistered,
+		isUserConnected,
+		connectAfterCheckout,
 		siteSuffix,
+		quantity,
 		productSlug,
-		adminUrl,
 		from,
 		redirectUrl,
-		isUserConnected,
+		adminUrl,
 	] );
 
 	debug( 'isRegistered is %s', isRegistered );

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -67,6 +67,7 @@ function Price( { value, currency, isOld } ) {
  * @param {React.ReactNode} props.supportingInfo - Complementary links or support/legal text
  * @param {string} [props.ctaButtonLabel]        - The label for the Call To Action button
  * @param {boolean} [props.hideTOS]              - Whether to hide the Terms of Service text
+ * @param {number} [props.quantity]              - The quantity of the product to purchase
  * @returns {object}                               ProductDetailCard react component.
  */
 const ProductDetailCard = ( {
@@ -78,6 +79,7 @@ const ProductDetailCard = ( {
 	supportingInfo,
 	ctaButtonLabel = null,
 	hideTOS = false,
+	quantity = null,
 } ) => {
 	const { fileSystemWriteAccess, siteSuffix, adminUrl, myJetpackUrl } =
 		window?.myJetpackInitialState ?? {};
@@ -131,6 +133,7 @@ const ProductDetailCard = ( {
 			adminUrl,
 			connectAfterCheckout: true,
 			from: 'my-jetpack',
+			quantity,
 		} );
 
 	const { run: trialCheckoutRedirect, hasCheckoutStarted: hasTrialCheckoutStarted } =
@@ -139,6 +142,7 @@ const ProductDetailCard = ( {
 			redirectUrl: myJetpackUrl,
 			siteSuffix,
 			from: 'my-jetpack',
+			quantity,
 		} );
 
 	// Suppported products icons.

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -40,6 +40,7 @@ import videoPressImage from './videopress.png';
  * @param {string} [props.ctaButtonLabel]        - The label for the Call To Action button
  * @param {boolean} [props.hideTOS]              - Whether to hide the Terms of Service text
  * @param {number} [props.quantity]              - The quantity of the product to purchase
+ * @param {number} [props.directCheckout]        - Whether to go straight to the checkout page, e.g. for products with usage tiers
  * @returns {object}                               ProductInterstitial react component.
  */
 export default function ProductInterstitial( {
@@ -54,6 +55,7 @@ export default function ProductInterstitial( {
 	ctaButtonLabel = null,
 	hideTOS = false,
 	quantity = null,
+	directCheckout = false,
 } ) {
 	const { activate, detail } = useProduct( slug );
 	const { isUpgradableByBundle, tiers } = detail;
@@ -82,7 +84,7 @@ export default function ProductInterstitial( {
 
 	const clickHandler = useCallback(
 		( checkout, product, tier ) => {
-			if ( product?.isBundle ) {
+			if ( product?.isBundle || directCheckout ) {
 				// Get straight to the checkout page.
 				checkout?.();
 				return;
@@ -113,7 +115,7 @@ export default function ProductInterstitial( {
 				checkout?.();
 			} );
 		},
-		[ navigateToMyJetpackOverviewPage, activate ]
+		[ directCheckout, activate, navigateToMyJetpackOverviewPage ]
 	);
 
 	return (
@@ -294,6 +296,7 @@ export function JetpackAIInterstitial() {
 			ctaButtonLabel={ ctaLabel }
 			hideTOS={ true }
 			quantity={ quantity }
+			directCheckout={ hasRequiredPlan }
 		>
 			<img src={ jetpackAiImage } alt="Jetpack AI" />
 		</ProductInterstitial>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -39,6 +39,7 @@ import videoPressImage from './videopress.png';
  * @param {string} props.imageContainerClassName - Append a class to the image container
  * @param {string} [props.ctaButtonLabel]        - The label for the Call To Action button
  * @param {boolean} [props.hideTOS]              - Whether to hide the Terms of Service text
+ * @param {number} [props.quantity]              - The quantity of the product to purchase
  * @returns {object}                               ProductInterstitial react component.
  */
 export default function ProductInterstitial( {
@@ -52,6 +53,7 @@ export default function ProductInterstitial( {
 	imageContainerClassName = '',
 	ctaButtonLabel = null,
 	hideTOS = false,
+	quantity = null,
 } ) {
 	const { activate, detail } = useProduct( slug );
 	const { isUpgradableByBundle, tiers } = detail;
@@ -166,6 +168,7 @@ export default function ProductInterstitial( {
 									preferProductName={ preferProductName }
 									ctaButtonLabel={ ctaButtonLabel }
 									hideTOS={ hideTOS }
+									quantity={ quantity }
 								/>
 							</Col>
 							<Col
@@ -180,6 +183,7 @@ export default function ProductInterstitial( {
 										trackButtonClick={ trackBundleClick }
 										onClick={ clickHandler }
 										className={ isUpgradableByBundle ? styles.container : null }
+										quantity={ quantity }
 									/>
 								) : (
 									children
@@ -273,7 +277,9 @@ export function JetpackAIInterstitial() {
 	const { onClickGoBack } = useGoBack( { slug } );
 
 	const currentTier = detail?.[ 'ai-assistant-feature' ]?.[ 'current-tier' ]?.value;
-	const hasNextTier = ! [ 1, 500 ].includes( currentTier );
+	const nextTier = detail?.[ 'ai-assistant-feature' ]?.[ 'next-tier' ]?.value;
+	const hasNextTier = !! nextTier && ! [ 1, 500 ].includes( currentTier );
+	const quantity = hasNextTier ? nextTier : null;
 
 	if ( ! hasNextTier ) {
 		return <JetpackAIInterstitialMoreRequests onClickGoBack={ onClickGoBack } />;
@@ -289,6 +295,7 @@ export function JetpackAIInterstitial() {
 			imageContainerClassName={ styles.aiImageContainer }
 			ctaButtonLabel={ ctaLabel }
 			hideTOS={ true }
+			quantity={ quantity }
 		>
 			<img src={ jetpackAiImage } alt="Jetpack AI" />
 		</ProductInterstitial>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -82,15 +82,13 @@ export default function ProductInterstitial( {
 
 	const clickHandler = useCallback(
 		( checkout, product, tier ) => {
-			const activateOrCheckout = () => ( product?.isBundle ? Promise.resolve() : activate() );
+			if ( product?.isBundle ) {
+				// Get straight to the checkout page.
+				checkout?.();
+				return;
+			}
 
-			activateOrCheckout().finally( () => {
-				if ( product?.isBundle ) {
-					// Get straight to the checkout page.
-					checkout?.();
-					return;
-				}
-
+			activate().finally( () => {
 				const postActivationUrl = product?.postActivationUrl;
 				const hasRequiredPlan = tier
 					? product?.hasRequiredTier?.[ tier ]

--- a/projects/packages/my-jetpack/changelog/update-ai-assistant-intertitial-checkout-url
+++ b/projects/packages/my-jetpack/changelog/update-ai-assistant-intertitial-checkout-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add direct checkout support for products with quantity-based plans


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #33365

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `quantity` prop to the checkout workflow hook, adding the necessary `:-q-` part of the URL
* Adds a `directCheckout` prop to the interstitial so that products that have a required plan but can be further upgraded by usage tiers can go to the checkout page directly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Due to the transitioning state we are now, it is easier to test locally, as there is a hardcoded function return value that needs to be disabled.

To simulate the current tier, on your sandbox change the value of `$current_licensed_quantity` on `get_current_tier`, in the helper file (`lib/jetpack-ai/usage/helper.php`)

* On `class-jetpack-ai.php`, change the return value of `get_next_usage_tier` to enable the correct next tier
* Go to the interstitial page (admin.php?page=my-jetpack#/add-jetpack-ai)
* Change the current tier to 0, 100 and 200, refreshing the interstitial page
* Check that clicking the upgrade button links to the checkout page with the next tiers `:-q-` URL suffix (keep the network tab open, as that is visible in the first request after redirect)

* On a Jetpack site, check that the other products correctly link to their checkout pages without regressions.