### PR TITLE
My Jetpack: Mark Jetpack AI as upgradable in interstitial page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -21,6 +21,7 @@ const ConnectedProductCard = ( {
 	Description = null,
 	additionalActions = null,
 	menuItems = [],
+	upgradeInInterstitial = false,
 } ) => {
 	const { isRegistered, isUserConnected } = useConnection();
 
@@ -136,6 +137,7 @@ const ConnectedProductCard = ( {
 			onInstallStandalone={ handleInstallStandalone }
 			onActivateStandalone={ handleInstallStandalone }
 			onDeactivateStandalone={ handleDeactivateStandalone }
+			upgradeInInterstitial={ upgradeInInterstitial }
 		>
 			{ children }
 		</ProductCard>

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -31,6 +31,7 @@ const ActionButton = ( {
 	isDeactivatingStandalone,
 	className,
 	onAdd,
+	upgradeInInterstitial,
 } ) => {
 	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
 	const [ currentAction, setCurrentAction ] = useState( {} );
@@ -75,11 +76,21 @@ const ActionButton = ( {
 					onClick: null,
 				};
 			}
-			case PRODUCT_STATUSES.NEEDS_PURCHASE:
+			case PRODUCT_STATUSES.NEEDS_PURCHASE: {
+				return {
+					...buttonState,
+					href: purchaseUrl || `#/add-${ slug }`,
+					size: 'small',
+					variant: 'primary',
+					weight: 'regular',
+					label: __( 'Purchase', 'jetpack-my-jetpack' ),
+					onClick: onAdd,
+				};
+			}
 			case PRODUCT_STATUSES.CAN_UPGRADE: {
 				const upgradeText = __( 'Upgrade', 'jetpack-my-jetpack' );
 				const purchaseText = __( 'Purchase', 'jetpack-my-jetpack' );
-				const buttonText = purchaseUrl ? upgradeText : purchaseText;
+				const buttonText = purchaseUrl || upgradeInInterstitial ? upgradeText : purchaseText;
 
 				return {
 					...buttonState,
@@ -152,6 +163,7 @@ const ActionButton = ( {
 		purchaseUrl,
 		slug,
 		status,
+		upgradeInInterstitial,
 	] );
 
 	const allActions = useMemo(

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ProductCard from '../connected-product-card';
 
 const AiCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="jetpack-ai" />;
+	return <ProductCard admin={ admin } slug="jetpack-ai" upgradeInInterstitial={ true } />;
 };
 
 AiCard.propTypes = {

--- a/projects/packages/my-jetpack/changelog/update-ai-assistant-my-jetpack-card-upgrade
+++ b/projects/packages/my-jetpack/changelog/update-ai-assistant-my-jetpack-card-upgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Mark Jetpack AI as upgradable in interstitial page

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.0.0",
+	"version": "4.0.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.0.0';
+	const PACKAGE_VERSION = '4.0.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -75,11 +75,11 @@ class Jetpack_Ai extends Product {
 	}
 
 	/**
-	 * Get the next usage tier
+	 * Get the current usage tier
 	 *
 	 * @return int
 	 */
-	public static function get_next_usage_tier() {
+	public static function get_current_usage_tier() {
 		$info = self::get_ai_assistant_feature();
 
 		// Bail early if it's not possible to fetch the feature data.
@@ -88,6 +88,17 @@ class Jetpack_Ai extends Product {
 		}
 
 		$current_tier = isset( $info['current-tier']['value'] ) ? $info['current-tier']['value'] : null;
+
+		return $current_tier;
+	}
+
+	/**
+	 * Get the next usage tier
+	 *
+	 * @return int
+	 */
+	public static function get_next_usage_tier() {
+		$current_tier = self::get_current_usage_tier();
 
 		if ( null === $current_tier ) {
 			return 1;
@@ -290,6 +301,23 @@ class Jetpack_Ai extends Product {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Checks whether the product can be upgraded to a different product.
+	 *
+	 * @return boolean
+	 */
+	public static function is_upgradable() {
+		$has_required_plan = self::has_required_plan();
+		$current_tier      = self::get_current_usage_tier();
+
+		// Mark as not upgradable if user is on unlimited tier or does not have any plan.
+		if ( ! $has_required_plan || null === $current_tier || 1 === $current_tier ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #33358

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Marks the Jetpack AI product as upgradable if there is a plan
* Adds a flag to allow the product card button to show "Upgrade" and link to the interstitial page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Locally or on a site with unlimited plan:
* Go to My Jetpack
* Confirm that there is no change to the Jetpack AI card, it still shows a disabled "Manage" button
![2023-11-20_16-49-34](https://github.com/Automattic/jetpack/assets/8486249/0e0d3a51-2902-405b-90d6-36cb01a2711d)

On a site with a tiered plan or by mocking the current tier in the wpcom helper file in the sandbox:
* Go to My Jetpack
* Check that the Jetpack AI card has an "Upgrade" button that links to the interstitial page
![2023-11-20_16-48-01](https://github.com/Automattic/jetpack/assets/8486249/46c781f1-d470-4e3b-8d32-0da97da5f536)

Without a plan or by mocking `has_required_plan` on `class-jetpack-ai.php` to return false:
* Go to My Jetpack
* Confirm that the Jetpack AI product card has a "Purchase" button that links to the interstitial page 
![2023-11-20_16-48-50-no-plan](https://github.com/Automattic/jetpack/assets/8486249/3b1af9c7-987f-48ab-a4ae-a12ba3863d30)
