### PR TITLE
My Jetpack: Add Jetpack AI prices by tier to the interstitial page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -120,8 +120,11 @@ const ProductDetailCard = ( {
 	 * Product needs purchase when:
 	 * - it's not free
 	 * - it does not have a required plan
+	 *
+	 * Or when:
+	 * - it's a quantity-based product
 	 */
-	const needsPurchase = ! isFree && ! hasRequiredPlan;
+	const needsPurchase = ( ! isFree && ! hasRequiredPlan ) || quantity != null;
 
 	const checkoutRedirectUrl = postCheckoutUrl ? postCheckoutUrl : myJetpackUrl;
 

--- a/projects/packages/my-jetpack/changelog/update-ai-assistant-interstitial-prices
+++ b/projects/packages/my-jetpack/changelog/update-ai-assistant-interstitial-prices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add Jetpack AI prices by tier to the interstitial page


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #33358

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Maps each Jetpack AI tier to its yearly price using the product's `price_tier_list`
* Shows the price in the interstitial component for already-activated products that are quantity-based 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On JN:
* Apply this PR to a JN site and just check that it acts as normal, with no obvious regression in the checkout flow

Test locally to be able to disable the hard return of the unlimited plan:
* Look for the `get_next_usage_tier` on `class-jetpack-ai.php` and change its commented return value
* Sandbox the public API
* In your sandbox, change the `$current_licensed_quantity` value in the `get_current_tier` function of the Jetpack AI usage Helper class to mock different tiers 
* Go to the interstitial page (?page=my-jetpack#/add-jetpack-ai)
* Check that *a* price is displayed for all tiers. At this point it should be the same price
* On your sandbox's `0-sandbox.php` file, enable the store sandbox flag with `define( 'USE_STORE_SANDBOX', true );`
* Here cache will prevent the prices from loading correctly, so you may need to force a `return true` on `class-wpcom-products.php`' `is_cache_old` function.
* Reload the interstitial page
* Check that each tier shows a different price that matches the one on the prices spreadsheet (p1700251365617209/1700165215.316789-slack-C054LN8RNVA)
