### PR TITLE
Adds Creator to My Jetpack

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -16,6 +16,7 @@ import {
 	BackupInterstitial,
 	BoostInterstitial,
 	CRMInterstitial,
+	CreatorInterstitial,
 	ExtrasInterstitial,
 	JetpackAIInterstitial,
 	ProtectInterstitial,
@@ -55,6 +56,7 @@ const MyJetpack = () => (
 				<Route path="/add-backup" element={ <BackupInterstitial /> } />
 				<Route path="/add-boost" element={ <BoostInterstitial /> } />
 				<Route path="/add-crm" element={ <CRMInterstitial /> } />
+				<Route path="/add-creator" element={ <CreatorInterstitial /> } />
 				<Route path="/add-jetpack-ai" element={ <JetpackAIInterstitial /> } />
 				<Route path="/add-extras" element={ <ExtrasInterstitial /> } />
 				<Route path="/add-protect" element={ <ProtectInterstitial /> } />

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/creator-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/creator-card.jsx
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ProductCard from '../connected-product-card';
+
+const CreatorCard = ( { admin } ) => {
+	return <ProductCard admin={ admin } slug="creator" upgradeInInterstitial={ true } />;
+};
+
+CreatorCard.propTypes = {
+	admin: PropTypes.bool.isRequired,
+};
+
+export default CreatorCard;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -5,6 +5,7 @@ import AiCard from './ai-card';
 import AntiSpamCard from './anti-spam-card';
 import BackupCard from './backup-card';
 import BoostCard from './boost-card';
+import CreatorCard from './creator-card';
 import CrmCard from './crm-card';
 import ScanAndProtectCard from './scan-protect-card';
 import SearchCard from './search-card';
@@ -33,6 +34,7 @@ const ProductCardsSection = () => {
 		videopress: VideopressCard,
 		stats: showJetpackStatsCard ? StatsCard : null,
 		crm: CrmCard,
+		creator: CreatorCard,
 		social: SocialCard,
 		ai: AiCard,
 	};

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -246,11 +246,7 @@ export function BoostInterstitial() {
  * @returns {object} CreatorInterstitial react component.
  */
 export function CreatorInterstitial() {
-	return (
-		<ProductInterstitial slug="creator" installsPlugin={ true }>
-			<img src={ boostImage } alt="Creator" />
-		</ProductInterstitial>
-	);
+	return <ProductInterstitial slug="creator" />;
 }
 
 /**

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -241,6 +241,19 @@ export function BoostInterstitial() {
 }
 
 /**
+ * CreatorInterstitial component
+ *
+ * @returns {object} CreatorInterstitial react component.
+ */
+export function CreatorInterstitial() {
+	return (
+		<ProductInterstitial slug="creator" installsPlugin={ true }>
+			<img src={ boostImage } alt="Creator" />
+		</ProductInterstitial>
+	);
+}
+
+/**
  * CRMInterstitial component
  *
  * @returns {object} CRMInterstitial react component.

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -246,7 +246,7 @@ export function BoostInterstitial() {
  * @returns {object} CreatorInterstitial react component.
  */
 export function CreatorInterstitial() {
-	return <ProductInterstitial slug="creator" />;
+	return <ProductInterstitial slug="creator" installsPlugin={ true } />;
 }
 
 /**

--- a/projects/packages/my-jetpack/changelog/Adding Jetpack Creator to My Jetpack
+++ b/projects/packages/my-jetpack/changelog/Adding Jetpack Creator to My Jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adding Jetpack Creator to My Jetpack

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -26,6 +26,7 @@ class Products {
 			'backup'     => Products\Backup::class,
 			'boost'      => Products\Boost::class,
 			'crm'        => Products\Crm::class,
+			'creator'    => Products\Creator::class,
 			'extras'     => Products\Extras::class,
 			'jetpack-ai' => Products\Jetpack_Ai::class,
 			'scan'       => Products\Scan::class,

--- a/projects/packages/my-jetpack/src/products/class-creator.php
+++ b/projects/packages/my-jetpack/src/products/class-creator.php
@@ -27,13 +27,11 @@ class Creator extends Product {
 	public static $slug = 'creator';
 
 	/**
-	 * Get the plugin slug - ovewrite it and return Jetpack's
+	 * The slug of the plugin associated with this product - Creator functionalities are part of Jetpack's main plugin
 	 *
-	 * @return ?string
+	 * @var string
 	 */
-	public static function get_plugin_slug() {
-		return self::JETPACK_PLUGIN_SLUG;
-	}
+	public static $plugin_slug = self::JETPACK_PLUGIN_SLUG;
 
 	/**
 	 * Get the plugin filename - ovewrite it and return Jetpack's
@@ -43,13 +41,6 @@ class Creator extends Product {
 	public static function get_plugin_filename() {
 		return self::JETPACK_PLUGIN_FILENAME;
 	}
-
-	/**
-	 * The slug of the plugin associated with this product.
-	 *
-	 * @var string
-	 */
-	public static $plugin_slug = 'jetpack-creator';
 
 	/**
 	 * Whether this product requires a user connection

--- a/projects/packages/my-jetpack/src/products/class-creator.php
+++ b/projects/packages/my-jetpack/src/products/class-creator.php
@@ -27,6 +27,15 @@ class Creator extends Product {
 	public static $slug = 'creator';
 
 	/**
+	 * Get the plugin slug - ovewrite it and return Jetpack's
+	 *
+	 * @return ?string
+	 */
+	public static function get_plugin_slug() {
+		return self::JETPACK_PLUGIN_SLUG;
+	}
+
+	/**
 	 * Get the plugin filename - ovewrite it and return Jetpack's
 	 *
 	 * @return ?string

--- a/projects/packages/my-jetpack/src/products/class-creator.php
+++ b/projects/packages/my-jetpack/src/products/class-creator.php
@@ -337,13 +337,7 @@ class Creator extends Product {
 		}
 		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
 			foreach ( $purchases_data as $purchase ) {
-				if ( str_starts_with( $purchase->product_slug, static::get_wpcom_biyearly_product_slug() ) ) {
-					return true;
-				}
-				if ( str_starts_with( $purchase->product_slug, static::get_wpcom_product_slug() ) ) {
-					return true;
-				}
-				if ( str_starts_with( $purchase->product_slug, static::get_wpcom_monthly_product_slug() ) ) {
+				if ( strpos( $purchase->product_slug, 'jetpack_creator' ) !== false ) {
 					return true;
 				}
 			}
@@ -358,14 +352,8 @@ class Creator extends Product {
 	 */
 	public static function is_upgradable() {
 		$has_required_plan = self::has_required_plan();
-
-		// Mark as not upgradable if user is on unlimited tier or does not have any plan.
-		if ( ! $has_required_plan ) {
-			return true;
-		}
-		return false;
+		return ! $has_required_plan;
 	}
-
 	/**
 	 * Activates the product by installing and activating its plugin
 	 *

--- a/projects/packages/my-jetpack/src/products/class-creator.php
+++ b/projects/packages/my-jetpack/src/products/class-creator.php
@@ -354,24 +354,4 @@ class Creator extends Product {
 		$has_required_plan = self::has_required_plan();
 		return ! $has_required_plan;
 	}
-	/**
-	 * Activates the product by installing and activating its plugin
-	 *
-	 * @param bool|WP_Error $current_result Is the result of the top level activation actions. You probably won't do anything if it is an WP_Error.
-	 * @return boolean|\WP_Error
-	 */
-	public static function do_product_specific_activation( $current_result ) {
-
-		$product_activation = parent::do_product_specific_activation( $current_result );
-
-		if ( is_wp_error( $product_activation ) && 'module_activation_failed' === $product_activation->get_error_code() ) {
-			// A bundle is not a module. There's nothing in the plugin to be activated, so it's ok to fail to activate the module.
-			$product_activation = true;
-		}
-
-		// We just "got started" in My Jetpack, so skip the in-plugin experience.
-		update_option( 'jb_get_started', false );
-
-		return $product_activation;
-	}
 }

--- a/projects/packages/my-jetpack/src/products/class-creator.php
+++ b/projects/packages/my-jetpack/src/products/class-creator.php
@@ -1,0 +1,387 @@
+<?php
+/**
+ * Creator product
+ *
+ * @package my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack\Products;
+
+use Automattic\Jetpack\My_Jetpack\Product;
+use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
+
+/**
+ * Class responsible for handling the Creator product
+ */
+class Creator extends Product {
+
+	const FREE_TIER_SLUG             = 'free';
+	const UPGRADED_TIER_SLUG         = 'upgraded';
+	const UPGRADED_TIER_PRODUCT_SLUG = 'jetpack_creator_yearly';
+
+	/**
+	 * The product slug
+	 *
+	 * @var string
+	 */
+	public static $slug = 'creator';
+
+	/**
+	 * Get the plugin filename - ovewrite it and return Jetpack's
+	 *
+	 * @return ?string
+	 */
+	public static function get_plugin_filename() {
+		return self::JETPACK_PLUGIN_FILENAME;
+	}
+
+	/**
+	 * The slug of the plugin associated with this product.
+	 *
+	 * @var string
+	 */
+	public static $plugin_slug = 'jetpack-creator';
+
+	/**
+	 * Whether this product requires a user connection
+	 *
+	 * @var string
+	 */
+	public static $requires_user_connection = false;
+
+	/**
+	 * Get the internationalized product name
+	 *
+	 * @return string
+	 */
+	public static function get_name() {
+		return __( 'Creator', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product title
+	 *
+	 * @return string
+	 */
+	public static function get_title() {
+		return __( 'Jetpack Creator', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product description
+	 *
+	 * @return string
+	 */
+	public static function get_description() {
+		return __( 'Create, grow, and monetize your audience', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product long description
+	 *
+	 * @return string
+	 */
+	public static function get_long_description() {
+		return __( 'Create, grow, and monetize your audience with powerful tools for creators.', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized features list
+	 *
+	 * @return array Features list
+	 */
+	public static function get_features() {
+		return array(
+			__( 'Create content that stands out', 'jetpack-my-jetpack' ),
+			__( 'Grow your subscribers through our creator network and tools', 'jetpack-my-jetpack' ),
+			__( 'Monetize your online presence and earn from your website', 'jetpack-my-jetpack' ),
+		);
+	}
+
+	/**
+	 * Get the product's available tiers
+	 *
+	 * @return string[] Slugs of the available tiers
+	 */
+	public static function get_tiers() {
+		return array(
+			self::UPGRADED_TIER_SLUG,
+			self::FREE_TIER_SLUG,
+		);
+	}
+
+	/**
+	 * Get the internationalized comparison of free vs upgraded features
+	 *
+	 * @return array[] Protect features comparison
+	 */
+	public static function get_features_by_tier() {
+		return array(
+			array(
+				'name'  => __( 'Import subscribers', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Import a CSV file of your existing subscribers to be sent your Newsletter.',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array(
+						'included'    => true,
+						'description' => __( '100 subscribers', 'jetpack-my-jetpack' ),
+					),
+					self::UPGRADED_TIER_SLUG => array(
+						'included'    => true,
+						'description' => __( 'Unlimited subscribers', 'jetpack-my-jetpack' ),
+					),
+				),
+			),
+			array(
+				'name'  => __( 'Transaction fees', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'<p>Fees are only collected when you accept payments.</p>
+                        <p>Fees are based on the Jetpack plan you have and are calculated as a percentage of your revenue from 10% on the Free plan to 2% on the Creator plan (plus Stripe fees).</p>',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array(
+						'included'    => true,
+						'description' => __( '10%', 'jetpack-my-jetpack' ),
+					),
+					self::UPGRADED_TIER_SLUG => array(
+						'included'    => true,
+						'description' => __( '2%', 'jetpack-my-jetpack' ),
+					),
+				),
+			),
+			array(
+				'name'  => __( 'Creator network', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'<p>The creator network is the network of websites either hosted with WordPress.com or self-hosted and connected with Jetpack.</p>
+                        <p>Sites that are part of the creator network can gain exposure to new readers. Sites on the Creator plan have enhanced distribution to more areas of the Reader.</p>',
+						'jetpack-my-jetpack'
+					),
+					'link'    => array(
+						'id'    => 'jetpack-boost-lazy-load',
+						'title' => 'web.dev',
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array( 'included' => true ),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'Jetpack Blocks', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Jetpack has over 40 Gutenberg blocks to help you with your content creation, such as displaying your podcasts, showing different content to repeat visitors, creating contact forms and many more.',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array( 'included' => true ),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'Paid content gating', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Lock your content behind a paid content block. To access the content, readers will need to pay a one-time fee or a recurring subscription.',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array( 'included' => true ),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'Paywall access', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Add a Paywall to your content which lets your visitors read a section of your content before being asked to subscribe to continue reading.',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array( 'included' => true ),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'Newsltter', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Start a Newsletter by sending your content as an email newsletter direct to your fans email inboxes.',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array( 'included' => true ),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'Pay with PayPal', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Accept payment with PayPal for simple payments like eBooks, courses and more.',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array( 'included' => false ),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'WordAds', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'<p>WordAds adds advertisements to your website. Start earning from your website traffic.</p>
+                        <p>Over 50 internet advertisers — including Google AdSense & Adx, AppNexus, Amazon A9, AOL Marketplace, Yahoo, Criteo, and more — bid to display ads in WordAds spots.</p>',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array( 'included' => false ),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'Dedicated email support', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'<p>Paid customers get dedicated email support from our world-class Happiness Engineers to help with any issue.</p>
+						 <p>All other questions are handled by our team as quickly as we are able to go through the WordPress support forum.</p>',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array( 'included' => false ),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get the product princing details
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing_for_ui() {
+		return array(
+			'tiers' => array(
+				self::FREE_TIER_SLUG     => array(
+					'available' => true,
+					'is_free'   => true,
+				),
+				self::UPGRADED_TIER_SLUG => array_merge(
+					array(
+						'available'          => true,
+						'wpcom_product_slug' => self::UPGRADED_TIER_PRODUCT_SLUG,
+					),
+					Wpcom_Products::get_product_pricing( self::UPGRADED_TIER_PRODUCT_SLUG )
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get the URL where the user manages the product
+	 *
+	 * @return ?string
+	 */
+	public static function get_manage_url() {
+		return admin_url( 'admin.php?page=jetpack#/settings?term=creator' );
+	}
+
+	/**
+	 * Get the WPCOM product slug used to make the purchase
+	 *
+	 * @return ?string
+	 */
+	public static function get_wpcom_product_slug() {
+		return 'jetpack_creator_yearly';
+	}
+
+	/**
+	 * Get the WPCOM product slug used to make the purchase
+	 *
+	 * @return ?string
+	 */
+	public static function get_wpcom_biyearly_product_slug() {
+		return 'jetpack_creator_bi_yearly';
+	}
+
+	/**
+	 * Get the WPCOM monthly product slug used to make the purchase
+	 *
+	 * @return ?string
+	 */
+	public static function get_wpcom_monthly_product_slug() {
+		return 'jetpack_creator_monthly';
+	}
+
+	/**
+	 * Checks whether the current plan (or purchases) of the site already supports the product
+	 *
+	 * @return boolean
+	 */
+	public static function has_required_plan() {
+		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
+			return false;
+		}
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				if ( str_starts_with( $purchase->product_slug, static::get_wpcom_biyearly_product_slug() ) ) {
+					return true;
+				}
+				if ( str_starts_with( $purchase->product_slug, static::get_wpcom_product_slug() ) ) {
+					return true;
+				}
+				if ( str_starts_with( $purchase->product_slug, static::get_wpcom_monthly_product_slug() ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Checks whether the product can be upgraded - i.e. this shows the /#add-creator interstitial
+	 *
+	 * @return boolean
+	 */
+	public static function is_upgradable() {
+		return true;
+	}
+
+	/**
+	 * Activates the product by installing and activating its plugin
+	 *
+	 * @param bool|WP_Error $current_result Is the result of the top level activation actions. You probably won't do anything if it is an WP_Error.
+	 * @return boolean|\WP_Error
+	 */
+	public static function do_product_specific_activation( $current_result ) {
+
+		$product_activation = parent::do_product_specific_activation( $current_result );
+
+		if ( is_wp_error( $product_activation ) && 'module_activation_failed' === $product_activation->get_error_code() ) {
+			// A bundle is not a module. There's nothing in the plugin to be activated, so it's ok to fail to activate the module.
+			$product_activation = true;
+		}
+
+		// We just "got started" in My Jetpack, so skip the in-plugin experience.
+		update_option( 'jb_get_started', false );
+
+		return $product_activation;
+	}
+}

--- a/projects/packages/my-jetpack/src/products/class-creator.php
+++ b/projects/packages/my-jetpack/src/products/class-creator.php
@@ -361,7 +361,13 @@ class Creator extends Product {
 	 * @return boolean
 	 */
 	public static function is_upgradable() {
-		return true;
+		$has_required_plan = self::has_required_plan();
+
+		// Mark as not upgradable if user is on unlimited tier or does not have any plan.
+		if ( ! $has_required_plan ) {
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-creator.php
+++ b/projects/packages/my-jetpack/src/products/class-creator.php
@@ -164,10 +164,6 @@ class Creator extends Product {
                         <p>Sites that are part of the creator network can gain exposure to new readers. Sites on the Creator plan have enhanced distribution to more areas of the Reader.</p>',
 						'jetpack-my-jetpack'
 					),
-					'link'    => array(
-						'id'    => 'jetpack-boost-lazy-load',
-						'title' => 'web.dev',
-					),
 				),
 				'tiers' => array(
 					self::FREE_TIER_SLUG     => array( 'included' => true ),

--- a/projects/plugins/jetpack/changelog/add-creator-to-my-jetpack
+++ b/projects/plugins/jetpack/changelog/add-creator-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+adding Creator to my jetpack

--- a/projects/plugins/jetpack/modules/carousel.php
+++ b/projects/plugins/jetpack/modules/carousel.php
@@ -9,7 +9,7 @@
  * Auto Activate: No
  * Module Tags: Photos and Videos
  * Feature: Appearance
- * Additional Search Queries: gallery, carousel, diaporama, slideshow, images, lightbox, exif, metadata, image
+ * Additional Search Queries: gallery, carousel, diaporama, slideshow, images, lightbox, exif, metadata, image, creator
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/modules/contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Forms\Jetpack_Forms;
  * Auto Activate: Yes
  * Module Tags: Other
  * Feature: Writing
- * Additional Search Queries: contact, form, grunion, feedback, submission, contact form, email, feedback, contact form plugin, custom form, custom form plugin, form builder, forms, form maker, survey, contact by jetpack, contact us, forms free
+ * Additional Search Queries: contact, form, grunion, feedback, submission, contact form, email, feedback, contact form plugin, custom form, custom form plugin, form builder, forms, form maker, survey, contact by jetpack, contact us, forms free, creator
  */
 
 /**

--- a/projects/plugins/jetpack/modules/enhanced-distribution.php
+++ b/projects/plugins/jetpack/modules/enhanced-distribution.php
@@ -8,7 +8,7 @@
  * Auto Activate: Public
  * Module Tags: Writing
  * Feature: Engagement
- * Additional Search Queries: google, seo, firehose, search, broadcast, broadcasting
+ * Additional Search Queries: google, seo, firehose, search, broadcast, broadcasting, creator
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/modules/google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts.php
@@ -9,7 +9,7 @@
  * Auto Activate: No
  * Module Tags: Fonts, Recommended
  * Feature: Writing
- * Additional Search Queries: fonts, webfonts, typography
+ * Additional Search Queries: fonts, webfonts, typography, creator
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/modules/related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts.php
@@ -10,7 +10,7 @@
  * Module Tags: Recommended
  * Feature: Engagement
  * // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInComment
- * Additional Search Queries: related, jetpack related posts, related posts for wordpress, related posts, popular posts, popular, related content, related post, contextual, context, contextual related posts, related articles, similar posts, easy related posts, related page, simple related posts, free related posts, related thumbnails, similar, engagement, yet another related posts plugin
+ * Additional Search Queries: related, jetpack related posts, related posts for wordpress, related posts, popular posts, popular, related content, related post, contextual, context, contextual related posts, related articles, similar posts, easy related posts, related page, simple related posts, free related posts, related thumbnails, similar, engagement, yet another related posts plugin, creator
  */
 class Jetpack_RelatedPosts_Module {
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -10,7 +10,7 @@
  * Auto Activate: No
  * Module Tags: Social
  * Feature: Engagement
- * Additional Search Queries: subscriptions, subscription, email, follow, followers, subscribers, signup, newsletter
+ * Additional Search Queries: subscriptions, subscription, email, follow, followers, subscribers, signup, newsletter, creator
  */
 
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.

--- a/projects/plugins/jetpack/modules/wordads.php
+++ b/projects/plugins/jetpack/modules/wordads.php
@@ -7,7 +7,7 @@
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Traffic, Appearance
- * Additional Search Queries: advertising, ad codes, ads
+ * Additional Search Queries: advertising, ad codes, ads, creator
  * Plans: premium, business, security, complete
  *
  * @package automattic/jetpack


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds Creator to My Jetpack, which are then managed via the settings modules. I've added creator search terms to most of them but some of the earn settings tabs aren't modules so do not show up in search. We can iterate on that later, we may need to look at whether it's worthwhile having a standalone product in future.

### Other information:

Couldn't see any E2E tests that needed to be updated.

## Jetpack product discussion
pf9WZf-9v-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to `/wp-admin/admin.php?page=my-jetpack` you should see a new card for Creator with a purchase CTA
* Clicking purchase should take you here `/wp-admin/admin.php?page=my-jetpack#/add-creator`
* This loads an interstitial the same style as boost
* Clicking start free, takes you to the settings page `/wp-admin/admin.php?page=jetpack#/settings?term=creator`
* I've added some additional search terms to the modules, not all are able to be searched for though (e.g. Settings -> Monetize -> Collect PayPal payments.
* Purchasing Creator changes the CTA from "Purchase" to "Manage" 

https://github.com/Automattic/jetpack/assets/4077604/77f9e538-6e63-4168-9b67-871dae8242c3

