### PR TITLE
Promote subscription: Add verbum_subscription_modal setting

### DIFF
--- a/projects/packages/sync/changelog/add-verbum-subscription-modal-settings
+++ b/projects/packages/sync/changelog/add-verbum-subscription-modal-settings
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add verbum_subscription_modal setting to manage subscription modal show/hide on Verbum
+Add jetpack_verbum_subscription_modal setting to manage subscription modal show/hide on Verbum

--- a/projects/packages/sync/changelog/add-verbum-subscription-modal-settings
+++ b/projects/packages/sync/changelog/add-verbum-subscription-modal-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add verbum_subscription_modal setting to manage subscription modal show/hide on Verbum

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.0.x-dev"
+			"dev-trunk": "2.1.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -189,6 +189,7 @@ class Defaults {
 		'wpcom_reader_views_enabled',
 		'wpcom_site_setup',
 		'wpcom_subscription_emails_use_excerpt',
+		'verbum_subscription_modal',
 	);
 
 	/**

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -189,7 +189,7 @@ class Defaults {
 		'wpcom_reader_views_enabled',
 		'wpcom_site_setup',
 		'wpcom_subscription_emails_use_excerpt',
-		'verbum_subscription_modal',
+		'jetpack_verbum_subscription_modal',
 	);
 
 	/**

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.0.2';
+	const PACKAGE_VERSION = '2.1.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/backup/changelog/add-verbum-subscription-modal-settings
+++ b/projects/plugins/backup/changelog/add-verbum-subscription-modal-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1347,7 +1347,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "f60145457cce4014db663ff9ef9963be0decab06"
+                "reference": "3f6f169a99069651197b86e530b80fd96333d2c4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1379,7 +1379,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-verbum-subscription-modal-settings
+++ b/projects/plugins/jetpack/changelog/add-verbum-subscription-modal-settings
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Add verbum_subscription_modal setting to manage subscription modal show/hide on Verbum
+Add jetpack_verbum_subscription_modal setting to manage subscription modal show/hide on Verbum

--- a/projects/plugins/jetpack/changelog/add-verbum-subscription-modal-settings
+++ b/projects/plugins/jetpack/changelog/add-verbum-subscription-modal-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add verbum_subscription_modal setting to manage subscription modal show/hide on Verbum

--- a/projects/plugins/jetpack/changelog/add-verbum-subscription-modal-settings#2
+++ b/projects/plugins/jetpack/changelog/add-verbum-subscription-modal-settings#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2461,7 +2461,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "f60145457cce4014db663ff9ef9963be0decab06"
+                "reference": "3f6f169a99069651197b86e530b80fd96333d2c4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2493,7 +2493,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -456,7 +456,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'page_on_front'                    => (string) get_option( 'page_on_front' ),
 						'page_for_posts'                   => (string) get_option( 'page_for_posts' ),
 						'subscription_options'             => (array) get_option( 'subscription_options' ),
-						'verbum_subscription_modal'        => (bool) get_option( 'verbum_subscription_modal', true ),
+						'jetpack_verbum_subscription_modal' => (bool) get_option( 'jetpack_verbum_subscription_modal', true ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -748,7 +748,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'jetpack_portfolio':
 				case 'jetpack_comment_likes_enabled':
 				case 'wpcom_reader_views_enabled':
-				case 'verbum_subscription_modal':
+				case 'jetpack_verbum_subscription_modal':
 					// settings are stored as 1|0.
 					$coerce_value = (int) $value;
 					if ( update_option( $key, $coerce_value ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -456,6 +456,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'page_on_front'                    => (string) get_option( 'page_on_front' ),
 						'page_for_posts'                   => (string) get_option( 'page_for_posts' ),
 						'subscription_options'             => (array) get_option( 'subscription_options' ),
+						'verbum_subscription_modal'        => (bool) get_option( 'verbum_subscription_modal', true ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -976,6 +977,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'wpcom_publish_posts_with_markdown':
 				case 'wpcom_publish_comments_with_markdown':
+				case 'verbum_subscription_modal':
 					$coerce_value = (bool) $value;
 					if ( update_option( $key, $coerce_value ) ) {
 						$updated[ $key ] = $coerce_value;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -748,6 +748,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'jetpack_portfolio':
 				case 'jetpack_comment_likes_enabled':
 				case 'wpcom_reader_views_enabled':
+				case 'verbum_subscription_modal':
 					// settings are stored as 1|0.
 					$coerce_value = (int) $value;
 					if ( update_option( $key, $coerce_value ) ) {
@@ -977,7 +978,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'wpcom_publish_posts_with_markdown':
 				case 'wpcom_publish_comments_with_markdown':
-				case 'verbum_subscription_modal':
 					$coerce_value = (bool) $value;
 					if ( update_option( $key, $coerce_value ) ) {
 						$updated[ $key ] = $coerce_value;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -127,7 +127,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'page_on_front'                           => '(string) The page ID of the page to use as the site\'s homepage. It will apply only if \'show_on_front\' is set to \'page\'.',
 			'page_for_posts'                          => '(string) The page ID of the page to use as the site\'s posts page. It will apply only if \'show_on_front\' is set to \'page\'.',
 			'subscription_options'                    => '(array) Array of three options used in subscription email templates: \'invitation\', \'welcome\' and \'comment_follow\' strings.',
-			'verbum_subscription_modal'               => '(bool) Whether Subscription modal is enabled in Verbum comments',
+			'jetpack_verbum_subscription_modal'       => '(bool) Whether Subscription modal is enabled in Verbum comments',
 		),
 
 		'response_format' => array(

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -127,6 +127,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'page_on_front'                           => '(string) The page ID of the page to use as the site\'s homepage. It will apply only if \'show_on_front\' is set to \'page\'.',
 			'page_for_posts'                          => '(string) The page ID of the page to use as the site\'s posts page. It will apply only if \'show_on_front\' is set to \'page\'.',
 			'subscription_options'                    => '(array) Array of three options used in subscription email templates: \'invitation\', \'welcome\' and \'comment_follow\' strings.',
+			'verbum_subscription_modal'               => '(bool) Whether Subscription modal is enabled in Verbum comments',
 		),
 
 		'response_format' => array(

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -241,7 +241,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_locked_mode'                            => false,
 			'wpcom_reader_views_enabled'                   => true,
 			'wpcom_site_setup'                             => '',
-			'verbum_subscription_modal'                    => true,
+			'jetpack_verbum_subscription_modal'            => true,
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -241,6 +241,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_locked_mode'                            => false,
 			'wpcom_reader_views_enabled'                   => true,
 			'wpcom_site_setup'                             => '',
+			'verbum_subscription_modal'                    => true,
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/projects/plugins/migration/changelog/add-verbum-subscription-modal-settings
+++ b/projects/plugins/migration/changelog/add-verbum-subscription-modal-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1347,7 +1347,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "f60145457cce4014db663ff9ef9963be0decab06"
+                "reference": "3f6f169a99069651197b86e530b80fd96333d2c4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1379,7 +1379,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/add-verbum-subscription-modal-settings
+++ b/projects/plugins/protect/changelog/add-verbum-subscription-modal-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1261,7 +1261,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "f60145457cce4014db663ff9ef9963be0decab06"
+                "reference": "3f6f169a99069651197b86e530b80fd96333d2c4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1293,7 +1293,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-verbum-subscription-modal-settings
+++ b/projects/plugins/search/changelog/add-verbum-subscription-modal-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1407,7 +1407,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "f60145457cce4014db663ff9ef9963be0decab06"
+                "reference": "3f6f169a99069651197b86e530b80fd96333d2c4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1439,7 +1439,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-verbum-subscription-modal-settings
+++ b/projects/plugins/social/changelog/add-verbum-subscription-modal-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1338,7 +1338,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "f60145457cce4014db663ff9ef9963be0decab06"
+                "reference": "3f6f169a99069651197b86e530b80fd96333d2c4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1370,7 +1370,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/add-verbum-subscription-modal-settings
+++ b/projects/plugins/starter-plugin/changelog/add-verbum-subscription-modal-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1261,7 +1261,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "f60145457cce4014db663ff9ef9963be0decab06"
+                "reference": "3f6f169a99069651197b86e530b80fd96333d2c4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1293,7 +1293,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/add-verbum-subscription-modal-settings
+++ b/projects/plugins/videopress/changelog/add-verbum-subscription-modal-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -59,6 +59,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_7"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_8_alpha"
 	}
 }

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1261,7 +1261,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "f60145457cce4014db663ff9ef9963be0decab06"
+                "reference": "3f6f169a99069651197b86e530b80fd96333d2c4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1293,7 +1293,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VideoPress
  * Plugin URI: https://wordpress.org/plugins/jetpack-videopress
  * Description: High quality, ad-free video.
- * Version: 1.7
+ * Version: 1.8-alpha
  * Author: Automattic - Jetpack Video team
  * Author URI: https://jetpack.com/videopress/
  * License: GPLv2 or later


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/verbum/issues/34

## Proposed changes:
* Add an option to enable/disable the subscription modal on Verbum.

PT: pb5gDS-3tB-p2
Calypso PR: https://github.com/Automattic/wp-calypso/pull/84448

We will add this to the `comments` section of `/settings/discussion/`
![image](https://github.com/Automattic/jetpack/assets/402286/53910819-46a2-4656-af31-46efa36dc274)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Calypso
Use this PR: https://github.com/Automattic/wp-calypso/pull/84448

### Developer console
* Follow the instructions of the first comment to apply on your sandbox
* Go to https://developer.wordpress.com/docs/api/console/
* Choose WPCOM API / v1.4 / GET
* Use this URL: `/sites/YOUR_SIMPLE_SITE_BLOG_ID/settings`
* Check for `verbum_subscription_modal`
