### PR TITLE
Gutenberg: Dequeue editor assets when they aren't in use

### DIFF
--- a/projects/plugins/jetpack/changelog/update-dequeue-editor-assets-perf
+++ b/projects/plugins/jetpack/changelog/update-dequeue-editor-assets-perf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Gutenberg: Dequeue editor assets when they aren't in use

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -633,7 +633,7 @@ class Jetpack_Gutenberg {
 
 			return;
 		}
-		
+
 		$status = new Status();
 
 		// Required for Analytics. See _inc/lib/admin-pages/class.jetpack-admin-page.php.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -622,6 +622,18 @@ class Jetpack_Gutenberg {
 			return;
 		}
 
+		/**
+		 * This can be called multiple times per page load in the admin, during the `enqueue_block_assets` action.
+		 * These assets are necessary for the admin for editing but are not necessary for each pattern preview.
+		 * Therefore we dequeue them, so they don't load for each pattern preview iframe.
+		 */
+		if ( ! wp_should_load_block_editor_scripts_and_styles() ) {
+			wp_dequeue_script( 'jp-tracks' );
+			wp_dequeue_script( 'jetpack-blocks-editor' );
+
+			return;
+		}
+		
 		$status = new Status();
 
 		// Required for Analytics. See _inc/lib/admin-pages/class.jetpack-admin-page.php.


### PR DESCRIPTION
Currently, on WP.com, the pattern inserter is cluttered with asset requests for every pattern preview. This causes the pattern inserter to reach the browser request limits as soon as the user browses through a couple of pattern pages. 

I spotted that this occurs because in Jetpack, we'll enqueue all the editor assets for the admin during the `enqueue_block_assets` action, and that action can be called multiple times, including [when retrieving the iframed editor assets](https://github.com/WordPress/gutenberg/blob/cc1870a49f57f89cb4c97b41782420a36f77e4da/lib/compat/wordpress-6.4/script-loader.php#L146). Because of that, all the Jetpack editor assets will be loaded inside each pattern preview iframe when they won't be utilized there.

This causes a serious bug: each pattern preview comes with hundreds of requests, and we're hitting the browser request limit and it will stop processing those assets. Furthermore, this results in errors in handling these patterns.

To resolve this, I'm suggesting we keep the asset enqueueing, but dequeue when we know that we shouldn't be loading the editor scripts and styles. Right now, I'm only suggesting doing the dequeuing for the scripts, but we'll likely have to do the same thing with styles. Dequeueing is cheap: even if an asset hasn't been enqueued yet, it will silently behave as a noop.

However, this immediately fixes the bug and allows the browser to load all previews as the user browses through pattern pages. These errors are no longer cluttering the console and there is a visible performance improvement on slower machines (can be tested with CPU throttling). I expect this should improve the performance of the pattern inserter in WP.com (which @mtias had mentioned before), but I think we have a few separate issues to address independently in that area.

## Proposed changes:
Gutenberg: Dequeue editor assets when they aren't in use

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None, but we've been discussing with @mtias that the pattern inserter is particularly slow on WP.com.

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:

* Apply this on WP.com
* Open a WP.com simple site. 
* Open the pattern inserter.
* Click on the button to browser all patterns.
* Click through some pattern tabs and verify that the patterns keep loading quicker than before.
* Verify you don't see new INSUFFICIENT_RESOURCES errors or undefined variable errors in the console.
* Test on a JN site too.

## Previews and screenshots

Browsing pattern inserter - before:

https://github.com/Automattic/jetpack/assets/8436925/d03a819a-2e5c-4bed-ab21-87033c89dbe1

Browsing pattern inserter - after:

https://github.com/Automattic/jetpack/assets/8436925/51c115f8-13ea-42db-b589-c8c557dec584

Error with the browser request limit

<img width="874" alt="Screenshot 2023-11-23 at 17 04 20" src="https://github.com/Automattic/jetpack/assets/8436925/c44e6084-c430-4583-a67c-c8895975c21d">

Error with result from the unprocessed assets

<img width="534" alt="Screenshot 2023-11-23 at 17 04 26" src="https://github.com/Automattic/jetpack/assets/8436925/cfd8c673-6fed-4fcc-8718-48eea783adbc">
