### PR TITLE
Contact Form: improve required label contrast

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-required-contrast
+++ b/projects/packages/forms/changelog/fix-contact-form-required-contrast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved Contact Form required label contrast

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -274,7 +274,7 @@
 	.required {
 		word-break: normal;
 		color: unset;
-		opacity: 0.45;
+		opacity: 0.6;
 		font-size: 85%;
 		margin-left: 0.25em;
 		font-weight: normal;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -125,11 +125,12 @@
 	gap: 12px;
 }
 
-.contact-form label span.required {
+.contact-form label span.required,
+.grunion-label-required {
 	font-size: 85%;
 	margin-left: 0.25em;
 	font-weight: normal;
-	opacity: 0.45;
+	opacity: 0.6;
 }
 
 .contact-form-submission {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/31203

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the editor, improve the contrast of the _required_ label in Contact forms to meet accessibility guidelines. In the front end, match the style of the editor.

Note: since the color of the labels depends on the theme, the `opacity` property is used to dim the _required_ text rather than `color`. For pure black (`#000000`), an opacity of `0.6` on a white background is equivalent to `#535353`. This results in a contrast ratio of 7.69:1, which meets the AA conformance level. This should be sufficient for most other colors.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test branch with this site
- Create a new post
- Add the Contact Form block
- Make sure a field is required
- Notice the color of _required_ is darker
- Visit the preview
- Notice the style of _required_ matches the editor

### Editor
| Before | After |
| - | - |
|<img width="174" alt="Screenshot 2023-11-21 at 2 49 20 PM" src="https://github.com/Automattic/jetpack/assets/1620183/4ac78892-5e8f-40f8-b75b-8350c404114b">|<img width="197" alt="Screenshot 2023-11-21 at 2 59 17 PM" src="https://github.com/Automattic/jetpack/assets/1620183/f4c6d1bf-5a40-4c5d-a1d4-ce4948371851">|

### Front End
| Before | After |
| - | - |
|<img width="195" alt="Screenshot 2023-11-21 at 2 49 28 PM" src="https://github.com/Automattic/jetpack/assets/1620183/d5d0f6b4-8121-47a0-b453-e2c622f11bf9">|<img width="174" alt="Screenshot 2023-11-21 at 3 00 28 PM" src="https://github.com/Automattic/jetpack/assets/1620183/6e9caf2d-d614-4527-9ad5-b689f0902f73">|


