### PR TITLE
AI Assistant: tier plans upgrade nudge update

### DIFF
--- a/projects/plugins/jetpack/changelog/add-tier-plans-upgrade-nudge
+++ b/projects/plugins/jetpack/changelog/add-tier-plans-upgrade-nudge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adjust UpgradeNudge for tier plans

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -1,6 +1,7 @@
 /*
  * External dependencies
  */
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import React from 'react';
@@ -53,9 +54,7 @@ const DefaultUpgradePrompt = (): React.ReactNode => {
 
 	if ( tierPlansEnabled ) {
 		if ( ! nextTier ) {
-			const contactEmailAddress = 'support@jetpack.com';
-			const contactEmailSubject = encodeURIComponent( 'Jetpack AI - Inquiry about more requests' );
-			const href = `mailto:${ contactEmailAddress }?subject=${ contactEmailSubject }`;
+			const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
 			return (
 				<Nudge
 					buttonText={ __( 'Contact Us', 'jetpack' ) }
@@ -64,7 +63,7 @@ const DefaultUpgradePrompt = (): React.ReactNode => {
 						'jetpack'
 					) }
 					className={ 'jetpack-ai-upgrade-banner' }
-					checkoutUrl={ href }
+					checkoutUrl={ contactHref }
 					visible={ true }
 					align={ null }
 					title={ null }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -24,8 +24,7 @@ const DefaultUpgradePrompt = (): React.ReactNode => {
 	const canUpgrade = canUserPurchasePlan();
 
 	const tierPlansEnabled =
-		window?.Jetpack_Editor_Initial_State?.available_blocks[ 'ai-enable-tier-plans-ui' ] &&
-		window.Jetpack_Editor_Initial_State.available_blocks[ 'ai-enable-tier-plans-ui' ].available;
+		window?.Jetpack_Editor_Initial_State?.available_blocks[ 'ai-enable-tier-plans-ui' ]?.available;
 
 	const { nextTier } = useAiFeature();
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import React from 'react';
 /*
  * Internal dependencies
@@ -22,6 +22,12 @@ const DefaultUpgradePrompt = (): React.ReactNode => {
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
 	const canUpgrade = canUserPurchasePlan();
 
+	const tierPlansEnabled =
+		window?.Jetpack_Editor_Initial_State?.available_blocks[ 'ai-enable-tier-plans-ui' ] &&
+		window.Jetpack_Editor_Initial_State.available_blocks[ 'ai-enable-tier-plans-ui' ].available;
+
+	const { nextTier } = useAiFeature();
+
 	if ( ! canUpgrade ) {
 		return (
 			<Nudge
@@ -39,6 +45,60 @@ const DefaultUpgradePrompt = (): React.ReactNode => {
 				) }
 				visible={ true }
 				align={ null }
+				title={ null }
+				context={ null }
+			/>
+		);
+	}
+
+	if ( tierPlansEnabled ) {
+		if ( ! nextTier ) {
+			const contactEmailAddress = 'support@jetpack.com';
+			const contactEmailSubject = encodeURIComponent( 'Jetpack AI - Inquiry about more requests' );
+			const href = `mailto:${ contactEmailAddress }?subject=${ contactEmailSubject }`;
+			return (
+				<Nudge
+					buttonText={ __( 'Contact Us', 'jetpack' ) }
+					description={ __(
+						'You have reached the request limit for your current plan.',
+						'jetpack'
+					) }
+					className={ 'jetpack-ai-upgrade-banner' }
+					checkoutUrl={ href }
+					visible={ true }
+					align={ null }
+					title={ null }
+					context={ null }
+				/>
+			);
+		}
+		return (
+			<Nudge
+				buttonText={ sprintf(
+					/* Translators: number of requests */
+					__( 'Upgrade to %d requests', 'jetpack' ),
+					nextTier.limit
+				) }
+				checkoutUrl={ checkoutUrl }
+				className={ 'jetpack-ai-upgrade-banner' }
+				description={ createInterpolateElement(
+					sprintf(
+						/* Translators: number of requests */
+						__(
+							'You have reached the requests limit for your current plan.<br /><strong>Upgrade now to increase your requests limit to %d.</strong>',
+							'jetpack'
+						),
+						nextTier.limit
+					),
+					{
+						br: <br />,
+						strong: <strong />,
+					}
+				) }
+				goToCheckoutPage={ autosaveAndRedirect }
+				isRedirecting={ isRedirecting }
+				visible={ true }
+				align={ 'center' }
 				title={ null }
 				context={ null }
 			/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -17,8 +17,7 @@ export default function useAICheckout(): {
 	isRedirecting: boolean;
 } {
 	const tierPlansEnabled =
-		window?.Jetpack_Editor_Initial_State?.available_blocks[ 'ai-enable-tier-plans-ui' ] &&
-		window.Jetpack_Editor_Initial_State.available_blocks[ 'ai-enable-tier-plans-ui' ].available;
+		window?.Jetpack_Editor_Initial_State?.available_blocks[ 'ai-enable-tier-plans-ui' ]?.available;
 
 	const { nextTier } = useAiFeature();
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -8,6 +8,7 @@ import {
 	getSiteFragment,
 } from '@automattic/jetpack-shared-extension-utils';
 import useAutosaveAndRedirect from '../../../../shared/use-autosave-and-redirect';
+import useAiFeature from '../use-ai-feature';
 
 export default function useAICheckout(): {
 	checkoutUrl: string;
@@ -15,9 +16,21 @@ export default function useAICheckout(): {
 	autosaveAndRedirect: ( event: any ) => void;
 	isRedirecting: boolean;
 } {
-	const wpcomCheckoutUrl = getRedirectUrl( 'jetpack-ai-monthly-plan-ai-assistant-block-banner', {
-		site: getSiteFragment(),
-	} );
+	const tierPlansEnabled =
+		window?.Jetpack_Editor_Initial_State?.available_blocks[ 'ai-enable-tier-plans-ui' ] &&
+		window.Jetpack_Editor_Initial_State.available_blocks[ 'ai-enable-tier-plans-ui' ].available;
+
+	const { nextTier } = useAiFeature();
+
+	const wpcomCheckoutUrl = tierPlansEnabled
+		? getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
+				site: getSiteFragment(),
+				path: `jetpack_ai_yearly:-q-${ nextTier?.limit }`,
+				query: `redirect_to=${ window.location.href }`,
+		  } )
+		: getRedirectUrl( 'jetpack-ai-monthly-plan-ai-assistant-block-banner', {
+				site: getSiteFragment(),
+		  } );
 
 	const checkoutUrl =
 		isAtomicSite() || isSimpleSite()


### PR DESCRIPTION
Adjust UpgradeNudge for tier plans usage

Fixes #33361

## Proposed changes:
This PR adds the tier plans flag to conditionally compose UpgradeNudge component accordingly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Work against the sandbox, it's easier to mock situations. Checkout D126642-code (maybe rebase it locally on your sandbox to make sure it works). Follow instructions on the diff, make sure you sandbox the store and API as well.

Enable tier plans on both local and sandbox: `add_filter( 'jetpack_ai_tier_plans_enabled', '__return_true' );`

Go to the editor. Dispatch the action to force the UpgradeNudge (see it both on the AI assistant prompt and in the excerpt (beta) inspector).
```js
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": false,
    "isOverLimit": false,
    "requestsCount": 15,
    "requestsLimit": 20,
    "requireUpgrade": true,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": null,
        "nextStart": null,
        "requestsCount": 15
    },
    "currentTier": {
        "value": 0,
	"limit": 20,
    },
    "nextTier": {
        "slug": "ai-assistant-tier-100",
        "limit": 100,
        "value": 100
    }
} );
```
Change `nextTier.limit` to see the UpgradeNudge changes on the UI. If you have sandboxed properly, you should be able to checkout the suggested tier.

Change `nextTier` to `null` to see the contact suggestion. See that the mailto link functions properly.

If you disable the tier plans filter, you should be back at the regular usage of the nudge and checkouts.
