### PR TITLE
Launchpad: Add dynamic titles to task lists

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-dynamic-titles
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-dynamic-titles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add dynamic titles to task lists

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -49,7 +49,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.0.x-dev"
+			"dev-trunk": "5.1.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.0.1-alpha",
+	"version": "5.1.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.0.1-alpha';
+	const PACKAGE_VERSION = '5.1.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -829,4 +829,16 @@ class Launchpad_Task_Lists {
 	private function disable_fullscreen_launchpad() {
 		return update_option( 'launchpad_screen', 'off' );
 	}
+
+	/**
+	 * Gets the title for a task list.
+	 *
+	 * @param string $id Task list id.
+	 * @return string|null The title for the task list.
+	 */
+	public function get_task_list_title( $id ) {
+		$task_list = $this->get_task_list( $id );
+
+		return $this->load_value_from_callback( $task_list, 'get_title', null );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -26,7 +26,6 @@ require_once __DIR__ . '/launchpad-task-definitions.php';
 function wpcom_launchpad_get_task_list_definitions() {
 	$core_task_list_definitions = array(
 		'build'                  => array(
-			'title'               => 'Build',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -42,7 +41,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'free'                   => array(
-			'title'               => 'Free',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -59,7 +57,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'link-in-bio'            => array(
-			'title'               => 'Link In Bio',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -74,7 +71,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'link-in-bio-tld'        => array(
-			'title'               => 'Link In Bio',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -89,7 +85,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'newsletter'             => array(
-			'title'               => 'Newsletter',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -106,7 +101,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'videopress'             => array(
-			'title'               => 'Videopress',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -120,7 +114,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'write'                  => array(
-			'title'               => 'Write',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -135,7 +128,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'start-writing'          => array(
-			'title'               => 'Start Writing',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -150,7 +142,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'design-first'           => array(
-			'title'               => 'Pick a Design',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -166,7 +157,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'intent-build'           => array(
-			'title'               => 'Keep Building',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -184,7 +174,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),
 		'intent-write'           => array(
-			'title'               => 'Blog',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -199,7 +188,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_is_intent_write_enabled',
 		),
 		'intent-free-newsletter' => array(
-			'title'               => 'Free Newsletter',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -214,7 +202,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_is_free_newsletter_enabled',
 		),
 		'intent-paid-newsletter' => array(
-			'title'               => 'Paid Newsletter',
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -27,6 +27,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 	$core_task_list_definitions = array(
 		'build'                  => array(
 			'title'               => 'Build',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'verify_domain_email',
 				'setup_general',
@@ -40,6 +43,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'free'                   => array(
 			'title'               => 'Free',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'verify_domain_email',
 				'plan_selected',
@@ -54,6 +60,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'link-in-bio'            => array(
 			'title'               => 'Link In Bio',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'verify_domain_email',
 				'design_selected',
@@ -66,6 +75,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'link-in-bio-tld'        => array(
 			'title'               => 'Link In Bio',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'verify_domain_email',
 				'design_selected',
@@ -78,6 +90,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'newsletter'             => array(
 			'title'               => 'Newsletter',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'setup_newsletter',
 				'plan_selected',
@@ -92,6 +107,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'videopress'             => array(
 			'title'               => 'Videopress',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'verify_domain_email',
 				'videopress_setup',
@@ -103,6 +121,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'write'                  => array(
 			'title'               => 'Write',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'verify_domain_email',
 				'setup_write',
@@ -115,6 +136,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'start-writing'          => array(
 			'title'               => 'Start Writing',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'verify_domain_email',
 				'first_post_published',
@@ -127,6 +151,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'design-first'           => array(
 			'title'               => 'Pick a Design',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'verify_domain_email',
 				'design_completed',
@@ -140,6 +167,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'intent-build'           => array(
 			'title'               => 'Keep Building',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'site_title',
 				'domain_claim',
@@ -155,6 +185,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'intent-write'           => array(
 			'title'               => 'Blog',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'site_title',
 				'domain_claim',
@@ -167,6 +200,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'intent-free-newsletter' => array(
 			'title'               => 'Free Newsletter',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'verify_email',
 				'share_site',
@@ -179,6 +215,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'intent-paid-newsletter' => array(
 			'title'               => 'Paid Newsletter',
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
 			'task_ids'            => array(
 				'verify_email',
 				'share_site',
@@ -192,7 +231,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_is_paid_newsletter_enabled',
 		),
 		'earn'                   => array(
-			'title'               => 'Earn',
 			'task_ids'            => array(
 				'stripe_connected',
 				'paid_offer_created',
@@ -200,7 +238,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => '__return_true',
 		),
 		'host-site'              => array(
-			'title'               => 'Hosting Flow',
 			'task_ids'            => array(
 				'site_theme_selected',
 				'install_custom_plugin',
@@ -212,7 +249,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_is_hosting_flow_enabled',
 		),
 		'subscribers'            => array(
-			'title'    => 'Subscribers',
 			'task_ids' => array(
 				'import_subscribers',
 				'add_subscribe_block',
@@ -986,3 +1022,17 @@ function add_launchpad_options_to_jetpack_sync( $allowed_options ) {
 	return array_merge( $allowed_options, $launchpad_options );
 }
 add_filter( 'jetpack_sync_options_whitelist', 'add_launchpad_options_to_jetpack_sync', 10, 1 );
+
+/**
+ * Get the title of a checklist by its slug.
+ *
+ * @param string $checklist_slug The slug of the checklist.
+ * @return string The title of the checklist.
+ */
+function wpcom_get_launchpad_checklist_title_by_checklist_slug( $checklist_slug ) {
+	if ( ! $checklist_slug ) {
+		return array();
+	}
+
+	return wpcom_launchpad_checklists()->get_task_list_title( $checklist_slug );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -146,6 +146,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
 			'is_enabled'         => wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ),
 			'is_dismissed'       => wpcom_launchpad_is_task_list_dismissed( $checklist_slug ),
+			'title'              => wpcom_get_launchpad_checklist_title_by_checklist_slug( $checklist_slug ),
 		);
 	}
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-dynamic-titles
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-dynamic-titles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_1"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_2_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "54ac9586debec21e360ef29954771f8c02748af5"
+                "reference": "cbb946efa1ecb320a17984c6d9e993da75670110"
             },
             "require": {
                 "php": ">=7.0"
@@ -33,7 +33,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.0.x-dev"
+                    "dev-trunk": "5.1.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.1
+ * Version: 2.0.2-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.1",
+	"version": "2.0.2-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/83880

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The task list title is currently hardcoded on the CustomerHome launchpad component. Meaning that all the task lists has the same name across different intents.
* This PR adds the possibility of defining the title on the back end, which can give as more flexibility on the titles. 
* For now, this will only be used on the task lists displayed on the Customer Home.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox and make sure you are sandboxed
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-dynamic-titles
```
* Navigate to the Developer Console: https://developer.wordpress.com/docs/api/console/
* Make a `GET` request to `wpcom/v2 -> /sites/:siteSlug/launchpad?checklist_slug=:checklist_slug`, please test all the cases below to ensure we are returning the title to all use cases in the Customer Home. Verify that you see the `title` key as shown in the screenshot below.
  - `build`
  - `free`
  - `link-in-bio`
  - `link-in-bio-tld`
  - `newsletter`
  - `videopress`
  - `write`
  - `start-writing`
  - `design-first`
  - `intent-build`
  - `intent-write`
  - `intent-free-newsletter`
  - `intent-paid-newsletter`

<img width="999" alt="Screen Shot 2023-11-22 at 10 01 08" src="https://github.com/Automattic/jetpack/assets/1234758/3f7b3b6b-22d8-480c-b993-d4a38ed857b9">


