### PR TITLE
Backport mu-wpcom-plugin 2.0.2, jetpack 12.9-a.11 Changes

### DIFF
--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.7] - 2023-11-24
+### Fixed
+- Fixed pre-publish UI reactivity for Jetpack Social [#34243]
+
 ## [0.41.6] - 2023-11-20
 ### Removed
 - Removed the 'jetpack/publicize' store. [#34111]
@@ -513,6 +517,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.41.7]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.6...v0.41.7
 [0.41.6]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.5...v0.41.6
 [0.41.5]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.4...v0.41.5
 [0.41.4]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.3...v0.41.4

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.41.7] - 2023-11-24
 ### Fixed
-- Fixed pre-publish UI reactivity for Jetpack Social [#34243]
+- Fixed pre-publish UI reactivity for Jetpack Social. [#34243]
 
 ## [0.41.6] - 2023-11-20
 ### Removed

--- a/projects/js-packages/publicize-components/changelog/fix-social-pre-publish-ui
+++ b/projects/js-packages/publicize-components/changelog/fix-social-pre-publish-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed pre-publish UI reactivity for Jetpack Social

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.41.7-alpha",
+	"version": "0.41.7",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-11-24
+
 ## [0.3.0] - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]
@@ -130,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.3.1]: https://github.com/Automattic/jetpack-admin-ui/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.25...0.3.0
 [0.2.25]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.24...0.2.25
 [0.2.24]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.23...0.2.24

--- a/projects/packages/admin-ui/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/packages/admin-ui/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use spaceship operator in sorting callbacks. No change to functionality.
-
-

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.3.1-alpha",
+	"version": "0.3.1",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.3.1-alpha';
+	const PACKAGE_VERSION = '0.3.1';
 
 	/**
 	 * Whether this class has been initialized

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.0] - 2023-11-24
 ### Added
-- Added whitelisting for payments endpoint [#34227]
+- Added whitelisting for the payments endpoint. [#34227]
 
 ## [0.13.0] - 2023-11-20
 ### Changed

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2023-11-24
+### Added
+- Added whitelisting for payments endpoint [#34227]
+
 ## [0.13.0] - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]
@@ -245,6 +249,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.14.0]: https://github.com/automattic/jetpack-blaze/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/automattic/jetpack-blaze/compare/v0.12.3...v0.13.0
 [0.12.3]: https://github.com/automattic/jetpack-blaze/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/automattic/jetpack-blaze/compare/v0.12.1...v0.12.2

--- a/projects/packages/blaze/changelog/fix-unnecessary-test-outputs
+++ b/projects/packages/blaze/changelog/fix-unnecessary-test-outputs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Avoid output in test. No change to the package itself.
-
-

--- a/projects/packages/blaze/changelog/vdimitrakis-SELFSERVE-830-whitelist-payments-endpoints
+++ b/projects/packages/blaze/changelog/vdimitrakis-SELFSERVE-830-whitelist-payments-endpoints
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added whitelisting for payments endpoint

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.14.0-alpha",
+	"version": "0.14.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.14.0-alpha';
+	const PACKAGE_VERSION = '0.14.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/boost-core/CHANGELOG.md
+++ b/projects/packages/boost-core/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2023-11-24
+### Changed
+- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
+- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+
 ## [0.2.1] - 2023-11-21
 ### Fixed
 - Made abstract static methods in `Automattic\Jetpack\Boost_Core\Lib\Cacheable` abstract, instead of being implemented to always throw. [#34220]
@@ -29,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduce new package. [#31163]
 
+[0.2.2]: https://github.com/Automattic/jetpack-boost-core/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Automattic/jetpack-boost-core/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-boost-core/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/Automattic/jetpack-boost-core/compare/v0.1.2...v0.1.3

--- a/projects/packages/boost-core/CHANGELOG.md
+++ b/projects/packages/boost-core/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.2] - 2023-11-24
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
-- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+- Replaced usage of strpos() with str_contains(). [#34137]
+- Replaced usage of substr() with str_starts_with() and str_ends_with(). [#34207]
 
 ## [0.2.1] - 2023-11-21
 ### Fixed

--- a/projects/packages/boost-core/changelog/update-strpos-str-contains
+++ b/projects/packages/boost-core/changelog/update-strpos-str-contains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_contains()

--- a/projects/packages/boost-core/changelog/update-substr-str-starts-end
+++ b/projects/packages/boost-core/changelog/update-substr-str-starts-end
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with().

--- a/projects/packages/boost-core/package.json
+++ b/projects/packages/boost-core/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-boost-core",
-	"version": "0.2.2-alpha",
+	"version": "0.2.2",
 	"description": "Core functionality for boost and relevant packages to depend on",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/boost-core/#readme",
 	"bugs": {

--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.3] - 2023-11-24
+
 ## [4.0.2] - 2023-11-21
 ### Removed
 - Removed `Utils::error_clear_last()`, the function can be called directly now. [#34222]
@@ -194,6 +196,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[4.0.3]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.2...4.0.3
 [4.0.2]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.0...4.0.1
 [4.0.0]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.11...4.0.0

--- a/projects/packages/changelogger/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/packages/changelogger/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use spaceship operator in sorting callbacks. No change to functionality.
-
-

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.0.3-alpha';
+	const VERSION = '4.0.3';
 
 	/**
 	 * Constructor.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2023-11-24
+
 ## [2.0.2] - 2023-11-21
 ### Changed
 - Replaced usage of strpos() with str_contains(). [#34137]
@@ -929,6 +931,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.0.3]: https://github.com/Automattic/jetpack-connection/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-connection/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-connection/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-connection/compare/v1.60.1...v2.0.0

--- a/projects/packages/connection/changelog/fix-unnecessary-test-outputs
+++ b/projects/packages/connection/changelog/fix-unnecessary-test-outputs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Avoid `error_log` output in `Test_Server_Sandbox`. No change to the package itself.
-
-

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.0.3-alpha';
+	const PACKAGE_VERSION = '2.0.3';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.24.1] - 2023-11-24
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
-- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
-- Fix Contact Form single and multiple choice inputs markup accessibility [#34147]
-- Forms Block: prioritize the use of form elements in the block inserter inside form blocks. [#34247]
+- Replaced usage of strpos() with str_contains(). [#34137]
+- Replaced usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+- Fixed markup accessibility issues for Contact Form's single and multiple choice inputs. [#34147]
+- Updated form blocks to prioritize the use of form elements in the block inserter. [#34247]
 
 ### Fixed
-- Improved Contact Form required label contrast [#34237]
-- Use correct sorting function in `Admin::grunion_ajax_shortcode()` [#34230]
+- Improved Contact Form required label contrast. [#34237]
+- Updated `Admin::grunion_ajax_shortcode()` to use the correct sorting function. [#34230]
 
 ## [0.24.0] - 2023-11-20
 ### Changed

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.1] - 2023-11-24
+### Changed
+- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
+- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+- Fix Contact Form single and multiple choice inputs markup accessibility [#34147]
+- Forms Block: prioritize the use of form elements in the block inserter inside form blocks. [#34247]
+
+### Fixed
+- Improved Contact Form required label contrast [#34237]
+- Use correct sorting function in `Admin::grunion_ajax_shortcode()` [#34230]
+
 ## [0.24.0] - 2023-11-20
 ### Changed
 - Replaced usage of strpos() with str_starts_with(). [#34135]
@@ -371,6 +382,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.24.1]: https://github.com/automattic/jetpack-forms/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/automattic/jetpack-forms/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/automattic/jetpack-forms/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/automattic/jetpack-forms/compare/v0.22.6...v0.23.0

--- a/projects/packages/forms/changelog/fix-contact-form-multiple-options-accessibility
+++ b/projects/packages/forms/changelog/fix-contact-form-multiple-options-accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Fix Contact Form single and multiple choice inputs markup accessibility

--- a/projects/packages/forms/changelog/fix-contact-form-required-contrast
+++ b/projects/packages/forms/changelog/fix-contact-form-required-contrast
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Improved Contact Form required label contrast

--- a/projects/packages/forms/changelog/fix-unnecessary-test-outputs
+++ b/projects/packages/forms/changelog/fix-unnecessary-test-outputs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Avoid actually trying to send mail during tests. No change to the package itself.
-
-

--- a/projects/packages/forms/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/packages/forms/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Use correct sorting function in `Admin::grunion_ajax_shortcode()`

--- a/projects/packages/forms/changelog/fix-use-spaceship-operator-in-sorting-functions#2
+++ b/projects/packages/forms/changelog/fix-use-spaceship-operator-in-sorting-functions#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use spaceship operator in sorting callbacks. No change to functionality.
-
-

--- a/projects/packages/forms/changelog/update-form-prioritize-form-innerblocks
+++ b/projects/packages/forms/changelog/update-form-prioritize-form-innerblocks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms Block: prioritize the use of form elements in the block inserter inside form blocks.

--- a/projects/packages/forms/changelog/update-strpos-str-contains
+++ b/projects/packages/forms/changelog/update-strpos-str-contains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_contains()

--- a/projects/packages/forms/changelog/update-substr-str-starts-end
+++ b/projects/packages/forms/changelog/update-substr-str-starts-end
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with().

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.24.1-alpha",
+	"version": "0.24.1",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.24.1-alpha';
+	const PACKAGE_VERSION = '0.24.1';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/google-fonts-provider/CHANGELOG.md
+++ b/projects/packages/google-fonts-provider/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.1] - 2023-11-24
 ### Changed
-- Code Modernization: add note of non-usage of PHP8+ functions yet. [#34137]
+- Added a non-usage note for PHP8+ functions. [#34137]
 
 ## [0.7.0] - 2023-11-20
 ### Changed

--- a/projects/packages/google-fonts-provider/CHANGELOG.md
+++ b/projects/packages/google-fonts-provider/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2023-11-24
+### Changed
+- Code Modernization: add note of non-usage of PHP8+ functions yet. [#34137]
+
 ## [0.7.0] - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]
@@ -94,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds a provider for Google Fonts using the new Webfonts API in Gutenberg
 
+[0.7.1]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.5.4...v0.6.0
 [0.5.4]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.5.3...v0.5.4

--- a/projects/packages/google-fonts-provider/changelog/update-strpos-str-contains
+++ b/projects/packages/google-fonts-provider/changelog/update-strpos-str-contains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: add note of non-usage of PHP8+ functions yet.

--- a/projects/packages/google-fonts-provider/package.json
+++ b/projects/packages/google-fonts-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-google-fonts-provider",
-	"version": "0.7.1-alpha",
+	"version": "0.7.1",
 	"description": "WordPress Webfonts provider for Google Fonts",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/google-fonts-provider/#readme",
 	"bugs": {

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2023-11-24
+
 ## [0.12.0] - 2023-11-20
 ### Added
 - Added idc query argument to url for tracking multisite idcs. [#34090]
@@ -449,6 +451,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.12.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.11.3...v0.12.0
 [0.11.3]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.11.1...v0.11.2

--- a/projects/packages/identity-crisis/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/packages/identity-crisis/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use spaceship operator in sorting callbacks. No change to functionality.
-
-

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.12.1-alpha",
+	"version": "0.12.1",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.12.1-alpha';
+	const PACKAGE_VERSION = '0.12.1';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-11-24
+### Changed
+- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
+- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+
 ## [0.3.0] - 2023-11-20
 ### Changed
 - Replaced usage of strpos() with str_starts_with(). [#34135]
@@ -56,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add image CDN package. [#29561]
 
+[0.3.1]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.8...v0.3.0
 [0.2.8]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.6...v0.2.7

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.1] - 2023-11-24
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
-- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+- Replaced usage of strpos() with str_contains(). [#34137]
+- Replaced usage of substr() with str_starts_with() and str_ends_with(). [#34207]
 
 ## [0.3.0] - 2023-11-20
 ### Changed

--- a/projects/packages/image-cdn/changelog/update-strpos-str-contains
+++ b/projects/packages/image-cdn/changelog/update-strpos-str-contains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_contains()

--- a/projects/packages/image-cdn/changelog/update-substr-str-starts-end
+++ b/projects/packages/image-cdn/changelog/update-substr-str-starts-end
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with().

--- a/projects/packages/image-cdn/package.json
+++ b/projects/packages/image-cdn/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-image-cdn",
-	"version": "0.3.1-alpha",
+	"version": "0.3.1",
 	"description": "Serve images through Jetpack's powerful CDN",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/image-cdn/#readme",
 	"bugs": {

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Assets;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.3.1-alpha';
+	const PACKAGE_VERSION = '0.3.1';
 
 	/**
 	 * Singleton.

--- a/projects/packages/import/CHANGELOG.md
+++ b/projects/packages/import/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2023-11-24
+### Changed
+- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
+
 ## [0.8.0] - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]
@@ -78,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed various imported resources hierarchies [#29012]
 
+[0.8.1]: https://github.com/Automattic/jetpack-import/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/Automattic/jetpack-import/compare/v0.7.4...v0.8.0
 [0.7.4]: https://github.com/Automattic/jetpack-import/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/Automattic/jetpack-import/compare/v0.7.2...v0.7.3

--- a/projects/packages/import/CHANGELOG.md
+++ b/projects/packages/import/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.1] - 2023-11-24
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
+- Replaced usage of strpos() with str_contains(). [#34137]
 
 ## [0.8.0] - 2023-11-20
 ### Changed

--- a/projects/packages/import/changelog/update-strpos-str-contains
+++ b/projects/packages/import/changelog/update-strpos-str-contains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_contains()

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-import",
-	"version": "0.8.1-alpha",
+	"version": "0.8.1",
 	"description": "Set of REST API routes used in WPCOM Unified Importer.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",
 	"bugs": {

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.8.1-alpha';
+	const PACKAGE_VERSION = '0.8.1';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2023-11-24
+### Added
+- Add dynamic titles to task lists [#34244]
+- Migrate Block Patterns [#34162]
+
+### Changed
+- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
+- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+
+### Fixed
+- Prevent fatal errors when filename is empty in the heif support feature [#34062]
+
 ## [5.0.0] - 2023-11-20
 ### Added
 - Ensure enable subscribe modal task in launchpad. [#33909]
@@ -438,6 +450,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.1.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.0.0...v5.1.0
 [5.0.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.18.0...v5.0.0
 [4.18.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.17.0...v4.18.0
 [4.17.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.16.2...v4.17.0

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.1.0] - 2023-11-24
 ### Added
-- Add dynamic titles to task lists [#34244]
-- Migrate Block Patterns [#34162]
+- Added dynamic titles to task lists. [#34244]
+- Migrated Block Patterns. [#34162]
 
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
-- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+- Replaced usage of strpos() with str_contains(). [#34137]
+- Replaced usage of substr() with str_starts_with() and str_ends_with(). [#34207]
 
 ### Fixed
-- Prevent fatal errors when filename is empty in the heif support feature [#34062]
+- Prevented fatal errors when filename is empty in the heif support feature. [#34062]
 
 ## [5.0.0] - 2023-11-20
 ### Added

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-dynamic-titles
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-dynamic-titles
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add dynamic titles to task lists

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-migrate-block-patterns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-migrate-block-patterns
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Migrate Block Patterns

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-prevent-fatal-error-for-heif-to-jpg
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-prevent-fatal-error-for-heif-to-jpg
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Prevent fatal errors when filename is empty in the heif support feature

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-strpos-str-contains
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-strpos-str-contains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_contains()

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-substr-str-starts-end
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-substr-str-starts-end
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with().

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.1.0-alpha",
+	"version": "5.1.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.1.0-alpha';
+	const PACKAGE_VERSION = '5.1.0';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.3] - 2023-11-24
+### Changed
+- My Jetpack: Change Jetpack AI insterstitial contact link to Jetpack Redirect [#34252]
+- My Jetpack: Link Jetpack AI Contact Us button to support email on interstitial page [#34240]
+- My Jetpack: Remove hardcoded tiers from Jetpack AI interstitial [#34259]
+- My Jetpack: Trust next tier provided by the Jetpack AI feature endpoint. [#34239]
+
 ## [4.0.2] - 2023-11-21
 ### Changed
 - Replace usage of strpos() with str_contains(). [#34137]
@@ -1118,6 +1125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.0.3]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.0.2...4.0.3
 [4.0.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.0.0...4.0.1
 [4.0.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.12.2...4.0.0

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.3] - 2023-11-24
 ### Changed
-- My Jetpack: Change Jetpack AI insterstitial contact link to Jetpack Redirect [#34252]
-- My Jetpack: Link Jetpack AI Contact Us button to support email on interstitial page [#34240]
-- My Jetpack: Remove hardcoded tiers from Jetpack AI interstitial [#34259]
-- My Jetpack: Trust next tier provided by the Jetpack AI feature endpoint. [#34239]
+- Changed Jetpack AI insterstitial contact link to Jetpack Redirect. [#34252]
+- Link Jetpack AI Contact Us button to support email on interstitial page. [#34240]
+- Removed hardcoded tiers from Jetpack AI interstitial. [#34259]
+- Trust next tier provided by the Jetpack AI feature endpoint. [#34239]
 
 ## [4.0.2] - 2023-11-21
 ### Changed

--- a/projects/packages/my-jetpack/changelog/update-ai-assistant-contact-us-jetpack-redirect
+++ b/projects/packages/my-jetpack/changelog/update-ai-assistant-contact-us-jetpack-redirect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: Change Jetpack AI insterstitial contact link to Jetpack Redirect

--- a/projects/packages/my-jetpack/changelog/update-ai-assistant-interstitial-contact-us
+++ b/projects/packages/my-jetpack/changelog/update-ai-assistant-interstitial-contact-us
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: Link Jetpack AI Contact Us button to support email on interstitial page

--- a/projects/packages/my-jetpack/changelog/update-ai-assistant-remove-hardcoded-tiers
+++ b/projects/packages/my-jetpack/changelog/update-ai-assistant-remove-hardcoded-tiers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: Remove hardcoded tiers from Jetpack AI interstitial

--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-trust-next-tier-from-feature-data
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-trust-next-tier-from-feature-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: Trust next tier provided by the Jetpack AI feature endpoint.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.0.3",
+	"version": "4.0.4-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.0.3-alpha",
+	"version": "4.0.3",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.0.3-alpha';
+	const PACKAGE_VERSION = '4.0.3';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.0.3';
+	const PACKAGE_VERSION = '4.0.4-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/post-list/CHANGELOG.md
+++ b/projects/packages/post-list/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.1] - 2023-11-24
 ### Changed
-- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+- Replaced usage of substr() with str_starts_with() and str_ends_with(). [#34207]
 
 ## [0.5.0] - 2023-11-20
 ### Changed

--- a/projects/packages/post-list/CHANGELOG.md
+++ b/projects/packages/post-list/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2023-11-24
+### Changed
+- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+
 ## [0.5.0] - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]
@@ -90,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the default columns displayed on the post and page list screens
 - Refactored thumbnail preview to function server side. All javascript removed.
 
+[0.5.1]: https://github.com/automattic/jetpack-post-list/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/automattic/jetpack-post-list/compare/v0.4.6...v0.5.0
 [0.4.6]: https://github.com/automattic/jetpack-post-list/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/automattic/jetpack-post-list/compare/v0.4.4...v0.4.5

--- a/projects/packages/post-list/changelog/update-substr-str-starts-end
+++ b/projects/packages/post-list/changelog/update-substr-str-starts-end
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with().

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Post_List;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.5.1-alpha';
+	const PACKAGE_VERSION = '0.5.1';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.1] - 2023-11-24
+### Removed
+- Removed the unused code [#34241]
+
 ## [0.37.0] - 2023-11-20
 ### Changed
 - Replaced usage of strpos() with str_starts_with(). [#34135]
@@ -418,6 +422,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.37.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.37.0...v0.37.1
 [0.37.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.6...v0.37.0
 [0.36.6]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.5...v0.36.6
 [0.36.5]: https://github.com/Automattic/jetpack-publicize/compare/v0.36.4...v0.36.5

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.37.1] - 2023-11-24
 ### Removed
-- Removed the unused code [#34241]
+- Removed unused code. [#34241]
 
 ## [0.37.0] - 2023-11-20
 ### Changed

--- a/projects/packages/publicize/changelog/update-cleanup-unused-jetpack-social-code
+++ b/projects/packages/publicize/changelog/update-cleanup-unused-jetpack-social-code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Removed the unused code

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.37.1-alpha",
+	"version": "0.37.1",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.40.1] - 2023-11-24
 ### Changed
-- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
-- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+- Replaced usage of strpos() with str_contains(). [#34137]
+- Replaced usage of substr() with str_starts_with() and str_ends_with(). [#34207]
 
 ## [0.40.0] - 2023-11-20
 ### Changed

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.1] - 2023-11-24
+### Changed
+- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
+- Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+
 ## [0.40.0] - 2023-11-20
 ### Changed
 - Replaced usage of strpos() with str_starts_with(). [#34135]
@@ -845,6 +850,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.40.1]: https://github.com/Automattic/jetpack-search/compare/v0.40.0...v0.40.1
 [0.40.0]: https://github.com/Automattic/jetpack-search/compare/v0.39.7...v0.40.0
 [0.39.7]: https://github.com/Automattic/jetpack-search/compare/v0.39.6...v0.39.7
 [0.39.6]: https://github.com/Automattic/jetpack-search/compare/v0.39.5...v0.39.6

--- a/projects/packages/search/changelog/update-strpos-str-contains
+++ b/projects/packages/search/changelog/update-strpos-str-contains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_contains()

--- a/projects/packages/search/changelog/update-substr-str-starts-end
+++ b/projects/packages/search/changelog/update-substr-str-starts-end
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of substr() with str_starts_with() and str_ends_with().

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.40.1-alpha",
+	"version": "0.40.1",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.40.1",
+	"version": "0.40.2-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.40.1-alpha';
+	const VERSION = '0.40.1';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.40.1';
+	const VERSION = '0.40.2-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.14.0 - 2023-11-24
 ### Added
-- Support load scripts conditionally for Stats widget [#34284]
+- Added support to load scripts conditionally for the Stats widget. [#34284]
 
 ## 0.13.0 - 2023-11-20
 ### Changed

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.14.0 - 2023-11-24
+### Added
+- Support load scripts conditionally for Stats widget [#34284]
+
 ## 0.13.0 - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]

--- a/projects/packages/stats-admin/changelog/fix-only-load-stats-data-when-widget-is-visible
+++ b/projects/packages/stats-admin/changelog/fix-only-load-stats-data-when-widget-is-visible
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Support load scripts conditionally for Stats widget

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.14.0-alpha",
+	"version": "0.14.0",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.14.0-alpha';
+	const VERSION = '0.14.0';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2023-11-24
+### Added
+- Add jetpack_verbum_subscription_modal setting to manage subscription modal show/hide on Verbum [#34258]
+
+### Fixed
+- Silence the call to `gzinflate` to avoid a few PHP warnings. [#34186]
+
 ## [2.0.2] - 2023-11-21
 ### Changed
 - Replaced usage of strpos() with str_contains(). [#34137]
@@ -976,6 +983,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.1.0]: https://github.com/Automattic/jetpack-sync/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/Automattic/jetpack-sync/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-sync/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-sync/compare/v1.60.1...v2.0.0

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.0] - 2023-11-24
 ### Added
-- Add jetpack_verbum_subscription_modal setting to manage subscription modal show/hide on Verbum [#34258]
+- Added jetpack_verbum_subscription_modal setting to manage subscription modal show/hide on Verbum. [#34258]
 
 ### Fixed
-- Silence the call to `gzinflate` to avoid a few PHP warnings. [#34186]
+- Silenced the call to `gzinflate` to avoid a few PHP warnings. [#34186]
 
 ## [2.0.2] - 2023-11-21
 ### Changed

--- a/projects/packages/sync/changelog/add-verbum-subscription-modal-settings
+++ b/projects/packages/sync/changelog/add-verbum-subscription-modal-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add jetpack_verbum_subscription_modal setting to manage subscription modal show/hide on Verbum

--- a/projects/packages/sync/changelog/silence-gzinflate
+++ b/projects/packages/sync/changelog/silence-gzinflate
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Silence the call to `gzinflate` to avoid a few PHP warnings.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.1.0-alpha';
+	const PACKAGE_VERSION = '2.1.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.2] - 2023-11-24
+
 ## [0.21.1] - 2023-11-21
 ### Changed
 - Replaced usage of strpos() with str_contains(). [#34137]
@@ -1196,6 +1198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.21.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.1...v0.21.2
 [0.21.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.20.2...v0.21.0
 [0.20.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.20.1...v0.20.2

--- a/projects/packages/videopress/changelog/kraftbj-patch-3
+++ b/projects/packages/videopress/changelog/kraftbj-patch-3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: It is only updating the URL in the package.json for capitalization. Not important for any changelog.
-
-

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.21.2-alpha",
+	"version": "0.21.2",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.21.2-alpha';
+	const PACKAGE_VERSION = '0.21.2';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -4,29 +4,27 @@
 
 ## 12.9-a.11 - 2023-11-24
 ### Enhancements
-- Adjust UpgradeNudge for tier plans [#34254]
-- Allow non wpcom sites to be suggested [#34112]
-- Display subscribers count on pre/post publish panels [#34267]
-- Prevent caching paywalled content [#34242]
-- Subscribe modal: apply dismissal cookie domain wide [#34245]
-
-### Bug fixes
-- Fix block name usage when unregistering Paywall block [#34274]
-- RNMobile: Revert setting default for video blocks added on mobile. [#34271]
+- Blogroll: Allowed non-WP.com sites to be suggested. [#34112]
+- Added subscribers count to pre- and post- publish panels when publishing posts in Newsletter Categories. [#34267]
+- Subscribe Modal: The modal is not shown at all after being dismissed, not just limited to the post it was dismissed on. [#34245]
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
-- Add feature flag for new like widget layout. [#34264]
-- Add jetpack_verbum_subscription_modal setting to manage subscription modal show/hide on Verbum [#34258]
-- Add the latest tier plans for 750 and 1000 requests [#34270]
-- Add tier enabled filter status to the ai-feature payload. Include on the ai-assistant data store. [#34260]
-- Blocks: remove Beta Amazon block. [#34228]
-- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
-- Code modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
-- fix paywall switch account on simple sites [#34250]
-- Introduce enable-tier-plans-ui beta flag [#34221]
-- Jetpack AI: Fix the Usage Panel upgrade button text to change depending on the next tier available. [#34251]
+- AI Assistant: Adjusted UpgradeNudge for tier plans. [#34254]
+- Prevented caching paywalled content. [#34242]
+- Fixed block name usage when unregistering Paywall block. [#34274]
+- Mobile: Reverted setting default for video blocks added on mobile. [#34271]
+- Added a feature flag for the new like widget layout. [#34264]
+- Added jetpack_verbum_subscription_modal setting to manage subscription modal show/hide on Verbum. [#34258]
+- Added the latest tier plans for 750 and 1000 requests. [#34270]
+- Added tier enabled filter status to the ai-feature payload. Include on the ai-assistant data store. [#34260]
+- Blocks: Remove Beta Amazon block. [#34228]
+- Code Modernization: Replaced usage of strpos() with str_contains() [#34137]
+- Code modernization: Replaced usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+- Fixed paywall switch account on simple sites. [#34250]
+- Introduced enable-tier-plans-ui beta flag. [#34221]
+- Jetpack AI: Fixed the Usage Panel upgrade button text to change depending on the next tier available. [#34251]
 - Jetpack AI: Handle Contact Us button on the Usage Panel when the site is a Simple or Atomic site. [#34273]
-- Odyssey Stats widget: only load scripts when the widget is visible [#34284]
+- Odyssey Stats widget: Only loading scripts when the widget is visible. [#34284]
 - Reuse email on memberships checkout form when recently subscribed but not logged in. [#34084]
 
 ## 12.9-a.9 - 2023-11-21

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.9-a.11 - 2023-11-24
+### Enhancements
+- Adjust UpgradeNudge for tier plans [#34254]
+- Allow non wpcom sites to be suggested [#34112]
+- Display subscribers count on pre/post publish panels [#34267]
+- Prevent caching paywalled content [#34242]
+- Subscribe modal: apply dismissal cookie domain wide [#34245]
+
+### Bug fixes
+- Fix block name usage when unregistering Paywall block [#34274]
+- RNMobile: Revert setting default for video blocks added on mobile. [#34271]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add feature flag for new like widget layout. [#34264]
+- Add jetpack_verbum_subscription_modal setting to manage subscription modal show/hide on Verbum [#34258]
+- Add the latest tier plans for 750 and 1000 requests [#34270]
+- Add tier enabled filter status to the ai-feature payload. Include on the ai-assistant data store. [#34260]
+- Blocks: remove Beta Amazon block. [#34228]
+- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
+- Code modernization: Replace usage of substr() with str_starts_with() and str_ends_with(). [#34207]
+- fix paywall switch account on simple sites [#34250]
+- Introduce enable-tier-plans-ui beta flag [#34221]
+- Jetpack AI: Fix the Usage Panel upgrade button text to change depending on the next tier available. [#34251]
+- Jetpack AI: Handle Contact Us button on the Usage Panel when the site is a Simple or Atomic site. [#34273]
+- Odyssey Stats widget: only load scripts when the widget is visible [#34284]
+- Reuse email on memberships checkout form when recently subscribed but not logged in. [#34084]
+
 ## 12.9-a.9 - 2023-11-21
 ### Bug fixes
 - Fixed all Google font definitions being printed in the head, instead only printing fonts that are used in global styles or required by block settings. [#34157]

--- a/projects/plugins/jetpack/changelog/Allow non wpcom sites to be suggested
+++ b/projects/plugins/jetpack/changelog/Allow non wpcom sites to be suggested
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Allow non wpcom sites to be suggested

--- a/projects/plugins/jetpack/changelog/add-750-1000-tier-plans
+++ b/projects/plugins/jetpack/changelog/add-750-1000-tier-plans
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add the latest tier plans for 750 and 1000 requests

--- a/projects/plugins/jetpack/changelog/add-introduce-tier-plans-beta-flag
+++ b/projects/plugins/jetpack/changelog/add-introduce-tier-plans-beta-flag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Introduce enable-tier-plans-ui beta flag

--- a/projects/plugins/jetpack/changelog/add-like-widget-feature-flag
+++ b/projects/plugins/jetpack/changelog/add-like-widget-feature-flag
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add feature flag for new like widget layout.

--- a/projects/plugins/jetpack/changelog/add-memberships-email-to-checkout-form
+++ b/projects/plugins/jetpack/changelog/add-memberships-email-to-checkout-form
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Reuse email on memberships checkout form when recently subscribed but not logged in.

--- a/projects/plugins/jetpack/changelog/add-prevent-batcache-when-accessing-paywalled-content
+++ b/projects/plugins/jetpack/changelog/add-prevent-batcache-when-accessing-paywalled-content
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Prevent caching paywalled content

--- a/projects/plugins/jetpack/changelog/add-remove-unecessary-v2
+++ b/projects/plugins/jetpack/changelog/add-remove-unecessary-v2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-

--- a/projects/plugins/jetpack/changelog/add-subscribers-count
+++ b/projects/plugins/jetpack/changelog/add-subscribers-count
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Display subscribers count on pre/post publish panels

--- a/projects/plugins/jetpack/changelog/add-tier-plans-upgrade-nudge
+++ b/projects/plugins/jetpack/changelog/add-tier-plans-upgrade-nudge
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Adjust UpgradeNudge for tier plans

--- a/projects/plugins/jetpack/changelog/add-verbum-subscription-modal-settings
+++ b/projects/plugins/jetpack/changelog/add-verbum-subscription-modal-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add jetpack_verbum_subscription_modal setting to manage subscription modal show/hide on Verbum

--- a/projects/plugins/jetpack/changelog/add-verbum-subscription-modal-settings#2
+++ b/projects/plugins/jetpack/changelog/add-verbum-subscription-modal-settings#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/change-tier-plans-beta-flag-on-store
+++ b/projects/plugins/jetpack/changelog/change-tier-plans-beta-flag-on-store
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add tier enabled filter status to the ai-feature payload. Include on the ai-assistant data store.

--- a/projects/plugins/jetpack/changelog/fix-only-load-stats-data-when-widget-is-visible
+++ b/projects/plugins/jetpack/changelog/fix-only-load-stats-data-when-widget-is-visible
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Odyssey Stats widget: only load scripts when the widget is visible

--- a/projects/plugins/jetpack/changelog/fix-only-load-stats-data-when-widget-is-visible#2
+++ b/projects/plugins/jetpack/changelog/fix-only-load-stats-data-when-widget-is-visible#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-paywall-block-registration
+++ b/projects/plugins/jetpack/changelog/fix-paywall-block-registration
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix block name usage when unregistering Paywall block

--- a/projects/plugins/jetpack/changelog/fix-paywall-switch-accounts-link
+++ b/projects/plugins/jetpack/changelog/fix-paywall-switch-accounts-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-fix paywall switch account on simple sites

--- a/projects/plugins/jetpack/changelog/fix-unnecessary-test-outputs
+++ b/projects/plugins/jetpack/changelog/fix-unnecessary-test-outputs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Expect output in `WP_Test_Jetpack_Sync_Sender` test instead of letting it go to the console. No change to the plugin itself.
-
-

--- a/projects/plugins/jetpack/changelog/fix-use-spaceship-operator-in-sorting-functions
+++ b/projects/plugins/jetpack/changelog/fix-use-spaceship-operator-in-sorting-functions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Use spaceship operator in sorting callbacks. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/remove-unneeded-function-exists-checks
+++ b/projects/plugins/jetpack/changelog/remove-unneeded-function-exists-checks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Remove unnecessary `function_exists`: `libxml_disable_entity_loader` added in 5.2.11 (and we call other libxml funcs without checks), `class_alias` added in 5.3, `libxml_use_internal_errors` already required by `DOMDocument`.
-
-

--- a/projects/plugins/jetpack/changelog/remove-unneeded-php-constant-checks
+++ b/projects/plugins/jetpack/changelog/remove-unneeded-php-constant-checks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Remove unneeded `defined()` checks. Should be no change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/remove-wpcs-v2-ignore
+++ b/projects/plugins/jetpack/changelog/remove-wpcs-v2-ignore
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Remove `phpcs:ignore` comment that was added because wpcom was still on v2 now that they've updated. No code changes.
-
-

--- a/projects/plugins/jetpack/changelog/rm-amazon-block
+++ b/projects/plugins/jetpack/changelog/rm-amazon-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Blocks: remove Beta Amazon block.

--- a/projects/plugins/jetpack/changelog/rnmobile-revert-default-src-for-converted-video-block
+++ b/projects/plugins/jetpack/changelog/rnmobile-revert-default-src-for-converted-video-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-RNMobile: Revert setting default for video blocks added on mobile.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-usage-panel-upgrade-button-text
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-usage-panel-upgrade-button-text
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: Fix the Usage Panel upgrade button text to change depending on the next tier available. 

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-handle-contact-us-upgrade-on-simple-sites
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-handle-contact-us-upgrade-on-simple-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: Handle Contact Us button on the Usage Panel when the site is a Simple or Atomic site.

--- a/projects/plugins/jetpack/changelog/update-rm-62-code
+++ b/projects/plugins/jetpack/changelog/update-rm-62-code
@@ -1,5 +1,0 @@
-Significance: patch
-Type: compat
-Comment: General: remove code that was added to remain compatible with versions of WordPress lower than 6.3.
-
-

--- a/projects/plugins/jetpack/changelog/update-strpos-str-contains
+++ b/projects/plugins/jetpack/changelog/update-strpos-str-contains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Code Modernization: Replace usage of strpos() with str_contains()

--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-site-wide
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-site-wide
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscribe modal: apply dismissal cookie domain wide

--- a/projects/plugins/jetpack/changelog/update-substr-str-starts-end
+++ b/projects/plugins/jetpack/changelog/update-substr-str-starts-end
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Code modernization: Replace usage of substr() with str_starts_with() and str_ends_with().

--- a/projects/plugins/jetpack/changelog/whitelist-payments-endpoints
+++ b/projects/plugins/jetpack/changelog/whitelist-payments-endpoints
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_9_a_10",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_9_a_11",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_9_a_11",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_9_a_12",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.9-a.10
+ * Version: 12.9-a.11
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '12.9-a.10' );
+define( 'JETPACK__VERSION', '12.9-a.11' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.9-a.11
+ * Version: 12.9-a.12
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '12.9-a.11' );
+define( 'JETPACK__VERSION', '12.9-a.12' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -436,7 +436,7 @@ class Jetpack_Likes {
 		/**
 		 * Enable an alternate Likes layout.
 		 *
-		 * @since $$next-version$$
+		 * @since 12.9
 		 *
 		 * @module likes
 		 *

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.9.0-a.11",
+	"version": "12.9.0-a.12",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.9.0-a.10",
+	"version": "12.9.0-a.11",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.2 - 2023-11-24
+
 ## 2.0.1 - 2023-11-21
 
 ## 2.0.0 - 2023-11-20

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-dynamic-titles
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-dynamic-titles
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-migrate-block-patterns
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-migrate-block-patterns
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_2_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_2"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.2-alpha
+ * Version: 2.0.2
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.2-alpha",
+	"version": "2.0.2",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.2, jetpack 12.9-a.11

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.