### PR TITLE
Revert "Jetpack: Re-add a WPCS v2 ignore (#33150)"

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-wpcs-v2-ignore
+++ b/projects/plugins/jetpack/changelog/remove-wpcs-v2-ignore
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Remove `phpcs:ignore` comment that was added because wpcom was still on v2 now that they've updated. No code changes.
+
+

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -840,7 +840,6 @@ EOT;
 			$extra_css = '';
 		}
 		// phpcs:disable WordPress.Security.EscapeOutput.HeredocOutputNotEscaped -- Escaped above where needed.
-		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- wpcom repo still uses WPCS v2, which uses a different code.
 		echo <<<EOT
 <style type="text/css">
 	#settings-reading-relatedposts .disabled { opacity:.5; filter:Alpha(opacity=50); }
@@ -910,7 +909,6 @@ EOT;
 	});
 </script>
 EOT;
-		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 		// phpcs:enable WordPress.Security.EscapeOutput.HeredocOutputNotEscaped
 	}
 
@@ -1974,9 +1972,7 @@ EOT;
 	 * Render AMP's reader mode CSS.
 	 */
 	public function render_amp_reader_mode_css() {
-		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- this is loading a CSS file.
-		echo file_get_contents( __DIR__ . '/related-posts.css' );
-		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		echo file_get_contents( __DIR__ . '/related-posts.css' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- this is loading a CSS file.
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Now that wpcom has updated to WPCS v3, we can remove this extra ignore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Related: p7H4VZ-4FG-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I suppose the thing to do would be to check this out on a sandbox and run wpcom's linting.