### PR TITLE
Newsletter Categories: Display subscribers count on pre/post publish panels

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-subscriptions-count.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-subscriptions-count.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * REST API endpoint for the Newsletter Categories
+ *
+ * @package automattic/jetpack
+ * @since 12.6
+ */
+
+use Automattic\Jetpack\Status\Host;
+
+require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Count
+ */
+class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Count extends WP_REST_Controller {
+	use WPCOM_REST_API_Proxy_Request_Trait;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->wpcom_is_wpcom_only_endpoint    = true;
+		$this->wpcom_is_site_specific_endpoint = true;
+		$this->base_api_path                   = 'wpcom';
+		$this->version                         = 'v2';
+		$this->namespace                       = $this->base_api_path . '/' . $this->version;
+		$this->rest_base                       = '/newsletter-categories';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		$options = array(
+			'show_in_index'       => true,
+			'methods'             => 'GET',
+			// if this is not a wpcom site, we need to proxy the request to wpcom
+			'callback'            => ( ( new Host() )->is_wpcom_simple() ) ? array(
+				$this,
+				'get_newsletter_categories_subscriptions_count',
+			) : array( $this, 'proxy_request_to_wpcom_as_user' ),
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'args'                => array(
+				'term_ids' => array(
+					'required'          => false,
+					'validate_callback' => function ( $param ) {
+						return empty( $param ) || ( is_string( $param ) && preg_match( '/^(\d+,)*\d+$/', $param ) );
+					},
+					'default'           => '',
+				),
+			),
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/subscriptions-count',
+			$options
+		);
+	}
+
+	/**
+	 * Get the subscriptions count for the given categories.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_newsletter_categories_subscriptions_count( WP_REST_Request $request ) {
+		require_lib( 'newsletter-categories' );
+
+		$blog_id  = get_current_blog_id();
+		$term_ids = explode( ',', $request->get_param( 'term_ids' ) );
+
+		$subscriptions_count = get_blog_subscriptions_aggregate_count( $blog_id, $term_ids );
+
+		return rest_ensure_response(
+			array(
+				'subscriptions_count' => $subscriptions_count,
+			)
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Count' );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-subscriptions-count.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-subscriptions-count.php
@@ -25,7 +25,7 @@ class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Count exten
 		$this->base_api_path                   = 'wpcom';
 		$this->version                         = 'v2';
 		$this->namespace                       = $this->base_api_path . '/' . $this->version;
-		$this->rest_base                       = '/newsletter-categories';
+		$this->rest_base                       = '/newsletter-categories/count';
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
@@ -58,7 +58,7 @@ class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Count exten
 
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/subscriptions-count',
+			$this->rest_base,
 			$options
 		);
 	}

--- a/projects/plugins/jetpack/changelog/add-subscribers-count
+++ b/projects/plugins/jetpack/changelog/add-subscribers-count
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Display subscribers count on pre/post publish panels

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -208,6 +208,12 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 		select( editorStore ).getEditedPostAttribute( 'categories' )
 	);
 
+	const subscriptionsCount = useSelect( select => {
+		return select( 'jetpack/membership-products' ).getNewsletterCategoriesSubscriptionsCount(
+			postCategories
+		);
+	} );
+
 	const reachCount = getReachForAccessLevelKey(
 		accessLevel,
 		emailSubscribers,
@@ -238,15 +244,27 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 		const formattedCategoryNames = getFormattedCategories( postCategories, newsletterCategories );
 
 		if ( formattedCategoryNames ) {
-			numberOfSubscribersText = sprintf(
-				// translators: %1s is the post name,  %2s is the list of categories
-				__(
-					'<postPublishedLink>%1$s</postPublishedLink> was sent to everyone subscribed to %2$s.',
-					'jetpack'
-				),
-				postName,
-				formattedCategoryNames
-			);
+			numberOfSubscribersText =
+				subscriptionsCount > 0
+					? sprintf(
+							// translators: %1s is the post name,  %2s is the list of categories
+							__(
+								'<postPublishedLink>%1$s</postPublishedLink> was sent to everyone subscribed to %2$s (%3$s subscribers).',
+								'jetpack'
+							),
+							postName,
+							formattedCategoryNames,
+							subscriptionsCount
+					  )
+					: sprintf(
+							// translators: %1s is the post name,  %2s is the list of categories
+							__(
+								'<postPublishedLink>%1$s</postPublishedLink> was sent to everyone subscribed to %2$s.',
+								'jetpack'
+							),
+							postName,
+							formattedCategoryNames
+					  );
 		}
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -28,6 +28,7 @@ import {
 } from '../../shared/memberships/settings';
 import {
 	getFormattedCategories,
+	getFormattedSubscriptionsCount,
 	getShowMisconfigurationWarning,
 } from '../../shared/memberships/utils';
 import { store as membershipProductsStore } from '../../store/membership-products';
@@ -242,29 +243,19 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 		accessLevel !== accessOptions.paid_subscribers.key
 	) {
 		const formattedCategoryNames = getFormattedCategories( postCategories, newsletterCategories );
+		const formattedSubscriptionsCount = getFormattedSubscriptionsCount( subscriptionsCount );
+		const categoryNamesAndSubscriptionsCount = formattedCategoryNames + formattedSubscriptionsCount;
 
 		if ( formattedCategoryNames ) {
-			numberOfSubscribersText =
-				subscriptionsCount > 0
-					? sprintf(
-							// translators: %1s is the post name,  %2s is the list of categories
-							__(
-								'<postPublishedLink>%1$s</postPublishedLink> was sent to everyone subscribed to %2$s (%3$s subscribers).',
-								'jetpack'
-							),
-							postName,
-							formattedCategoryNames,
-							subscriptionsCount
-					  )
-					: sprintf(
-							// translators: %1s is the post name,  %2s is the list of categories
-							__(
-								'<postPublishedLink>%1$s</postPublishedLink> was sent to everyone subscribed to %2$s.',
-								'jetpack'
-							),
-							postName,
-							formattedCategoryNames
-					  );
+			numberOfSubscribersText = sprintf(
+				// translators: %1s is the post name, %2s is the list of categories with subscriptions count
+				__(
+					'<postPublishedLink>%1$s</postPublishedLink> was sent to everyone subscribed to %2$s.',
+					'jetpack'
+				),
+				postName,
+				categoryNamesAndSubscriptionsCount
+			);
 		}
 	}
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -310,6 +310,12 @@ export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
 		select( editorStore ).getEditedPostAttribute( 'categories' )
 	);
 
+	const subscriptionsCount = useSelect( select => {
+		return select( 'jetpack/membership-products' ).getNewsletterCategoriesSubscriptionsCount(
+			postCategories
+		);
+	} );
+
 	if ( isLoading ) {
 		return (
 			<Flex direction="column" align="center">
@@ -330,11 +336,21 @@ export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
 
 			if ( formattedCategoryNames ) {
 				return createInterpolateElement(
-					sprintf(
-						// translators: %1$s: list of categories names
-						__( 'This post will be sent to everyone subscribed to %1$s.', 'jetpack' ),
-						formattedCategoryNames
-					),
+					subscriptionsCount > 0
+						? sprintf(
+								// translators: %1$s: list of categories names, %2$s: number of subscribers
+								__(
+									'This post will be sent to everyone subscribed to %1$s (%2$s subscribers).',
+									'jetpack'
+								),
+								formattedCategoryNames,
+								subscriptionsCount
+						  )
+						: sprintf(
+								// translators: %1$s: list of categories names
+								__( 'This post will be sent to everyone subscribed to %1$s.', 'jetpack' ),
+								formattedCategoryNames
+						  ),
 					{ strong: <strong /> }
 				);
 			}

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -27,6 +27,7 @@ import {
 } from './constants';
 import {
 	getFormattedCategories,
+	getFormattedSubscriptionsCount,
 	getShowMisconfigurationWarning,
 	MisconfigurationWarning,
 } from './utils';
@@ -333,24 +334,17 @@ export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
 		}
 		if ( newsletterCategoriesEnabled && newsletterCategories.length ) {
 			const formattedCategoryNames = getFormattedCategories( postCategories, newsletterCategories );
+			const formattedSubscriptionsCount = getFormattedSubscriptionsCount( subscriptionsCount );
+			const categoryNamesAndSubscriptionsCount =
+				formattedCategoryNames + formattedSubscriptionsCount;
 
 			if ( formattedCategoryNames ) {
 				return createInterpolateElement(
-					subscriptionsCount > 0
-						? sprintf(
-								// translators: %1$s: list of categories names, %2$s: number of subscribers
-								__(
-									'This post will be sent to everyone subscribed to %1$s (%2$s subscribers).',
-									'jetpack'
-								),
-								formattedCategoryNames,
-								subscriptionsCount
-						  )
-						: sprintf(
-								// translators: %1$s: list of categories names
-								__( 'This post will be sent to everyone subscribed to %1$s.', 'jetpack' ),
-								formattedCategoryNames
-						  ),
+					sprintf(
+						// translators: %1$s is the list of categories with subscriptions count
+						__( 'This post will be sent to everyone subscribed to %1$s.', 'jetpack' ),
+						categoryNamesAndSubscriptionsCount
+					),
 					{ strong: <strong /> }
 				);
 			}

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.js
@@ -124,3 +124,15 @@ export const getFormattedCategories = ( postCategories, newsletterCategories ) =
 
 	return formattedCategories;
 };
+
+export const getFormattedSubscriptionsCount = subscriptionsCount => {
+	if ( subscriptionsCount === 1 ) {
+		return __( ' (1 subscriber)', 'jetpack' );
+	}
+
+	return sprintf(
+		// translators: %s is the number of subscribers in numerical format
+		__( ' (%s subscribers)', 'jetpack' ),
+		subscriptionsCount
+	);
+};

--- a/projects/plugins/jetpack/extensions/store/membership-products/actions.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/actions.js
@@ -113,3 +113,9 @@ export const setNewsletterCategories = newsletterCategories => ( {
 	type: 'SET_NEWSLETTER_CATEGORIES',
 	newsletterCategories,
 } );
+
+export const setNewsletterCategoriesSubscriptionsCount =
+	newsletterCategoriesSubscriptionsCount => ( {
+		type: 'SET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT',
+		newsletterCategoriesSubscriptionsCount,
+	} );

--- a/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
@@ -42,6 +42,11 @@ export default function reducer( state = DEFAULT_STATE, action ) {
 				...state,
 				newsletterCategories: action.newsletterCategories,
 			};
+		case 'SET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT':
+			return {
+				...state,
+				newsletterCategoriesSubscriptionsCount: action.newsletterCategoriesSubscriptionsCount,
+			};
 	}
 	return state;
 }

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -121,7 +121,8 @@ const fetchNewsletterCategories = async () => {
 
 export const fetchNewsletterCategoriesSubscriptionsCount = async termIds => {
 	const response = await apiFetch( {
-		path: `/wpcom/v2/newsletter-categories/subscriptions-count?term_ids=${ termIds.join( ',' ) }`,
+		path: `/wpcom/v2/newsletter-categories/count?term_ids=${ termIds.join( ',' ) }`,
+		method: 'GET',
 	} );
 
 	if ( ! response || typeof response !== 'object' ) {

--- a/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
@@ -30,3 +30,6 @@ export const getSubscriberCounts = state => state.subscriberCounts;
 export const getNewsletterCategories = state => state.newsletterCategories.categories;
 
 export const getNewsletterCategoriesEnabled = state => state.newsletterCategories.enabled;
+
+export const getNewsletterCategoriesSubscriptionsCount = state =>
+	state.newsletterCategoriesSubscriptionsCount;

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
@@ -10,6 +10,7 @@ import {
 	setSiteSlug,
 	setConnectedAccountDefaultCurrency,
 	setNewsletterCategories,
+	setNewsletterCategoriesSubscriptionsCount,
 } from '../actions';
 import * as utils from '../utils';
 
@@ -314,5 +315,19 @@ describe( 'Membership Products Actions', () => {
 
 		// Then
 		expect( result ).toStrictEqual( anyValidNewsletterCategoriesWithType );
+	} );
+
+	test( 'Set newsletter categories subscriptions count works as expected', () => {
+		// Given
+		const anyValidNewsletterCategoriesSubscriptionsCountWithType = {
+			type: 'SET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT',
+			newsletterCategoriesSubscriptionsCount: ANY_VALID_DATA,
+		};
+
+		// When
+		const result = setNewsletterCategoriesSubscriptionsCount( ANY_VALID_DATA );
+
+		// Then
+		expect( result ).toStrictEqual( anyValidNewsletterCategoriesSubscriptionsCountWithType );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/reducer-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/reducer-test.js
@@ -127,4 +127,25 @@ describe( 'Membership products reducer testing', () => {
 			newsletterCategories: anyNewsletterCategories,
 		} );
 	} );
+
+	test( 'set newsletter categories subscriptions count action type adds the newsletter categories subscriptions count to the returned state.', () => {
+		// Given
+		const anyNewsletterCategoriesSubscriptionsCount = 1;
+		const anySetNewsletterCategoriesSubscriptionsCountAction = {
+			type: 'SET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT',
+			newsletterCategoriesSubscriptionsCount: anyNewsletterCategoriesSubscriptionsCount,
+		};
+
+		// When
+		const returnedState = reducer(
+			DEFAULT_STATE,
+			anySetNewsletterCategoriesSubscriptionsCountAction
+		);
+
+		// Then
+		expect( returnedState ).toStrictEqual( {
+			...DEFAULT_STATE,
+			newsletterCategoriesSubscriptionsCount: anyNewsletterCategoriesSubscriptionsCount,
+		} );
+	} );
 } );

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/selectors-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/selectors-test.js
@@ -1,6 +1,7 @@
 import {
 	getNewsletterCategories,
 	getNewsletterCategoriesEnabled,
+	getNewsletterCategoriesSubscriptionsCount,
 	getNewsletterProducts,
 	getProducts,
 } from '../selectors';
@@ -43,6 +44,16 @@ describe( 'Membership Products Selectors', () => {
 		);
 		expect( getNewsletterCategoriesEnabled( state ) ).toStrictEqual(
 			state.newsletterCategories.enabled
+		);
+	} );
+
+	test( 'getNewsletterCategoriesSubscriptionsCount works as expected', () => {
+		const state = {
+			newsletterCategoriesSubscriptionsCount: 1,
+		};
+
+		expect( getNewsletterCategoriesSubscriptionsCount( state ) ).toStrictEqual(
+			state.newsletterCategoriesSubscriptionsCount
 		);
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes https://github.com/Automattic/wp-calypso/issues/83636

## Proposed changes:
* Add resolver to fetch subscriptions count for newsletter categories
* Add `/newsletter-categories/count` endpoint
* Display subscribers count on pre/post-publish panels

<img width="292" alt="Screenshot 2023-11-23 at 11 01 22" src="https://github.com/Automattic/jetpack/assets/3113712/fe3fe23c-2157-4872-a12d-73946cc4c851">

<img width="288" alt="Screenshot 2023-11-23 at 11 01 34" src="https://github.com/Automattic/jetpack/assets/3113712/4c3a176b-571a-4697-8e2c-cc69dcfb783d">

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your local
* Spin up a JurassicTube site
* Enable and select some Newsletter Categories
* Subscribe to this site
* Go to your site > Posts > Add New
* Select a Newsletter Category as the post category
* Click on Publish
  * You should see the `This post will be sent to everyone subscribed to {category name} {subscribers count}.`
* Click on Publish (the one on the pre-publish panel)
  * You should see the `This post was sent to everyone subscribed to {category name} {subscribers count}.`