### PR TITLE
Clean up output from various tests

### DIFF
--- a/projects/packages/blaze/changelog/fix-unnecessary-test-outputs
+++ b/projects/packages/blaze/changelog/fix-unnecessary-test-outputs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Avoid output in test. No change to the package itself.
+
+

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -146,14 +146,14 @@ class Test_Blaze extends BaseTestCase {
 		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
 
 		// Ensure that no menu is added by default.
-		$this->assertEmpty( menu_page_url( 'advertising' ) );
+		$this->assertEmpty( menu_page_url( 'advertising', false ) );
 
 		wp_set_current_user( $this->admin_id );
 
 		add_filter( 'jetpack_blaze_enabled', '__return_true' );
 
 		Blaze::enable_blaze_menu();
-		$this->assertNotEmpty( menu_page_url( 'advertising' ) );
+		$this->assertNotEmpty( menu_page_url( 'advertising', false ) );
 
 		add_filter( 'jetpack_blaze_enabled', '__return_false' );
 	}

--- a/projects/packages/connection/changelog/fix-unnecessary-test-outputs
+++ b/projects/packages/connection/changelog/fix-unnecessary-test-outputs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Avoid `error_log` output in `Test_Server_Sandbox`. No change to the package itself.
+
+

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.0.2';
+	const PACKAGE_VERSION = '2.0.3-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/tests/.phpcs.dir.xml
+++ b/projects/packages/connection/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/connection/tests/php/test_Server_Sandbox.php
+++ b/projects/packages/connection/tests/php/test_Server_Sandbox.php
@@ -141,7 +141,12 @@ class Test_Server_Sandbox extends BaseTestCase {
 		Constants::set_constant( 'JETPACK__SANDBOX_DOMAIN', $sandbox_constant );
 		$headers = array();
 
-		( new Server_Sandbox() )->server_sandbox( $url, $headers );
+		ini_set( 'error_log', '/dev/null' );
+		try {
+			( new Server_Sandbox() )->server_sandbox( $url, $headers );
+		} finally {
+			ini_restore( 'error_log' );
+		}
 
 		$this->assertSame( $expected_url, $url );
 		$this->assertSame( $expected_headers, $headers );
@@ -205,7 +210,12 @@ class Test_Server_Sandbox extends BaseTestCase {
 			add_filter( 'jetpack_sandbox_add_profile_parameter', '__return_true' );
 		}
 
-		( new Server_Sandbox() )->server_sandbox( $url, $headers, $body, $method );
+		ini_set( 'error_log', '/dev/null' );
+		try {
+			( new Server_Sandbox() )->server_sandbox( $url, $headers, $body, $method );
+		} finally {
+			ini_restore( 'error_log' );
+		}
 
 		$this->assertSame( $expected_url, $url );
 

--- a/projects/packages/forms/changelog/fix-unnecessary-test-outputs
+++ b/projects/packages/forms/changelog/fix-unnecessary-test-outputs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Avoid actually trying to send mail during tests. No change to the package itself.
+
+

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -66,6 +66,9 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 * @before
 	 */
 	public function set_up_test_case() {
+		// Avoid actually trying to send any mail.
+		add_filter( 'pre_wp_mail', '__return_true', PHP_INT_MAX );
+
 		$this->set_globals();
 
 		$author_id = wp_insert_user(

--- a/projects/plugins/jetpack/changelog/fix-unnecessary-test-outputs
+++ b/projects/plugins/jetpack/changelog/fix-unnecessary-test-outputs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Expect output in `WP_Test_Jetpack_Sync_Sender` test instead of letting it go to the console. No change to the plugin itself.
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -682,6 +682,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	 */
 	public function test_do_dedicated_sync_and_exit_will_not_re_spawn_dedicated_sync_request_with_empty_queue() {
 		$this->expectException( ExitException::class );
+		$this->expectOutputString( Dedicated_Sender::DEDICATED_SYNC_VALIDATION_STRING );
 
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
 		self::factory()->post->create();
@@ -702,6 +703,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	 */
 	public function test_do_dedicated_sync_and_exit_will_not_re_spawn_dedicated_sync_request_with_locked_queue() {
 		$this->expectException( ExitException::class );
+		$this->expectOutputString( Dedicated_Sender::DEDICATED_SYNC_VALIDATION_STRING );
 
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
 		$this->sender->get_sync_queue()->lock( 0 );
@@ -723,6 +725,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	 */
 	public function test_do_dedicated_sync_and_exit_will_re_spawn_dedicated_sync_request() {
 		$this->expectException( ExitException::class );
+		$this->expectOutputString( Dedicated_Sender::DEDICATED_SYNC_VALIDATION_STRING );
 
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
 		// Process one action at each run.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Tests shouldn't produce extraneous output to the console, but some of ours were.

* packages/blaze: Prints URLs due to not passing `false` for the `$display` parameter to `menu_page_url()`.
* packages/connection: `error_log()` output, which we can redirect to /dev/null.
* packages/forms: In CI it prints a bunch of "sh: 1: /usr/sbin/sendmail: not found", while locally it doesn't because that exists and it **actually sends mail** (to an example.com address, at least, which has no MX and so is undeliverable). The 'pre_wp_mail' filter easily prevents the sending of mail.
* plugins/jetpack: Output from sync, which we can expect as part of the test.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the logs for these tests. Should be no more extraneous output.
  * [x] packages/blaze: [trunk](https://github.com/Automattic/jetpack/actions/runs/6960387572/job/18939766663#step:9:1128) → [pr](https://github.com/Automattic/jetpack/actions/runs/6960749555/job/18940894129?pr=34256#step:9:578)
  * [x] packages/connection: [trunk](https://github.com/Automattic/jetpack/actions/runs/6960387572/job/18939766663#step:9:2132) → [pr](https://github.com/Automattic/jetpack/actions/runs/6960749555/job/18940894129?pr=34256#step:9:722)
  * [x] packages/forms: [trunk](https://github.com/Automattic/jetpack/actions/runs/6960387572/job/18939766663#step:9:2588) → [pr](https://github.com/Automattic/jetpack/actions/runs/6960749555/job/18940894129?pr=34256#step:9:857)
  * [x] plugins/jetpack: [trunk](https://github.com/Automattic/jetpack/actions/runs/6960387572/job/18939766663#step:9:6826) → [pr](https://github.com/Automattic/jetpack/actions/runs/6960749555/job/18940894129?pr=34256#step:9:3098)