### PR TITLE
Use spaceship operator in sorting functions

### DIFF
--- a/projects/packages/admin-ui/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/packages/admin-ui/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use spaceship operator in sorting callbacks. No change to functionality.
+
+

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.3.0",
+	"version": "0.3.1-alpha",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.3.0';
+	const PACKAGE_VERSION = '0.3.1-alpha';
 
 	/**
 	 * Whether this class has been initialized
@@ -104,7 +104,7 @@ class Admin_Menu {
 			function ( $a, $b ) {
 				$position_a = empty( $a['position'] ) ? 0 : $a['position'];
 				$position_b = empty( $b['position'] ) ? 0 : $b['position'];
-				$result     = $position_a - $position_b;
+				$result     = $position_a <=> $position_b;
 
 				if ( 0 === $result ) {
 					$result = strcmp( $a['menu_title'], $b['menu_title'] );

--- a/projects/packages/changelogger/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/packages/changelogger/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use spaceship operator in sorting callbacks. No change to functionality.
+
+

--- a/projects/packages/changelogger/lib/ChangeEntry.php
+++ b/projects/packages/changelogger/lib/ChangeEntry.php
@@ -193,9 +193,7 @@ class ChangeEntry implements JsonSerializable {
 	 * @return int
 	 */
 	protected static function compareTimestamp( ChangeEntry $a, ChangeEntry $b, array $config ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$aa = $a->getTimestamp();
-		$bb = $b->getTimestamp();
-		return $aa < $bb ? -1 : ( $aa > $bb ? 1 : 0 );
+		return $a->getTimestamp() <=> $b->getTimestamp();
 	}
 
 	/**

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.0.1';
+	const VERSION = '4.0.2-alpha';
 
 	/**
 	 * Constructor.

--- a/projects/packages/changelogger/src/Plugins/WordpressVersioning.php
+++ b/projects/packages/changelogger/src/Plugins/WordpressVersioning.php
@@ -193,11 +193,13 @@ class WordpressVersioning implements VersioningPlugin {
 	public function compareVersions( $a, $b ) {
 		$aa = $this->parseVersion( $a );
 		$bb = $this->parseVersion( $b );
-		if ( $aa['major'] !== $bb['major'] ) {
-			return $aa['major'] < $bb['major'] ? -1 : 1;
+
+		$ret = $aa['major'] <=> $bb['major'];
+		if ( ! $ret ) {
+			$ret = $aa['point'] <=> $bb['point'];
 		}
-		if ( $aa['point'] !== $bb['point'] ) {
-			return $aa['point'] - $bb['point'];
+		if ( $ret ) {
+			return $ret;
 		}
 
 		$avalues = $this->parsePrerelease( $aa['prerelease'] );
@@ -206,11 +208,11 @@ class WordpressVersioning implements VersioningPlugin {
 		$l = min( count( $avalues ), count( $bvalues ) );
 		for ( $i = 0; $i < $l; $i++ ) {
 			if ( $avalues[ $i ] !== $bvalues[ $i ] ) {
-				return $avalues[ $i ] - $bvalues[ $i ];
+				return $avalues[ $i ] <=> $bvalues[ $i ];
 			}
 		}
 
-		return count( $avalues ) - count( $bvalues );
+		return count( $avalues ) <=> count( $bvalues );
 	}
 
 	/**

--- a/projects/packages/changelogger/src/ValidateCommand.php
+++ b/projects/packages/changelogger/src/ValidateCommand.php
@@ -154,13 +154,14 @@ EOF
 			$messages,
 			function ( $a, $b ) {
 				// @codeCoverageIgnoreStart
-				if ( $a[2] !== $b[2] ) {
-					return $a[2] - $b[2];
+				$ret = $a[2] <=> $b[2];
+				if ( ! $ret ) {
+					$ret = strcmp( $a[0], $b[0] );
 				}
-				if ( $a[0] !== $b[0] ) {
-					return strcmp( $a[0], $b[0] );
+				if ( ! $ret ) {
+					$ret = strcmp( $a[1], $b[1] );
 				}
-				return strcmp( $a[1], $b[1] );
+				return $ret;
 				// @codeCoverageIgnoreEnd
 			}
 		);

--- a/projects/packages/changelogger/src/WriteCommand.php
+++ b/projects/packages/changelogger/src/WriteCommand.php
@@ -427,7 +427,7 @@ EOF
 				$ret = ChangeEntry::compare( $a, $b, $sortConfig );
 				if ( 0 === $ret ) {
 					// Stability.
-					$ret = array_search( $a, $changes, true ) - array_search( $b, $changes, true );
+					$ret = array_search( $a, $changes, true ) <=> array_search( $b, $changes, true );
 				}
 				return $ret;
 			}

--- a/projects/packages/changelogger/tests/php/tests/lib/ChangeEntryTest.php
+++ b/projects/packages/changelogger/tests/php/tests/lib/ChangeEntryTest.php
@@ -101,14 +101,12 @@ class ChangeEntryTest extends TestCase {
 	 * @param int         $expect Expected value.
 	 */
 	public function testCompare( ChangeEntry $a, ChangeEntry $b, array $config, $expect ) {
-		$ret = ChangeEntry::compare( $a, $b, $config );
 		// We only care about the sign of the return value.
-		$ret = $ret < 0 ? -1 : ( $ret > 0 ? 1 : 0 );
+		$ret = ChangeEntry::compare( $a, $b, $config ) <=> 0;
 		$this->assertSame( $expect, $ret );
 
-		$ret = ChangeEntry::compare( $b, $a, $config );
 		// We only care about the sign of the return value.
-		$ret = $ret < 0 ? -1 : ( $ret > 0 ? 1 : 0 );
+		$ret = ChangeEntry::compare( $b, $a, $config ) <=> 0;
 		$this->assertSame( -$expect, $ret );
 	}
 

--- a/projects/packages/forms/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/packages/forms/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use correct sorting function in `Admin::grunion_ajax_shortcode()`

--- a/projects/packages/forms/changelog/fix-use-spaceship-operator-in-sorting-functions#2
+++ b/projects/packages/forms/changelog/fix-use-spaceship-operator-in-sorting-functions#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use spaceship operator in sorting callbacks. No change to functionality.
+
+

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -935,7 +935,7 @@ class Admin {
 	 */
 	public function grunion_sort_objects( $a, $b ) {
 		if ( isset( $a['order'] ) && isset( $b['order'] ) ) {
-			return $a['order'] - $b['order'];
+			return $a['order'] <=> $b['order'];
 		}
 		return 0;
 	}
@@ -961,7 +961,7 @@ class Admin {
 
 		if ( isset( $_POST['fields'] ) && is_array( $_POST['fields'] ) ) {
 			$fields = sanitize_text_field( stripslashes_deep( $_POST['fields'] ) );
-			usort( $fields, 'grunion_sort_objects' );
+			usort( $fields, array( $this, 'grunion_sort_objects' ) );
 
 			$field_shortcodes = array();
 

--- a/projects/packages/identity-crisis/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/packages/identity-crisis/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use spaceship operator in sorting callbacks. No change to functionality.
+
+

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.12.0",
+	"version": "0.12.1-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.12.0';
+	const PACKAGE_VERSION = '0.12.1-alpha';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/identity-crisis/src/class-ui.php
+++ b/projects/packages/identity-crisis/src/class-ui.php
@@ -153,7 +153,7 @@ class UI {
 				$priority1 = ( array_key_exists( 'priority', $c1 ) && (int) $c1['priority'] ) ? (int) $c1['priority'] : 10;
 				$priority2 = ( array_key_exists( 'priority', $c2 ) && (int) $c2['priority'] ) ? (int) $c2['priority'] : 10;
 
-				return $priority1 > $priority2 ? 1 : -1;
+				return $priority1 <=> $priority2;
 			}
 		);
 

--- a/projects/plugins/jetpack/_inc/lib/widgets.php
+++ b/projects/plugins/jetpack/_inc/lib/widgets.php
@@ -643,13 +643,7 @@ class Jetpack_Widgets {
 	public static function sort_widgets( $a, $b ) {
 		$a_val = (int) self::get_widget_instance_key( $a['id'] );
 		$b_val = (int) self::get_widget_instance_key( $b['id'] );
-		if ( $a_val > $b_val ) {
-			return 1;
-		}
-		if ( $a_val < $b_val ) {
-			return -1;
-		}
-		return 0;
+		return $a_val <=> $b_val;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/plugins/jetpack/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Use spaceship operator in sorting callbacks. No change to functionality.
+
+

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -228,15 +228,7 @@ class Jetpack_Admin {
 	 * @return int Indicating the relative ordering of module1 and module2.
 	 */
 	public static function sort_requires_connection_last( $module1, $module2 ) {
-		if ( (bool) $module1['requires_connection'] === (bool) $module2['requires_connection'] ) {
-			return 0;
-		} elseif ( $module1['requires_connection'] ) {
-			return 1;
-		} elseif ( $module2['requires_connection'] ) {
-			return -1;
-		}
-
-		return 0;
+		return ( (bool) $module1['requires_connection'] ) <=> ( (bool) $module2['requires_connection'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4856,11 +4856,7 @@ endif;
 	 * @return int 0 if the same sort or (+/-) to indicate which is greater.
 	 */
 	public static function sort_modules( $a, $b ) {
-		if ( $a['sort'] === $b['sort'] ) {
-			return 0;
-		}
-
-		return ( $a['sort'] < $b['sort'] ) ? -1 : 1;
+		return $a['sort'] <=> $b['sort'];
 	}
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
@@ -85,25 +85,16 @@ class WPCOM_JSON_API_List_Roles_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$a_is_core_role  = in_array( $a->name, $core_role_names, true );
 		$b_is_core_role  = in_array( $b->name, $core_role_names, true );
 
-		// if $a is a core_role and $b is not, $a always comes first.
-		if ( $a_is_core_role && ! $b_is_core_role ) {
-			return -1;
-		}
-
-		// if $b is a core_role and $a is not, $b always comes first.
-		if ( $b_is_core_role && ! $a_is_core_role ) {
-			return 1;
+		// Core roles always come before non-core roles.
+		if ( $a_is_core_role !== $b_is_core_role ) {
+			return $b_is_core_role <=> $a_is_core_role;
 		}
 
 		// otherwise the one with the > number of capabilities comes first.
 		$a_cap_count = is_countable( $a->capabilities ) ? count( $a->capabilities ) : 0;
 		$b_cap_count = is_countable( $b->capabilities ) ? count( $b->capabilities ) : 0;
 
-		if ( $a_cap_count === $b_cap_count ) {
-			return 0;
-		}
-
-		return ( $a_cap_count > $b_cap_count ) ? -1 : 1;
+		return $b_cap_count <=> $a_cap_count;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/comments/base.php
+++ b/projects/plugins/jetpack/modules/comments/base.php
@@ -160,11 +160,7 @@ class Highlander_Comments_Base {
 	 * @return int
 	 */
 	public function sort_comments_by_comment_date_gmt( $a, $b ) {
-		if ( $a->comment_date_gmt === $b->comment_date_gmt ) {
-			return 0;
-		}
-
-		return $a->comment_date_gmt < $b->comment_date_gmt ? -1 : 1;
+		return $a->comment_date_gmt <=> $b->comment_date_gmt;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -558,7 +558,7 @@ function grunion_esc_attr( $attr ) {
  */
 function grunion_sort_objects( $a, $b ) {
 	if ( isset( $a['order'] ) && isset( $b['order'] ) ) {
-		return $a['order'] - $b['order'];
+		return $a['order'] <=> $b['order'];
 	}
 	return 0;
 }

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -474,7 +474,7 @@ class Jetpack_Plugin_Search {
 	 * @param array $m2 Array 2 to sort.
 	 */
 	private function by_sorting_option( $m1, $m2 ) {
-		return $m1['sort'] - $m2['sort'];
+		return $m1['sort'] <=> $m2['sort'];
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -696,7 +696,7 @@ class Sharing_Service_Total {
 	 * @param object $a Sharing_Service_Total object.
 	 * @param object $b Sharing_Service_Total object.
 	 *
-	 * @return bool
+	 * @return int -1, 0, or 1 if $a is <, =, or > $b
 	 */
 	public static function cmp( $a, $b ) {
 		if ( $a->total === $b->total ) {
@@ -757,7 +757,7 @@ class Sharing_Post_Total {
 	 * @param object $a Sharing_Post_Total object.
 	 * @param object $b Sharing_Post_Total object.
 	 *
-	 * @return bool
+	 * @return int -1, 0, or 1 if $a is <, =, or > $b
 	 */
 	public static function cmp( $a, $b ) {
 		if ( $a->total === $b->total ) {

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -700,9 +700,9 @@ class Sharing_Service_Total {
 	 */
 	public static function cmp( $a, $b ) {
 		if ( $a->total === $b->total ) {
-			return $a->name < $b->name;
+			return $b->name <=> $a->name;
 		}
-		return $a->total < $b->total;
+		return $b->total <=> $a->total;
 	}
 }
 
@@ -761,9 +761,9 @@ class Sharing_Post_Total {
 	 */
 	public static function cmp( $a, $b ) {
 		if ( $a->total === $b->total ) {
-			return $a->id < $b->id;
+			return $b->id <=> $a->id;
 		}
-		return $a->total < $b->total;
+		return $b->total <=> $a->total;
 	}
 }
 

--- a/projects/plugins/jetpack/modules/tiled-gallery/math/class-constrained-array-rounding.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/math/class-constrained-array-rounding.php
@@ -91,10 +91,7 @@ class Jetpack_Constrained_Array_Rounding {
 	 * @return int
 	 */
 	private static function cmp_desc_fraction( $a, $b ) {
-		if ( $a['fraction'] === $b['fraction'] ) {
-			return 0;
-		}
-		return $a['fraction'] > $b['fraction'] ? -1 : 1;
+		return $b['fraction'] <=> $a['fraction'];
 	}
 
 	/**
@@ -106,9 +103,6 @@ class Jetpack_Constrained_Array_Rounding {
 	 * @return int
 	 */
 	private static function cmp_asc_index( $a, $b ) {
-		if ( $a['index'] === $b['index'] ) {
-			return 0;
-		}
-		return $a['index'] < $b['index'] ? -1 : 1;
+		return $a['index'] <=> $b['index'];
 	}
 }

--- a/projects/plugins/protect/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/plugins/protect/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use spaceship operator in sorting callbacks. No change to functionality.
+
+

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -290,21 +290,14 @@ class Status {
 			$threats,
 			function ( $a, $b ) {
 				// sort primarily based on the presence of threats
-				if ( ! empty( $a->threats ) && empty( $b->threats ) ) {
-					return -1;
-				}
-				if ( empty( $a->threats ) && ! empty( $b->threats ) ) {
-					return 1;
-				}
+				$ret = empty( $a->threats ) <=> empty( $b->threats );
+
 				// sort secondarily on whether the item has been checked
-				if ( $a->checked && ! $b->checked ) {
-					return 1;
-				}
-				if ( ! $a->checked && $b->checked ) {
-					return -1;
+				if ( ! $ret ) {
+					$ret = $a->checked <=> $b->checked;
 				}
 
-				return 0;
+				return $ret;
 			}
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PHP 7 introduced the spaceship operator, `$a <=> $b`, which is basically equivalent to `$a < $b ? -1 : $a > $b ? 1 : 0`. It also won't do the wrong thing with floats like `$a - $b` might.

There's a difference versus `strcmp` in that `strcmp` will always cast arguments to strings while `<=>` will do PHP's normal type comparisons, so something like `strcmp( 1, 10 )` would be different from `1 <=> 10`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* All the things should still sort in the same orders.
