### PR TITLE
Publicize: do not display module toggles when not connected

### DIFF
--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -100,7 +100,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 									'jetpack'
 								) }
 							</p>
-							{ showUpgradeLink && (
+							{ showUpgradeLink && isLinked && (
 								<>
 									<p>
 										{ ! hasSocialBasicFeatures
@@ -145,17 +145,21 @@ export const Publicize = withModuleSettingsFormHelpers(
 									</p>
 								</>
 							) }
-							<ModuleToggle
-								slug="publicize"
-								disabled={ unavailableInOfflineMode || ! this.props.isLinked }
-								activated={ isActive }
-								toggling={ this.props.isSavingAnyOption( 'publicize' ) }
-								toggleModule={ this.props.toggleModuleNow }
-							>
-								{ __( 'Automatically share your posts to social networks', 'jetpack' ) }
-							</ModuleToggle>
-							{ shouldShowChildElements && hasAutoConversion && <AutoConversionSection /> }
-							{ shouldShowChildElements && hasSocialImageGenerator && (
+							{ isLinked && (
+								<ModuleToggle
+									slug="publicize"
+									disabled={ unavailableInOfflineMode }
+									activated={ isActive }
+									toggling={ this.props.isSavingAnyOption( 'publicize' ) }
+									toggleModule={ this.props.toggleModuleNow }
+								>
+									{ __( 'Automatically share your posts to social networks', 'jetpack' ) }
+								</ModuleToggle>
+							) }
+							{ shouldShowChildElements && hasAutoConversion && isLinked && (
+								<AutoConversionSection />
+							) }
+							{ shouldShowChildElements && hasSocialImageGenerator && isLinked && (
 								<SocialImageGeneratorSection />
 							) }
 						</SettingsGroup>

--- a/projects/plugins/jetpack/changelog/fix-publicize-no-display-unconnected
+++ b/projects/plugins/jetpack/changelog/fix-publicize-no-display-unconnected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: do not display the Auto-sharing toggle when your account is not connected yet.


### PR DESCRIPTION
## Proposed changes:

When an admin is not connected to WordPress.com, let's not display the toggle to turn Publicize on or off. This way they would not inadvertently disable a feature that other authors on the site may be using for their own posts.

The invitation to connect your account to WordPress.com remains, so you can take action and toggle the module once you're connected.

**When not connected**

<img width="1103" alt="Screenshot 2023-11-20 at 11 24 01" src="https://github.com/Automattic/jetpack/assets/426388/ef53caa1-c0ec-4830-ae54-8887b9c48a79">

**When connected**

<img width="1110" alt="Screenshot 2023-11-20 at 11 23 56" src="https://github.com/Automattic/jetpack/assets/426388/2ddf7615-72cb-4d9f-8ad7-1e77411e3e40">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related discussion: p1699929025605869-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's connected to WordPress.com. 
* Go to Jetpack > Settings > Sharing
* Enable the Publicize feature.
* Go to Users > Add New and create a new admin.
* In a new browser, log in with that user.
* Go to Jetpack > Settings > Sharing.
   * You should only see an invitation to connect.
