### PR TITLE
Update CTAs on My Jetpack page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -54,19 +54,12 @@ const ActionButton = ( {
 		switch ( status ) {
 			case PRODUCT_STATUSES.ABSENT:
 			case PRODUCT_STATUSES.ABSENT_WITH_PLAN: {
-				const buttonText =
-					status === PRODUCT_STATUSES.ABSENT
-						? __( 'Learn more', 'jetpack-my-jetpack' )
-						: sprintf(
-								/* translators: placeholder is product name. */
-								__( 'Install %s', 'jetpack-my-jetpack' ),
-								name
-						  );
+				const buttonText = __( 'Learn more', 'jetpack-my-jetpack' );
 				return {
 					...buttonState,
 					href: `#/add-${ slug }`,
 					size: 'small',
-					variant: 'link',
+					variant: 'primary',
 					weight: 'regular',
 					label: buttonText,
 					onClick: null,
@@ -149,7 +142,6 @@ const ActionButton = ( {
 		buttonState,
 		isManageDisabled,
 		manageUrl,
-		name,
 		onActivate,
 		onAdd,
 		onFixConnection,

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -56,11 +56,7 @@ const ActionButton = ( {
 			case PRODUCT_STATUSES.ABSENT_WITH_PLAN: {
 				const buttonText =
 					status === PRODUCT_STATUSES.ABSENT
-						? sprintf(
-								/* translators: placeholder is product name. */
-								__( 'Get %s', 'jetpack-my-jetpack' ),
-								name
-						  )
+						? __( 'Learn more', 'jetpack-my-jetpack' )
 						: sprintf(
 								/* translators: placeholder is product name. */
 								__( 'Install %s', 'jetpack-my-jetpack' ),
@@ -113,9 +109,7 @@ const ActionButton = ( {
 					onClick: onAdd,
 				};
 			case PRODUCT_STATUSES.ACTIVE: {
-				const viewText = __( 'View', 'jetpack-my-jetpack' );
-				const manageText = __( 'Manage', 'jetpack-my-jetpack' );
-				const buttonText = purchaseUrl ? viewText : manageText;
+				const buttonText = __( 'View', 'jetpack-my-jetpack' );
 
 				return {
 					...buttonState,

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-ctas
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-ctas
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update the CTAs in My Jetpack for more clarity and to avoid inconsistencies

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -76,7 +76,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.0.x-dev"
+			"dev-trunk": "4.1.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.0.4-alpha",
+	"version": "4.1.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.0.4-alpha';
+	const PACKAGE_VERSION = '4.1.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/backup/changelog/update-my-jetpack-ctas
+++ b/projects/plugins/backup/changelog/update-my-jetpack-ctas
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -927,7 +927,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -959,7 +959,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/update-my-jetpack-ctas
+++ b/projects/plugins/boost/changelog/update-my-jetpack-ctas
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -983,7 +983,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1015,7 +1015,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-ctas
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-ctas
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1686,7 +1686,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1718,7 +1718,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/update-my-jetpack-ctas
+++ b/projects/plugins/migration/changelog/update-my-jetpack-ctas
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -927,7 +927,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -959,7 +959,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/update-my-jetpack-ctas
+++ b/projects/plugins/protect/changelog/update-my-jetpack-ctas
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/update-my-jetpack-ctas
+++ b/projects/plugins/search/changelog/update-my-jetpack-ctas
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/update-my-jetpack-ctas
+++ b/projects/plugins/social/changelog/update-my-jetpack-ctas
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-ctas
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-ctas
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/update-my-jetpack-ctas
+++ b/projects/plugins/videopress/changelog/update-my-jetpack-ctas
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0c6e86b2596c29ab1d0ad6afb91854324e324537"
+                "reference": "3b915a71708fa11091e035d006b975201def6bb8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update CTA copy from "Get {productName}" and "Install {productName}" to "Learn more", and "Manage" to "View".

<img width="1099" alt="image" src="https://github.com/Automattic/jetpack/assets/5714212/b16cd6c9-7a09-4eab-8c42-4ab256545a5f">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-pQh-p2#comment-67814

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this branch locally or using Jetpack Beta on a JN site
* Make sure to have only one or a few products
* Visit `/wp-admin/admin.php?page=my-jetpack`
* Make sure that "Manage" is replaced with "View" for the products that you have active
* Confirm that the buttons that used to be either "Get ..." or "Install ..." are now "Learn more", and look like a primary button