### PR TITLE
Jetpack AI: Handle "Contact Us" upgrade on the usage panel for Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-handle-contact-us-upgrade-on-simple-sites
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-handle-contact-us-upgrade-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Handle Contact Us button on the Usage Panel when the site is a Simple or Atomic site.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -104,7 +104,7 @@ const useUpgradeButtonText = ( planType: PlanType, nextTierRequestLimit: number 
  * Helper to get the Contact Us URL
  * @returns {object} an object with the Contact Us URL, the autosaveAndRedirect function and a boolean indicating if we are redirecting
  */
-const useAIContactUs = (): {
+const useContactUsLink = (): {
 	contactUsURL: string;
 	autosaveAndRedirectContactUs: () => void;
 	isRedirectingContactUs: boolean;
@@ -121,7 +121,7 @@ const useAIContactUs = (): {
 
 export default function UsagePanel() {
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
-	const { contactUsURL, autosaveAndRedirectContactUs } = useAIContactUs();
+	const { contactUsURL, autosaveAndRedirectContactUs } = useContactUsLink();
 	const canUpgrade = canUserPurchasePlan();
 
 	// fetch usage data

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import React from 'react';
@@ -11,6 +13,7 @@ import './style.scss';
 import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
 import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import { canUserPurchasePlan } from '../../../../blocks/ai-assistant/lib/connection';
+import useAutosaveAndRedirect from '../../../../shared/use-autosave-and-redirect';
 import UsageControl from '../usage-bar';
 import './style.scss';
 import { PLAN_TYPE_FREE, PLAN_TYPE_TIERED, PLAN_TYPE_UNLIMITED } from '../usage-bar/types';
@@ -97,8 +100,28 @@ const useUpgradeButtonText = ( planType: PlanType, nextTierRequestLimit: number 
 	);
 };
 
+/**
+ * Helper to get the Contact Us URL
+ * @returns {object} an object with the Contact Us URL, the autosaveAndRedirect function and a boolean indicating if we are redirecting
+ */
+const useAIContactUs = (): {
+	contactUsURL: string;
+	autosaveAndRedirectContactUs: () => void;
+	isRedirectingContactUs: boolean;
+} => {
+	const contactUsURL = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
+	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( contactUsURL );
+
+	return {
+		contactUsURL,
+		autosaveAndRedirectContactUs: autosaveAndRedirect,
+		isRedirectingContactUs: isRedirecting,
+	};
+};
+
 export default function UsagePanel() {
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
+	const { contactUsURL, autosaveAndRedirectContactUs } = useAIContactUs();
 	const canUpgrade = canUserPurchasePlan();
 
 	// fetch usage data
@@ -120,6 +143,10 @@ export default function UsagePanel() {
 	// Determine the upgrade button text
 	const upgradeButtonText = useUpgradeButtonText( planType, nextTier?.limit );
 
+	// Handle upgrade for simple and atomic sites on the last plan
+	const showContactUsCallToAction =
+		( isSimpleSite() || isAtomicSite() ) && planType === PLAN_TYPE_TIERED && ! nextTier;
+
 	return (
 		<div className="jetpack-ai-usage-panel">
 			<>
@@ -133,15 +160,30 @@ export default function UsagePanel() {
 
 				{ ( planType === PLAN_TYPE_FREE || planType === PLAN_TYPE_TIERED ) && canUpgrade && (
 					<div className="jetpack-ai-usage-panel-upgrade-button">
-						<Button
-							variant="primary"
-							label="Upgrade your Jetpack AI plan"
-							href={ checkoutUrl }
-							onClick={ autosaveAndRedirect }
-							disabled={ isRedirecting }
-						>
-							{ upgradeButtonText }
-						</Button>
+						{ showContactUsCallToAction && (
+							<>
+								<p>{ __( 'Need more requests?', 'jetpack' ) }</p>
+								<Button
+									variant="primary"
+									label={ __( 'Contact us for more requests', 'jetpack' ) }
+									href={ contactUsURL }
+									onClick={ autosaveAndRedirectContactUs }
+								>
+									{ __( 'Contact Us', 'jetpack' ) }
+								</Button>
+							</>
+						) }
+						{ ! showContactUsCallToAction && (
+							<Button
+								variant="primary"
+								label={ __( 'Upgrade your Jetpack AI plan', 'jetpack' ) }
+								href={ checkoutUrl }
+								onClick={ autosaveAndRedirect }
+								disabled={ isRedirecting }
+							>
+								{ upgradeButtonText }
+							</Button>
+						) }
 					</div>
 				) }
 			</>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34219.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the upgrade button on the usage panel when the site is on the last tier and is a Simple or Atomic site
* In this case, the upgrade path is to send a message asking for more requests
   * for Jetpack sites, this details is handled by the My Jetpack interstitial
   * for Simple and Atomic, there is no interstitial and therefore we need to do everything on the usage panel itself

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this branch to your sandbox using the command that will be provided below (or rsync it):

```
bin/jetpack-downloader test jetpack update/jetpack-ai-handle-contact-us-upgrade-on-simple-sites
```

* Sandbox a Simple site for testing
* Go to the block editor and open the usage panel on the Jetpack sidebar
* Open the browser console and dispatch the following action:

```
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": true,
    "isOverLimit": false,
    "requestsCount": 0,
    "requestsLimit": 20,
    "requireUpgrade": false,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": "2023-11-01 00:00:00",
        "nextStart": "2023-12-01 00:00:00",
        "requestsCount": 0
    },
    "currentTier": {
        "slug": "jetpack_ai_yearly:-q-1000",
        "limit": 1000,
        "value": 1000
    },
    "nextTier": null,
    "tier-plans-enabled":true
} );
```

* Confirm that you see:
   * a new text saying "Need more requests?"
   * a button saying "Contact Us"
* Confirm the URL of the button is the following:

<img width="600" alt="Screenshot 2023-11-23 at 15 02 38" src="https://github.com/Automattic/jetpack/assets/6760046/a7a61db5-1b1a-4789-b8a0-4390d1bc530a">

* Confirm that, when you click the button, your email client is prompted to open
* The expected UI:

<img width="250" alt="Screenshot 2023-11-23 at 15 00 09" src="https://github.com/Automattic/jetpack/assets/6760046/24d9d449-6b8a-40f7-8680-5af2d736fcba">

---

* Do the same test for a Jetpack site
* Confirm that, for the Jetpack site, you see:
   * **No** text saying "Need more requests?"
   * a button saying "Get more requests"
* Confirm that in this case the link goes to the Jetpack interstitial
* The expected UI:

<img width="250" alt="Screenshot 2023-11-23 at 15 30 26" src="https://github.com/Automattic/jetpack/assets/6760046/b330f3bd-3489-47a8-8abd-346d2daa11bd">

---

* Do the same test again for the Simple and the Jetpack sites, but now dispatching the following action (that will set the current plan as the 500 one):

```
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": true,
    "isOverLimit": false,
    "requestsCount": 0,
    "requestsLimit": 20,
    "requireUpgrade": false,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": "2023-11-01 00:00:00",
        "nextStart": "2023-12-01 00:00:00",
        "requestsCount": 0
    },
    "currentTier": {
        "slug": "jetpack_ai_yearly:-q-500",
        "limit": 500,
        "value": 500
    },
    "nextTier": {
        "slug": "jetpack_ai_yearly:-q-750",
        "limit": 750,
        "value": 750
    },
    "tier-plans-enabled":true
} );
```

* In this case, confirm that the button on the Simple site:
   * Says "Get 750 requests" (meaning it is showing the value of the next plan, as before)
   * Leads you to the checkout page
* In this case, confirm that the button on the Jetpack site:
   * Says "Get 750 requests" (meaning it is showing the value of the next plan, as before)
   * Leads you to the interstitial page
* This is to make sure the previous behavior is not broken