### PR TITLE
Backport mu-wpcom-plugin 2.0.0, jetpack 12.9-a.7 Changes

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/changelog/force-a-release
+++ b/projects/github-actions/pr-is-up-to-date/changelog/force-a-release
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Removed jetpack/publicize store
+Update dependencies.

--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-11-20
+### Changed
+- Include built JavaScript code in addition to TypeScript. [#34118]
+
 ## [0.1.16] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -162,6 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.2.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.16...v0.2.0
 [0.1.16]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.13...v0.1.14

--- a/projects/js-packages/ai-client/changelog/update-ai-client-expose-compiles-files
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-expose-compiles-files
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-AI Client: include built JavaScript code in addition to TypeScript.

--- a/projects/js-packages/ai-client/changelog/update-node-20
+++ b/projects/js-packages/ai-client/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.2.0-alpha",
+	"version": "0.2.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/analytics/CHANGELOG.md
+++ b/projects/js-packages/analytics/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### This is a list detailing changes for the Jetpack RNA Analytics package releases.
 
+## [0.1.28] - 2023-11-20
+
 ## [0.1.27] - 2023-08-23
 ### Changed
 - Updated package dependencies. [#32605]
@@ -110,5 +112,6 @@
 ### Added
 - Initial release of jetpack-api package.
 
+[0.1.28]: https://github.com/Automattic/jetpack-analytics/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/Automattic/jetpack-analytics/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/Automattic/jetpack-analytics/compare/v0.1.25...v0.1.26

--- a/projects/js-packages/analytics/changelog/update-node-20
+++ b/projects/js-packages/analytics/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/analytics/package.json
+++ b/projects/js-packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-analytics",
-	"version": "0.1.28-alpha",
+	"version": "0.1.28",
 	"description": "Jetpack Analytics Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/analytics/#readme",
 	"bugs": {

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.16.6] - 2023-11-20
+
 ## [0.16.5] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -279,6 +281,7 @@
 - Add the API methods left behind by the previous PR.
 - Initial release of jetpack-api package
 
+[0.16.6]: https://github.com/Automattic/jetpack-api/compare/v0.16.5...v0.16.6
 [0.16.5]: https://github.com/Automattic/jetpack-api/compare/v0.16.4...v0.16.5
 [0.16.4]: https://github.com/Automattic/jetpack-api/compare/v0.16.3...v0.16.4
 [0.16.3]: https://github.com/Automattic/jetpack-api/compare/v0.16.2...v0.16.3

--- a/projects/js-packages/api/changelog/update-node-20
+++ b/projects/js-packages/api/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.16.6-alpha",
+	"version": "0.16.6",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.31] - 2023-11-20
+
 ## [1.0.30] - 2023-10-17
 ### Changed
 - Updated package dependencies. [#33646]
@@ -143,6 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 - Replace missing domains too.
 
+[1.0.31]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.30...v1.0.31
 [1.0.30]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.29...v1.0.30
 [1.0.29]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.28...v1.0.29
 [1.0.28]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.27...v1.0.28

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/update-node-20
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.0.31-alpha",
+	"version": "1.0.31",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/babel-plugin-replace-textdomain/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.13] - 2023-11-20
+
 ## [0.6.12] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -232,6 +234,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.13]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.12...0.6.13
 [0.6.12]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.11...0.6.12
 [0.6.11]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.10...0.6.11
 [0.6.10]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.9...0.6.10

--- a/projects/js-packages/base-styles/changelog/update-node-20
+++ b/projects/js-packages/base-styles/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.13-alpha",
+	"version": "0.6.13",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.17] - 2023-11-20
+
 ## [0.1.16] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -81,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.17]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.13...v0.1.14

--- a/projects/js-packages/boost-score-api/changelog/update-node-20
+++ b/projects/js-packages/boost-score-api/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.17-alpha",
+	"version": "0.1.17",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.45.2] - 2023-11-20
+
 ## [0.45.1] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -880,6 +882,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.45.2]: https://github.com/Automattic/jetpack-components/compare/0.45.1...0.45.2
 [0.45.1]: https://github.com/Automattic/jetpack-components/compare/0.45.0...0.45.1
 [0.45.0]: https://github.com/Automattic/jetpack-components/compare/0.44.4...0.45.0
 [0.44.4]: https://github.com/Automattic/jetpack-components/compare/0.44.3...0.44.4

--- a/projects/js-packages/components/changelog/update-node-20
+++ b/projects/js-packages/components/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.45.2-alpha",
+	"version": "0.45.2",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/config/CHANGELOG.md
+++ b/projects/js-packages/config/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.23] - 2023-11-20
+
 ## [0.1.22] - 2023-10-24
 ### Fixed
 - Remove "private" flag from package.json so package can be published. [#33744]
@@ -94,5 +96,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fixed and improved README
 
+[0.1.23]: https://github.com/Automattic/jetpack-config-js/compare/v0.1.22...v0.1.23
 [0.1.22]: https://github.com/Automattic/jetpack-config-js/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/Automattic/jetpack-config-js/compare/v0.1.20...v0.1.21

--- a/projects/js-packages/config/changelog/update-node-20
+++ b/projects/js-packages/config/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/config/package.json
+++ b/projects/js-packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-config",
-	"version": "0.1.23-alpha",
+	"version": "0.1.23",
 	"description": "Handles Jetpack global configuration shared across all packages",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/config/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [0.30.8] - 2023-11-20
 ### Added
-- Connection: Add optional quantity to product checkout workflow hook [#34177]
+- Add optional quantity to product checkout workflow hook. [#34177]
 
 ## [0.30.7] - 2023-11-14
 ### Changed

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.30.8] - 2023-11-20
+### Added
+- Connection: Add optional quantity to product checkout workflow hook [#34177]
+
 ## [0.30.7] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -660,6 +664,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.30.8]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.7...v0.30.8
 [0.30.7]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.6...v0.30.7
 [0.30.6]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.5...v0.30.6
 [0.30.5]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.4...v0.30.5

--- a/projects/js-packages/connection/changelog/update-ai-assistant-intertitial-checkout-url
+++ b/projects/js-packages/connection/changelog/update-ai-assistant-intertitial-checkout-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Connection: Add optional quantity to product checkout workflow hook

--- a/projects/js-packages/connection/changelog/update-node-20
+++ b/projects/js-packages/connection/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.30.8-alpha",
+	"version": "0.30.8",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2023-11-20
+
 ## [1.1.2] - 2023-10-17
 ### Changed
 - Updated package dependencies. [#33646]
@@ -184,6 +186,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.1.3]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.36...v1.1.0

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/update-node-20
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.1.3-alpha",
+	"version": "1.1.3",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-check-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.41] - 2023-11-20
+
 ## [2.0.40] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -191,6 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.41]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.40...v2.0.41
 [2.0.40]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.39...v2.0.40
 [2.0.39]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.38...v2.0.39
 [2.0.38]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.37...v2.0.38

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-node-20
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.41-alpha",
+	"version": "2.0.41",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.53 - 2023-11-20
+
 ## 0.10.52 - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]

--- a/projects/js-packages/idc/changelog/update-node-20
+++ b/projects/js-packages/idc/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.53-alpha",
+	"version": "0.10.53",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.13 - 2023-11-20
+
 ## 0.11.12 - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]

--- a/projects/js-packages/licensing/changelog/update-node-20
+++ b/projects/js-packages/licensing/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.11.13-alpha",
+	"version": "0.11.13",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.61 - 2023-11-20
+
 ## 0.2.60 - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]

--- a/projects/js-packages/partner-coupon/changelog/update-node-20
+++ b/projects/js-packages/partner-coupon/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.61-alpha",
+	"version": "0.2.61",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.41.6] - 2023-11-20
 ### Removed
-- Removed jetpack/publicize store [#34111]
+- Removed the 'jetpack/publicize' store. [#34111]
 
 ## [0.41.5] - 2023-11-14
 ### Added

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.6] - 2023-11-20
+### Removed
+- Removed jetpack/publicize store [#34111]
+
 ## [0.41.5] - 2023-11-14
 ### Added
 - Added unit tests for Jetpack social store connections. [#34064]
@@ -509,6 +513,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.41.6]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.5...v0.41.6
 [0.41.5]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.4...v0.41.5
 [0.41.4]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.3...v0.41.4
 [0.41.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.2...v0.41.3

--- a/projects/js-packages/publicize-components/changelog/update-node-20
+++ b/projects/js-packages/publicize-components/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/publicize-components/changelog/update-remove-jetpack-publicize-store
+++ b/projects/js-packages/publicize-components/changelog/update-remove-jetpack-publicize-store
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Removed jetpack/publicize store

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.41.6-alpha",
+	"version": "0.41.6",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/remove-asset-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/remove-asset-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.20] - 2023-11-20
+
 ## [1.0.19] - 2023-03-20
 ### Changed
 - Updated package dependencies. [#29471]
@@ -93,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.0.20]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.19...v1.0.20
 [1.0.19]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.18...v1.0.19
 [1.0.18]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.17...v1.0.18
 [1.0.17]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.16...v1.0.17

--- a/projects/js-packages/remove-asset-webpack-plugin/changelog/update-node-20
+++ b/projects/js-packages/remove-asset-webpack-plugin/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/remove-asset-webpack-plugin/package.json
+++ b/projects/js-packages/remove-asset-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/remove-asset-webpack-plugin",
-	"version": "1.0.20-alpha",
+	"version": "1.0.20",
 	"description": "A Webpack plugin to remove assets from the build.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/remove-asset-webpack-plugin/README.md#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2] - 2023-11-20
+
 ## [0.13.1] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -288,6 +290,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.13.2]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.1...0.13.2
 [0.13.1]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.0...0.13.1
 [0.13.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.12.6...0.13.0
 [0.12.6]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.12.5...0.12.6

--- a/projects/js-packages/shared-extension-utils/changelog/update-node-20
+++ b/projects/js-packages/shared-extension-utils/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.13.2-alpha",
+	"version": "0.13.2",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.2 - 2023-11-20
+
 ## 3.0.1 - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]

--- a/projects/js-packages/webpack-config/changelog/update-node-20
+++ b/projects/js-packages/webpack-config/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.0.2-alpha",
+	"version": "3.0.2",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/a8c-mc-stats/CHANGELOG.md
+++ b/projects/packages/a8c-mc-stats/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.4.22] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.4.21] - 2023-08-23
@@ -126,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Creates the MC Stats package
 
+[2.0.0]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.22...v2.0.0
 [1.4.22]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.21...v1.4.22
 [1.4.21]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.20...v1.4.21
 [1.4.20]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.19...v1.4.20

--- a/projects/packages/a8c-mc-stats/CHANGELOG.md
+++ b/projects/packages/a8c-mc-stats/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.4.22] - 2023-09-19
 

--- a/projects/packages/a8c-mc-stats/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/a8c-mc-stats/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/abtest/CHANGELOG.md
+++ b/projects/packages/abtest/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.10.14] - 2023-08-28
 ### Changed
 - Updated package dependencies. [#32605]
@@ -284,6 +288,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a simple A/B test package
 
+[2.0.0]: https://github.com/Automattic/jetpack-abtest/compare/v1.10.14...v2.0.0
 [1.10.14]: https://github.com/Automattic/jetpack-abtest/compare/v1.10.13...v1.10.14
 [1.10.13]: https://github.com/Automattic/jetpack-abtest/compare/v1.10.12...v1.10.13
 [1.10.12]: https://github.com/Automattic/jetpack-abtest/compare/v1.10.11...v1.10.12

--- a/projects/packages/abtest/CHANGELOG.md
+++ b/projects/packages/abtest/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.10.14] - 2023-08-28
 ### Changed

--- a/projects/packages/abtest/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/abtest/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/action-bar/CHANGELOG.md
+++ b/projects/packages/action-bar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.1.32] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -138,6 +142,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds the Action Bar package and Jetpack plugin module for follows, likes, and comments. Just a scaffold to build on, for now. [#25447]
 
+[0.2.0]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.32...v0.2.0
 [0.1.32]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.31...v0.1.32
 [0.1.31]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.30...v0.1.31
 [0.1.30]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.29...v0.1.30

--- a/projects/packages/action-bar/CHANGELOG.md
+++ b/projects/packages/action-bar/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.1.32] - 2023-11-14
 ### Changed

--- a/projects/packages/action-bar/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/action-bar/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/action-bar/changelog/update-node-20
+++ b/projects/packages/action-bar/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/action-bar/package.json
+++ b/projects/packages/action-bar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-action-bar",
-	"version": "0.2.0-alpha",
+	"version": "0.2.0",
 	"description": "An easy way for visitors to follow, like, and comment on your WordPress site.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/action-bar/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.2.25] - 2023-11-14
 

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.2.25] - 2023-11-14
 
 ## [0.2.24] - 2023-10-30
@@ -126,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.3.0]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.25...0.3.0
 [0.2.25]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.24...0.2.25
 [0.2.24]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.23...0.2.24
 [0.2.23]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.22...0.2.23

--- a/projects/packages/admin-ui/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/admin-ui/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/admin-ui/changelog/update-node-20
+++ b/projects/packages/admin-ui/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.3.0-alpha",
+	"version": "0.3.0",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.3.0-alpha';
+	const PACKAGE_VERSION = '0.3.0';
 
 	/**
 	 * Whether this class has been initialized

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.18.15] - 2023-11-14
 ### Changed

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.18.15] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -378,6 +382,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[2.0.0]: https://github.com/Automattic/jetpack-assets/compare/v1.18.15...v2.0.0
 [1.18.15]: https://github.com/Automattic/jetpack-assets/compare/v1.18.14...v1.18.15
 [1.18.14]: https://github.com/Automattic/jetpack-assets/compare/v1.18.13...v1.18.14
 [1.18.13]: https://github.com/Automattic/jetpack-assets/compare/v1.18.12...v1.18.13

--- a/projects/packages/assets/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/assets/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/assets/changelog/update-node-20
+++ b/projects/packages/assets/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/assets/changelog/update-strpos-str-starts-with
+++ b/projects/packages/assets/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Comment why we don't use str_starts_with() in Assets::wp_default_scripts_hook. No change to functionality.
-

--- a/projects/packages/autoloader/CHANGELOG.md
+++ b/projects/packages/autoloader/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [2.12.0] - 2023-09-28
 ### Added
 - Add an `AutoloadGenerator::VERSION` constant, and use that for the autoloader's version in preference to whatever Composer has. [#33156]
@@ -332,6 +336,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Custom Autoloader
 
+[3.0.0]: https://github.com/Automattic/jetpack-autoloader/compare/v2.12.0...v3.0.0
 [2.12.0]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.23...v2.12.0
 [2.11.23]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.22...v2.11.23
 [2.11.22]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.21...v2.11.22

--- a/projects/packages/autoloader/CHANGELOG.md
+++ b/projects/packages/autoloader/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [2.12.0] - 2023-09-28
 ### Added

--- a/projects/packages/autoloader/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/autoloader/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/autoloader/src/AutoloadGenerator.php
+++ b/projects/packages/autoloader/src/AutoloadGenerator.php
@@ -21,7 +21,7 @@ use Composer\Util\PackageSorter;
  */
 class AutoloadGenerator {
 
-	const VERSION = '3.0.0-alpha';
+	const VERSION = '3.0.0';
 
 	/**
 	 * IO object.

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.17.12] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -510,6 +514,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[2.0.0]: https://github.com/Automattic/jetpack-backup/compare/v1.17.12...v2.0.0
 [1.17.12]: https://github.com/Automattic/jetpack-backup/compare/v1.17.11...v1.17.12
 [1.17.11]: https://github.com/Automattic/jetpack-backup/compare/v1.17.10...v1.17.11
 [1.17.10]: https://github.com/Automattic/jetpack-backup/compare/v1.17.9...v1.17.10

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.17.12] - 2023-11-14
 ### Changed

--- a/projects/packages/backup/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/backup/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/backup/changelog/update-node-20
+++ b/projects/packages/backup/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.0.0-alpha';
+	const PACKAGE_VERSION = '2.0.0';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.12.3] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -241,6 +245,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.13.0]: https://github.com/automattic/jetpack-blaze/compare/v0.12.3...v0.13.0
 [0.12.3]: https://github.com/automattic/jetpack-blaze/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/automattic/jetpack-blaze/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/automattic/jetpack-blaze/compare/v0.12.0...v0.12.1

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.12.3] - 2023-11-14
 ### Changed

--- a/projects/packages/blaze/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/blaze/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/blaze/changelog/update-node-20
+++ b/projects/packages/blaze/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.13.0-alpha",
+	"version": "0.13.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.13.0-alpha';
+	const PACKAGE_VERSION = '0.13.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/blocks/CHANGELOG.md
+++ b/projects/packages/blocks/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.6.2] - 2023-10-23
 ### Fixed
 - Fix missing block translations. [#33546]
@@ -165,6 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Blocks: introduce new package for block management
 
+[2.0.0]: https://github.com/Automattic/jetpack-blocks/compare/v1.6.2...v2.0.0
 [1.6.2]: https://github.com/Automattic/jetpack-blocks/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/Automattic/jetpack-blocks/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/Automattic/jetpack-blocks/compare/v1.5.0...v1.6.0

--- a/projects/packages/blocks/CHANGELOG.md
+++ b/projects/packages/blocks/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- The package now requires PHP >= 7.0. [#34192]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.6.2] - 2023-10-23
 ### Fixed

--- a/projects/packages/blocks/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/blocks/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/blocks/changelog/update-strpos-str-starts-with
+++ b/projects/packages/blocks/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/boost-core/CHANGELOG.md
+++ b/projects/packages/boost-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.1.3] - 2023-09-19
 

--- a/projects/packages/boost-core/CHANGELOG.md
+++ b/projects/packages/boost-core/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.1.3] - 2023-09-19
+
 - Minor internal updates.
 
 ## [0.1.2] - 2023-09-01
@@ -20,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduce new package. [#31163]
 
+[0.2.0]: https://github.com/Automattic/jetpack-boost-core/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/Automattic/jetpack-boost-core/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Automattic/jetpack-boost-core/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Automattic/jetpack-boost-core/compare/v0.1.0...v0.1.1

--- a/projects/packages/boost-core/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/boost-core/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/boost-core/changelog/update-node-20
+++ b/projects/packages/boost-core/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/boost-core/package.json
+++ b/projects/packages/boost-core/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-boost-core",
-	"version": "0.2.0-alpha",
+	"version": "0.2.0",
 	"description": "Core functionality for boost and relevant packages to depend on",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/boost-core/#readme",
 	"bugs": {

--- a/projects/packages/boost-speed-score/CHANGELOG.md
+++ b/projects/packages/boost-speed-score/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.2.2] - 2023-09-19
 ### Fixed
 - Fixed deprecation notice in PHP 8.2. [#33079]
@@ -27,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new package for Boost Speed Score [#30914]
 - Add a new argument to `Speed_Score` to identify where the request was made from (e.g. 'boost-plugin', 'jetpack-dashboard', etc). [#31012]
 
+[0.3.0]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.1.0...v0.2.0

--- a/projects/packages/boost-speed-score/CHANGELOG.md
+++ b/projects/packages/boost-speed-score/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.2.2] - 2023-09-19
 ### Fixed

--- a/projects/packages/boost-speed-score/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/boost-speed-score/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -23,7 +23,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.3.0-alpha';
+	const PACKAGE_VERSION = '0.3.0';
 
 	/**
 	 * An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup passed to the constructor

--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2023-11-20
+### Changed
+- General: updated PHP requirement to PHP 7.0+ [#34126]
+
 ## [3.3.11] - 2023-09-28
 ### Changed
 - Minor internal updates.
@@ -179,6 +183,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[4.0.0]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.11...4.0.0
 [3.3.11]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.10...3.3.11
 [3.3.10]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.9...3.3.10
 [3.3.9]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.8...3.3.9

--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [4.0.0] - 2023-11-20
 ### Changed
-- General: updated PHP requirement to PHP 7.0+ [#34126]
+- Updated required PHP version to >= 7.0. [#34126]
 
 ## [3.3.11] - 2023-09-28
 ### Changed

--- a/projects/packages/changelogger/changelog/update-php-requirements
+++ b/projects/packages/changelogger/changelog/update-php-requirements
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-General: updated PHP requirement to PHP 7.0+

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.0.0-alpha';
+	const VERSION = '4.0.0';
 
 	/**
 	 * Constructor.

--- a/projects/packages/compat/CHANGELOG.md
+++ b/projects/packages/compat/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.7.8] - 2023-11-14
 

--- a/projects/packages/compat/CHANGELOG.md
+++ b/projects/packages/compat/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.7.8] - 2023-11-14
 
 ## [1.7.7] - 2023-09-19
@@ -131,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jetpack 7.5: Back compatibility package
 
+[2.0.0]: https://github.com/Automattic/jetpack-compat/compare/v1.7.8...v2.0.0
 [1.7.8]: https://github.com/Automattic/jetpack-compat/compare/v1.7.7...v1.7.8
 [1.7.7]: https://github.com/Automattic/jetpack-compat/compare/v1.7.6...v1.7.7
 [1.7.6]: https://github.com/Automattic/jetpack-compat/compare/v1.7.5...v1.7.6

--- a/projects/packages/compat/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/compat/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/composer-plugin/CHANGELOG.md
+++ b/projects/packages/composer-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.1.14] - 2023-09-19
 

--- a/projects/packages/composer-plugin/CHANGELOG.md
+++ b/projects/packages/composer-plugin/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.1.14] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.1.13] - 2023-08-23
@@ -89,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the Jetpack Installer package.
 
+[2.0.0]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.14...v2.0.0
 [1.1.14]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.13...v1.1.14
 [1.1.13]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.12...v1.1.13
 [1.1.12]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.11...v1.1.12

--- a/projects/packages/composer-plugin/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/composer-plugin/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/config/CHANGELOG.md
+++ b/projects/packages/config/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.15.4] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.15.3] - 2023-06-26
@@ -187,6 +192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Trying to add deterministic initialization.
 
+[2.0.0]: https://github.com/Automattic/jetpack-config/compare/v1.15.4...v2.0.0
 [1.15.4]: https://github.com/Automattic/jetpack-config/compare/v1.15.3...v1.15.4
 [1.15.3]: https://github.com/Automattic/jetpack-config/compare/v1.15.2...v1.15.3
 [1.15.2]: https://github.com/Automattic/jetpack-config/compare/v1.15.1...v1.15.2

--- a/projects/packages/config/CHANGELOG.md
+++ b/projects/packages/config/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.15.4] - 2023-09-19
 

--- a/projects/packages/config/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/config/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Added
+- Confirm blog ID and access token were saved before proceeding with connection flow. [#34136]
+
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- The package now requires PHP >= 7.0. [#34192]
+
+### Fixed
+- Connection: ensure that partner partners are passed on during the connection process, regardless of the plugin you use to connect. [#33832]
+
 ## [1.60.1] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -912,6 +923,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.0.0]: https://github.com/Automattic/jetpack-connection/compare/v1.60.1...v2.0.0
 [1.60.1]: https://github.com/Automattic/jetpack-connection/compare/v1.60.0...v1.60.1
 [1.60.0]: https://github.com/Automattic/jetpack-connection/compare/v1.59.0...v1.60.0
 [1.59.0]: https://github.com/Automattic/jetpack-connection/compare/v1.58.3...v1.59.0

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Confirm blog ID and access token were saved before proceeding with connection flow. [#34136]
 
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- The package now requires PHP >= 7.0. [#34192]
+- Replace usage of strpos() with str_starts_with(). [#34135]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ### Fixed
-- Connection: ensure that partner partners are passed on during the connection process, regardless of the plugin you use to connect. [#33832]
+- Ensured that partner partners are passed on during the connection process, regardless of the plugin you use to connect. [#33832]
 
 ## [1.60.1] - 2023-11-14
 ### Changed

--- a/projects/packages/connection/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/connection/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/connection/changelog/fix-connection-partner-standalone-sites
+++ b/projects/packages/connection/changelog/fix-connection-partner-standalone-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Connection: ensure that partner partners are passed on during the connection process, regardless of the plugin you use to connect.

--- a/projects/packages/connection/changelog/update-connection-handle-database-failure
+++ b/projects/packages/connection/changelog/update-connection-handle-database-failure
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Confirm blog ID and access token were saved before proceeding with connection flow.

--- a/projects/packages/connection/changelog/update-node-20
+++ b/projects/packages/connection/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/connection/changelog/update-strpos-str-starts-with
+++ b/projects/packages/connection/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.0.0-alpha';
+	const PACKAGE_VERSION = '2.0.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-partner-coupon.php
+++ b/projects/packages/connection/src/class-partner-coupon.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Jetpack_Partner_Coupon
  *
  * @since partner-1.6.0
- * @since $$next-version$$
+ * @since 2.0.0
  */
 class Partner_Coupon {
 
@@ -438,7 +438,7 @@ class Partner_Coupon {
 		 * Allow external code to add additional supported partners.
 		 *
 		 * @since partner-1.6.0
-		 * @since $$next-version$$
+		 * @since 2.0.0
 		 *
 		 * @param array $supported_partners A list of supported partners.
 		 * @return array
@@ -456,7 +456,7 @@ class Partner_Coupon {
 		 * Allow external code to add additional supported presets.
 		 *
 		 * @since partner-1.6.0
-		 * @since $$next-version$$
+		 * @since 2.0.0
 		 *
 		 * @param array $supported_presets A list of supported presets.
 		 * @return array

--- a/projects/packages/connection/src/class-partner.php
+++ b/projects/packages/connection/src/class-partner.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack;
  * This class introduces functionality used by Jetpack hosting partners.
  *
  * @since partner-1.0.0
- * @since $$next-version$$
+ * @since 2.0.0
  */
 class Partner {
 
@@ -29,7 +29,7 @@ class Partner {
 	 * Singleton instance.
 	 *
 	 * @since partner-1.0.0
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 *
 	 * @var Partner This class instance.
 	 */
@@ -45,7 +45,7 @@ class Partner {
 	 * Initializes the class or returns the singleton.
 	 *
 	 * @since partner-1.0.0
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 *
 	 * @return Partner | false
 	 */
@@ -90,7 +90,7 @@ class Partner {
 	 * Adds the partner subsidiary code to the passed array.
 	 *
 	 * @since partner-1.5.0
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 *
 	 * @param array $params The parameters array.
 	 *
@@ -107,7 +107,7 @@ class Partner {
 	 * Adds the affiliate code to the passed array.
 	 *
 	 * @since partner-1.5.0
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 *
 	 * @param array $params The parameters array.
 	 *
@@ -124,7 +124,7 @@ class Partner {
 	 * Returns the passed URL with the partner code added as a URL query arg.
 	 *
 	 * @since partner-1.0.0
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 *
 	 * @param string $type The partner code.
 	 * @param string $url The URL where the partner subsidiary id will be added.
@@ -139,7 +139,7 @@ class Partner {
 	 * Gets the partner code in an associative array format
 	 *
 	 * @since partner-1.5.0
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 *
 	 * @param string $type The partner code.
 	 * @return array
@@ -169,7 +169,7 @@ class Partner {
 	 * Returns a partner code.
 	 *
 	 * @since partner-1.0.0
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 *
 	 * @param string $type This can be either 'affiliate' or 'subsidiary'. Returns empty string when code is unknown.
 	 *
@@ -183,7 +183,7 @@ class Partner {
 				 *
 				 * @since partner-1.0.0
 				 * @since-jetpack 6.9.0
-				 * @since $$next-version$$
+				 * @since 2.0.0
 				 *
 				 * @param string $affiliate_code The affiliate code, blank by default.
 				 */
@@ -193,7 +193,7 @@ class Partner {
 				 * Allow to filter the partner subsidiary id.
 				 *
 				 * @since partner-1.0.0
-				 * @since $$next-version$$
+				 * @since 2.0.0
 				 *
 				 * @param string $subsidiary_id The partner subsidiary id, blank by default.
 				 */

--- a/projects/packages/constants/CHANGELOG.md
+++ b/projects/packages/constants/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.6.23] - 2023-08-23
 ### Changed

--- a/projects/packages/constants/CHANGELOG.md
+++ b/projects/packages/constants/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.6.23] - 2023-08-23
 ### Changed
 - Updated package dependencies. [#32605]
@@ -154,6 +158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Finish the constants package
 
+[2.0.0]: https://github.com/Automattic/jetpack-constants/compare/v1.6.23...v2.0.0
 [1.6.23]: https://github.com/Automattic/jetpack-constants/compare/v1.6.22...v1.6.23
 [1.6.22]: https://github.com/Automattic/jetpack-constants/compare/v1.6.21...v1.6.22
 [1.6.21]: https://github.com/Automattic/jetpack-constants/compare/v1.6.20...v1.6.21

--- a/projects/packages/constants/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/constants/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/device-detection/CHANGELOG.md
+++ b/projects/packages/device-detection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.5.1] - 2023-11-14
 
 ## [1.5.0] - 2023-11-13
@@ -169,6 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moving jetpack_is_mobile into a package
 
+[2.0.0]: https://github.com/Automattic/jetpack-device-detection/compare/v1.5.1...v2.0.0
 [1.5.1]: https://github.com/Automattic/jetpack-device-detection/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/Automattic/jetpack-device-detection/compare/v1.4.27...v1.5.0
 [1.4.27]: https://github.com/Automattic/jetpack-device-detection/compare/v1.4.26...v1.4.27

--- a/projects/packages/device-detection/CHANGELOG.md
+++ b/projects/packages/device-detection/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.5.1] - 2023-11-14
 

--- a/projects/packages/device-detection/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/device-detection/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/error/CHANGELOG.md
+++ b/projects/packages/error/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.3.21] - 2023-08-28
 ### Changed

--- a/projects/packages/error/CHANGELOG.md
+++ b/projects/packages/error/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.3.21] - 2023-08-28
 ### Changed
 - Updated package dependencies. [#32605]
@@ -128,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a jetpack-error package
 
+[2.0.0]: https://github.com/Automattic/jetpack-error/compare/v1.3.21...v2.0.0
 [1.3.21]: https://github.com/Automattic/jetpack-error/compare/v1.3.20...v1.3.21
 [1.3.20]: https://github.com/Automattic/jetpack-error/compare/v1.3.19...v1.3.20
 [1.3.19]: https://github.com/Automattic/jetpack-error/compare/v1.3.18...v1.3.19

--- a/projects/packages/error/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/error/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.24.0] - 2023-11-20
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- The package now requires PHP >= 7.0. [#34192]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ### Fixed
-- Add an accessible name to the Contact Form dropdown rendered in the front-end [#34139]
+- Added an accessible name to the Contact Form dropdown rendered in the front-end. [#34139]
 - Avoid errors when a saved feedback form does not have the expected WP_Post format. [#34129]
 
 ## [0.23.1] - 2023-11-14

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - 2023-11-20
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- The package now requires PHP >= 7.0. [#34192]
+
+### Fixed
+- Add an accessible name to the Contact Form dropdown rendered in the front-end [#34139]
+- Avoid errors when a saved feedback form does not have the expected WP_Post format. [#34129]
+
 ## [0.23.1] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -362,6 +371,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.24.0]: https://github.com/automattic/jetpack-forms/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/automattic/jetpack-forms/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/automattic/jetpack-forms/compare/v0.22.6...v0.23.0
 [0.22.6]: https://github.com/automattic/jetpack-forms/compare/v0.22.5...v0.22.6

--- a/projects/packages/forms/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/forms/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/forms/changelog/fix-contact-form-dropdown-label-accessible-name
+++ b/projects/packages/forms/changelog/fix-contact-form-dropdown-label-accessible-name
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Add an accessible name to the Contact Form dropdown rendered in the front-end

--- a/projects/packages/forms/changelog/fix-defensive-post-check-contact-form
+++ b/projects/packages/forms/changelog/fix-defensive-post-check-contact-form
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Avoid errors when a saved feedback form does not have the expected WP_Post format.

--- a/projects/packages/forms/changelog/update-node-20
+++ b/projects/packages/forms/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/forms/changelog/update-strpos-str-starts-with
+++ b/projects/packages/forms/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.24.0-alpha",
+	"version": "0.24.0",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.24.0-alpha';
+	const PACKAGE_VERSION = '0.24.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/google-fonts-provider/CHANGELOG.md
+++ b/projects/packages/google-fonts-provider/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.6.0] - 2023-10-23
 ### Added

--- a/projects/packages/google-fonts-provider/CHANGELOG.md
+++ b/projects/packages/google-fonts-provider/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.6.0] - 2023-10-23
 ### Added
 - Google Fonts: Integrate the google fonts with the new font library. [#33203]
@@ -90,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds a provider for Google Fonts using the new Webfonts API in Gutenberg
 
+[0.7.0]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.5.4...v0.6.0
 [0.5.4]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.5.2...v0.5.3

--- a/projects/packages/google-fonts-provider/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/google-fonts-provider/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/google-fonts-provider/changelog/update-node-20
+++ b/projects/packages/google-fonts-provider/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/google-fonts-provider/package.json
+++ b/projects/packages/google-fonts-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-google-fonts-provider",
-	"version": "0.7.0-alpha",
+	"version": "0.7.0",
 	"description": "WordPress Webfonts provider for Google Fonts",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/google-fonts-provider/#readme",
 	"bugs": {

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0] - 2023-11-20
 ### Added
-- Connection: add idc query argument to url for tracking multisite idcs. [#34090]
+- Added idc query argument to url for tracking multisite idcs. [#34090]
 
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- The package now requires PHP >= 7.0. [#34192]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.11.3] - 2023-11-14
 ### Changed

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2023-11-20
+### Added
+- Connection: add idc query argument to url for tracking multisite idcs. [#34090]
+
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.11.3] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -441,6 +449,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.12.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.11.3...v0.12.0
 [0.11.3]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.11.0...v0.11.1

--- a/projects/packages/identity-crisis/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/identity-crisis/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/identity-crisis/changelog/add-idc-multisite-tracking
+++ b/projects/packages/identity-crisis/changelog/add-idc-multisite-tracking
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Connection: add idc query argument to url for tracking multisite idcs.

--- a/projects/packages/identity-crisis/changelog/update-node-20
+++ b/projects/packages/identity-crisis/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/identity-crisis/changelog/update-strpos-str-starts-with
+++ b/projects/packages/identity-crisis/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.12.0-alpha",
+	"version": "0.12.0",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.12.0-alpha';
+	const PACKAGE_VERSION = '0.12.0';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-11-20
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.2.8] - 2023-11-03
 ### Changed
 - Update dependencies. [#33946]
@@ -51,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add image CDN package. [#29561]
 
+[0.3.0]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.8...v0.3.0
 [0.2.8]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.5...v0.2.6

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2023-11-20
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
 - The package now requires PHP >= 7.0. [#34192]
 
 ## [0.2.8] - 2023-11-03

--- a/projects/packages/image-cdn/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/image-cdn/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/image-cdn/changelog/update-node-20
+++ b/projects/packages/image-cdn/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/image-cdn/changelog/update-strpos-str-starts-with
+++ b/projects/packages/image-cdn/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/image-cdn/package.json
+++ b/projects/packages/image-cdn/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-image-cdn",
-	"version": "0.3.0-alpha",
+	"version": "0.3.0",
 	"description": "Serve images through Jetpack's powerful CDN",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/image-cdn/#readme",
 	"bugs": {

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Assets;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.3.0-alpha';
+	const PACKAGE_VERSION = '0.3.0';
 
 	/**
 	 * Singleton.

--- a/projects/packages/import/CHANGELOG.md
+++ b/projects/packages/import/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.7.4] - 2023-09-19
 

--- a/projects/packages/import/CHANGELOG.md
+++ b/projects/packages/import/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.7.4] - 2023-09-19
+
 - Minor internal updates.
 
 ## [0.7.3] - 2023-09-11
@@ -73,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed various imported resources hierarchies [#29012]
 
+[0.8.0]: https://github.com/Automattic/jetpack-import/compare/v0.7.4...v0.8.0
 [0.7.4]: https://github.com/Automattic/jetpack-import/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/Automattic/jetpack-import/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/Automattic/jetpack-import/compare/v0.7.1...v0.7.2

--- a/projects/packages/import/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/import/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/import/changelog/update-node-20
+++ b/projects/packages/import/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-import",
-	"version": "0.8.0-alpha",
+	"version": "0.8.0",
 	"description": "Set of REST API routes used in WPCOM Unified Importer.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",
 	"bugs": {

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.8.0-alpha';
+	const PACKAGE_VERSION = '0.8.0';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/ip/CHANGELOG.md
+++ b/projects/packages/ip/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.1.6] - 2023-09-19
 

--- a/projects/packages/ip/CHANGELOG.md
+++ b/projects/packages/ip/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.1.6] - 2023-09-19
+
 - Minor internal updates.
 
 ## [0.1.5] - 2023-08-23
@@ -34,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add jetpack-ip package functionality [#28846]
 - Initialized the package. [#28765]
 
+[0.2.0]: https://github.com/automattic/jetpack-ip/compare/v0.1.6...v0.2.0
 [0.1.6]: https://github.com/automattic/jetpack-ip/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/automattic/jetpack-ip/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/automattic/jetpack-ip/compare/v0.1.3...v0.1.4

--- a/projects/packages/ip/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/ip/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/ip/src/class-utils.php
+++ b/projects/packages/ip/src/class-utils.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\IP;
  */
 class Utils {
 
-	const PACKAGE_VERSION = '0.2.0-alpha';
+	const PACKAGE_VERSION = '0.2.0';
 
 	/**
 	 * Get the current user's IP address.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2023-11-20
+### Added
+- Always enable subscribe modal task in launchpad. [#33909]
+- Launchpad: Add query parameter to write three posts prompt [#34160]
+
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [4.18.0] - 2023-11-09
 ### Added
 - Take id_map in consideration when checking if a task is completed inside wpcom_launchpad_is_task_option_completed. [#34009]
@@ -429,6 +438,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.0.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.18.0...v5.0.0
 [4.18.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.17.0...v4.18.0
 [4.17.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.16.2...v4.17.0
 [4.16.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.16.1...v4.16.2

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.0.0] - 2023-11-20
 ### Added
-- Always enable subscribe modal task in launchpad. [#33909]
-- Launchpad: Add query parameter to write three posts prompt [#34160]
+- Ensure enable subscribe modal task in launchpad. [#33909]
+- Launchpad: Add query parameter to the write three posts prompt. [#34160]
 
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- The package now requires PHP >= 7.0. [#34192]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [4.18.0] - 2023-11-09
 ### Added

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-query-param-to-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-query-param-to-task
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Launchpad: Add query parameter to write three posts prompt

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-node-20
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-strpos-str-starts-with
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-subscribe-modal-filters
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-subscribe-modal-filters
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Always enable subscribe modal task in launchpad.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.0.0-alpha",
+	"version": "5.0.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.0.0-alpha';
+	const PACKAGE_VERSION = '5.0.0';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ### Removed
-- Do not require the Partner package anymore. Rely on the Connection package instead. [#33832]
+- Removed the Partner package requirement. Relying on the Connection package instead. [#33832]
 
 ## [2.5.3] - 2023-11-14
 ### Changed

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
+### Removed
+- Do not require the Partner package anymore. Rely on the Connection package instead. [#33832]
+
 ## [2.5.3] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -647,6 +654,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.0.0]: https://github.com/Automattic/jetpack-jitm/compare/v2.5.3...v3.0.0
 [2.5.3]: https://github.com/Automattic/jetpack-jitm/compare/v2.5.2...v2.5.3
 [2.5.2]: https://github.com/Automattic/jetpack-jitm/compare/v2.5.1...v2.5.2
 [2.5.1]: https://github.com/Automattic/jetpack-jitm/compare/v2.5.0...v2.5.1

--- a/projects/packages/jitm/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/jitm/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/jitm/changelog/fix-connection-partner-standalone-sites
+++ b/projects/packages/jitm/changelog/fix-connection-partner-standalone-sites
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Do not require the Partner package anymore. Rely on the Connection package instead.

--- a/projects/packages/jitm/changelog/update-node-20
+++ b/projects/packages/jitm/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.0.0-alpha';
+	const PACKAGE_VERSION = '3.0.0';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/licensing/CHANGELOG.md
+++ b/projects/packages/licensing/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.8.4] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.8.3] - 2023-08-23
@@ -249,6 +254,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Licensing: Add support for Jetpack licenses
 
+[2.0.0]: https://github.com/Automattic/jetpack-licensing/compare/v1.8.4...v2.0.0
 [1.8.4]: https://github.com/Automattic/jetpack-licensing/compare/v1.8.3...v1.8.4
 [1.8.3]: https://github.com/Automattic/jetpack-licensing/compare/v1.8.2...v1.8.3
 [1.8.2]: https://github.com/Automattic/jetpack-licensing/compare/v1.8.1...v1.8.2

--- a/projects/packages/licensing/CHANGELOG.md
+++ b/projects/packages/licensing/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.8.4] - 2023-09-19
 

--- a/projects/packages/licensing/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/licensing/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/logo/CHANGELOG.md
+++ b/projects/packages/logo/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.6.3] - 2023-09-19
 

--- a/projects/packages/logo/CHANGELOG.md
+++ b/projects/packages/logo/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.6.3] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.6.2] - 2023-08-23
@@ -161,6 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Add a basic Jetpack Logo package
 
+[2.0.0]: https://github.com/Automattic/jetpack-logo/compare/v1.6.3...v2.0.0
 [1.6.3]: https://github.com/Automattic/jetpack-logo/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/Automattic/jetpack-logo/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/Automattic/jetpack-logo/compare/v1.6.0...v1.6.1

--- a/projects/packages/logo/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/logo/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2023-11-20
+### Added
+- Display an "Activity Log" menu item to connected users. [#34174]
+- My Jetpack: Add direct checkout support for products with quantity-based plans [#34177]
+- My Jetpack: Add Jetpack AI prices by tier to the interstitial page [#34196]
+
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- General: updated PHP requirement to PHP 7.0+ [#34126]
+- Remove condition from the backup undoable event call, this datapoint will be removed [#33997]
+
 ## [3.12.2] - 2023-11-14
 ### Changed
 - My Jetpack: Fix a bug causing PHP fatal errors when the Jetpack AI feature information is not available. [#34095]
@@ -1099,6 +1110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.0.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.12.2...4.0.0
 [3.12.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.12.1...3.12.2
 [3.12.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.12.0...3.12.1
 [3.12.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.11.1...3.12.0

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.0] - 2023-11-20
 ### Added
 - Display an "Activity Log" menu item to connected users. [#34174]
-- My Jetpack: Add direct checkout support for products with quantity-based plans [#34177]
-- My Jetpack: Add Jetpack AI prices by tier to the interstitial page [#34196]
+- Added direct checkout support for products with quantity-based plans. [#34177]
+- Added Jetpack AI prices by tier to the interstitial page. [#34196]
 
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- General: updated PHP requirement to PHP 7.0+ [#34126]
-- Remove condition from the backup undoable event call, this datapoint will be removed [#33997]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Updated required PHP version to >= 7.0. [#34126]
+- Removed condition from the backup undoable event call, this datapoint will be removed. [#33997]
 
 ## [3.12.2] - 2023-11-14
 ### Changed

--- a/projects/packages/my-jetpack/changelog/add-activitylog-menu
+++ b/projects/packages/my-jetpack/changelog/add-activitylog-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Display an "Activity Log" menu item to connected users.

--- a/projects/packages/my-jetpack/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/my-jetpack/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Declare PHP >=7.0 requirement in composer.json. #34126 already handled adding a changelog entry for this.
-

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-interstitial-benefit-case
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-interstitial-benefit-case
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Text: fix capitalization.
-
-

--- a/projects/packages/my-jetpack/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/packages/my-jetpack/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Remove condition from the backup undoable event call, this datapoint will be removed

--- a/projects/packages/my-jetpack/changelog/update-ai-assistant-interstitial-prices
+++ b/projects/packages/my-jetpack/changelog/update-ai-assistant-interstitial-prices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-My Jetpack: Add Jetpack AI prices by tier to the interstitial page

--- a/projects/packages/my-jetpack/changelog/update-ai-assistant-intertitial-checkout-url
+++ b/projects/packages/my-jetpack/changelog/update-ai-assistant-intertitial-checkout-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-My Jetpack: Add direct checkout support for products with quantity-based plans

--- a/projects/packages/my-jetpack/changelog/update-node-20
+++ b/projects/packages/my-jetpack/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/my-jetpack/changelog/update-php-requirements
+++ b/projects/packages/my-jetpack/changelog/update-php-requirements
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-General: updated PHP requirement to PHP 7.0+

--- a/projects/packages/my-jetpack/changelog/update-strpos-str-starts-with
+++ b/projects/packages/my-jetpack/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.0.0-alpha",
+	"version": "4.0.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.0.0-alpha';
+	const PACKAGE_VERSION = '4.0.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/password-checker/CHANGELOG.md
+++ b/projects/packages/password-checker/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.2.14] - 2023-08-23
 ### Changed

--- a/projects/packages/password-checker/CHANGELOG.md
+++ b/projects/packages/password-checker/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.2.14] - 2023-08-23
 ### Changed
 - Updated package dependencies. [#32605]
@@ -108,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.
 
+[0.3.0]: https://github.com/Automattic/jetpack-password-checker/compare/v0.2.14...v0.3.0
 [0.2.14]: https://github.com/Automattic/jetpack-password-checker/compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com/Automattic/jetpack-password-checker/compare/v0.2.12...v0.2.13
 [0.2.12]: https://github.com/Automattic/jetpack-password-checker/compare/v0.2.11...v0.2.12

--- a/projects/packages/password-checker/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/password-checker/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/plans/CHANGELOG.md
+++ b/projects/packages/plans/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.3.5] - 2023-10-24
 

--- a/projects/packages/plans/CHANGELOG.md
+++ b/projects/packages/plans/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.3.5] - 2023-10-24
+
 - Updated package dependencies.
 
 ## [0.3.4] - 2023-08-23
@@ -105,6 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Moved the options class into Connection. [#24095]
 
+[0.4.0]: https://github.com/Automattic/jetpack-plans/compare/v0.3.5...v0.4.0
 [0.3.5]: https://github.com/Automattic/jetpack-plans/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Automattic/jetpack-plans/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Automattic/jetpack-plans/compare/v0.3.2...v0.3.3

--- a/projects/packages/plans/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/plans/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/plans/changelog/update-node-20
+++ b/projects/packages/plans/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.4.0-alpha",
+	"version": "0.4.0",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/plugins-installer/CHANGELOG.md
+++ b/projects/packages/plugins-installer/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.2.6] - 2023-11-14
 

--- a/projects/packages/plugins-installer/CHANGELOG.md
+++ b/projects/packages/plugins-installer/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.2.6] - 2023-11-14
 
 ## [0.2.5] - 2023-08-23
@@ -58,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix method logic
 
+[0.3.0]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.2.6...v0.3.0
 [0.2.6]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.2.3...v0.2.4

--- a/projects/packages/plugins-installer/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/plugins-installer/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/post-list/CHANGELOG.md
+++ b/projects/packages/post-list/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.4.6] - 2023-08-28
 ### Changed
 - Updated package dependencies. [#32605]
@@ -86,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the default columns displayed on the post and page list screens
 - Refactored thumbnail preview to function server side. All javascript removed.
 
+[0.5.0]: https://github.com/automattic/jetpack-post-list/compare/v0.4.6...v0.5.0
 [0.4.6]: https://github.com/automattic/jetpack-post-list/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/automattic/jetpack-post-list/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/automattic/jetpack-post-list/compare/v0.4.3...v0.4.4

--- a/projects/packages/post-list/CHANGELOG.md
+++ b/projects/packages/post-list/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.4.6] - 2023-08-28
 ### Changed

--- a/projects/packages/post-list/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/post-list/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Post_List;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.5.0-alpha';
+	const PACKAGE_VERSION = '0.5.0';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.0] - 2023-11-20
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- Removed jetpack/publicize store [#34111]
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.36.6] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -412,6 +418,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.37.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.6...v0.37.0
 [0.36.6]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.5...v0.36.6
 [0.36.5]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.4...v0.36.5
 [0.36.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.3...v0.36.4

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.37.0] - 2023-11-20
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- Removed jetpack/publicize store [#34111]
-- The package now requires PHP >= 7.0. [#34192]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Removed the 'jetpack/publicize' store. [#34111]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.36.6] - 2023-11-14
 ### Changed

--- a/projects/packages/publicize/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/publicize/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/publicize/changelog/update-node-20
+++ b/projects/packages/publicize/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/publicize/changelog/update-strpos-str-starts-with
+++ b/projects/packages/publicize/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.37.0-alpha",
+	"version": "0.37.0",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/redirect/CHANGELOG.md
+++ b/projects/packages/redirect/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- The package now requires PHP >= 7.0. [#34192]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.7.27] - 2023-09-19
 

--- a/projects/packages/redirect/CHANGELOG.md
+++ b/projects/packages/redirect/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.7.27] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.7.26] - 2023-08-23
@@ -187,6 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create Jetpack Redirect package
 
+[2.0.0]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.27...v2.0.0
 [1.7.27]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.26...v1.7.27
 [1.7.26]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.25...v1.7.26
 [1.7.25]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.24...v1.7.25

--- a/projects/packages/redirect/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/redirect/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/redirect/changelog/update-strpos-str-starts-with
+++ b/projects/packages/redirect/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/roles/CHANGELOG.md
+++ b/projects/packages/roles/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.4.25] - 2023-09-19
 

--- a/projects/packages/roles/CHANGELOG.md
+++ b/projects/packages/roles/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.4.25] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.4.24] - 2023-08-23
@@ -154,6 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jetpack DNA: Introduce a Roles package
 
+[2.0.0]: https://github.com/Automattic/jetpack-roles/compare/v1.4.25...v2.0.0
 [1.4.25]: https://github.com/Automattic/jetpack-roles/compare/v1.4.24...v1.4.25
 [1.4.24]: https://github.com/Automattic/jetpack-roles/compare/v1.4.23...v1.4.24
 [1.4.23]: https://github.com/Automattic/jetpack-roles/compare/v1.4.22...v1.4.23

--- a/projects/packages/roles/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/roles/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.40.0] - 2023-11-20
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- The package now requires PHP >= 7.0. [#34192]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.39.7] - 2023-11-14
 ### Changed

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.0] - 2023-11-20
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.39.7] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -840,6 +845,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.40.0]: https://github.com/Automattic/jetpack-search/compare/v0.39.7...v0.40.0
 [0.39.7]: https://github.com/Automattic/jetpack-search/compare/v0.39.6...v0.39.7
 [0.39.6]: https://github.com/Automattic/jetpack-search/compare/v0.39.5...v0.39.6
 [0.39.5]: https://github.com/Automattic/jetpack-search/compare/v0.39.4...v0.39.5

--- a/projects/packages/search/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/search/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/search/changelog/update-node-20
+++ b/projects/packages/search/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/search/changelog/update-strpos-str-starts-with
+++ b/projects/packages/search/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.40.0-alpha",
+	"version": "0.40.0",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.40.0-alpha';
+	const VERSION = '0.40.0';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.13.0 - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## 0.12.2 - 2023-09-19
 ### Changed

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.0 - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## 0.12.2 - 2023-09-19
 ### Changed
 - Updated Jetpack submenu sort order so individual features are alpha-sorted. [#32958]

--- a/projects/packages/stats-admin/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/stats-admin/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/stats-admin/changelog/update-node-20
+++ b/projects/packages/stats-admin/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.13.0-alpha",
+	"version": "0.13.0",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.13.0-alpha';
+	const VERSION = '0.13.0';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.6.6] - 2023-10-23
 ### Fixed
 - Stats: Increase timeout to 20s. [#33549]
@@ -100,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.7.0]: https://github.com/Automattic/jetpack-stats/compare/v0.6.6...v0.7.0
 [0.6.6]: https://github.com/Automattic/jetpack-stats/compare/v0.6.5...v0.6.6
 [0.6.5]: https://github.com/Automattic/jetpack-stats/compare/v0.6.4...v0.6.5
 [0.6.4]: https://github.com/Automattic/jetpack-stats/compare/v0.6.3...v0.6.4

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.6.6] - 2023-10-23
 ### Fixed

--- a/projects/packages/stats/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/stats/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.19.0] - 2023-11-13
 ### Added

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.19.0] - 2023-11-13
 ### Added
 - Added Host::get_source_query() to return the 'source' query param from the current URL. [#33984]
@@ -289,6 +293,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[2.0.0]: https://github.com/Automattic/jetpack-status/compare/v1.19.0...v2.0.0
 [1.19.0]: https://github.com/Automattic/jetpack-status/compare/v1.18.5...v1.19.0
 [1.18.5]: https://github.com/Automattic/jetpack-status/compare/v1.18.4...v1.18.5
 [1.18.4]: https://github.com/Automattic/jetpack-status/compare/v1.18.3...v1.18.4

--- a/projects/packages/status/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/status/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-11-20
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.60.1] - 2023-10-31
 
 ## [1.60.0] - 2023-10-26
@@ -964,6 +969,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.0.0]: https://github.com/Automattic/jetpack-sync/compare/v1.60.1...v2.0.0
 [1.60.1]: https://github.com/Automattic/jetpack-sync/compare/v1.60.0...v1.60.1
 [1.60.0]: https://github.com/Automattic/jetpack-sync/compare/v1.59.2...v1.60.0
 [1.59.2]: https://github.com/Automattic/jetpack-sync/compare/v1.59.1...v1.59.2

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2023-11-20
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- The package now requires PHP >= 7.0. [#34192]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [1.60.1] - 2023-10-31
 

--- a/projects/packages/sync/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/sync/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/sync/changelog/update-strpos-str-starts-with
+++ b/projects/packages/sync/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.0.0-alpha';
+	const PACKAGE_VERSION = '2.0.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.21.0] - 2023-11-20
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- The package now requires PHP >= 7.0. [#34192]
-- VideoPress Uploader: clarify video preview poster image selection notice [#32948]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Updated required PHP version to >= 7.0. [#34192]
+- Clarified video preview poster image selection notice in the VideoPress uploader. [#32948]
 
 ### Fixed
-- Enqueue token-bridge script when processing videopress shortcode [#34121]
-- Fix interaction with memberships and VideoPress privacy. [#34189]
+- Enqueued token-bridge script when processing videopress shortcode. [#34121]
+- Fixed interaction with memberships and VideoPress privacy. [#34189]
 
 ## [0.20.2] - 2023-11-14
 ### Changed

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2023-11-20
+### Changed
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- The package now requires PHP >= 7.0. [#34192]
+- VideoPress Uploader: clarify video preview poster image selection notice [#32948]
+
+### Fixed
+- Enqueue token-bridge script when processing videopress shortcode [#34121]
+- Fix interaction with memberships and VideoPress privacy. [#34189]
+
 ## [0.20.2] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -1182,6 +1192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.21.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.20.2...v0.21.0
 [0.20.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.20.1...v0.20.2
 [0.20.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.19.3...v0.20.0

--- a/projects/packages/videopress/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/videopress/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/videopress/changelog/fix-token-bridge-enqueue-on-shortcode
+++ b/projects/packages/videopress/changelog/fix-token-bridge-enqueue-on-shortcode
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Enqueue token-bridge script when processing videopress shortcode

--- a/projects/packages/videopress/changelog/fix-videopress-gated-memberships-precedence
+++ b/projects/packages/videopress/changelog/fix-videopress-gated-memberships-precedence
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix interaction with memberships and VideoPress privacy.

--- a/projects/packages/videopress/changelog/update-node-20
+++ b/projects/packages/videopress/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/videopress/changelog/update-poster-image-selection-notice
+++ b/projects/packages/videopress/changelog/update-poster-image-selection-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress Uploader: clarify video preview poster image selection notice

--- a/projects/packages/videopress/changelog/update-strpos-str-starts-with
+++ b/projects/packages/videopress/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.21.0-alpha",
+	"version": "0.21.0",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.21.0-alpha';
+	const PACKAGE_VERSION = '0.21.0';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.11.15] - 2023-11-14
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.11.15] - 2023-11-14
 
 ## [0.11.14] - 2023-10-30
@@ -239,6 +243,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.12.0]: https://github.com/Automattic/jetpack-waf/compare/v0.11.15...v0.12.0
 [0.11.15]: https://github.com/Automattic/jetpack-waf/compare/v0.11.14...v0.11.15
 [0.11.14]: https://github.com/Automattic/jetpack-waf/compare/v0.11.13...v0.11.14
 [0.11.13]: https://github.com/Automattic/jetpack-waf/compare/v0.11.12...v0.11.13

--- a/projects/packages/waf/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/waf/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-11-20
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [0.2.58] - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34093]
@@ -271,6 +275,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.0]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.58...v0.3.0
 [0.2.58]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.57...v0.2.58
 [0.2.57]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.56...v0.2.57
 [0.2.56]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.55...v0.2.56

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2023-11-20
 ### Changed
-- The package now requires PHP >= 7.0. [#34192]
+- Updated required PHP version to >= 7.0. [#34192]
 
 ## [0.2.58] - 2023-11-14
 ### Changed

--- a/projects/packages/wordads/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/wordads/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/wordads/changelog/update-node-20
+++ b/projects/packages/wordads/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.0-alpha",
+	"version": "0.3.0",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.0-alpha';
+	const VERSION = '0.3.0';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -4,37 +4,37 @@
 
 ## 12.9-a.7 - 2023-11-20
 ### Enhancements
-- Add subscribe modal to Newsletter settings [#33909]
-- AI Assistant: compute if the site requires an upgrade depending on on the current tier too [#34083]
-- AI Assistant: do not perform AI Assistant feature request from the backend [#34132]
-- AI Assistant: ensure the client performs AI data feature request at least once [#34109]
-- CSS Concatenation: avoid optimizing CSS loading when less than 2 modules that require it are active. [#34110]
-- Jetpack AI: Open usage panel to production users. [#34122]
-- Jetpack AI: Update logic for the require upgrade field to also work for tiered sites. [#34170]
-- Jetpack AI: use the Usage Helper to set fields on the ai-assistant-feature endpoint. [#34151]
-- Use new async flow to get isOverLimit from useAiFeature. Fix wee typos on excerpt term" [#34156]
+- Subscribe Modal: Added a subscribe modal toggle to the Newsletter settings. [#33909]
+- CSS Concatenation: Avoid optimizing CSS loading when less than 2 modules that require it are active. [#34110]
+- Jetpack AI: Enabled the AI Assistant usage panel. [#34122]
 
 ### Improved compatibility
-- General: the plugin now requires PHP 7.0 and above. [#34126]
-- General: update WordPress version requirements to WordPress 6.3. [#34127]
+- Updated PHP version reqirements to PHP 7.0 or newer. [#34126]
+- Updated WordPress version requirements to WordPress 6.3. [#34127]
 
 ### Bug fixes
-- Add missing BLOCK_NAME constant to SimplePayments block [#34143]
-- Contact Form: avoid errors when a saved submitted contact form is requested but does not exist anymore. [#34129]
-- Restores Woo Express free trial upgrade JITM [#34167]
-- RNMobile: Ensure text is always visible in Contact Info block. [#33873]
+- Added missing BLOCK_NAME constant to SimplePayments block. [#34143]
+- Contact Form: Prevented errors when a saved submitted contact form is requested but does not exist anymore. [#34129]
+- WoA: Restored Woo Express free trial upgrade JITM. [#34167]
+- Mobile: Ensured text is always visible in Contact Info block on mobile. [#33873]
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
-- Blocks: update block support from __experimentalLayout to layout. [#34128]
-- change wording [#34130]
-- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
-- Dashboard: ensure the menu item focus supports the new "activity log" menu item. [#34174]
-- Partnerships: stop initializing the Partner package in the Jetpack plugin, it is now done directly in the Connection package. [#33832]
-- Rearrange the code for readability and make use of specific calls on different contexts. Leave comments behind for the future [#34176]
-- Removed jetpack/publicize store [#34111]
-- Subscribe Block: link to https://wordpress.com/email-subscriptions when Subscribed [#34148]
+- Jetpack AI: Compute if the site requires an upgrade depending on the current tier. [#34083]
+- Jetpack AI: Stopped requesting AI Assistant feature data from the backend. [#34132]
+- Jetpack AI: Ensured the client performs the AI data feature request at least once. [#34109]
+- Jetpack AI: Updated logic for the require upgrade field to also work for tiered sites. [#34170]
+- Jetpack AI: Use the Usage Helper to set fields on the ai-assistant-feature endpoint. [#34151]
+- Use new async flow to get isOverLimit from useAiFeature. [#34156]
+- Blocks: Updated block support from __experimentalLayout to layout. [#34128]
+- Subscribe Modal: Updated wording. [#34130]
+- Replaced usage of strpos() with str_starts_with(). [#34135]
+- Dashboard: Ensured the menu item focus supports the new "activity log" menu item. [#34174]
+- Partnerships: Stopped initializing the Partner package in the Jetpack plugin, it is now done directly in the Connection package. [#33832]
+- Rearranged the code for readability and made use of specific calls on different contexts. [#34176]
+- Removed the 'jetpack/publicize' store. [#34111]
+- Subscribe Block: Link to https://wordpress.com/email-subscriptions when subscribed. [#34148]
 - Updated package dependencies. [#34119]
-- Use the same value as in backend for unlimited plan limit (needed for int comparisons), 999.999.999 (almost a billion), as a constant. Replace literal value usage. [#34169]
+- Use the same value as in backend for unlimited plan limit (needed for int comparisons), 999.999.999 (almost a billion), as a constant. [#34169]
 
 ## 12.9-a.5 - 2023-11-14
 ### Enhancements

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.9-a.7 - 2023-11-20
+### Enhancements
+- Add subscribe modal to Newsletter settings [#33909]
+- AI Assistant: compute if the site requires an upgrade depending on on the current tier too [#34083]
+- AI Assistant: do not perform AI Assistant feature request from the backend [#34132]
+- AI Assistant: ensure the client performs AI data feature request at least once [#34109]
+- CSS Concatenation: avoid optimizing CSS loading when less than 2 modules that require it are active. [#34110]
+- Jetpack AI: Open usage panel to production users. [#34122]
+- Jetpack AI: Update logic for the require upgrade field to also work for tiered sites. [#34170]
+- Jetpack AI: use the Usage Helper to set fields on the ai-assistant-feature endpoint. [#34151]
+- Use new async flow to get isOverLimit from useAiFeature. Fix wee typos on excerpt term" [#34156]
+
+### Improved compatibility
+- General: the plugin now requires PHP 7.0 and above. [#34126]
+- General: update WordPress version requirements to WordPress 6.3. [#34127]
+
+### Bug fixes
+- Add missing BLOCK_NAME constant to SimplePayments block [#34143]
+- Contact Form: avoid errors when a saved submitted contact form is requested but does not exist anymore. [#34129]
+- Restores Woo Express free trial upgrade JITM [#34167]
+- RNMobile: Ensure text is always visible in Contact Info block. [#33873]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Blocks: update block support from __experimentalLayout to layout. [#34128]
+- change wording [#34130]
+- Code Modernization: Replace usage of strpos() with str_starts_with(). [#34135]
+- Dashboard: ensure the menu item focus supports the new "activity log" menu item. [#34174]
+- Partnerships: stop initializing the Partner package in the Jetpack plugin, it is now done directly in the Connection package. [#33832]
+- Rearrange the code for readability and make use of specific calls on different contexts. Leave comments behind for the future [#34176]
+- Removed jetpack/publicize store [#34111]
+- Subscribe Block: link to https://wordpress.com/email-subscriptions when Subscribed [#34148]
+- Updated package dependencies. [#34119]
+- Use the same value as in backend for unlimited plan limit (needed for int comparisons), 999.999.999 (almost a billion), as a constant. Replace literal value usage. [#34169]
+
 ## 12.9-a.5 - 2023-11-14
 ### Enhancements
 - Subscribe Block: Improved the redirect logic after confirming a subscriptions. [#34086]

--- a/projects/plugins/jetpack/changelog/add-activitylog-menu
+++ b/projects/plugins/jetpack/changelog/add-activitylog-menu
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-activitylog-menu-react-ffocus
+++ b/projects/plugins/jetpack/changelog/add-activitylog-menu-react-ffocus
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Dashboard: ensure the menu item focus supports the new "activity log" menu item.

--- a/projects/plugins/jetpack/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/plugins/jetpack/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/change-ai-excerpt-use-assistant-data
+++ b/projects/plugins/jetpack/changelog/change-ai-excerpt-use-assistant-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Use new async flow to get isOverLimit from useAiFeature. Fix wee typos on excerpt term"

--- a/projects/plugins/jetpack/changelog/change-default-unlimited-request-limit
+++ b/projects/plugins/jetpack/changelog/change-default-unlimited-request-limit
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Use the same value as in backend for unlimited plan limit (needed for int comparisons), 999.999.999 (almost a billion), as a constant. Replace literal value usage.

--- a/projects/plugins/jetpack/changelog/change-jp-ai-helper-code-rearrange
+++ b/projects/plugins/jetpack/changelog/change-jp-ai-helper-code-rearrange
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Rearrange the code for readability and make use of specific calls on different contexts. Leave comments behind for the future

--- a/projects/plugins/jetpack/changelog/fix-connection-partner-standalone-sites
+++ b/projects/plugins/jetpack/changelog/fix-connection-partner-standalone-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Partnerships: stop initializing the Partner package in the Jetpack plugin, it is now done directly in the Connection package.

--- a/projects/plugins/jetpack/changelog/fix-connection-partner-standalone-sites#2
+++ b/projects/plugins/jetpack/changelog/fix-connection-partner-standalone-sites#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-defensive-post-check-contact-form
+++ b/projects/plugins/jetpack/changelog/fix-defensive-post-check-contact-form
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Contact Form: avoid errors when a saved submitted contact form is requested but does not exist anymore.

--- a/projects/plugins/jetpack/changelog/fix-simple-payments-missing-block-name
+++ b/projects/plugins/jetpack/changelog/fix-simple-payments-missing-block-name
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Add missing BLOCK_NAME constant to SimplePayments block

--- a/projects/plugins/jetpack/changelog/fix-token-bridge-enqueue-on-shortcode
+++ b/projects/plugins/jetpack/changelog/fix-token-bridge-enqueue-on-shortcode
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-woo-free-trial-jitm
+++ b/projects/plugins/jetpack/changelog/fix-woo-free-trial-jitm
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Restores Woo Express free trial upgrade JITM

--- a/projects/plugins/jetpack/changelog/remove-unneeded-condition-from-product-data-api
+++ b/projects/plugins/jetpack/changelog/remove-unneeded-condition-from-product-data-api
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Just updating lockfile
-
-

--- a/projects/plugins/jetpack/changelog/renovate-scssphp-scssphp-1.x-lockfile
+++ b/projects/plugins/jetpack/changelog/renovate-scssphp-scssphp-1.x-lockfile
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/rnmobile-ensure-contact-info-text-visibility
+++ b/projects/plugins/jetpack/changelog/rnmobile-ensure-contact-info-text-visibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-RNMobile: Ensure text is always visible in Contact Info block.

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-compute-require-plan-based-on-current-tier
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-compute-require-plan-based-on-current-tier
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: compute if the site requires an upgrade depending on on the current tier too

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-do-not-perform-ai-assistant-request-from-backend
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-do-not-perform-ai-assistant-request-from-backend
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: do not perform AI Assistant feature request from the backend

--- a/projects/plugins/jetpack/changelog/update-block-layout-support
+++ b/projects/plugins/jetpack/changelog/update-block-layout-support
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Blocks: update block support from __experimentalLayout to layout.

--- a/projects/plugins/jetpack/changelog/update-concatenated-css-more-flexible
+++ b/projects/plugins/jetpack/changelog/update-concatenated-css-more-flexible
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-CSS Concatenation: avoid optimizing CSS loading when less than 2 modules that require it are active.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-site-require-upgrade-field
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-site-require-upgrade-field
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Jetpack AI: Update logic for the require upgrade field to also work for tiered sites.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-move-usage-panel-to-production
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-move-usage-panel-to-production
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Jetpack AI: Open usage panel to production users.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-use-usage-helper-for-fields
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-use-usage-helper-for-fields
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Jetpack AI: use the Usage Helper to set fields on the ai-assistant-feature endpoint.

--- a/projects/plugins/jetpack/changelog/update-node-20
+++ b/projects/plugins/jetpack/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/plugins/jetpack/changelog/update-paywall-access-question
+++ b/projects/plugins/jetpack/changelog/update-paywall-access-question
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-change wording

--- a/projects/plugins/jetpack/changelog/update-php-requirements
+++ b/projects/plugins/jetpack/changelog/update-php-requirements
@@ -1,4 +1,0 @@
-Significance: major
-Type: compat
-
-General: the plugin now requires PHP 7.0 and above.

--- a/projects/plugins/jetpack/changelog/update-php-requirements#2
+++ b/projects/plugins/jetpack/changelog/update-php-requirements#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-remove-jetpack-publicize-store
+++ b/projects/plugins/jetpack/changelog/update-remove-jetpack-publicize-store
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Removed jetpack/publicize store

--- a/projects/plugins/jetpack/changelog/update-strpos-str-starts-with
+++ b/projects/plugins/jetpack/changelog/update-strpos-str-starts-with
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Code Modernization: Replace usage of strpos() with str_starts_with().

--- a/projects/plugins/jetpack/changelog/update-subscribe-block-subscribed-behavior
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-subscribed-behavior
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscribe Block: link to https://wordpress.com/email-subscriptions when Subscribed

--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-filters
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-filters
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add subscribe modal to Newsletter settings

--- a/projects/plugins/jetpack/changelog/update-wp-requirements-63
+++ b/projects/plugins/jetpack/changelog/update-wp-requirements-63
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-General: update WordPress version requirements to WordPress 6.3.

--- a/projects/plugins/jetpack/changelog/y
+++ b/projects/plugins/jetpack/changelog/y
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: ensure the client performs AI data feature request at least once

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_9_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_9_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_9_a_6",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_9_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.9-a.6
+ * Version: 12.9-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '12.9-a.6' );
+define( 'JETPACK__VERSION', '12.9-a.7' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.9-a.7
+ * Version: 12.9-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '12.9-a.7' );
+define( 'JETPACK__VERSION', '12.9-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.9.0-a.7",
+	"version": "12.9.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.9.0-a.6",
+	"version": "12.9.0-a.7",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.0.0 - 2023-11-20
 ### Changed
-- General: updated PHP requirement to PHP 7.0+ [#34126]
+- Updated the required PHP version to >= 7.0. [#34126]
 
 ## 1.7.11 - 2023-11-14
 ### Changed

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2023-11-20
+### Changed
+- General: updated PHP requirement to PHP 7.0+ [#34126]
+
 ## 1.7.11 - 2023-11-14
 ### Changed
 - Updated package dependencies. [#34087]

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-query-param-to-task
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-query-param-to-task
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-node-20
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-php-requirements
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-php-requirements
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-General: updated PHP requirement to PHP 7.0+

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-subscribe-modal-filters
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-subscribe-modal-filters
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_0_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_0"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.0-alpha
+ * Version: 2.0.0
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.0-alpha",
+	"version": "2.0.0",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.0, jetpack 12.9-a.7

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.