### PR TITLE
My Jetpack: Trust next tier from Jetpack AI feature data

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-trust-next-tier-from-feature-data
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-trust-next-tier-from-feature-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Trust next tier provided by the Jetpack AI feature endpoint.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -98,20 +98,17 @@ class Jetpack_Ai extends Product {
 	 * @return int
 	 */
 	public static function get_next_usage_tier() {
-		$current_tier = self::get_current_usage_tier();
+		$info = self::get_ai_assistant_feature();
 
-		if ( null === $current_tier ) {
-			return 1;
-		}
-
-		// If the current tier is 1 or 500, there is no next tier.
-		if ( 1 === $current_tier || 500 === $current_tier ) {
+		// Bail early if it's not possible to fetch the feature data.
+		if ( is_wp_error( $info ) ) {
 			return null;
 		}
 
-		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-		// return $info['next-tier']['value'];
-		return 1; // Return the unlimited tier for now.
+		// Trust the next tier provided by the feature data.
+		$next_tier = isset( $info['next-tier']['value'] ) ? $info['next-tier']['value'] : null;
+
+		return $next_tier;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34232. Depends on D129607-code.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change `get_next_usage_tier` on My Jetpack `Jetpack AI` product class to trust the value provided by the backend, with no extra rules attached

**Note:** this is not adding support to the new tiers, 750 and 1000.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Depends on D129607-code; apply it to your sandbox and then sandbox the `public-api` domain
* Run this branch on your Jetpack testing site
* We are going to test 2 scenarios: tiered plans disabled and tiered plans enabled

### Tiered plans disabled

* On your sandbox, still with the D129607-code patch applied, make sure the `jetpack_ai_tier_plans_enabled` will return false:

```
add_filter( 'jetpack_ai_tier_plans_enabled', '__return_false' );
```

* Visit `/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai` on your testing site
* The expected behavior on this scenario is:
   * when the site is on the free plan, you should see the "unlimited plan" interstitial:

<img width="600" alt="Screenshot 2023-11-21 at 17 52 14" src="https://github.com/Automattic/jetpack/assets/6760046/7a8fdc43-c695-44f6-9909-17a9682b4ffe">

   * when the site is on the paid plan, they should see the "Contact Us" interstitial:

<img width="600" alt="Screenshot 2023-11-21 at 17 52 53" src="https://github.com/Automattic/jetpack/assets/6760046/6c7a6f13-6bd1-4f04-982c-00dfb0d7564f">

* To test both cases, change the `wp-content/lib/jetpack-ai/usage/helper.php` file to hardcode return values on the `get_tier_licensed_quantity` method:
   * 0 will get you the free plan
   * 1 will get you the unlimited plan

<img width="400" alt="Screenshot 2023-11-21 at 15 53 48" src="https://github.com/Automattic/jetpack/assets/6760046/3d1a2e0a-0227-49c1-934b-cff75844ac96">

---

### Tiered plans enabled

* On your sandbox, still with the D129607-code patch applied, make sure the `jetpack_ai_tier_plans_enabled` will return true:

```
add_filter( 'jetpack_ai_tier_plans_enabled', '__return_true' );
```

* Visit `/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai` on your testing site
* The expected behavior on this scenario is:
   * when the site is on the free plan, you should see the "100 requests" interstitial:

<img width="600" alt="Screenshot 2023-11-21 at 18 05 37" src="https://github.com/Automattic/jetpack/assets/6760046/b23ba128-eeaf-48d9-8608-47b511c5e82e">

   * when the site is on the 100 requests plan, you should see the "200 requests" interstitial:

<img width="600" alt="Screenshot 2023-11-21 at 18 06 33" src="https://github.com/Automattic/jetpack/assets/6760046/f7514b9a-11fa-453c-9c17-c22a8321eada">

   * when the site is on the 200 requests plan, you should see the "500 requests" interstitial:

<img width="600" alt="Screenshot 2023-11-21 at 18 14 22" src="https://github.com/Automattic/jetpack/assets/6760046/10d9ba3c-a05b-4380-bc45-7d19daa6dec6">

   * when the site is on the 500 requests plan, you should see the "750 requests" interstitial, but this is not supported by the code yet, so we can skip this scenario
   * when the site is on the 750 requests plan, you should see the "1000 requests" interstitial, but this is not supported by the code yet, so we can skip this scenario
   * when the site is on the 1000 requests plan, you should see the "Contact Us" interstitial, but this is not supported by the code yet, so we may need to skip this scenario and test it when the support for the new tiers is ready
* To test the cases, change the `wp-content/lib/jetpack-ai/usage/helper.php` file to hardcode return values on the `get_tier_licensed_quantity` method:
   * 0 will get you the free plan
   * 100, 200 and 500 will get you the respective tiered plans

<img width="400" alt="Screenshot 2023-11-21 at 18 21 16" src="https://github.com/Automattic/jetpack/assets/6760046/34f2c4d3-24f5-4007-a13f-207992bbd546">

---

* It's critical that the interstitial for the current plan structure (free + unlimited paid) is not broken since it's the one users will see for now