### PR TITLE
Small code uncluttering

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -775,7 +775,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'callback'            => __CLASS__ . '::set_subscriber_cookie_and_redirect',
 				'permission_callback' => '__return_true',
 				'args'                => array(
-					'redirect)url' => array(
+					'redirect_url' => array(
 						'required'          => true,
 						'description'       => __( 'The URL to redirect_to.', 'jetpack' ),
 						'validate_callback' => 'wp_http_validate_url',

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -774,6 +774,16 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => __CLASS__ . '::set_subscriber_cookie_and_redirect',
 				'permission_callback' => '__return_true',
+				'args'                => array(
+					'redirect)url' => array(
+						'required'          => true,
+						'description'       => __( 'The URL to redirect_to.', 'jetpack' ),
+						'validate_callback' => 'wp_http_validate_url',
+						'sanitize_callback' => 'sanitize_url',
+						'type'              => 'string',
+						'format'            => 'uri',
+					),
+				),
 			)
 		);
 	}
@@ -815,16 +825,18 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Set subscriber cookie and redirect
 	 *
+	 * @param string $redirect_url The URL to redirect to.
+	 *
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public static function set_subscriber_cookie_and_redirect() {
+	public static function set_subscriber_cookie_and_redirect( $redirect_url ) {
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
 		$token                = $subscription_service->get_and_set_token_from_request();
 		$payload              = $subscription_service->decode_token( $token );
 		$is_valid_token       = ! empty( $payload );
-		if ( $is_valid_token && isset( $payload['redirect_url'] ) ) {
-			return new WP_REST_Response( null, 302, array( 'location' => $payload['redirect_url'] ) );
+		if ( $is_valid_token ) {
+			return new WP_REST_Response( null, 302, array( 'location' => $redirect_url ) );
 		}
 		return new WP_Error( 'invalid-token', 'Invalid Token' );
 	}

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -825,18 +825,18 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Set subscriber cookie and redirect
 	 *
-	 * @param string $redirect_url The URL to redirect to.
+	 * @param \WP_Rest_Request $request The URL to redirect to.
 	 *
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public static function set_subscriber_cookie_and_redirect( $redirect_url ) {
+	public static function set_subscriber_cookie_and_redirect( $request ) {
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
 		$token                = $subscription_service->get_and_set_token_from_request();
 		$payload              = $subscription_service->decode_token( $token );
 		$is_valid_token       = ! empty( $payload );
 		if ( $is_valid_token ) {
-			return new WP_REST_Response( null, 302, array( 'location' => $redirect_url ) );
+			return new WP_REST_Response( null, 302, array( 'location' => $request['redirect_url'] ) );
 		}
 		return new WP_Error( 'invalid-token', 'Invalid Token' );
 	}

--- a/projects/plugins/jetpack/changelog/add-remove-unecessary-v2
+++ b/projects/plugins/jetpack/changelog/add-remove-unecessary-v2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -999,7 +999,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		$redirect_url = get_current_url();
 	} else {
 		// On self-hosted we will save and hide the token
-		$redirect_url = 'https://' . get_site_url() . '/wp-json/jetpack/v4/subscribers/auth';
+		$redirect_url = get_site_url() . '/wp-json/jetpack/v4/subscribers/auth';
 		$redirect_url = add_query_arg( 'redirect_url', get_current_url(), $redirect_url );
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1000,7 +1000,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 	} else {
 		// On self-hosted we will save and hide the token
 		$redirect_url = get_site_url() . '/wp-json/jetpack/v4/subscribers/auth';
-		$redirect_url = add_query_arg( 'redirect_url', get_current_url(), $redirect_url );
+		$redirect_url = add_query_arg( 'redirect_url', rawurlencode( get_current_url() ), $redirect_url );
 	}
 
 	$sign_in_link = add_query_arg(

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -997,7 +997,6 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		array(
 			'site_id'      => intval( \Jetpack_Options::get_option( 'id' ) ),
 			'redirect_url' => rawurlencode( get_current_url() ),
-			'v2'           => '',
 		),
 		'https://subscribe.wordpress.com/memberships/jwt'
 	);

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1000,7 +1000,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 	} else {
 		// On self-hosted we will save and hide the token
 		$redirect_url = get_site_url() . '/wp-json/jetpack/v4/subscribers/auth';
-		$redirect_url = add_query_arg( 'redirect_url', rawurlencode( get_current_url() ), $redirect_url );
+		$redirect_url = add_query_arg( 'redirect_url', get_current_url(), $redirect_url );
 	}
 
 	$sign_in_link = add_query_arg(

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -997,6 +997,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		array(
 			'site_id'      => intval( \Jetpack_Options::get_option( 'id' ) ),
 			'redirect_url' => rawurlencode( get_current_url() ),
+			'v2'           => '',
 		),
 		'https://subscribe.wordpress.com/memberships/jwt'
 	);

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -993,11 +993,20 @@ function get_paywall_blocks( $newsletter_access_level ) {
 
 	$sign_in         = '';
 	$switch_accounts = '';
-	$sign_in_link    = add_query_arg(
+
+	if ( ( new Host() )->is_wpcom_simple() ) {
+		// On WPCOM we will redirect directly to the current page
+		$redirect_url = get_current_url();
+	} else {
+		// On self-hosted we will save and hide the token
+		$redirect_url = 'https://' . get_site_url() . '/wp-json/jetpack/v4/subscribers/auth';
+		$redirect_url = add_query_arg( 'redirect_url', get_current_url(), $redirect_url );
+	}
+
+	$sign_in_link = add_query_arg(
 		array(
 			'site_id'      => intval( \Jetpack_Options::get_option( 'id' ) ),
-			'redirect_url' => rawurlencode( get_current_url() ),
-			'v2'           => '',
+			'redirect_url' => rawurlencode( $redirect_url ),
 		),
 		'https://subscribe.wordpress.com/memberships/jwt'
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Works with D129819-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Unclutter a bit some code and prevent adding extra information in token:
  * Do not use "v2" anymore and use regular redirect
  * Leave "v2" code on WPCOM until next Jetpack release

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D129819-code on your sandbox
* Open a new JN site and set it up with a gated post
* OR you can use https://unfair-bee.jurassic.ninja/2023/11/23/gold/
* Open a new incognito on https://unfair-bee.jurassic.ninja/2023/11/23/gold/
* (optional) Subscribe
* (option) Open a new incognito
* With any email address, click on `Already a higher-tier paid subscriber? ` 
*  After login, you should be redirected to the same post, have access to the content (or not depending of the optional) and no token in the URL.

https://github.com/Automattic/jetpack/assets/790558/62635d3f-bb81-4292-96cd-97b61cafe63d


