### PR TITLE
Jetpack AI: Change text for upgrade button on Usage Panel depending on the tier

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-usage-panel-upgrade-button-text
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-usage-panel-upgrade-button-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Fix the Usage Panel upgrade button text to change depending on the next tier available. 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #34219.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the text of the upgrade button depending on the current and next tier available
* The rule is the following:
   - when the current tier is free, show "Upgrade"
   - when the current tier is 100, show "Get 200 requests"
   - when the current tier is 200, show "Get 500 requests"
   - when the current tier is 500, show "Get 750 requests"
   - when the current tier is 750, show "Get 1000 requests"
   - when the current tier is 1000 (the last tier), show "Get more requests"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Let's test it by dispatching actions on the local store, then checking the rendered UI

### The current tier is free

Action to dispatch:

```
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": false,
    "isOverLimit": false,
    "requestsCount": 15,
    "requestsLimit": 20,
    "requireUpgrade": false,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": null,
        "nextStart": null,
        "requestsCount": 15
    },
    "currentTier": {
        "value": 0,
	"limit": 20,
    },
    "nextTier": {
        "slug": "ai-assistant-tier-100",
        "limit": 100,
        "value": 100
    }
} );
```

Expected result:

<img width="250" alt="Screenshot 2023-11-22 at 11 28 50" src="https://github.com/Automattic/jetpack/assets/6760046/956023f9-47a0-44fa-b2d9-d37ed39ee70a">

### The current tier is 100

Action to dispatch:

```
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": true,
    "isOverLimit": false,
    "requestsCount": 15,
    "requestsLimit": 20,
    "requireUpgrade": false,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": "2023-12-01 00:00:00",
        "nextStart": "2023-12-01 00:00:00",
        "requestsCount": 15
    },
    "currentTier": {
        "slug": "ai-assistant-tier-100",
        "value": 100,
	"limit": 100,
    },
    "nextTier": {
        "slug": "ai-assistant-tier-200",
        "limit": 200,
        "value": 200
    }
} );
```

Expected result:

<img width="250" alt="Screenshot 2023-11-22 at 11 29 18" src="https://github.com/Automattic/jetpack/assets/6760046/e737187b-3d75-46b8-9c16-a7dae70a158a">

### The current tier is 200

Action to dispatch:

```
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": true,
    "isOverLimit": false,
    "requestsCount": 15,
    "requestsLimit": 20,
    "requireUpgrade": false,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": "2023-12-01 00:00:00",
        "nextStart": "2023-12-01 00:00:00",
        "requestsCount": 15
    },
    "currentTier": {
        "slug": "ai-assistant-tier-200",
        "value": 200,
	"limit": 200,
    },
    "nextTier": {
        "slug": "ai-assistant-tier-500",
        "limit": 500,
        "value": 500
    }
} );
```

Expected result:

<img width="250" alt="Screenshot 2023-11-22 at 11 30 00" src="https://github.com/Automattic/jetpack/assets/6760046/98ce5ab3-a4fe-449a-9a84-03a95f1d885c">

### The current tier is 500

Action to dispatch:

```
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": true,
    "isOverLimit": false,
    "requestsCount": 15,
    "requestsLimit": 20,
    "requireUpgrade": false,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": "2023-12-01 00:00:00",
        "nextStart": "2023-12-01 00:00:00",
        "requestsCount": 15
    },
    "currentTier": {
        "slug": "ai-assistant-tier-500",
        "value": 500,
	"limit": 500,
    },
    "nextTier": {
        "slug": "ai-assistant-tier-750",
        "limit": 750,
        "value": 750
    }
} );
```

Expected result:

<img width="250" alt="Screenshot 2023-11-22 at 11 26 58" src="https://github.com/Automattic/jetpack/assets/6760046/1584df2b-51ed-4a3d-8422-1e02d0e5cfb8">

### The current tier is 750

Action to dispatch:

```
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": true,
    "isOverLimit": false,
    "requestsCount": 15,
    "requestsLimit": 20,
    "requireUpgrade": false,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": "2023-12-01 00:00:00",
        "nextStart": "2023-12-01 00:00:00",
        "requestsCount": 15
    },
    "currentTier": {
        "slug": "ai-assistant-tier-750",
        "value": 750,
	"limit": 750,
    },
    "nextTier": {
        "slug": "ai-assistant-tier-1000",
        "limit": 1000,
        "value": 1000
    }
} );
```

Expected result:

<img width="250" alt="Screenshot 2023-11-22 at 11 27 33" src="https://github.com/Automattic/jetpack/assets/6760046/91e894e6-1422-42af-9659-102f2127adeb">

### The current tier is 1000

Action to dispatch:

```
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": true,
    "isOverLimit": false,
    "requestsCount": 15,
    "requestsLimit": 20,
    "requireUpgrade": false,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": "2023-12-01 00:00:00",
        "nextStart": "2023-12-01 00:00:00",
        "requestsCount": 15
    },
    "currentTier": {
        "slug": "ai-assistant-tier-1000",
        "value": 1000,
	"limit": 1000,
    },
    "nextTier": null
} );
```

Expected result:

<img width="250" alt="Screenshot 2023-11-22 at 11 28 01" src="https://github.com/Automattic/jetpack/assets/6760046/6039f82a-0095-4d74-9bee-4bd66798f0ef">

### The current tier is unlimited

Action to dispatch:

```
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": true,
    "isOverLimit": false,
    "requestsCount": 15,
    "requestsLimit": 20,
    "requireUpgrade": false,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": "2023-12-01 00:00:00",
        "nextStart": "2023-12-01 00:00:00",
        "requestsCount": 15
    },
    "currentTier": {
        "value": 1,
	"limit": 999999999,
    },
    "nextTier": null
} );
```

Expected result (no upgrade button):

<img width="250" alt="Screenshot 2023-11-22 at 11 31 16" src="https://github.com/Automattic/jetpack/assets/6760046/90d67f4e-2558-49d2-9236-4c1f4b341d3d">
