### PR TITLE
CRM: Resolves 3389 - remove axios dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2800,9 +2800,6 @@ importers:
       '@wordpress/icons':
         specifier: 9.38.0
         version: 9.38.0(react@18.2.0)
-      axios:
-        specifier: 1.6.2
-        version: 1.6.2
       classnames:
         specifier: 2.3.2
         version: 2.3.2

--- a/projects/plugins/crm/changelog/fix-crm-3389-remove_axios_dependencies
+++ b/projects/plugins/crm/changelog/fix-crm-3389-remove_axios_dependencies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Replaced axios with native fetch.
+
+

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -29,7 +29,6 @@
 		"@wordpress/element": "5.24.0",
 		"@wordpress/i18n": "4.47.0",
 		"@wordpress/icons": "9.38.0",
-		"axios": "1.6.2",
 		"classnames": "2.3.2",
 		"prop-types": "15.8.1",
 		"react": "18.2.0",

--- a/projects/plugins/crm/src/js/components/automations-admin/components/workflow-row/index.tsx
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/workflow-row/index.tsx
@@ -70,7 +70,7 @@ export const WorkflowRow: React.FC< WorkflowRowProps > = props => {
 					<div className={ styles.triggers }>
 						{ workflow.triggers.map( ( trigger: Trigger ) => {
 							return (
-								<div className={ styles.triggers__item }>
+								<div key={ trigger.slug } className={ styles.triggers__item }>
 									{ trigger.title }
 									<IconTooltip
 										title={ trigger.title }

--- a/projects/plugins/crm/src/js/components/automations-admin/components/workflow-table/index.tsx
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/workflow-table/index.tsx
@@ -34,6 +34,7 @@ export const WorkflowTable: React.FC< WorkflowTableProps > = props => {
 	const getSortableWorkflowTableHeader = ( column: SortableWorkflowTableColumn ) => {
 		return (
 			<WorkflowTableHeader
+				key={ column }
 				column={ column }
 				onClick={ getSortableHeaderOnClick( column ) }
 				selectedForSort={ sortedColumn === column }
@@ -49,14 +50,22 @@ export const WorkflowTable: React.FC< WorkflowTableProps > = props => {
 	return (
 		<div className={ styles.container }>
 			<table className={ styles.table }>
-				<tr className={ styles[ 'header-row' ] }>
-					<WorkflowTableHeader column={ 'checkbox' } />
-					{ sortableColumns.map( column => getSortableWorkflowTableHeader( column ) ) }
-					<WorkflowTableHeader column={ 'edit' } />
-				</tr>
-				{ sortedWorkflows.map( workflow => (
-					<WorkflowRow workflow={ workflow } refetchWorkflows={ refetchWorkflows } />
-				) ) }
+				<thead>
+					<tr className={ styles[ 'header-row' ] }>
+						<WorkflowTableHeader column={ 'checkbox' } />
+						{ sortableColumns.map( column => getSortableWorkflowTableHeader( column ) ) }
+						<WorkflowTableHeader column={ 'edit' } />
+					</tr>
+				</thead>
+				<tbody>
+					{ sortedWorkflows.map( workflow => (
+						<WorkflowRow
+							key={ workflow.id }
+							workflow={ workflow }
+							refetchWorkflows={ refetchWorkflows }
+						/>
+					) ) }
+				</tbody>
 			</table>
 		</div>
 	);

--- a/projects/plugins/crm/src/js/data/query-functions.ts
+++ b/projects/plugins/crm/src/js/data/query-functions.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { Workflow, ServerPreparedWorkflow } from 'crm/state/automations-admin/types';
 import { getServerPreparedWorkflow } from 'crm/state/automations-admin/util';
 
@@ -7,24 +6,43 @@ declare let jpcrmAutomationsInitialState: any;
 
 const v4ApiRoot = `${ jpcrmAutomationsInitialState.apiRoot }jetpack-crm/v4`;
 
-const api = axios.create( {
-	baseURL: v4ApiRoot,
-	headers: { 'X-WP-Nonce': jpcrmAutomationsInitialState.apiNonce },
-} );
+type fetchAutomationsAPIOptions = {
+	headers: HeadersInit;
+	method: string;
+	body?: string;
+};
+
+const callAutomationsAPI = async ( relative_url: string, payload?: object ) => {
+	const options: fetchAutomationsAPIOptions = {
+		headers: {
+			'X-WP-Nonce': jpcrmAutomationsInitialState.apiNonce,
+			'Content-Type': 'application/json',
+		},
+		method: 'GET',
+	};
+	if ( payload ) {
+		options.method = 'POST';
+		options.body = JSON.stringify( payload );
+	}
+	const response = await fetch( v4ApiRoot + relative_url, options );
+	return await response.json();
+};
 
 // /wp-json/jetpack-crm/v4/automation/workflows
 export const getAutomationWorkflows =
 	( hydrate: ( workflows: Workflow[] ) => void ) => async () => {
-		const result = await api.get< Workflow[] >( '/automation/workflows' );
-		result.data && hydrate( result.data );
+		const result: Workflow[] = await callAutomationsAPI( '/automation/workflows' );
+		result && hydrate( result );
 		return result;
 	};
 
 // /wp-json/jetpack-crm/v4/automation/workflows/:id
 export const postAutomationWorkflow = async ( workflow: Workflow ) => {
 	const serverPreparedWorkflow = getServerPreparedWorkflow( workflow );
-	return await api.post< ServerPreparedWorkflow >(
+
+	const result: ServerPreparedWorkflow = await callAutomationsAPI(
 		`/automation/workflows/${ workflow.id }`,
 		serverPreparedWorkflow
 	);
+	return result;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: Resolves Automattic/zero-bs-crm#3389 - remove axios dependencies

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In Automattic/jetpack#34238 the axios dependency was updated. However, we really don't even need this dependency, as we can just use `fetch`.

This PR removes the axios dependency in favor of `fetch`, adding a small `callAutomationsAPI` wrapper function. I also fixed a few React errors due to items not having a `key` prop and table data not being wrapped in `<thead>` and `<tbody>`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

No functionality should have changed between `trunk` and the `fix/crm/3389-remove_axios_dependencies` branch. Likewise, automations is behind a feature flag.

1. Enable automations feature flag:
    ```
    add_filter( 'jetpack_crm_feature_flag_automations', '__return_true' );
    add_filter( 'jetpack_crm_feature_flag_api_v4', '__return_true' );
    ```
2. Go to the automations dashboard: `/wp-admin/admin.php?page=jpcrm-automations#/automations`
3. Ensure it is populated with any workflows you'd previously added, and that you can edit them. If you don't have any, there are two example workflows in #33424.