### PR TITLE
Update/refactor data request for my jetpack cards

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
@@ -5,6 +5,8 @@ import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import { useEffect, useState, useMemo } from 'react';
 import useAnalytics from '../../../hooks/use-analytics';
+import useBackupRewindableEvents from '../../../hooks/use-backup-rewindable-events';
+import useCountBackupItems from '../../../hooks/use-count-backup-items';
 import { useProduct } from '../../../hooks/use-product';
 import ProductCard from '../../connected-product-card';
 import { PRODUCT_STATUSES } from '../../product-card/action-button';
@@ -38,96 +40,6 @@ const getTitle = slug => {
 		default:
 			return slug;
 	}
-};
-
-const NoBackupsValueSection = ( { siteData } ) => {
-	const [ itemsToShow, setItemsToShow ] = useState( 3 );
-
-	const sortedData = useMemo( () => {
-		const data = [];
-
-		Object.keys( siteData ).forEach( key => {
-			// We can safely filter out any values that are 0
-			if ( siteData[ key ] === 0 ) {
-				return;
-			}
-
-			data.push( [ key, siteData[ key ] ] );
-		} );
-
-		data.sort( ( a, b ) => {
-			return a[ 1 ] < b[ 1 ] ? 1 : -1;
-		} );
-
-		return data;
-	}, [ siteData ] );
-
-	// Only show 2 data points on certain screen widths where the cards are squished
-	useEffect( () => {
-		window.onresize = () => {
-			if ( ( window.innerWidth >= 961 && window.innerWidth <= 1070 ) || window.innerWidth < 290 ) {
-				setItemsToShow( 2 );
-			} else {
-				setItemsToShow( 3 );
-			}
-		};
-
-		return () => {
-			window.onresize = null;
-		};
-	}, [] );
-
-	const moreValue = sortedData.length > itemsToShow ? sortedData.length - itemsToShow : 0;
-	const shortenedNumberConfig = { maximumFractionDigits: 1, notation: 'compact' };
-
-	return (
-		<div className={ styles[ 'no-backup-stats' ] }>
-			<div className={ styles[ 'main-stats' ] }>
-				{ sortedData.slice( 0, itemsToShow ).map( ( item, i ) => {
-					const slug = item[ 0 ].split( '_' )[ 1 ];
-					const value = item[ 1 ];
-
-					return (
-						<div
-							className={ classNames( styles[ 'main-stat' ], `main-stat-${ i }` ) }
-							key={ i + slug }
-							title={ getTitle( slug ) }
-						>
-							{ getIcon( slug ) }
-							<span>{ numberFormat( value, shortenedNumberConfig ) }</span>
-						</div>
-					);
-				} ) }
-			</div>
-
-			{ moreValue > 0 && (
-				<p className={ styles[ 'more-stats' ] }>
-					{
-						// translators: %s is the number of items that are not shown
-						sprintf( __( '+%s more', 'jetpack-my-jetpack' ), moreValue )
-					}
-				</p>
-			) }
-		</div>
-	);
-};
-
-const WithBackupsValueSection = ( { lastUndoableEvent } ) => {
-	if ( ! lastUndoableEvent || ! lastUndoableEvent.data ) {
-		return null;
-	}
-	const { last_rewindable_event: lastRewindableEvent = {} } = lastUndoableEvent.data;
-
-	if ( ! lastRewindableEvent ) {
-		return null;
-	}
-
-	return (
-		<div className={ styles.activity }>
-			<Gridicon icon={ lastRewindableEvent.gridicon } size={ 24 } />
-			<p className={ styles.summary }>{ lastRewindableEvent.summary }</p>
-		</div>
-	);
 };
 
 const getTimeSinceLastRenewableEvent = lastRewindableEventTime => {
@@ -181,20 +93,25 @@ const getTimeSinceLastRenewableEvent = lastRewindableEventTime => {
 	}
 };
 
-const BackupCard = ( { admin, productData, fetchingProductData } ) => {
+const BackupCard = ( { admin } ) => {
 	const slug = 'backup';
-
-	const { recordEvent } = useAnalytics();
 	const { detail } = useProduct( slug );
 	const { status } = detail;
 	const hasBackups = status === PRODUCT_STATUSES.ACTIVE || status === PRODUCT_STATUSES.CAN_UPGRADE;
 
-	const { site_data: siteData = {}, last_undoable_event: lastUndoableEvent = {} } =
-		productData || {};
+	return hasBackups ? (
+		<WithBackupsValueSection admin={ admin } slug={ slug } />
+	) : (
+		<NoBackupsValueSection admin={ admin } slug={ slug } />
+	);
+};
 
-	const lastRewindableEventTime = lastUndoableEvent?.data?.last_rewindable_event?.published;
-	const hasRewindableEvent = hasBackups && lastUndoableEvent?.data?.last_rewindable_event;
-	const undoBackupId = lastUndoableEvent?.data?.undo_backup_id;
+const WithBackupsValueSection = ( { admin, slug } ) => {
+	const { backupRewindableEvents, fetchingBackupRewindableEvents } = useBackupRewindableEvents();
+	const lastRewindableEventTime = backupRewindableEvents?.last_rewindable_event?.published;
+	const lastRewindableEvent = backupRewindableEvents?.last_rewindable_event;
+	const undoBackupId = backupRewindableEvents?.undo_backup_id;
+	const { recordEvent } = useAnalytics();
 
 	const handleUndoClick = () => {
 		recordEvent( 'jetpack_myjetpack_backup_card_undo_click', {
@@ -230,23 +147,98 @@ const BackupCard = ( { admin, productData, fetchingProductData } ) => {
 			admin={ admin }
 			slug={ slug }
 			showMenu
-			isDataLoading={ fetchingProductData }
-			Description={ hasRewindableEvent ? WithBackupsDescription : null }
-			additionalActions={ hasRewindableEvent ? [ undoAction ] : null }
+			isDataLoading={ fetchingBackupRewindableEvents }
+			Description={ lastRewindableEvent ? WithBackupsDescription : null }
+			additionalActions={ lastRewindableEvent ? [ undoAction ] : [] }
 		>
-			{ hasBackups ? (
-				<WithBackupsValueSection lastUndoableEvent={ lastUndoableEvent } />
-			) : (
-				<NoBackupsValueSection siteData={ siteData } />
-			) }
+			{ lastRewindableEvent ? (
+				<div className={ styles.activity }>
+					<Gridicon icon={ lastRewindableEvent.gridicon } size={ 24 } />
+					<p className={ styles.summary }>{ lastRewindableEvent.summary }</p>
+				</div>
+			) : null }
+		</ProductCard>
+	);
+};
+
+const NoBackupsValueSection = ( { admin, slug } ) => {
+	const [ itemsToShow, setItemsToShow ] = useState( 3 );
+	const { countBackupItems: siteData, fetchingCountBackupItems: isFetching } =
+		useCountBackupItems();
+
+	const sortedData = useMemo( () => {
+		const data = [];
+
+		Object.keys( siteData ).forEach( key => {
+			// We can safely filter out any values that are 0
+			if ( siteData[ key ] === 0 ) {
+				return;
+			}
+
+			data.push( [ key, siteData[ key ] ] );
+		} );
+
+		data.sort( ( a, b ) => {
+			return a[ 1 ] < b[ 1 ] ? 1 : -1;
+		} );
+
+		return data;
+	}, [ siteData ] );
+
+	// Only show 2 data points on certain screen widths where the cards are squished
+	useEffect( () => {
+		window.onresize = () => {
+			if ( ( window.innerWidth >= 961 && window.innerWidth <= 1070 ) || window.innerWidth < 290 ) {
+				setItemsToShow( 2 );
+			} else {
+				setItemsToShow( 3 );
+			}
+		};
+
+		return () => {
+			window.onresize = null;
+		};
+	}, [] );
+
+	const moreValue = sortedData.length > itemsToShow ? sortedData.length - itemsToShow : 0;
+	const shortenedNumberConfig = { maximumFractionDigits: 1, notation: 'compact' };
+
+	return (
+		<ProductCard admin={ admin } slug={ slug } showMenu isDataLoading={ isFetching }>
+			<div className={ styles[ 'no-backup-stats' ] }>
+				<div className={ styles[ 'main-stats' ] }>
+					{ sortedData.slice( 0, itemsToShow ).map( ( item, i ) => {
+						const itemSlug = item[ 0 ].split( '_' )[ 1 ];
+						const value = item[ 1 ];
+
+						return (
+							<div
+								className={ classNames( styles[ 'main-stat' ], `main-stat-${ i }` ) }
+								key={ i + itemSlug }
+								title={ getTitle( itemSlug ) }
+							>
+								{ getIcon( itemSlug ) }
+								<span>{ numberFormat( value, shortenedNumberConfig ) }</span>
+							</div>
+						);
+					} ) }
+				</div>
+
+				{ moreValue > 0 && (
+					<p className={ styles[ 'more-stats' ] }>
+						{
+							// translators: %s is the number of items that are not shown
+							sprintf( __( '+%s more', 'jetpack-my-jetpack' ), moreValue )
+						}
+					</p>
+				) }
+			</div>
 		</ProductCard>
 	);
 };
 
 BackupCard.propTypes = {
 	admin: PropTypes.bool.isRequired,
-	productData: PropTypes.object,
-	fetchingProductData: PropTypes.bool.isRequired,
 };
 
 NoBackupsValueSection.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -1,6 +1,5 @@
 import { Container, Col } from '@automattic/jetpack-components';
 import React from 'react';
-import useProductData from '../../hooks/use-product-data';
 import AiCard from './ai-card';
 import AntiSpamCard from './anti-spam-card';
 import BackupCard from './backup-card';
@@ -22,8 +21,6 @@ const { showJetpackStatsCard = false } = window.myJetpackInitialState?.myJetpack
  * @returns {object} ProductCardsSection React component.
  */
 const ProductCardsSection = () => {
-	const { productData, fetchingProductData } = useProductData();
-
 	const items = {
 		backups: BackupCard,
 		scan: ScanAndProtectCard,
@@ -52,11 +49,7 @@ const ProductCardsSection = () => {
 
 				return (
 					<Col tagName="li" sm={ 4 } md={ 4 } lg={ 4 } key={ key }>
-						<Item
-							admin={ !! window?.myJetpackInitialState?.userIsAdmin }
-							productData={ productData[ key ] }
-							fetchingProductData={ fetchingProductData }
-						/>
+						<Item admin={ !! window?.myJetpackInitialState?.userIsAdmin } />
 					</Col>
 				);
 			} ) }

--- a/projects/packages/my-jetpack/_inc/hooks/use-backup-rewindable-events/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-backup-rewindable-events/index.js
@@ -1,0 +1,16 @@
+import { useSelect } from '@wordpress/data';
+import { STORE_ID } from '../../state/store';
+
+/**
+ * React custom hook to get the backup rewindable events
+ *
+ * @returns {object} product data
+ */
+export default function useBackupRewindableEvents() {
+	return {
+		backupRewindableEvents: useSelect( select => select( STORE_ID ).getBackupRewindableEvents() ),
+		fetchingBackupRewindableEvents: useSelect( select =>
+			select( STORE_ID ).isFetchingBackupRewindableEvents()
+		),
+	};
+}

--- a/projects/packages/my-jetpack/_inc/hooks/use-count-backup-items/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-count-backup-items/index.js
@@ -1,0 +1,16 @@
+import { useSelect } from '@wordpress/data';
+import { STORE_ID } from '../../state/store';
+
+/**
+ * React custom hook to get the count of things that the site has that can be backed up
+ *
+ * @returns {object} product data
+ */
+export default function useCountBackupItems() {
+	return {
+		countBackupItems: useSelect( select => select( STORE_ID ).getCountBackupItems() ),
+		fetchingCountBackupItems: useSelect( select =>
+			select( STORE_ID ).isFetchingCountBackupItems()
+		),
+	};
+}

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -21,10 +21,14 @@ const SET_CHAT_AVAILABILITY_IS_FETCHING = 'SET_CHAT_AVAILABILITY_IS_FETCHING';
 const SET_CHAT_AVAILABILITY = 'SET_CHAT_AVAILABILITY';
 const SET_CHAT_AUTHENTICATION_IS_FETCHING = 'SET_CHAT_AUTHENTICATION_IS_FETCHING';
 const SET_CHAT_AUTHENTICATION = 'SET_CHAT_AUTHENTICATION';
-const SET_PRODUCT_DATA_IS_FETCHING = 'SET_PRODUCT_DATA_IS_FETCHING';
-const SET_PRODUCT_DATA = 'SET_PRODUCT_DATA';
 const SET_STATS_COUNTS_IS_FETCHING = 'SET_STATS_COUNTS_IS_FETCHING';
 const SET_STATS_COUNTS = 'SET_STATS_COUNTS';
+
+const SET_BACKUP_REWINDABLE_EVENTS_IS_FETCHING = 'SET_BACKUP_REWINDABLE_EVENTS_IS_FETCHING';
+const SET_BACKUP_REWINDABLE_EVENTS = 'SET_BACKUP_REWINDABLE_EVENTS';
+
+const SET_COUNT_BACKUP_ITEMS = 'SET_COUNT_BACKUP_ITEMS';
+const SET_COUNT_BACKUP_ITEMS_IS_FETCHING = 'SET_COUNT_BACKUP_ITEMS_IS_FETCHING';
 
 const SET_GLOBAL_NOTICE = 'SET_GLOBAL_NOTICE';
 const CLEAN_GLOBAL_NOTICE = 'CLEAN_GLOBAL_NOTICE';
@@ -44,8 +48,12 @@ const setChatAuthenticationIsFetching = isFetching => {
 	return { type: SET_CHAT_AUTHENTICATION_IS_FETCHING, isFetching };
 };
 
-const setProductDataIsFetching = isFetching => {
-	return { type: SET_PRODUCT_DATA_IS_FETCHING, isFetching };
+const setBackupRewindableEventsIsFetching = isFetching => {
+	return { type: SET_BACKUP_REWINDABLE_EVENTS_IS_FETCHING, isFetching };
+};
+
+const setCountBackupItemsIsFetching = isFetching => {
+	return { type: SET_COUNT_BACKUP_ITEMS_IS_FETCHING, isFetching };
 };
 
 const setStatsCountsIsFetching = isFetching => {
@@ -82,7 +90,15 @@ const setAvailableLicenses = availableLicenses => {
 
 const setProduct = product => ( { type: SET_PRODUCT, product } );
 
-const setProductData = productData => ( { type: SET_PRODUCT_DATA, productData } );
+const setBackupRewindableEvents = rewindableEvents => ( {
+	type: SET_BACKUP_REWINDABLE_EVENTS,
+	rewindableEvents,
+} );
+
+const setCountBackupItems = backupItems => ( {
+	type: SET_COUNT_BACKUP_ITEMS,
+	backupItems,
+} );
 
 const setStatsCounts = statsCounts => ( { type: SET_STATS_COUNTS, statsCounts } );
 
@@ -287,13 +303,15 @@ const actions = {
 	setPurchases,
 	setChatAvailability,
 	setChatAuthentication,
-	setProductDataIsFetching,
-	setProductData,
 	setAvailableLicensesIsFetching,
 	fetchAvailableLicenses,
 	setAvailableLicenses,
 	setProductStats,
 	setIsFetchingProductStats,
+	setBackupRewindableEvents,
+	setBackupRewindableEventsIsFetching,
+	setCountBackupItems,
+	setCountBackupItemsIsFetching,
 	setStatsCounts,
 	setStatsCountsIsFetching,
 	...noticeActions,
@@ -320,8 +338,10 @@ export {
 	SET_CHAT_AVAILABILITY_IS_FETCHING,
 	SET_CHAT_AUTHENTICATION,
 	SET_CHAT_AUTHENTICATION_IS_FETCHING,
-	SET_PRODUCT_DATA_IS_FETCHING,
-	SET_PRODUCT_DATA,
+	SET_BACKUP_REWINDABLE_EVENTS_IS_FETCHING,
+	SET_BACKUP_REWINDABLE_EVENTS,
+	SET_COUNT_BACKUP_ITEMS_IS_FETCHING,
+	SET_COUNT_BACKUP_ITEMS,
 	SET_STATS_COUNTS_IS_FETCHING,
 	SET_STATS_COUNTS,
 	actions as default,

--- a/projects/packages/my-jetpack/_inc/state/constants.js
+++ b/projects/packages/my-jetpack/_inc/state/constants.js
@@ -3,7 +3,8 @@ const ODYSSEY_STATS_API_NAMESPACE = 'jetpack/v4/stats-app';
 
 export const REST_API_SITE_PURCHASES_ENDPOINT = `${ REST_API_NAMESPACE }/site/purchases`;
 export const REST_API_SITE_PRODUCTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/products`;
-export const REST_API_SITE_PRODUCT_DATA_ENDPOINT = `${ REST_API_NAMESPACE }/site/product-data`;
+export const REST_API_REWINDABLE_BACKUP_EVENTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/backup/undo-event`;
+export const REST_API_COUNT_BACKUP_ITEMS_ENDPOINT = `${ REST_API_NAMESPACE }/site/backup/count-items`;
 export const REST_API_CHAT_AVAILABILITY_ENDPOINT = `${ REST_API_NAMESPACE }/chat/availability`;
 export const REST_API_CHAT_AUTHENTICATION_ENDPOINT = `${ REST_API_NAMESPACE }/chat/authentication`;
 export const PRODUCTS_THAT_NEEDS_INITIAL_FETCH = [ 'scan' ];

--- a/projects/packages/my-jetpack/_inc/state/reducers.js
+++ b/projects/packages/my-jetpack/_inc/state/reducers.js
@@ -16,8 +16,10 @@ import {
 	CLEAN_GLOBAL_NOTICE,
 	SET_PRODUCT_STATS,
 	SET_IS_FETCHING_PRODUCT_STATS,
-	SET_PRODUCT_DATA_IS_FETCHING,
-	SET_PRODUCT_DATA,
+	SET_BACKUP_REWINDABLE_EVENTS_IS_FETCHING,
+	SET_BACKUP_REWINDABLE_EVENTS,
+	SET_COUNT_BACKUP_ITEMS_IS_FETCHING,
+	SET_COUNT_BACKUP_ITEMS,
 	SET_STATS_COUNTS_IS_FETCHING,
 	SET_STATS_COUNTS,
 } from './actions';
@@ -81,18 +83,37 @@ const products = ( state = {}, action ) => {
 	}
 };
 
-const productData = ( state = {}, action ) => {
+const backupRewindableEvents = ( state = {}, action ) => {
 	switch ( action.type ) {
-		case SET_PRODUCT_DATA_IS_FETCHING:
+		case SET_BACKUP_REWINDABLE_EVENTS_IS_FETCHING:
 			return {
 				...state,
 				isFetching: action.isFetching,
 			};
 
-		case SET_PRODUCT_DATA:
+		case SET_BACKUP_REWINDABLE_EVENTS:
 			return {
 				...state,
-				items: action?.productData || {},
+				items: action?.rewindableEvents || {},
+			};
+
+		default:
+			return state;
+	}
+};
+
+const countBackupItems = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SET_COUNT_BACKUP_ITEMS_IS_FETCHING:
+			return {
+				...state,
+				isFetching: action.isFetching,
+			};
+
+		case SET_COUNT_BACKUP_ITEMS:
+			return {
+				...state,
+				items: action?.backupItems || {},
 			};
 
 		default:
@@ -255,7 +276,8 @@ const statsCounts = ( state = {}, action ) => {
 
 const reducers = combineReducers( {
 	products,
-	productData,
+	backupRewindableEvents,
+	countBackupItems,
 	purchases,
 	chatAvailability,
 	chatAuthentication,

--- a/projects/packages/my-jetpack/_inc/state/resolvers.js
+++ b/projects/packages/my-jetpack/_inc/state/resolvers.js
@@ -12,11 +12,12 @@ import { PRODUCT_STATUSES } from '../components/product-card';
 import {
 	REST_API_SITE_PURCHASES_ENDPOINT,
 	REST_API_SITE_PRODUCTS_ENDPOINT,
+	REST_API_REWINDABLE_BACKUP_EVENTS_ENDPOINT,
 	REST_API_CHAT_AVAILABILITY_ENDPOINT,
 	REST_API_CHAT_AUTHENTICATION_ENDPOINT,
-	REST_API_SITE_PRODUCT_DATA_ENDPOINT,
 	PRODUCTS_THAT_NEEDS_INITIAL_FETCH,
 	getStatsHighlightsEndpoint,
+	REST_API_COUNT_BACKUP_ITEMS_ENDPOINT,
 } from './constants';
 import resolveProductStatsRequest from './stats-resolvers';
 
@@ -133,15 +134,32 @@ const myJetpackResolvers = {
 			}
 		},
 
-	getProductData: () => {
+	getBackupRewindableEvents: () => {
 		return async ( { dispatch } ) => {
-			dispatch.setProductDataIsFetching( true );
+			dispatch.setBackupRewindableEventsIsFetching( true );
 
 			try {
-				dispatch.setProductData( await apiFetch( { path: REST_API_SITE_PRODUCT_DATA_ENDPOINT } ) );
-				dispatch.setProductDataIsFetching( false );
+				dispatch.setBackupRewindableEvents(
+					await apiFetch( { path: REST_API_REWINDABLE_BACKUP_EVENTS_ENDPOINT } )
+				);
+				dispatch.setBackupRewindableEventsIsFetching( false );
 			} catch ( error ) {
-				dispatch.setProductDataIsFetching( false );
+				dispatch.setBackupRewindableEventsIsFetching( false );
+			}
+		};
+	},
+
+	getCountBackupItems: () => {
+		return async ( { dispatch } ) => {
+			dispatch.setCountBackupItemsIsFetching( true );
+
+			try {
+				dispatch.setCountBackupItems(
+					await apiFetch( { path: REST_API_COUNT_BACKUP_ITEMS_ENDPOINT } )
+				);
+				dispatch.setCountBackupItemsIsFetching( false );
+			} catch ( error ) {
+				dispatch.setCountBackupItemsIsFetching( false );
 			}
 		};
 	},

--- a/projects/packages/my-jetpack/_inc/state/selectors.js
+++ b/projects/packages/my-jetpack/_inc/state/selectors.js
@@ -77,9 +77,14 @@ const productSelectors = {
 	getProductsThatRequiresUserConnection,
 };
 
-const productDataSelectors = {
-	getProductData: state => state.productData?.items || {},
-	isFetchingProductData: state => state.productData?.isFetching || false,
+const backupRewindableEventsSelectors = {
+	getBackupRewindableEvents: state => state.backupRewindableEvents?.items || {},
+	isFetchingBackupRewindableEvents: state => state.backupRewindableEvents?.isFetching || false,
+};
+
+const countBackupItemsSelectors = {
+	getCountBackupItems: state => state.countBackupItems?.items || {},
+	isFetchingCountBackupItems: state => state.countBackupItems.isFetching || false,
 };
 
 const purchasesSelectors = {
@@ -152,11 +157,12 @@ const selectors = {
 	...purchasesSelectors,
 	...chatAvailabilitySelectors,
 	...chatAuthenticationSelectors,
-	...productDataSelectors,
 	...availableLicensesSelectors,
 	...noticeSelectors,
 	...pluginSelectors,
 	...productStatsSelectors,
+	...backupRewindableEventsSelectors,
+	...countBackupItemsSelectors,
 	...statsCountsSelectors,
 };
 

--- a/projects/packages/my-jetpack/changelog/update-refactor-data-request-for-my-jetpack-cards
+++ b/projects/packages/my-jetpack/changelog/update-refactor-data-request-for-my-jetpack-cards
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update the API calls used for My Jetpack backup card

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -76,7 +76,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.0.x-dev"
+			"dev-trunk": "4.1.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.0.4-alpha",
+	"version": "4.1.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.0.4-alpha';
+	const PACKAGE_VERSION = '4.1.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/backup/changelog/update-refactor-data-request-for-my-jetpack-cards
+++ b/projects/plugins/backup/changelog/update-refactor-data-request-for-my-jetpack-cards
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -927,7 +927,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -959,7 +959,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/update-refactor-data-request-for-my-jetpack-cards
+++ b/projects/plugins/boost/changelog/update-refactor-data-request-for-my-jetpack-cards
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -983,7 +983,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1015,7 +1015,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/update-refactor-data-request-for-my-jetpack-cards
+++ b/projects/plugins/jetpack/changelog/update-refactor-data-request-for-my-jetpack-cards
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1686,7 +1686,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1718,7 +1718,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/update-refactor-data-request-for-my-jetpack-cards
+++ b/projects/plugins/migration/changelog/update-refactor-data-request-for-my-jetpack-cards
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -927,7 +927,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -959,7 +959,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/update-refactor-data-request-for-my-jetpack-cards
+++ b/projects/plugins/protect/changelog/update-refactor-data-request-for-my-jetpack-cards
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/update-refactor-data-request-for-my-jetpack-cards
+++ b/projects/plugins/search/changelog/update-refactor-data-request-for-my-jetpack-cards
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/update-refactor-data-request-for-my-jetpack-cards
+++ b/projects/plugins/social/changelog/update-refactor-data-request-for-my-jetpack-cards
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/update-refactor-data-request-for-my-jetpack-cards
+++ b/projects/plugins/starter-plugin/changelog/update-refactor-data-request-for-my-jetpack-cards
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/update-refactor-data-request-for-my-jetpack-cards
+++ b/projects/plugins/videopress/changelog/update-refactor-data-request-for-my-jetpack-cards
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This diff changes the way the backup card collects data to display. It removes a call to a remote WPCOM endpoint in favor of a local API call and makes an additional call more direct.
* Overall, the goal of this PR is to remove the dependency on the `sites/%d/jetpack-product-data` endpoint in favor of other existing remote endpoints or plugin-local endpoints.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Get a Jetpack testing site and check out this PR using the beta plugin
* Follow the test plan from https://github.com/Automattic/jetpack/pull/33997 and make sure that everything still works as described.
* Confirm that no errors show in the console while testing and that the automated tests are still passing

