### PR TITLE
Form Block: prioritize form elements in form block inserter

### DIFF
--- a/projects/packages/forms/changelog/update-form-prioritize-form-innerblocks
+++ b/projects/packages/forms/changelog/update-form-prioritize-form-innerblocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms Block: prioritize the use of form elements in the block inserter inside form blocks.

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -60,6 +60,8 @@ const ALLOWED_BLOCKS = [
 	'core/video',
 ];
 
+const PRIORITIZED_INSERTER_BLOCKS = [ ...map( validFields, block => `jetpack/${ block.name }` ) ];
+
 const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
 const CUSTOMIZING_FORMS_URL = 'https://jetpack.com/support/jetpack-blocks/contact-form/';
 
@@ -343,7 +345,11 @@ export const JetpackContactFormEdit = forwardRef(
 				</InspectorControls>
 
 				<div className={ formClassnames } style={ style } ref={ ref }>
-					<InnerBlocks allowedBlocks={ ALLOWED_BLOCKS } templateInsertUpdatesSelection={ false } />
+					<InnerBlocks
+						allowedBlocks={ ALLOWED_BLOCKS }
+						prioritizedInserterBlocks={ PRIORITIZED_INSERTER_BLOCKS }
+						templateInsertUpdatesSelection={ false }
+					/>
 				</div>
 			</>
 		);


### PR DESCRIPTION
Fixes #31716

## Proposed changes:

When you're adding elements to an existing form added via the Form block, you're most  likely more interested in adding other form elements (although adding free text is also an option). With that in mind, it makes sense to prioritize listing other form elements in the block inserter, over core blocks:

**Before**

<img width="1077" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/4d0aaae3-09fc-494d-89d4-9544d6eef9a5">

**After**

<img width="994" alt="Screenshot 2023-11-22 at 14 37 36" src="https://github.com/Automattic/jetpack/assets/426388/b81eaf78-aeeb-41fb-a029-a7a5a2b14396">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Primary issue: #32865

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Posts > Add New
* Add a new Form block
* Once the block has been added to the page, click on the "+" icon inside the form to add additional elements to the form
    * You should see green Jetpack form elements in the inserter.
    * Clicking to browse all available elements should reveal Jetpack form elements as well as core blocks.
