### PR TITLE
Fix VideoPress and Memberships privacy setting override

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-gated-memberships-precedence
+++ b/projects/packages/videopress/changelog/fix-videopress-gated-memberships-precedence
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix interaction with memberships and VideoPress privacy.

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -144,10 +144,14 @@ class Access_Control {
 		$default_auth        = $this->get_default_user_capability_for_post( $post_to_check );
 		$restriction_details = $this->default_video_restriction_details( $default_auth );
 
-		if ( $this->jetpack_memberships_available() ) {
-			$memberships_can_view_post         = \Jetpack_Memberships::user_can_view_post( $embedded_post_id );
-			$restriction_details               = $this->get_subscriber_only_restriction_details( $default_auth );
-			$restriction_details['can_access'] = $memberships_can_view_post;
+		$is_memberships_active = ( new Modules() )->is_active( 'memberships' );
+		if ( $this->jetpack_memberships_available() && $is_memberships_active ) {
+			$post_access_level = \Jetpack_Memberships::get_post_access_level();
+			if ( 'everybody' !== $post_access_level ) {
+				$memberships_can_view_post         = \Jetpack_Memberships::user_can_view_post( $embedded_post_id );
+				$restriction_details               = $this->get_subscriber_only_restriction_details( $default_auth );
+				$restriction_details['can_access'] = $memberships_can_view_post;
+			}
 		}
 
 		return $this->check_block_level_access(

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -144,8 +144,7 @@ class Access_Control {
 		$default_auth        = $this->get_default_user_capability_for_post( $post_to_check );
 		$restriction_details = $this->default_video_restriction_details( $default_auth );
 
-		$is_memberships_active = ( new Modules() )->is_active( 'memberships' );
-		if ( $this->jetpack_memberships_available() && $is_memberships_active ) {
+		if ( $this->jetpack_memberships_available() ) {
 			$post_access_level = \Jetpack_Memberships::get_post_access_level();
 			if ( 'everybody' !== $post_access_level ) {
 				$memberships_can_view_post         = \Jetpack_Memberships::user_can_view_post( $embedded_post_id );

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -145,7 +145,7 @@ class Access_Control {
 		$restriction_details = $this->default_video_restriction_details( $default_auth );
 
 		if ( $this->jetpack_memberships_available() ) {
-			$post_access_level = \Jetpack_Memberships::get_post_access_level();
+			$post_access_level = \Jetpack_Memberships::get_post_access_level( $embedded_post_id );
 			if ( 'everybody' !== $post_access_level ) {
 				$memberships_can_view_post         = \Jetpack_Memberships::user_can_view_post( $embedded_post_id );
 				$restriction_details               = $this->get_subscriber_only_restriction_details( $default_auth );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only allow memberships to override privacy access if the post access level is set to an access level that requires subscription.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post and add a private video.
* Do not set membership access. (i.e. the default which is 'everybody')
* Check the video post logged in to the site. It should work.
* Check the video post logged out. It should not work.

