### PR TITLE
Fix block registration to prevent console errors in the full site editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-block-registration
+++ b/projects/plugins/jetpack/changelog/fix-block-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed console errors being thrown for Jetpack blocks inside the Full Site Editor.

--- a/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
+++ b/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
@@ -47,7 +47,7 @@ export default function registerJetpackBlock(
 
 	const prefixedName = jpPrefix + rawName;
 	const result = registerBlockType(
-		nameOrMetadata === 'object' ? nameOrMetadata : prefixedName,
+		typeof nameOrMetadata === 'object' ? nameOrMetadata : prefixedName,
 		settings
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This is an attempt at fixing an issue with the full site editor, where currently all of our blocks are causing the following console error to be thrown:

>The block "jetpack/***" must have a title.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p9dueE-7Zq-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Open the full site editor on your test site.
- There should be no errors being logged in the console anymore.
- Jetpack blocks should still be registered correctly and available.

