### PR TITLE
Improving likes: Add feature flag for new like widget layout

### DIFF
--- a/projects/plugins/jetpack/changelog/add-like-widget-feature-flag
+++ b/projects/plugins/jetpack/changelog/add-like-widget-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add feature flag for new like widget layout.

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -53,7 +53,6 @@ class Jetpack_Likes {
 	 */
 	public static function init() {
 		static $instance = null;
-		add_filter( 'likes_new_layout', '__return_true' );
 
 		if ( ! $instance ) {
 			$instance = new Jetpack_Likes();

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -53,6 +53,7 @@ class Jetpack_Likes {
 	 */
 	public static function init() {
 		static $instance = null;
+		add_filter( 'likes_new_layout', '__return_true' );
 
 		if ( ! $instance ) {
 			$instance = new Jetpack_Likes();
@@ -433,7 +434,7 @@ class Jetpack_Likes {
 		* we need a slightly more unique id / name for the widget wrapper.
 		*/
 		$uniqid     = uniqid();
-		$new_layout = apply_filters( 'likes_new_layout', false ) ? '&amp;ver=2' : '';
+		$new_layout = apply_filters( 'likes_new_layout', false ) ? '&amp;n=1' : '';
 
 		$src      = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s', $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$name     = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -432,9 +432,10 @@ class Jetpack_Likes {
 		* If the same post appears more then once on a page the page goes crazy
 		* we need a slightly more unique id / name for the widget wrapper.
 		*/
-		$uniqid = uniqid();
+		$uniqid     = uniqid();
+		$new_layout = apply_filters( 'likes_new_layout', false ) ? '&amp;n=1' : '';
 
-		$src      = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s', $blog_id, $post_id, $domain, $uniqid );
+		$src      = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s', $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$name     = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$wrapper  = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$headline = sprintf(

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -432,7 +432,7 @@ class Jetpack_Likes {
 		* If the same post appears more then once on a page the page goes crazy
 		* we need a slightly more unique id / name for the widget wrapper.
 		*/
-		$uniqid     = uniqid();
+		$uniqid = uniqid();
 		/**
 		 * Enable an alternate Likes layout.
 		 *

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -433,7 +433,7 @@ class Jetpack_Likes {
 		* we need a slightly more unique id / name for the widget wrapper.
 		*/
 		$uniqid     = uniqid();
-		$new_layout = apply_filters( 'likes_new_layout', false ) ? '&amp;n=1' : '';
+		$new_layout = apply_filters( 'likes_new_layout', false ) ? '&amp;ver=2' : '';
 
 		$src      = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s', $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$name     = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -433,6 +433,15 @@ class Jetpack_Likes {
 		* we need a slightly more unique id / name for the widget wrapper.
 		*/
 		$uniqid     = uniqid();
+		/**
+		 * Enable an alternate Likes layout.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @module likes
+		 *
+		 * @param bool $new_layout Enable the new Likes layout. False by default.
+		 */
 		$new_layout = apply_filters( 'likes_new_layout', false ) ? '&amp;n=1' : '';
 
 		$src      = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s', $blog_id, $post_id, $domain, $uniqid, $new_layout );

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -24,7 +24,7 @@ function jetpack_likes_master_iframe() {
 
 	$likes_locale = ( '' === $_locale || 'en' === $_locale ) ? '' : '&amp;lang=' . strtolower( $_locale );
 	/** This filter is documented in projects/plugins/jetpack/modules/likes.php */
-	$new_layout   = apply_filters( 'likes_new_layout', false ) ? '&amp;n=1' : '';
+	$new_layout = apply_filters( 'likes_new_layout', false ) ? '&amp;n=1' : '';
 
 	$src = sprintf(
 		'https://widgets.wp.com/likes/master.html?ver=%1$s#ver=%1$s%2$s%3$s',

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -23,11 +23,13 @@ function jetpack_likes_master_iframe() {
 	$_locale   = isset( $gp_locale->slug ) ? $gp_locale->slug : '';
 
 	$likes_locale = ( '' === $_locale || 'en' === $_locale ) ? '' : '&amp;lang=' . strtolower( $_locale );
+	$new_layout   = apply_filters( 'likes_new_layout', false ) ? '&amp;n=1' : '';
 
 	$src = sprintf(
-		'https://widgets.wp.com/likes/master.html?ver=%1$s#ver=%1$s%2$s',
+		'https://widgets.wp.com/likes/master.html?ver=%1$s#ver=%1$s%2$s%3$s',
 		$version,
-		$likes_locale
+		$likes_locale,
+		$new_layout
 	);
 
 	/* translators: The value of %d is not available at the time of output */

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -23,6 +23,7 @@ function jetpack_likes_master_iframe() {
 	$_locale   = isset( $gp_locale->slug ) ? $gp_locale->slug : '';
 
 	$likes_locale = ( '' === $_locale || 'en' === $_locale ) ? '' : '&amp;lang=' . strtolower( $_locale );
+	/** This filter is documented in projects/plugins/jetpack/modules/likes.php */
 	$new_layout   = apply_filters( 'likes_new_layout', false ) ? '&amp;n=1' : '';
 
 	$src = sprintf(


### PR DESCRIPTION
Issue https://github.com/Automattic/wp-calypso/issues/84419

## Proposed changes:
A new feature flag was introduced in the likes module to allow an optional new layout for the like button widget. This can be toggled through filters, allowing more flexibility and control over the liking feature's appearance. This should add more customization options without affecting existing behavior when the flag is off.

When the `likes_new_layout` filter returns true, `&n=1` is appended to the iframes' source.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this PR
2. Access your site through JT
3. Enable likes in `Jetpack > Settings > Sharing`
4. Either edit the file directly, or add a filter somewhere to set it to true

```
add_filter( 'likes_new_layout', '__return_true' );
```

5. Verify that the iframes src contains `&n=1`. There is one where the likes are displayed, and then another one that calls `https://widgets.wp.com/likes/master.html` near the end of the HTML.
