### PR TITLE
My Jetpack: Remove hardcoded tiers from Jetpack AI interstitial

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -276,9 +276,9 @@ export function JetpackAIInterstitial() {
 	const { detail } = useProduct( slug );
 	const { onClickGoBack } = useGoBack( { slug } );
 
-	const nextTier = detail?.[ 'ai-assistant-feature' ]?.[ 'next-tier' ]?.value;
+	const nextTier = detail?.[ 'ai-assistant-feature' ]?.[ 'next-tier' ] || null;
 
-	if ( nextTier == null ) {
+	if ( ! nextTier ) {
 		return <JetpackAIInterstitialMoreRequests onClickGoBack={ onClickGoBack } />;
 	}
 
@@ -292,7 +292,7 @@ export function JetpackAIInterstitial() {
 			imageContainerClassName={ styles.aiImageContainer }
 			ctaButtonLabel={ ctaLabel }
 			hideTOS={ true }
-			quantity={ nextTier }
+			quantity={ nextTier.value }
 			directCheckout={ hasRequiredPlan }
 		>
 			<img src={ jetpackAiImage } alt="Jetpack AI" />

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -276,12 +276,9 @@ export function JetpackAIInterstitial() {
 	const { detail } = useProduct( slug );
 	const { onClickGoBack } = useGoBack( { slug } );
 
-	const currentTier = detail?.[ 'ai-assistant-feature' ]?.[ 'current-tier' ]?.value;
 	const nextTier = detail?.[ 'ai-assistant-feature' ]?.[ 'next-tier' ]?.value;
-	const hasNextTier = !! nextTier && ! [ 1, 500 ].includes( currentTier );
-	const quantity = hasNextTier ? nextTier : null;
 
-	if ( ! hasNextTier ) {
+	if ( nextTier == null ) {
 		return <JetpackAIInterstitialMoreRequests onClickGoBack={ onClickGoBack } />;
 	}
 
@@ -295,7 +292,7 @@ export function JetpackAIInterstitial() {
 			imageContainerClassName={ styles.aiImageContainer }
 			ctaButtonLabel={ ctaLabel }
 			hideTOS={ true }
-			quantity={ quantity }
+			quantity={ nextTier }
 			directCheckout={ hasRequiredPlan }
 		>
 			<img src={ jetpackAiImage } alt="Jetpack AI" />

--- a/projects/packages/my-jetpack/changelog/update-ai-assistant-remove-hardcoded-tiers
+++ b/projects/packages/my-jetpack/changelog/update-ai-assistant-remove-hardcoded-tiers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Remove hardcoded tiers from Jetpack AI interstitial

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -127,14 +127,13 @@ class Jetpack_Ai extends Product {
 	 * @return string
 	 */
 	public static function get_long_description_by_usage_tier( $tier ) {
-		$long_descriptions = array(
+		$long_descriptions  = array(
 			1   => __( 'Jetpack AI Assistant brings the power of AI right into your WordPress editor, letting your content creation soar to new heights.', 'jetpack-my-jetpack' ),
 			100 => __( 'The most advanced AI technology Jetpack has to offer.', 'jetpack-my-jetpack' ),
-			200 => __( 'Upgrade and increase the amount of your available monthly requests to continue using the most advanced AI technology Jetpack has to offer.', 'jetpack-my-jetpack' ),
-			500 => __( 'Upgrade and increase the amount of your available monthly requests to continue using the most advanced AI technology Jetpack has to offer.', 'jetpack-my-jetpack' ),
 		);
+		$tiered_description = __( 'Upgrade and increase the amount of your available monthly requests to continue using the most advanced AI technology Jetpack has to offer.', 'jetpack-my-jetpack' );
 
-		return isset( $long_descriptions[ $tier ] ) ? $long_descriptions[ $tier ] : null;
+		return isset( $long_descriptions[ $tier ] ) ? $long_descriptions[ $tier ] : $tiered_description;
 	}
 
 	/**
@@ -155,7 +154,7 @@ class Jetpack_Ai extends Product {
 	 * @return string
 	 */
 	public static function get_features_by_usage_tier( $tier ) {
-		$features = array(
+		$features        = array(
 			1   => array(
 				__( 'Artificial intelligence chatbot', 'jetpack-my-jetpack' ),
 				__( 'Generate text, tables, lists, and forms', 'jetpack-my-jetpack' ),
@@ -172,15 +171,13 @@ class Jetpack_Ai extends Product {
 				__( 'Priority support', 'jetpack-my-jetpack' ),
 				__( '100 requests per month', 'jetpack-my-jetpack' ),
 			),
-			200 => array(
-				__( '200 requests per month', 'jetpack-my-jetpack' ),
-			),
-			500 => array(
-				__( '500 requests per month', 'jetpack-my-jetpack' ),
-			),
+		);
+		$tiered_features = array(
+			/* translators: %d is the number of requests. */
+			sprintf( __( '%d requests per month', 'jetpack-my-jetpack' ), $tier ),
 		);
 
-		return isset( $features[ $tier ] ) ? $features[ $tier ] : array();
+		return isset( $features[ $tier ] ) ? $features[ $tier ] : $tiered_features;
 	}
 
 	/**
@@ -222,21 +219,18 @@ class Jetpack_Ai extends Product {
 			}
 		}
 
-		$tiers  = array( 100, 200, 500 );
 		$prices = array( 1 => $base_pricing );
 
-		foreach ( $tiers as $tier_value ) {
-			if ( isset( $yearly_prices[ $tier_value ] ) ) {
-					$prices[ $tier_value ] = array_merge(
-						$base_pricing,
-						array(
-							'full_price'            => $yearly_prices[ $tier_value ],
-							'discount_price'        => $yearly_prices[ $tier_value ],
-							'is_introductory_offer' => false,
-							'introductory_offer'    => null,
-						)
-					);
-			}
+		foreach ( $yearly_prices as $units => $price ) {
+			$prices[ $units ] = array_merge(
+				$base_pricing,
+				array(
+					'full_price'            => $price,
+					'discount_price'        => $price,
+					'is_introductory_offer' => false,
+					'introductory_offer'    => null,
+				)
+			);
 		}
 
 		return isset( $prices[ $tier ] ) ? $prices[ $tier ] : array();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34208

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes most hardcoded tier references, keeping only `100` as that tier has different text for it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Mock the `get_tier_licensed_quantity` value for `500`, `750` or `1000`. At this point you know the drill.
* In your sandbox, enable `USE_STORE_SANDBOX`
* Sandbox the public API
* Locally, on `packages/my-jetpack/src/class-wpcom-products.php`, return true on `is_cache_old` to update the prices at the next request
* Go to the Jetpack AI interstitial page
* Check that the new tiers are included and working
* Remove the `return true` on the cache function after disabling `USE_STORE_SANDBOX` to get the production prices back