### PR TITLE
Contact Form: fix styling issues for Outlined and Animated styles

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-single-checkbox
+++ b/projects/packages/forms/changelog/fix-contact-form-single-checkbox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Contact Form: improved checkbox field design

--- a/projects/packages/forms/changelog/fix-contact-form-styles
+++ b/projects/packages/forms/changelog/fix-contact-form-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: fix styling issues for Outlined and Animated styles

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -889,7 +889,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						style="' . $this->label_styles . '"
 					>'
 			. esc_html( $label )
-			. ( $required ? '<span>' . $required_field_text . '</span>' : '' ) .
+			. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .
 			'</label>
 				</div>
 				<div class="notched-label__trailing"></div>
@@ -914,7 +914,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				style="' . $this->label_styles . '"
 			>'
 			. esc_html( $label )
-			. ( $required ? '<span>' . $required_field_text . '</span>' : '' ) .
+			. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .
 			'</label>';
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -679,9 +679,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_checkbox_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		$field  = "<label class='grunion-field-label checkbox" . ( $this->is_error() ? ' form-error' : '' ) . "' style='" . $this->label_styles . "'>";
-		$field .= "\t\t<input type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
-		$field .= "\t\t" . esc_html( $label ) . ( $required ? '<span>' . $required_field_text . '</span>' : '' );
+		$field  = "<input id='" . esc_attr( $id ) . "' type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
+		$field .= "<label for='" . esc_attr( $id ) . "' class='grunion-field-label checkbox" . ( $this->is_error() ? ' form-error' : '' ) . "' style='" . $this->label_styles . "'>";
+		$field .= esc_html( $label ) . ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' );
 		$field .= "</label>\n";
 		$field .= "<div class='clear-form'></div>\n";
 		return $field;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -424,8 +424,8 @@
 }
 
 
-.contact-form .is-style-outlined .grunion-field-wrap:not(.grunion-field-checkbox-wrap):not(.grunion-field-consent-wrap),
-.contact-form .is-style-animated .grunion-field-wrap:not(.grunion-field-checkbox-wrap):not(.grunion-field-consent-wrap) {
+.contact-form .is-style-outlined .grunion-field-wrap:not(.grunion-field-checkbox-wrap):not(.grunion-field-consent-wrap):not(.grunion-field-checkbox-multiple-wrap):not(.grunion-field-radio-wrap),
+.contact-form .is-style-animated .grunion-field-wrap:not(.grunion-field-checkbox-wrap):not(.grunion-field-consent-wrap):not(.grunion-field-checkbox-multiple-wrap):not(.grunion-field-radio-wrap) {
 	--notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
 	position: relative;
 	display: flex;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -106,7 +106,10 @@
 	display: none;
 }
 
-.contact-form label.checkbox,
+.contact-form label.checkbox {
+	font-weight: normal;
+}
+
 .contact-form label.checkbox-multiple,
 .contact-form label.radio {
 	margin-bottom: 0;
@@ -276,9 +279,13 @@
 	max-width: 75%;
 }
 
-.grunion-field-checkbox-wrap,
 .grunion-field-consent-wrap {
 	align-self: center;
+}
+
+.grunion-field-checkbox-wrap {
+	display: inline-flex;
+	align-items: baseline;
 }
 
 @media only screen and ( min-width: 600px ) {

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -1077,8 +1077,8 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$this->assertFieldClasses( $wrapper_div, $attributes );
 		$this->assertFieldLabel( $wrapper_div, $attributes );
 
-		$label = $this->getFirstElement( $wrapper_div, 'label' );
-		$input = $this->getFirstElement( $label, 'input' );
+		$label = $wrapper_div->getElementsByTagName( 'label' )->item( 0 );
+		$input = $wrapper_div->getElementsByTagName( 'input' )->item( 0 );
 
 		$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label ' . $attributes['type'], 'label class doesn\'t match' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The _Animated_ and _Outlined_ styles of the _Contact Form_ had some design issues:
- The _required_ labels are not contrasted (as they are in the _Default_ style) and not prepended by some space.
- The _Single Choice_ and _Multiple Choice_ inputs are misaligned with the _Animated_ style.

_Outlined style_
<img width="500" alt="Screenshot 2023-11-23 at 2 22 56 PM" src="https://github.com/Automattic/jetpack/assets/1620183/38784369-8fc1-4116-a78f-bdde3e37cd06">

_Animated style_
<img width="500" alt="Screenshot 2023-11-23 at 2 23 02 PM" src="https://github.com/Automattic/jetpack/assets/1620183/bfedced9-f41d-4cb4-9352-f99920323efe">
<img width="500" alt="Screenshot 2023-11-23 at 2 23 11 PM" src="https://github.com/Automattic/jetpack/assets/1620183/661e0757-7ec6-4bec-99b5-c7511fa9cc76">

This PR styles the _required_ labels like they are in the _Default_ style and aligns the fields properly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Create a new post
- Add the _Contact Form_ block
- Add a _Single Choice_ and _Multiple Choice_ fields
- Select a style
<img width="287" alt="Screenshot 2023-11-23 at 2 41 43 PM" src="https://github.com/Automattic/jetpack/assets/1620183/bd2069e0-e290-4178-b586-ebc0371786a6">

- Open the preview
- Notice the issues mentioned above are fixed

_Outlined style_
<img width="500" alt="Screenshot 2023-11-23 at 2 25 30 PM" src="https://github.com/Automattic/jetpack/assets/1620183/b2b1fd48-7e34-4980-92a0-d914a37d5e36">


_Animated style_
<img width="500" alt="Screenshot 2023-11-23 at 2 26 59 PM" src="https://github.com/Automattic/jetpack/assets/1620183/83d438aa-a2d4-432c-82ee-548c987edcb5">
<img width="500" alt="Screenshot 2023-11-23 at 2 28 46 PM" src="https://github.com/Automattic/jetpack/assets/1620183/541cada1-312d-41ee-8e54-5cbeed300ce9">

