### PR TITLE
Storybook: Fix boost storybook

### DIFF
--- a/projects/js-packages/storybook/changelog/fix-boost-storybook
+++ b/projects/js-packages/storybook/changelog/fix-boost-storybook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added boost back to storybook

--- a/projects/js-packages/storybook/composer.json
+++ b/projects/js-packages/storybook/composer.json
@@ -37,6 +37,7 @@
 				"js-packages/idc",
 				"packages/my-jetpack",
 				"packages/search",
+				"plugins/boost",
 				"plugins/protect",
 				"packages/videopress"
 			]

--- a/projects/js-packages/storybook/storybook/main.mjs
+++ b/projects/js-packages/storybook/storybook/main.mjs
@@ -87,6 +87,16 @@ const sbconfig = {
 			fileURLToPath( new URL( '../../../packages/search/src/dashboard/', import.meta.url ) )
 		);
 
+		config.resolve.alias = {
+			...config.resolve.alias,
+
+			// Boost specific aliases
+			$lib: path.join( __dirname, '../../../plugins/boost/app/assets/src/js/lib' ),
+			$features: path.join( __dirname, '../../../plugins/boost/app/assets/src/js/features' ),
+			$layout: path.join( __dirname, '../../../plugins/boost/app/assets/src/js/layout' ),
+			$svg: path.join( __dirname, '../../../plugins/boost/app/assets/src/js/svg' ),
+		};
+
 		return config;
 	},
 	refs: {

--- a/projects/js-packages/storybook/storybook/projects.js
+++ b/projects/js-packages/storybook/storybook/projects.js
@@ -10,6 +10,7 @@ const projects = [
 	'../../../packages/my-jetpack/_inc/components',
 	'../../../packages/search/src/dashboard/components',
 	'../../../plugins/protect/src/js/components',
+	'../../../plugins/boost/app/assets/src/js',
 	'../../../packages/videopress/src/client/admin/components',
 	'../../../packages/videopress/src/client/components',
 	'../../../packages/videopress/src/client/block-editor',


### PR DESCRIPTION
## Proposed changes:
* Fix build issue in storybook to install boost again.
* Storybook now understand boost aliases.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
* Go to `projects/js-packages/storybook`
* Run `pnpm run storybook:dev`
* Make sure storybook runs and Boost components are visible

![image](https://github.com/Automattic/jetpack/assets/3737780/1aa0990e-9672-4ded-8618-0537df111d96)


