### PR TITLE
Memberships: Rename hasNewsletterPlans to hasTierPlans

### DIFF
--- a/projects/plugins/jetpack/changelog/rename-has-newsletter-plans-to-has-tier-plans
+++ b/projects/plugins/jetpack/changelog/rename-has-newsletter-plans-to-has-tier-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Rename hasNewsletterPlans to hasTierPlans for memberships.

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -16,11 +16,11 @@ function PaywallEdit( { className } ) {
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const accessLevel = useAccessLevel( postType );
 
-	const { stripeConnectUrl, hasNewsletterPlans } = useSelect( select => {
+	const { stripeConnectUrl, hasTierPlans } = useSelect( select => {
 		const { getNewsletterProducts, getConnectUrl } = select( 'jetpack/membership-products' );
 		return {
 			stripeConnectUrl: getConnectUrl(),
-			hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
+			hasTierPlans: getNewsletterProducts()?.length !== 0,
 		};
 	} );
 
@@ -35,10 +35,7 @@ function PaywallEdit( { className } ) {
 	}, [ accessLevel, setAccess ] );
 
 	function selectAccess( value ) {
-		if (
-			accessOptions.paid_subscribers.key === value &&
-			( stripeConnectUrl || ! hasNewsletterPlans )
-		) {
+		if ( accessOptions.paid_subscribers.key === value && ( stripeConnectUrl || ! hasTierPlans ) ) {
 			setShowDialog( true );
 			return;
 		}
@@ -133,7 +130,7 @@ function PaywallEdit( { className } ) {
 						isEditorPanel={ true }
 						accessLevel={ _accessLevel }
 						stripeConnectUrl={ stripeConnectUrl }
-						hasNewsletterPlans={ hasNewsletterPlans }
+						hasTierPlans={ hasTierPlans }
 						postHasPaywallBlock={ true }
 					/>
 				</PanelBody>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -68,7 +68,7 @@ export function SubscriptionEdit( props ) {
 		borderColor,
 		setBorderColor,
 		fontSize,
-		hasNewsletterPlans,
+		hasTierPlans,
 	} = props;
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( name );
@@ -282,7 +282,7 @@ export function SubscriptionEdit( props ) {
 			{ isNewsletterFeatureEnabled() && (
 				<BlockControls>
 					<Toolbar>
-						<GetAddPaidPlanButton context={ 'toolbar' } hasNewsletterPlans={ hasNewsletterPlans } />
+						<GetAddPaidPlanButton context={ 'toolbar' } hasTierPlans={ hasTierPlans } />
 					</Toolbar>
 				</BlockControls>
 			) }
@@ -333,7 +333,7 @@ export default compose( [
 	withSelect( select => {
 		const newsletterPlans = select( 'jetpack/membership-products' )?.getNewsletterProducts();
 		return {
-			hasNewsletterPlans: newsletterPlans?.length !== 0,
+			hasTierPlans: newsletterPlans?.length !== 0,
 		};
 	} ),
 	withColors(

--- a/projects/plugins/jetpack/extensions/shared/components/plans-setup-dialog/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/plans-setup-dialog/index.jsx
@@ -8,15 +8,15 @@ import { getPaidPlanLink } from '../../memberships/utils';
 import useAutosaveAndRedirect from '../../use-autosave-and-redirect';
 
 export default function PlansSetupDialog( { showDialog, closeDialog } ) {
-	const { hasNewsletterPlans } = useSelect( select => {
+	const { hasTierPlans } = useSelect( select => {
 		const { getNewsletterProducts, getConnectUrl } = select( 'jetpack/membership-products' );
 		return {
 			stripeConnectUrl: getConnectUrl(),
-			hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
+			hasTierPlans: getNewsletterProducts()?.length !== 0,
 		};
 	} );
 
-	const paidLink = getPaidPlanLink( hasNewsletterPlans );
+	const paidLink = getPaidPlanLink( hasTierPlans );
 	const { autosaveAndRedirect } = useAutosaveAndRedirect( paidLink );
 
 	return (

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -119,7 +119,7 @@ function TierSelector() {
 
 export function NewsletterAccessRadioButtons( {
 	accessLevel,
-	hasNewsletterPlans,
+	hasTierPlans,
 	stripeConnectUrl,
 	isEditorPanel = false,
 	postHasPaywallBlock: postHasPaywallBlock = false,
@@ -140,7 +140,7 @@ export function NewsletterAccessRadioButtons( {
 				onChange={ value => {
 					if (
 						accessOptions.paid_subscribers.key === value &&
-						( stripeConnectUrl || ! hasNewsletterPlans )
+						( stripeConnectUrl || ! hasTierPlans )
 					) {
 						setShowDialog( true );
 						return;
@@ -175,9 +175,9 @@ export function NewsletterAccessRadioButtons( {
 				] }
 				selected={ accessLevel }
 			/>
-			{ accessLevel === accessOptions.paid_subscribers.key &&
-				isStripeConnected &&
-				hasNewsletterPlans && <TierSelector></TierSelector> }
+			{ accessLevel === accessOptions.paid_subscribers.key && isStripeConnected && hasTierPlans && (
+				<TierSelector></TierSelector>
+			) }
 
 			{ isEditorPanel && (
 				<PlansSetupDialog closeDialog={ closeDialog } showDialog={ showDialog } />
@@ -187,21 +187,19 @@ export function NewsletterAccessRadioButtons( {
 }
 
 export function NewsletterAccessDocumentSettings( { accessLevel } ) {
-	const { hasNewsletterPlans, stripeConnectUrl, isLoading, foundPaywallBlock } = useSelect(
-		select => {
-			const { getNewsletterProducts, getConnectUrl, isApiStateLoading } = select(
-				'jetpack/membership-products'
-			);
-			const { getBlocks } = select( 'core/block-editor' );
+	const { hasTierPlans, stripeConnectUrl, isLoading, foundPaywallBlock } = useSelect( select => {
+		const { getNewsletterProducts, getConnectUrl, isApiStateLoading } = select(
+			'jetpack/membership-products'
+		);
+		const { getBlocks } = select( 'core/block-editor' );
 
-			return {
-				isLoading: isApiStateLoading(),
-				stripeConnectUrl: getConnectUrl(),
-				hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
-				foundPaywallBlock: getBlocks().find( block => block.name === paywallBlockMetadata.name ),
-			};
-		}
-	);
+		return {
+			isLoading: isApiStateLoading(),
+			stripeConnectUrl: getConnectUrl(),
+			hasTierPlans: getNewsletterProducts()?.length !== 0,
+			foundPaywallBlock: getBlocks().find( block => block.name === paywallBlockMetadata.name ),
+		};
+	} );
 
 	const postVisibility = useSelect( select => select( editorStore ).getEditedPostVisibility() );
 	const { selectBlock } = useDispatch( 'core/block-editor' );
@@ -266,7 +264,7 @@ export function NewsletterAccessDocumentSettings( { accessLevel } ) {
 											isEditorPanel={ true }
 											accessLevel={ _accessLevel }
 											stripeConnectUrl={ stripeConnectUrl }
-											hasNewsletterPlans={ hasNewsletterPlans }
+											hasTierPlans={ hasTierPlans }
 											postHasPaywallBlock={ foundPaywallBlock }
 										/>
 									</div>
@@ -298,7 +296,7 @@ export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
 			return {
 				isLoading: isApiStateLoading(),
 				stripeConnectUrl: getConnectUrl(),
-				hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
+				hasTierPlans: getNewsletterProducts()?.length !== 0,
 				postHasPaywallBlock: getBlocks().some( block => block.name === paywallBlockMetadata.name ),
 				newsletterCategories: getNewsletterCategories(),
 				newsletterCategoriesEnabled: getNewsletterCategoriesEnabled(),

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.js
@@ -50,21 +50,21 @@ export const MisconfigurationWarning = () => (
 	</Notice>
 );
 
-export default function GetAddPaidPlanButton( { context = 'other', hasNewsletterPlans } ) {
-	const addPaidPlanButtonText = hasNewsletterPlans
+export default function GetAddPaidPlanButton( { context = 'other', hasTierPlans } ) {
+	const addPaidPlanButtonText = hasTierPlans
 		? _x( 'Manage plans', 'unused context to distinguish translations', 'jetpack' )
 		: __( 'Set up a paid plan', 'jetpack' );
 
 	if ( 'toolbar' === context ) {
 		return (
-			<ToolbarButton href={ getPaidPlanLink( hasNewsletterPlans ) } target="_blank">
+			<ToolbarButton href={ getPaidPlanLink( hasTierPlans ) } target="_blank">
 				{ addPaidPlanButtonText }
 			</ToolbarButton>
 		);
 	}
 
 	return (
-		<Button variant="primary" href={ getPaidPlanLink( hasNewsletterPlans ) } target="_blank">
+		<Button variant="primary" href={ getPaidPlanLink( hasTierPlans ) } target="_blank">
 			{ addPaidPlanButtonText }
 		</Button>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 210-gh-automattic/gold

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Renames hasNewsletterPlans to hasTierPlans for memberships

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox.
* Test on a wpcom simple site or JN site (using this branch in JN - adding sandbox constant and enabling global http shouldn't be needed).
* Try purchasing a tiered newsletter plan. Everything should work as it used to with no regressions.
