### PR TITLE
tools: Avoid empty changelog entries in releases

### DIFF
--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -174,7 +174,7 @@ for SLUG in "${TO_RELEASE[@]}"; do
 	# Avoid "There are no changes with content for this write. Proceed?" prompts and empty changelog entries.
 	ANY=false
 	for f in "$CHANGES_DIR"/*; do
-		if [[ -n $( sed -n '/^$/,$ { /[^ \t]/ p }' "$CHANGES_DIR"/* ) ]]; then
+		if [[ -n $( sed -n -e '/^$/,$ { /[^ \t]/ p }' "$f" ) ]]; then
 			ANY=true
 			break
 		fi

--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -172,7 +172,14 @@ for SLUG in "${TO_RELEASE[@]}"; do
 	RELEASED[$SLUG]=1
 
 	# Avoid "There are no changes with content for this write. Proceed?" prompts and empty changelog entries.
-	if [[ -z $( sed -sn '/^$/,$ { /[^ \t]/ p }' "$CHANGES_DIR"/* ) ]]; then
+	ANY=false
+	for f in "$CHANGES_DIR"/*; do
+		if [[ -n $( sed -n '/^$/,$ { /[^ \t]/ p }' "$CHANGES_DIR"/* ) ]]; then
+			ANY=true
+			break
+		fi
+	done
+	if ! $ANY; then
 		debug "  no changes with content, adding one"
 		changelogger_add 'Internal updates.' '' --filename=avoid-empty-changelog-entry
 	fi

--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -174,7 +174,7 @@ for SLUG in "${TO_RELEASE[@]}"; do
 	# Avoid "There are no changes with content for this write. Proceed?" prompts and empty changelog entries.
 	ANY=false
 	for f in "$CHANGES_DIR"/*; do
-		if [[ -n $( sed -n -e '/^$/,$ { /[^ \t]/ p }' "$f" ) ]]; then
+		if [[ -n $( sed -n -e '/^$/,$ { /[^ \t]/ p; }' "$f" ) ]]; then
 			ANY=true
 			break
 		fi

--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -171,6 +171,12 @@ for SLUG in "${TO_RELEASE[@]}"; do
 	info "Processing $SLUG..."
 	RELEASED[$SLUG]=1
 
+	# Avoid "There are no changes with content for this write. Proceed?" prompts and empty changelog entries.
+	if [[ -z $( sed -sn '/^$/,$ { /[^ \t]/ p }' "$CHANGES_DIR"/* ) ]]; then
+		debug "  no changes with content, adding one"
+		changelogger_add 'Internal updates.' '' --filename=avoid-empty-changelog-entry
+	fi
+
 	# Fetch old version from changelogger.
 	debug "  changelogger version current (for old version)"
 	if ! OLDVER=$( changelogger version current 2>/dev/null ); then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When `tools/changelogger-release.sh` is about to release a project, have it check for whether changelogger is going to prompt for "There are no changes with content for this write" and supply a change file with some content ("Internal updates") to both avoid the prompt and avoid the resulting empty entry in the changelog.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/34213#discussion_r1399722631

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out 6e2ed4566db621514afdcfbec595d927e38be3fa, cherry-pick this change, then run `tools/changelogger-release.sh plugins/jetpack`. There should be no prompts about "There are no changes with content for this write", and `git diff '**/CHANGELOG.md'` should not have any empty entries being added.