### PR TITLE
Add/prevent batcache when accessing paywalled content

### DIFF
--- a/projects/plugins/jetpack/changelog/add-prevent-batcache-when-accessing-paywalled-content
+++ b/projects/plugins/jetpack/changelog/add-prevent-batcache-when-accessing-paywalled-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Prevent caching paywalled content

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -605,7 +605,9 @@ class Jetpack_Memberships {
 
 		if ( $can_view_post && $post_access_level !== Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY ) {
 			// Prevent batcache to cache paywalled content
-			nocache_headers();
+			if ( headers_sent() === false ) {
+				nocache_headers();
+			}
 		}
 
 		self::$user_can_view_post_cache[ $cache_key ] = $can_view_post;

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -605,8 +605,8 @@ class Jetpack_Memberships {
 
 		if ( $can_view_post && $post_access_level !== Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY ) {
 			// Prevent batcache to cache paywalled content
-			if ( headers_sent() === false ) {
-				nocache_headers();
+			if ( function_exists( 'batcache_cancel' ) ) {
+				batcache_cancel();
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -603,6 +603,11 @@ class Jetpack_Memberships {
 
 		$can_view_post = $paywall->visitor_can_view_content( $all_newsletters_plan_ids, $post_access_level );
 
+		if ( $can_view_post && $post_access_level !== Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY ) {
+			// Prevent batcache to cache paywalled content
+			nocache_headers();
+		}
+
 		self::$user_can_view_post_cache[ $cache_key ] = $can_view_post;
 		return $can_view_post;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Send no-cache headers so batcache is disabled when user access a paywalled content

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Works only on Atomic (can't see batcache on simple)
* Deploy on your sandbox
* Sandbox your preferred site
* Create a paywalled content
* Access gated content and notice a batcache hit
* Access paywall and notice no cache header

