### PR TITLE
Jetpack Google Fonts: Filter out deprecated google fonts data from user global styles

### DIFF
--- a/projects/plugins/jetpack/changelog/feat-filter-out-deprecated-google-fonts-data
+++ b/projects/plugins/jetpack/changelog/feat-filter-out-deprecated-google-fonts-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack Google Fonts: Filter out the old google fonts data from user global styles

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -75,7 +75,7 @@ class Jetpack_Google_Font_Face {
 
 		$global_styles_font_slug = $this->get_font_slug_from_setting( $global_styles );
 		if ( $global_styles_font_slug ) {
-			$this->fonts_in_use[] = $global_styles_font_slug;
+			$this->add_font( $global_styles_font_slug );
 		}
 
 		if ( isset( $global_styles['blocks'] ) ) {
@@ -83,7 +83,7 @@ class Jetpack_Google_Font_Face {
 				$font_slug = $this->get_font_slug_from_setting( $setting );
 
 				if ( $font_slug ) {
-					$this->fonts_in_use[] = $font_slug;
+					$this->add_font( $font_slug );
 				}
 			}
 		}
@@ -93,7 +93,7 @@ class Jetpack_Google_Font_Face {
 				$font_slug = $this->get_font_slug_from_setting( $setting );
 
 				if ( $font_slug ) {
-					$this->fonts_in_use[] = $font_slug;
+					$this->add_font( $font_slug );
 				}
 			}
 		}
@@ -109,11 +109,20 @@ class Jetpack_Google_Font_Face {
 	 */
 	public function collect_block_fonts( $content, $parsed_block ) {
 		if ( ! is_admin() && isset( $parsed_block['attrs']['fontFamily'] ) ) {
-			$block_font_family    = $parsed_block['attrs']['fontFamily'];
-			$this->fonts_in_use[] = $block_font_family;
+			$block_font_family = $parsed_block['attrs']['fontFamily'];
+			$this->add_font( $block_font_family );
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Add the specify font to the fonts_in_use list.
+	 *
+	 * @param string $font_slug The font slug.
+	 */
+	public function add_font( $font_slug ) {
+		$this->fonts_in_use[] = _wp_to_kebab_case( $font_slug );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Tracking;
+
 /**
  * Gets the Google Fonts data
  *
@@ -220,9 +222,15 @@ function jetpack_google_fonts_user_global_styles_pre_save( $post_data ) {
 		return $post_data;
 	}
 
+	$prev_count = count( $raw_data['settings']['typography']['fontFamilies'] );
 	$raw_data['settings']['typography']['fontFamilies'] = jetpack_google_fonts_filter_out_deprecated_font_data(
 		$raw_data['settings']['typography']['fontFamilies']
 	);
+
+	if ( $prev_count !== count( $raw_data['settings']['typography']['fontFamilies'] ) ) {
+		$tracking = new Tracking();
+		$tracking->record_user_event( 'jetpack_google_fonts_clean_up_dirty_data' );
+	}
 
 	/**
 	 * Clean up the empty properties

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -58,11 +58,15 @@ function jetpack_get_google_fonts_data() {
  * @return object[] The map of the the available Google Fonts.
  */
 function jetpack_get_available_google_fonts_map( $google_fonts_data ) {
+	$font_families = isset( $google_fonts_data ) && isset( $google_fonts_data['fontFamilies'] )
+		? $google_fonts_data['fontFamilies']
+		: array();
+
 	$jetpack_google_fonts_list = array_map(
 		function ( $font_family ) {
 			return $font_family['name'];
 		},
-		$google_fonts_data['fontFamilies']
+		$font_families
 	);
 
 	/** This filter is documented in modules/google-fonts/wordpress-6.3/load-google-fonts.php */

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -149,22 +149,15 @@ function jetpack_register_google_fonts_to_theme_json( $theme_json ) {
 add_filter( 'wp_theme_json_data_default', 'jetpack_register_google_fonts_to_theme_json' );
 
 /**
- * Unregister the google fonts data from user's theme json data that were stored by accident.
+ * Filter out the deprecated font families that are from the jetpack-google-fonts provider.
  *
- * @param WP_Theme_JSON_Data $theme_json The theme json data of user.
- * @return WP_Theme_JSON_Data The filtered theme json data.
+ * @param object[] $font_families The font families.
+ * @return object[] The filtered font families.
  */
-function jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user( $theme_json ) {
-	$raw_data = $theme_json->get_data();
-	$origin   = 'custom';
-	if ( empty( $raw_data['settings']['typography']['fontFamilies'][ $origin ] ) ) {
-		return $theme_json;
-	}
-
-	// Filter out the font definitions that are from the jetpack-google-fonts provider.
-	$raw_data['settings']['typography']['fontFamilies'][ $origin ] = array_values(
+function jetpack_google_fonts_filter_out_deprecated_font_data( $font_families ) {
+	return array_values(
 		array_filter(
-			$raw_data['settings']['typography']['fontFamilies'][ $origin ],
+			$font_families,
 			function ( $font_family ) {
 				$has_deprecated_google_fonts_data = false;
 				foreach ( $font_family['fontFace'] as $font_face ) {
@@ -179,12 +172,75 @@ function jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user( $
 			}
 		)
 	);
+}
+
+/**
+ * Unregister the google fonts data from user's theme json data that were stored by accident.
+ *
+ * @param WP_Theme_JSON_Data $theme_json The theme json data of user.
+ * @return WP_Theme_JSON_Data The filtered theme json data.
+ */
+function jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user( $theme_json ) {
+	$raw_data = $theme_json->get_data();
+	$origin   = 'custom';
+	if ( empty( $raw_data['settings']['typography']['fontFamilies'][ $origin ] ) ) {
+		return $theme_json;
+	}
+
+	// Filter out the font definitions that are from the jetpack-google-fonts provider.
+	$raw_data['settings']['typography']['fontFamilies'][ $origin ] = jetpack_google_fonts_filter_out_deprecated_font_data(
+		$raw_data['settings']['typography']['fontFamilies'][ $origin ]
+	);
 
 	$theme_json_class = get_class( $theme_json );
 	return new $theme_json_class( $raw_data, 'custom' );
 }
 
 add_filter( 'wp_theme_json_data_user', 'jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user' );
+
+/**
+ * Filter out the font families from the jetpack-google-fonts provider when saving the user global styles.
+ *
+ * @param array $post_data The post data to filter.
+ * @return array The filtered post data.
+ */
+function jetpack_google_fonts_user_global_styles_pre_save( $post_data ) {
+	if ( $post_data['post_type'] !== 'wp_global_styles' ) {
+		return $post_data;
+	}
+
+	$post_content        = stripslashes( $post_data['post_content'] );
+	$raw_data            = json_decode( $post_content, true );
+	$json_decoding_error = json_last_error();
+	if ( JSON_ERROR_NONE !== $json_decoding_error ) {
+		return $post_data;
+	}
+
+	if ( empty( $raw_data['settings']['typography']['fontFamilies'] ) ) {
+		return $post_data;
+	}
+
+	$raw_data['settings']['typography']['fontFamilies'] = jetpack_google_fonts_filter_out_deprecated_font_data(
+		$raw_data['settings']['typography']['fontFamilies']
+	);
+
+	/**
+	 * Clean up the empty properties
+	 */
+	if ( empty( $raw_data['settings']['typography']['fontFamilies'] ) ) {
+		unset( $raw_data['settings']['typography']['fontFamilies'] );
+	}
+
+	if ( empty( $raw_data['settings']['typography'] ) ) {
+		unset( $raw_data['settings']['typography'] );
+	}
+
+	$post_data['post_content'] = wp_json_encode( $raw_data );
+
+	return $post_data;
+}
+
+add_filter( 'wp_insert_post_data', 'jetpack_google_fonts_user_global_styles_pre_save' );
 
 if ( ! class_exists( 'Jetpack_Google_Font_Face' ) ) {
 	/**

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -148,6 +148,44 @@ function jetpack_register_google_fonts_to_theme_json( $theme_json ) {
 
 add_filter( 'wp_theme_json_data_default', 'jetpack_register_google_fonts_to_theme_json' );
 
+/**
+ * Unregister the google fonts data from user's theme json data that were stored by accident.
+ *
+ * @param WP_Theme_JSON_Data $theme_json The theme json data of user.
+ * @return WP_Theme_JSON_Data The filtered theme json data.
+ */
+function jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user( $theme_json ) {
+	$raw_data = $theme_json->get_data();
+	$origin   = 'custom';
+	if ( empty( $raw_data['settings']['typography']['fontFamilies'][ $origin ] ) ) {
+		return $theme_json;
+	}
+
+	// Filter out the font definitions that are from the jetpack-google-fonts provider.
+	$raw_data['settings']['typography']['fontFamilies'][ $origin ] = array_values(
+		array_filter(
+			$raw_data['settings']['typography']['fontFamilies'][ $origin ],
+			function ( $font_family ) {
+				$has_deprecated_google_fonts_data = false;
+				foreach ( $font_family['fontFace'] as $font_face ) {
+					$provider = isset( $font_face['provider'] ) ? $font_face['provider'] : '';
+					if ( $provider === 'jetpack-google-fonts' ) {
+						$has_deprecated_google_fonts_data = true;
+						break;
+					}
+				}
+
+				return ! $has_deprecated_google_fonts_data;
+			}
+		)
+	);
+
+	$theme_json_class = get_class( $theme_json );
+	return new $theme_json_class( $raw_data, 'custom' );
+}
+
+add_filter( 'wp_theme_json_data_user', 'jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user' );
+
 if ( ! class_exists( 'Jetpack_Google_Font_Face' ) ) {
 	/**
 	 * Load Jetpack Google Font Face


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/4535, pbxlJb-52N-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* The old Google Fonts data, such as the following, was inadvertently stored in the user's global styles. As a result, the Google Fonts cannot be loaded correctly.
  ```json
  [
	{
		"fontFamily": "'Albert Sans'",
		"name": "Albert Sans",
		"slug": "albert-sans",
		"fontFace": {
			"albert-sans-100-900-italic": {
				"origin": "gutenberg_wp_fonts_api",
				"provider": "jetpack-google-fonts",
				"fontFamily": "Albert Sans",
				"fontStyle": "italic",
				"fontWeight": "100 900",
				"fontDisplay": "fallback"
			},
			"albert-sans-100-900-normal": {
				"origin": "gutenberg_wp_fonts_api",
				"provider": "jetpack-google-fonts",
				"fontFamily": "Albert Sans",
				"fontStyle": "normal",
				"fontWeight": "100 900",
				"fontDisplay": "fallback"
			}
		}
	}
  ]
  ```
* This PR adds a new hook to filter out those data from user global styles to resolve the issue

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to WoA site
* Install changes from this PR by Jetpack Beta Tester
* Go to the Site Editor
* Update the global styles first
* Open the DevTool, and find the request from the previous step
* Copy the request as followed, `/wp-json/wp/v2/global-styles/<global_styles_id>`.
  ![image](https://github.com/Automattic/jetpack/assets/13596067/e646c576-7f1d-4349-8486-82a6bdfd7421)
* Trigger the code with the body below on the console to insert the dirty data. Note that you have to replace the `<global_styles_id>` with the real id on your site.
  ```
  `{"id":<global_styles_id>,"styles":{},"settings":{"typography":{"fontFamilies":{"theme":[{"fontFamily":"'Albert Sans'","name":"Albert Sans","slug":"albert-sans","fontFace":{"albert-sans-100-900-italic":{"origin":"gutenberg_wp_fonts_api","provider":"jetpack-google-fonts","fontFamily":"Albert Sans","fontStyle":"italic","fontWeight":"100 900","fontDisplay":"fallback"},"albert-sans-100-900-normal":{"origin":"gutenberg_wp_fonts_api","provider":"jetpack-google-fonts","fontFamily":"Albert Sans","fontStyle":"normal","fontWeight":"100 900","fontDisplay":"fallback"}}}]}}}}`
  ```
* Refresh the page
* Ensure you're able to see the Google Fonts when you want to change the font family
* Pick the “Albert Sans” font for the “Text”
* Visit your homepage, and ensure the font of the text is rendered correctly