### PR TITLE
Add 750 and 1000 tier plans

### DIFF
--- a/projects/plugins/jetpack/changelog/add-750-1000-tier-plans
+++ b/projects/plugins/jetpack/changelog/add-750-1000-tier-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add the latest tier plans for 750 and 1000 requests

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/types.ts
@@ -8,7 +8,7 @@ export type UpgradeTypeProp = 'vip' | 'default';
 
 export type TierUnlimitedProps = {
 	slug: 'ai-assistant-tier-unlimited';
-	limit: number;
+	limit: 999999999;
 	value: 1;
 	readableLimit: string;
 };
@@ -37,6 +37,18 @@ export type Tier500Props = {
 	value: 500;
 };
 
+export type Tier750Props = {
+	slug: 'ai-assistant-tier-750';
+	limit: 750;
+	value: 750;
+};
+
+export type Tier1000Props = {
+	slug: 'ai-assistant-tier-1000';
+	limit: 1000;
+	value: 1000;
+};
+
 export type TierProp = {
 	slug: TierSlugProp;
 	limit: TierLimitProp;
@@ -49,21 +61,27 @@ export type TierLimitProp =
 	| TierFreeProps[ 'limit' ]
 	| Tier100Props[ 'limit' ]
 	| Tier200Props[ 'limit' ]
-	| Tier500Props[ 'limit' ];
+	| Tier500Props[ 'limit' ]
+	| Tier750Props[ 'limit' ]
+	| Tier1000Props[ 'limit' ];
 
 export type TierSlugProp =
 	| TierUnlimitedProps[ 'slug' ]
 	| TierFreeProps[ 'slug' ]
 	| Tier100Props[ 'slug' ]
 	| Tier200Props[ 'slug' ]
-	| Tier500Props[ 'slug' ];
+	| Tier500Props[ 'slug' ]
+	| Tier750Props[ 'slug' ]
+	| Tier1000Props[ 'slug' ];
 
 export type TierValueProp =
 	| TierUnlimitedProps[ 'value' ]
 	| TierFreeProps[ 'value' ]
 	| Tier100Props[ 'value' ]
 	| Tier200Props[ 'value' ]
-	| Tier500Props[ 'value' ];
+	| Tier500Props[ 'value' ]
+	| Tier750Props[ 'value' ]
+	| Tier1000Props[ 'value' ];
 
 export type AiFeatureProps = {
 	hasFeature: boolean;


### PR DESCRIPTION
Add proptypes/definitions for latest tier plans

Fixes #

## Proposed changes:
This PR adds the 750 and 1000 requests tier plans to properly handle those coming from backend

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visual review is fine. Otherwise, force backend to return either a 750 or a 1000 request tier plan as current. Confirm with the store current and next tier are properly set:

```js
wp.data.select( 'wordpress-com/plans' ).getAiAssistantFeature();
```