### PR TITLE
Fix/paywall switch accounts link

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-paywall-switch-accounts-link
+++ b/projects/plugins/jetpack/changelog/fix-paywall-switch-accounts-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+fix paywall switch account on simple sites

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -993,9 +993,17 @@ function get_paywall_blocks( $newsletter_access_level ) {
 
 	$sign_in         = '';
 	$switch_accounts = '';
+	$sign_in_link    = add_query_arg(
+		array(
+			'site_id'      => intval( \Jetpack_Options::get_option( 'id' ) ),
+			'redirect_url' => rawurlencode( get_current_url() ),
+			'v2'           => '',
+		),
+		'https://subscribe.wordpress.com/memberships/jwt'
+	);
 	if ( is_user_auth() ) {
 		if ( ( new Host() )->is_wpcom_simple() ) {
-			$switch_accounts_link = wp_logout_url( get_current_url() );
+			$switch_accounts_link = wp_logout_url( $sign_in_link );
 			$switch_accounts      = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->
 <p class="has-text-align-center" style="font-size:14px"><a href="' . $switch_accounts_link . '">' . __( 'Switch Accounts', 'jetpack' ) . '</a></p>
 <!-- /wp:paragraph -->';
@@ -1005,15 +1013,6 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			// custom domain
 			$sign_in_link = wpcom_logmein_redirect_url( get_current_url(), false, null, 'link', get_current_blog_id() );
-		} else {
-			$sign_in_link = add_query_arg(
-				array(
-					'site_id'      => intval( \Jetpack_Options::get_option( 'id' ) ),
-					'redirect_url' => rawurlencode( get_current_url() ),
-					'v2'           => '',
-				),
-				'https://subscribe.wordpress.com/memberships/jwt'
-			);
 		}
 		$access_question = get_paywall_access_question( $newsletter_access_level );
 		$sign_in         = '<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}}} -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1700657592404529-slack-C052XEUUBL4

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix Switch Accounts link
<img width="674" alt="Screenshot 2023-11-22 at 11 22 13" src="https://github.com/Automattic/jetpack/assets/104869/2d7f6bdf-bf61-42cd-b3fc-fae5882605a4">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Patch your sandbox with this branch and sandbox a test site `bin/jetpack-downloader test jetpack fix/paywall-switch-accounts-link`
* On a simple site go to a paid only post as a free subscriber
* Test the Switch Accounts link

Follow up: improve https://subscribe.wordpress.com/memberships/jwt to not send the token if user is logged in to wpcom and it's a simple site.