### PR TITLE
Subscribe modal: don't show modal again in another blog post after dismissing

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-site-wide
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-site-wide
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe modal: apply dismissal cookie domain wide

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -8,7 +8,7 @@ domReady( function () {
 	}
 
 	const close = document.getElementsByClassName( 'jetpack-subscribe-modal__close' )[ 0 ];
-	const modalDismissedCookie = 'jetpack_subscribe_modal_dismissed';
+	const modalDismissedCookie = 'jetpack_post_subscribe_modal_dismissed';
 	const hasModalDismissedCookie =
 		document.cookie && document.cookie.indexOf( modalDismissedCookie ) > -1;
 	let hasLoaded = false;
@@ -43,6 +43,6 @@ domReady( function () {
 	function setModalDismissedCookie() {
 		// Expires in 1 day
 		const expires = new Date( Date.now() + 86400 * 1000 ).toUTCString();
-		document.cookie = `${ modalDismissedCookie }=true; expires=${ expires };`;
+		document.cookie = `${ modalDismissedCookie }=true; expires=${ expires };path=/;`;
 	}
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/jetpack/issues/34138

Applies dismissal cookie domain wide, not post specific.

Stops subscribe modal from showing up again in another blog post after dismissing it in another.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Apply subscribe modal cookie site-wide, not to specific post only, by adding `path=/` to the cookie.
* Rename cookie to have "post" — this will make the cookie more specific, if we add the same modal later to comments, likes, etc.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have subscribe modal enabled from Newsletter settings
* Have two "open to everyone" blog posts

**Before**
* Visit first post as incognito, dismiss the modal

    <img width="781" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/694cd090-d692-46ad-80b8-3c78fd1b50bc">

* Then 2nd post, note that you still see the modal. Dismiss it.
* You should see two cookies with two paths:

   <img width="1094" alt="Screenshot 2023-11-22 at 15 13 28" src="https://github.com/Automattic/jetpack/assets/87168/4d16a255-6d00-43b8-8fc6-f0adaea12eba">


**After**
* Visit first post as incognito, dismiss the modal
* Then 2nd post, you shouldn't see the modal again.
* You should have just one cookie from both visits, with path set to `/`
