### PR TITLE
RNA: Fix ActionPopover CSS variables

### DIFF
--- a/projects/js-packages/components/changelog/update-rna-action-popover-theme-provider
+++ b/projects/js-packages/components/changelog/update-rna-action-popover-theme-provider
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RNA: Fix ActionPopover CSS variables

--- a/projects/js-packages/components/components/action-popover/index.tsx
+++ b/projects/js-packages/components/components/action-popover/index.tsx
@@ -10,6 +10,7 @@ import Text from '../text';
 /**
  * Internal dependencies
  */
+import ThemeProvider from '../theme-provider';
 import styles from './styles.module.scss';
 /**
  * Types
@@ -60,44 +61,46 @@ const ActionPopover = ( {
 
 	return (
 		<Popover { ...popoverProps }>
-			<div className={ styles.wrapper }>
-				<div className={ styles.header }>
-					<Text variant="title-small" className={ styles.title }>
-						{ title }
-					</Text>
-					{ ! hideCloseButton && (
-						<>
-							<Button
-								size="small"
-								variant="tertiary"
-								aria-label="close"
-								className={ styles[ 'close-button' ] }
-								icon={ close }
-								iconSize={ 16 }
-								onClick={ onClose }
-							/>
-						</>
-					) }
-				</div>
-				{ children }
-				<div className={ styles.footer }>
-					{ showSteps && (
-						<Text variant="body" className={ styles.steps }>
-							{ stepsText }
+			<ThemeProvider>
+				<div className={ styles.wrapper }>
+					<div className={ styles.header }>
+						<Text variant="title-small" className={ styles.title }>
+							{ title }
 						</Text>
-					) }
-					<Button
-						variant="primary"
-						className={ styles[ 'action-button' ] }
-						disabled={ buttonDisabled }
-						onClick={ onClick }
-						isExternalLink={ buttonExternalLink }
-						href={ buttonHref }
-					>
-						{ buttonContent }
-					</Button>
+						{ ! hideCloseButton && (
+							<>
+								<Button
+									size="small"
+									variant="tertiary"
+									aria-label="close"
+									className={ styles[ 'close-button' ] }
+									icon={ close }
+									iconSize={ 16 }
+									onClick={ onClose }
+								/>
+							</>
+						) }
+					</div>
+					{ children }
+					<div className={ styles.footer }>
+						{ showSteps && (
+							<Text variant="body" className={ styles.steps }>
+								{ stepsText }
+							</Text>
+						) }
+						<Button
+							variant="primary"
+							className={ styles[ 'action-button' ] }
+							disabled={ buttonDisabled }
+							onClick={ onClick }
+							isExternalLink={ buttonExternalLink }
+							href={ buttonHref }
+						>
+							{ buttonContent }
+						</Button>
+					</div>
 				</div>
-			</div>
+			</ThemeProvider>
 		</Popover>
 	);
 };

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.45.2",
+	"version": "0.45.3-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34225

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the ThemeProvider for the content of ActionPopover to fix all instances of this component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard of a site with no videos
* Upload one video
* Wait for the publish popover to be displayed
* Check that the styling is correct

| Before | After
| - | -
| ![2023-11-21_11-16-32](https://github.com/Automattic/jetpack/assets/8486249/e7f02566-008c-4a03-9079-74da2a23e633) | ![2023-11-21_11-16-40](https://github.com/Automattic/jetpack/assets/8486249/5c7df164-f029-4787-88f9-0cddd35973cd)
