### PR TITLE
codesniffer: Enable and fix `Modernize.FunctionCalls.Dirname.Nested` sniff

### DIFF
--- a/docs/examples/bootstrap.php
+++ b/docs/examples/bootstrap.php
@@ -6,7 +6,7 @@
  */
 
 // Assume we're in tests/php/bootstrap.php.
-$_plugin_root = dirname( dirname( __DIR__ ) );
+$_plugin_root = dirname( __DIR__, 2 );
 
 // Locate WordPress or wordpress-develop. We look in several places.
 if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
@@ -18,9 +18,9 @@ if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 } elseif ( false !== getenv( 'WP_TESTS_DIR' ) ) {
 	// WordPress core environment variable.
 	$_tests_dir = getenv( 'WP_TESTS_DIR' );
-} elseif ( file_exists( dirname( dirname( $_plugin_root ) ) . '/tests/phpunit/includes/bootstrap.php' ) ) {
+} elseif ( file_exists( dirname( $_plugin_root, 2 ) . '/tests/phpunit/includes/bootstrap.php' ) ) {
 	// Installed inside wordpress-develop.
-	$_tests_dir = dirname( dirname( $_plugin_root ) ) . '/tests/phpunit/includes/bootstrap.php';
+	$_tests_dir = dirname( $_plugin_root, 2 ) . '/tests/phpunit/includes/bootstrap.php';
 } elseif ( file_exists( '/vagrant/www/wordpress-develop/public_html/tests/phpunit/includes/bootstrap.php' ) ) {
 	// VVV.
 	$_tests_dir = '/vagrant/www/wordpress-develop/public_html/tests/phpunit';

--- a/projects/packages/assets/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
+++ b/projects/packages/assets/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Replace nested `dirname` with use of the php 7.0+ `$levels` parameter. No change in functionality.
+
+

--- a/projects/packages/assets/tests/php/test-assets.php
+++ b/projects/packages/assets/tests/php/test-assets.php
@@ -29,7 +29,7 @@ class AssetsTest extends TestCase {
 	 */
 	public function set_up() {
 		Monkey\setUp();
-		$plugin_dir = dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/';
+		$plugin_dir = dirname( __DIR__, 4 ) . '/';
 		Jetpack_Constants::set_constant( 'JETPACK__PLUGIN_FILE', $plugin_dir . 'jetpack.php' );
 
 		Functions\stubs(
@@ -180,7 +180,7 @@ class AssetsTest extends TestCase {
 	public function get_file_url_for_environment_package_path_data_provider() {
 		$min_path     = 'src/js/test.min.js';
 		$non_min_path = 'src/js/test.js';
-		$package_path = dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/packages/test-package/test-package.php';
+		$package_path = dirname( __DIR__, 4 ) . '/packages/test-package/test-package.php';
 
 		return array(
 			'script-debug-true'  => array(

--- a/projects/packages/autoloader/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
+++ b/projects/packages/autoloader/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Replace nested `dirname` with use of the php 7.0+ `$levels` parameter. No change in functionality.
+
+

--- a/projects/packages/autoloader/src/AutoloadGenerator.php
+++ b/projects/packages/autoloader/src/AutoloadGenerator.php
@@ -21,7 +21,7 @@ use Composer\Util\PackageSorter;
  */
 class AutoloadGenerator {
 
-	const VERSION = '3.0.0';
+	const VERSION = '3.0.1-alpha';
 
 	/**
 	 * IO object.

--- a/projects/packages/autoloader/src/class-plugin-locator.php
+++ b/projects/packages/autoloader/src/class-plugin-locator.php
@@ -31,7 +31,7 @@ class Plugin_Locator {
 	 */
 	public function find_current_plugin() {
 		// Escape from `vendor/__DIR__` to root plugin directory.
-		$plugin_directory = dirname( dirname( __DIR__ ) );
+		$plugin_directory = dirname( __DIR__, 2 );
 
 		// Use the path processor to ensure that this is an autoloader we're referencing.
 		$path = $this->path_processor->find_directory_with_autoloader( $plugin_directory, array() );

--- a/projects/packages/autoloader/tests/php/bootstrap.php
+++ b/projects/packages/autoloader/tests/php/bootstrap.php
@@ -9,7 +9,7 @@
 define( 'TEST_DIR', str_replace( '\\', '/', __DIR__ ) );
 
 // Make sure its easy to reference the test files.
-define( 'TEST_PACKAGE_DIR', dirname( dirname( TEST_DIR ) ) );
+define( 'TEST_PACKAGE_DIR', dirname( TEST_DIR, 2 ) );
 define( 'TEST_TEMP_DIR', __DIR__ . DIRECTORY_SEPARATOR . 'tmp' );
 
 // phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged

--- a/projects/packages/changelogger/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
+++ b/projects/packages/changelogger/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Replace nested `dirname` with use of the php 7.0+ `$levels` parameter. No change in functionality.
+
+

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.0.0';
+	const VERSION = '4.0.1-alpha';
 
 	/**
 	 * Constructor.

--- a/projects/packages/changelogger/tests/php/tests/src/ConfigTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ConfigTest.php
@@ -156,7 +156,7 @@ class ConfigTest extends TestCase {
 
 		$this->resetConfigCache();
 		putenv( 'COMPOSER=' . __DIR__ . '/../../../../composer.json' );
-		$this->assertSame( dirname( dirname( dirname( dirname( __DIR__ ) ) ) ), Config::base() );
+		$this->assertSame( dirname( __DIR__, 4 ), Config::base() );
 	}
 
 	/**

--- a/projects/packages/codesniffer/Jetpack/ruleset.xml
+++ b/projects/packages/codesniffer/Jetpack/ruleset.xml
@@ -74,6 +74,11 @@
 	<!-- Only include select VIP rules -->
 	<rule ref="WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath" />
 
+	<!-- Re-enable this rule that was disabled by WordPress-Extra now that we're on PHP 7.0+. -->
+	<rule ref="Modernize.FunctionCalls.Dirname.Nested">
+		<severity>5</severity>
+	</rule>
+
 	<!-- Elevate undefined variables to an Error instead of a Warning. -->
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">
 		<type>error</type>

--- a/projects/packages/codesniffer/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
+++ b/projects/packages/codesniffer/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enable `Modernize.FunctionCalls.Dirname.Nested` sniff that is currently being disabled by WordPress-Extra.

--- a/projects/packages/connection/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
+++ b/projects/packages/connection/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Replace nested `dirname` with use of the php 7.0+ `$levels` parameter. No change in functionality.
+
+

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.0.0';
+	const PACKAGE_VERSION = '2.0.1-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/tests/php/test_Server_Sandbox.php
+++ b/projects/packages/connection/tests/php/test_Server_Sandbox.php
@@ -245,7 +245,7 @@ class Test_Server_Sandbox extends BaseTestCase {
 	 * admin bar menu when the JETPACK__DOMAIN_SANDBOX constant is not set.
 	 */
 	public function test_admin_bar_add_sandbox_item_constant_not_set() {
-		require_once dirname( dirname( __DIR__ ) ) . '/wordpress/wp-includes/class-wp-admin-bar.php';
+		require_once dirname( __DIR__, 2 ) . '/wordpress/wp-includes/class-wp-admin-bar.php';
 
 		$wp_admin_bar = new \WP_Admin_Bar();
 		( new Server_Sandbox() )->admin_bar_add_sandbox_item( $wp_admin_bar );
@@ -260,7 +260,7 @@ class Test_Server_Sandbox extends BaseTestCase {
 	 */
 	public function test_admin_bar_add_sandbox_item_constant_set() {
 		Constants::set_constant( 'JETPACK__SANDBOX_DOMAIN', 'www.example.com' );
-		require_once dirname( dirname( __DIR__ ) ) . '/wordpress/wp-includes/class-wp-admin-bar.php';
+		require_once dirname( __DIR__, 2 ) . '/wordpress/wp-includes/class-wp-admin-bar.php';
 
 		$wp_admin_bar = new \WP_Admin_Bar();
 		( new Server_Sandbox() )->admin_bar_add_sandbox_item( $wp_admin_bar );

--- a/projects/packages/waf/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
+++ b/projects/packages/waf/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Replace nested `dirname` with use of the php 7.0+ `$levels` parameter. No change in functionality.
+
+

--- a/projects/packages/waf/src/class-waf-standalone-bootstrap.php
+++ b/projects/packages/waf/src/class-waf-standalone-bootstrap.php
@@ -80,7 +80,7 @@ class Waf_Standalone_Bootstrap {
 		if ( isset( $jetpack_autoloader_loader ) ) {
 			$class_file = $jetpack_autoloader_loader->find_class_file( Waf_Runner::class );
 			if ( $class_file ) {
-				$autoload_file = dirname( dirname( dirname( dirname( dirname( $class_file ) ) ) ) ) . '/vendor/autoload.php';
+				$autoload_file = dirname( $class_file, 5 ) . '/vendor/autoload.php';
 			}
 		}
 
@@ -91,13 +91,13 @@ class Waf_Standalone_Bootstrap {
 		) {
 			$package_file = InstalledVersions::getInstallPath( 'automattic/jetpack-waf' );
 			if ( substr( $package_file, -23 ) === '/automattic/jetpack-waf' ) {
-				$autoload_file = dirname( dirname( dirname( $package_file ) ) ) . '/vendor/autoload.php';
+				$autoload_file = dirname( $package_file, 3 ) . '/vendor/autoload.php';
 			}
 		}
 
 		// Guess. First look for being in a `vendor/automattic/jetpack-waf/src/', then see if we're standalone with our own vendor dir.
 		if ( null === $autoload_file ) {
-			$autoload_file = dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/vendor/autoload.php';
+			$autoload_file = dirname( __DIR__, 4 ) . '/vendor/autoload.php';
 			if ( ! file_exists( $autoload_file ) ) {
 				$autoload_file = dirname( __DIR__ ) . '/vendor/autoload.php';
 			}

--- a/projects/plugins/crm/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
+++ b/projects/plugins/crm/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Replace nested `dirname` with use of the php 7.0+ `$levels` parameter. No change in functionality.
+
+

--- a/projects/plugins/crm/tests/php/bootstrap.php
+++ b/projects/plugins/crm/tests/php/bootstrap.php
@@ -13,7 +13,7 @@ define( 'JETPACK_CRM_TESTS_ROOT', __DIR__ );
 /**
  * Assume we're in tests/php/bootstrap.php.
  */
-$_plugin_root = dirname( dirname( __DIR__ ) );
+$_plugin_root = dirname( __DIR__, 2 );
 
 /**
  * Locate WordPress or wordpress-develop. We look in several places.

--- a/projects/plugins/jetpack/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
+++ b/projects/plugins/jetpack/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Replace nested `dirname` with use of the php 7.0+ `$levels` parameter. No change in functionality.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -5,7 +5,7 @@
 
 use WpOrg\Requests\Requests;
 
-require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once dirname( __DIR__, 2 ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
 
 /**
  * Class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -5,7 +5,7 @@
 
 use WpOrg\Requests\Requests;
 
-require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once dirname( __DIR__, 2 ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
 
 /**
  * Class WP_Test_WPCOM_REST_API_V2_Endpoint_External_Media
@@ -42,7 +42,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_External_Media extends WP_Test_Jetpack_
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		static::$user_id    = $factory->user->create( array( 'role' => 'administrator' ) );
-		static::$image_path = dirname( dirname( __DIR__ ) ) . '/files/jetpack.jpg';
+		static::$image_path = dirname( __DIR__, 2 ) . '/files/jetpack.jpg';
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
@@ -7,7 +7,7 @@
 
 use WpOrg\Requests\Requests;
 
-require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once dirname( __DIR__, 2 ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
 
 /**
  * Class WP_Test_WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-send-email-preview.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-send-email-preview.php
@@ -7,7 +7,7 @@
 
 use WpOrg\Requests\Requests;
 
-require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once dirname( __DIR__, 2 ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
 
 /**
  * Class WP_Test_WPCOM_REST_API_V2_Endpoint_Send_Email_Preview

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-transient.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-transient.php
@@ -5,7 +5,7 @@
 
 use WpOrg\Requests\Requests;
 
-require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once dirname( __DIR__, 2 ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
 
 /**
  * Class WP_Test_WPCOM_REST_API_V2_Endpoint_Transient

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/class-test-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/class-test-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -12,7 +12,7 @@
 /**
  * The base testcase class.
  */
-require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once dirname( __DIR__, 2 ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
 
 use Automattic\Jetpack\VideoPress\WPCOM_REST_API_V2_Attachment_VideoPress_Field;
 
@@ -59,7 +59,7 @@ class Test_WPCOM_REST_API_V2_Attachment_VideoPress_Data extends WP_Test_Jetpack_
 					)
 				);
 
-		$attachment_id = self::factory()->attachment->create_upload_object( dirname( dirname( __DIR__ ) ) . '/jetpack-icon.jpg', 0 );
+		$attachment_id = self::factory()->attachment->create_upload_object( dirname( __DIR__, 2 ) . '/jetpack-icon.jpg', 0 );
 		$object        = array(
 			'id' => $attachment_id,
 		);

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-attachment-fields-videopress.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-attachment-fields-videopress.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once dirname( __DIR__, 2 ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
 
 use Automattic\Jetpack\VideoPress\WPCOM_REST_API_V2_Attachment_VideoPress_Field;
 
@@ -46,7 +46,7 @@ class Test_WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WP_Test_Jetpack
 					$this->returnValue( 'mocked_videopress_guid' )
 				);
 
-		$attachment_id = self::factory()->attachment->create_upload_object( dirname( dirname( __DIR__ ) ) . '/jetpack-icon.jpg', 0 );
+		$attachment_id = self::factory()->attachment->create_upload_object( dirname( __DIR__, 2 ) . '/jetpack-icon.jpg', 0 );
 		$object        = array(
 			'id' => $attachment_id,
 		);

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-class.service-api-keys.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-class.service-api-keys.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once dirname( __DIR__, 2 ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
 
 /**
  * @group publicize

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-class.subscribers-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-class.subscribers-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once dirname( __DIR__, 2 ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
 
 if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) && defined( 'JETPACK__PLUGIN_DIR' ) && JETPACK__PLUGIN_DIR ) {
 	require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions.php';

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once dirname( __DIR__, 2 ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
 
 /**
  * Tests that Posts and Custom Post Types do have Publicize data in REST API

--- a/projects/plugins/jetpack/tests/php/lib/class-wp-test-jetpack-rest-testcase.php
+++ b/projects/plugins/jetpack/tests/php/lib/class-wp-test-jetpack-rest-testcase.php
@@ -4,7 +4,7 @@
 require_once __DIR__ . '/class-wp-test-spy-rest-server.php';
 
 if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-	require_once dirname( dirname( dirname( __DIR__ ) ) ) . '/core/includes/testcase-rest-api.php';
+	require_once dirname( __DIR__, 3 ) . '/core/includes/testcase-rest-api.php';
 }
 
 abstract class WP_Test_Jetpack_REST_Testcase extends WP_Test_REST_TestCase {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The WordPress-Extra ruleset turns this off. Now that we've dropped PHP 5.6, we can turn it on.

Then, of course, we have to fix all the existing instances of the problem.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Relevant to pdqkMK-UN-p2#comment-1342

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Everything should continue to work