### PR TITLE
Odyssey Stats widget: Only load stats script when widget is visible

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-only-load-stats-data-when-widget-is-visible
+++ b/projects/packages/stats-admin/changelog/fix-only-load-stats-data-when-widget-is-visible
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support load scripts conditionally for Stats widget

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -52,7 +52,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.13.x-dev"
+			"dev-trunk": "0.14.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.13.0",
+	"version": "0.14.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.13.0';
+	const VERSION = '0.14.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
+++ b/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
@@ -34,9 +34,11 @@ class WP_Dashboard_Odyssey_Widget {
 					src="//en.wordpress.com/i/loading/loading-64.gif"
 				/>
 				<p>
-				<?php if ( $is_toggled_open ) { ?>
-					echo __( 'Please reload the page to see your stats...', 'jetpack-stats-admin' );
-				<?php } ?>
+				<?php
+				if ( $is_toggled_open ) {
+					echo esc_html__( 'Please reload the page to see your stats...', 'jetpack-stats-admin' );
+				}
+				?>
 				</p>
 			</div>
 		</div>

--- a/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
+++ b/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
@@ -13,11 +13,14 @@ namespace Automattic\Jetpack\Stats_Admin;
  * @package jetpack-stats-admin
  */
 class WP_Dashboard_Odyssey_Widget {
+	const DASHBOARD_WIDGET_ID = 'jetpack_summary_widget';
 
 	/**
 	 * Renders the widget and fires a dashboard widget action.
 	 */
-	public static function render() {
+	public function render() {
+		// The widget is always rendered, so if it was hidden and then toggled open, we need to ask user to refresh the page to load data properly.
+		$is_toggled_open = $this->is_widget_hidden();
 		?>
 		<div id="dashboard_stats" class="jp-stats-widget" style="min-height: 200px;">
 			<div class="hide-if-js"><?php esc_html_e( 'Your Jetpack Stats widget requires JavaScript to function properly.', 'jetpack-stats-admin' ); ?></div>
@@ -30,6 +33,11 @@ class WP_Dashboard_Odyssey_Widget {
 					alt=<?php echo esc_attr( __( 'Loading', 'jetpack-stats-admin' ) ); ?>
 					src="//en.wordpress.com/i/loading/loading-64.gif"
 				/>
+				<p>
+				<?php if ( $is_toggled_open ) { ?>
+					echo __( 'Please reload the page to see your stats...', 'jetpack-stats-admin' );
+				<?php } ?>
+				</p>
 			</div>
 		</div>
 		<?php
@@ -56,5 +64,25 @@ class WP_Dashboard_Odyssey_Widget {
 				'enqueue_css'          => false,
 			)
 		);
+	}
+
+	/**
+	 * Load the admin scripts when the widget is visible.
+	 */
+	public function maybe_load_admin_scripts() {
+		if ( $this->is_widget_hidden() ) {
+			return;
+		}
+		$this->load_admin_scripts();
+	}
+
+	/**
+	 * Returns true if the widget is hidden for the current screen and current user.
+	 *
+	 * @return bool
+	 */
+	public function is_widget_hidden() {
+		$hidden = get_hidden_meta_boxes( get_current_screen() );
+		return in_array( self::DASHBOARD_WIDGET_ID, $hidden, true );
 	}
 }

--- a/projects/plugins/jetpack/changelog/fix-only-load-stats-data-when-widget-is-visible
+++ b/projects/plugins/jetpack/changelog/fix-only-load-stats-data-when-widget-is-visible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Odyssey Stats widget: only load scripts when the widget is visible

--- a/projects/plugins/jetpack/changelog/fix-only-load-stats-data-when-widget-is-visible#2
+++ b/projects/plugins/jetpack/changelog/fix-only-load-stats-data-when-widget-is-visible#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -68,15 +68,16 @@ class Jetpack_Stats_Dashboard_Widget {
 				// New widget implemented in Odyssey Stats.
 				$stats_widget = new Dashboard_Stats_Widget();
 				wp_add_dashboard_widget(
-					'jetpack_summary_widget',
+					Dashboard_Stats_Widget::DASHBOARD_WIDGET_ID,
 					$widget_title,
 					array( $stats_widget, 'render' )
 				);
-				$stats_widget->load_admin_scripts();
+				// Only load scripts when the widget is not hidden
+				$stats_widget->maybe_load_admin_scripts();
 			} else {
 				// Legacy widget.
 				wp_add_dashboard_widget(
-					'jetpack_summary_widget',
+					Dashboard_Stats_Widget::DASHBOARD_WIDGET_ID,
 					$widget_title,
 					array( __CLASS__, 'render_widget' )
 				);

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2338,7 +2338,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "3f110b7bd2d893fcea2d2d34d96d9d525cf69004"
+                "reference": "86416376823afc0d70cb40dd35c9d6a8d60c241b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2362,7 +2362,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.13.x-dev"
+                    "dev-trunk": "0.14.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jpop-issues/issues/8700

## Proposed changes:

- Only load script when the Stats widget is visible
- As the widget is always rendered by the dashboard, it's not possible to load data easily when it's toggled visible. So we added a notice saying 'Please reload the page to see your Stats.'.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Go to you local test instance with Stats module enabled
* Open `/wp-admin/`
* Click 'Screen Options' on the top right of the page
* Uncheck `Jetpack Stats`
* Refresh
* Inspect network requests
* Ensure there are no stats requests described in https://github.com/Automattic/jpop-issues/issues/8700
* Click 'Screen Options' on the top right of the page
*  Check `Jetpack Stats`
* Ensure you see  'Please reload the page to see your Stats.'
* Refresh
* Ensure you see the widget working properly

<img width="447" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/e18d6000-9cb3-4db7-a09c-49efbd59a0f1">

<img width="452" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/28bc008d-5fbc-45f8-8d3d-8f8915ecbac5">


