### PR TITLE
Search: fix title for product layout

### DIFF
--- a/projects/packages/search/changelog/fix-instant-search-title-layout
+++ b/projects/packages/search/changelog/fix-instant-search-title-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: fix title layout for product layout

--- a/projects/packages/search/src/instant-search/components/search-result-product.scss
+++ b/projects/packages/search/src/instant-search/components/search-result-product.scss
@@ -52,6 +52,9 @@ $item-spacing: 16px;
 		$column-count: 5;
 		width: calc( ( 100% - ( #{$item-spacing} * #{$column-count} ) ) / #{$column-count} );
 	}
+	.jetpack-instant-search__search-result-title-link {
+		display: initial;
+	}
 }
 
 .jetpack-instant-search__search-result > .jetpack-instant-search__search-result-product-img-link {


### PR DESCRIPTION
Fixes Automattic/jpop-issues/issues/8682

## Proposed changes:

* Reset display for title in product layout, so that it's properly wrapped

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Go to you local test site with Instant Search enabled
* Change layout to 'Product (for WooCommerce stores)' on page `/wp-admin/admin.php?page=jetpack-search-configure`
* Open the search model from the frontend `/?s=`
* Ensure titles are properly wrapped not like what's described in https://github.com/Automattic/jpop-issues/issues/8682

<img width="737" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/94b1d97f-da72-439a-8a7d-bb7877c2f7a3">


