### PR TITLE
Clean up code with comments about PHP 5

### DIFF
--- a/projects/packages/boost-core/changelog/remove-cleanup-php5.6-code
+++ b/projects/packages/boost-core/changelog/remove-cleanup-php5.6-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Abstract static methods in `Automattic\Jetpack\Boost_Core\Lib\Cacheable` are now actually abstract, instead of being implemented to always throw.

--- a/projects/packages/boost-core/package.json
+++ b/projects/packages/boost-core/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-boost-core",
-	"version": "0.2.0",
+	"version": "0.2.1-alpha",
 	"description": "Core functionality for boost and relevant packages to depend on",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/boost-core/#readme",
 	"bugs": {

--- a/projects/packages/boost-core/src/lib/class-cacheable.php
+++ b/projects/packages/boost-core/src/lib/class-cacheable.php
@@ -58,15 +58,8 @@ abstract class Cacheable implements \JsonSerializable {
 	 * @param array $data Serialized data to restore the object from.
 	 *
 	 * @throws \Exception Throw an exception to remind to implement the method in child classes.
-	 *
-	 *  phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	 */
-	public static function jsonUnserialize( $data ) {
-		// PHP 5.6 does not support abstract static classes. Throwing an error is a way to make sure we remember to override them in the child classes.
-		$class = get_called_class();
-		throw new \Exception( "Must implement static method jsonUnserialize in class $class" );
-	}
-	// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	abstract public static function jsonUnserialize( $data );
 
 	/**
 	 * Fetch an object with the given ID.
@@ -137,9 +130,5 @@ abstract class Cacheable implements \JsonSerializable {
 	 *
 	 * @throws \Exception Throw an exception to remind to implement the method in child classes.
 	 */
-	protected static function cache_prefix() {
-		// PHP 5.6 does not support abstract static classes. Throwing an error is a way to make sure we remember to override them in the child classes.
-		$class = get_called_class();
-		throw new \Exception( "Must implement static method cache_prefix in class $class" );
-	}
+	abstract protected static function cache_prefix();
 }

--- a/projects/packages/licensing/changelog/remove-cleanup-php5.6-code
+++ b/projects/packages/licensing/changelog/remove-cleanup-php5.6-code
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix test class to use `set_up_before_class()` instead of having to cry inside.
+
+

--- a/projects/packages/licensing/tests/.phpcs.dir.xml
+++ b/projects/packages/licensing/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/stats/changelog/remove-cleanup-php5.6-code
+++ b/projects/packages/stats/changelog/remove-cleanup-php5.6-code
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove comment about tests failing in PHP 5.6 when run out of order. What was happening is that in PHPUnit <6.0, `@before` ran after `setUp()` so the first test's `Stats::init()` call would hook the hooks before WorDBless saved them. In PHPUnit 6.0 the `@before`-annotated methods run first so WorDBless saves the hooks before that first test's `Stats::init()` call.
+
+

--- a/projects/packages/stats/tests/php/test-main.php
+++ b/projects/packages/stats/tests/php/test-main.php
@@ -14,13 +14,6 @@ use Jetpack_Options;
 /**
  * Class to test the Main class.
  *
- * Important! All the *_with_jp_version_lt_11_5_a_2 need to run before their counterpart
- * that test the same hooks but without JP version set to `11.5-a.1`.
- * This happens because the PHP 5.6 unit tests would fail as the global $wp_filter
- * is not being properly reset between tests.
- *
- * @todo Investigate why this happens and fix it.
- *
  * @covers Automattic\Jetpack\Stats\Main
  */
 class Test_Main extends StatsBaseTestCase {
@@ -33,8 +26,6 @@ class Test_Main extends StatsBaseTestCase {
 
 	/**
 	 * Set up before each test
-	 *
-	 * @before
 	 */
 	protected function set_up() {
 		parent::set_up();
@@ -48,8 +39,6 @@ class Test_Main extends StatsBaseTestCase {
 
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		parent::tear_down();

--- a/projects/plugins/beta/changelog/remove-cleanup-php5.6-code
+++ b/projects/plugins/beta/changelog/remove-cleanup-php5.6-code
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Use `( function() {} )();` now that we no longer support PHP 5.6.
+
+

--- a/projects/plugins/beta/src/admin/branch-card.template.php
+++ b/projects/plugins/beta/src/admin/branch-card.template.php
@@ -33,8 +33,7 @@ $active_branch = $active_branch; // Dummy assignment to fool VariableAnalysis.Co
 
 // -------------
 
-// TODO: Once we drop PHP 5.6 support, we can do `( function () { ... } )();` instead of assigning to `$tmp`.
-$tmp = function ( $plugin, $branch, $active_branch ) {
+( function ( $plugin, $branch, $active_branch ) {
 	$slug      = 'dev' === $branch->which ? $plugin->dev_plugin_slug() : $plugin->plugin_slug();
 	$classes   = array( 'dops-foldable-card', 'has-expanded-summary', 'dops-card', 'branch-card' );
 	$data_attr = '';
@@ -107,5 +106,4 @@ $tmp = function ( $plugin, $branch, $active_branch ) {
 				</div>
 			</div>
 	<?php
-};
-$tmp( $plugin, $branch, $active_branch );
+} )( $plugin, $branch, $active_branch );

--- a/projects/plugins/beta/src/admin/show-needed-updates.template.php
+++ b/projects/plugins/beta/src/admin/show-needed-updates.template.php
@@ -18,8 +18,7 @@ $plugin = isset( $plugin ) ? $plugin : null; // phpcs:ignore WordPress.WP.Global
 
 // -------------
 
-// TODO: Once we drop PHP 5.6 support, we can do `( function () { ... } )();` instead of assigning to `$tmp`.
-$tmp = function ( $plugin ) {
+( function ( $plugin ) {
 	$updates = Utils::plugins_needing_update( true );
 	if ( isset( $plugin ) ) {
 		$updates = array_intersect_key(
@@ -99,5 +98,4 @@ $tmp = function ( $plugin ) {
 		<?php } ?>
 	</div>
 	<?php
-};
-$tmp( $plugin );
+} )( $plugin );

--- a/projects/plugins/jetpack/_inc/lib/debugger/debug-functions.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/debug-functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WP Site Health functionality temporarily stored in this file until all of Jetpack is PHP 5.3+
+ * WP Site Health debugging functions.
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/changelog/remove-cleanup-php5.6-code
+++ b/projects/plugins/jetpack/changelog/remove-cleanup-php5.6-code
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update some comments that referred to PHP 5.
+
+

--- a/projects/plugins/jetpack/functions.cookies.php
+++ b/projects/plugins/jetpack/functions.cookies.php
@@ -9,7 +9,7 @@
  */
 
 /**
- * A PHP 5.X compatible version of the array argument version of PHP 7.3's setcookie().
+ * A PHP 7.0 compatible version of the array argument version of PHP 7.3's setcookie().
  *
  * Useful for setting SameSite cookies in PHP 7.2 or earlier.
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In some code we attached comments referring to what we could do once PHP 5 support was dropped. That happened, so let's clean it up.

Left one instance in
`projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-test-base.php` because that looks like it will need more testing to make sure the called-for replacement functions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Everything should continue to work
