### PR TITLE
Monetize: Update link to Plans screen

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-earn-plans-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-earn-plans-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Earn: Update link to plans page.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.1.0",
+	"version": "5.1.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.1.0';
+	const PACKAGE_VERSION = '5.1.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -167,7 +167,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_visible_callback' => 'wpcom_launchpad_has_goal_paid_subscribers',
 			'get_calypso_path'    => function ( $task, $default, $data ) {
-				return '/earn/payments-plans/' . $data['site_slug_encoded'] . '#add-newsletter-payment-plan';
+				return '/earn/payments/' . $data['site_slug_encoded'] . '#add-newsletter-payment-plan';
 			},
 		),
 		'setup_newsletter'                => array(
@@ -479,7 +479,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_has_goal_paid_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/earn/payments-plans/' . $data['site_slug_encoded'];
+				return '/earn/payments/' . $data['site_slug_encoded'];
 			},
 		),
 		'add_about_page'                  => array(
@@ -517,7 +517,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_has_paid_membership_plans',
 			'is_visible_callback'  => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/earn/payments-plans/' . $data['site_slug_encoded'];
+				return '/earn/payments/' . $data['site_slug_encoded'];
 			},
 		),
 

--- a/projects/plugins/jetpack/changelog/update-earn-plans-url
+++ b/projects/plugins/jetpack/changelog/update-earn-plans-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Earn: Update link to plans page.

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
@@ -68,7 +68,7 @@ function NewProduct( { onClose } ) {
 			<MenuItem>
 				{ siteSlug && (
 					<ExternalLink
-						href={ `https://wordpress.com/earn/payments-plans/${ siteSlug }#add-new-payment-plan` }
+						href={ `https://wordpress.com/earn/payments/${ siteSlug }#add-new-payment-plan` }
 					>
 						{ getMessageByProductType( 'add a new product', productType ) }
 					</ExternalLink>

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.js
@@ -23,7 +23,7 @@ export const encodeValueForShortcodeAttribute = value => {
 };
 
 export const getPaidPlanLink = alreadyHasTierPlans => {
-	const link = 'https://wordpress.com/earn/payments-plans/' + location.hostname;
+	const link = 'https://wordpress.com/earn/payments/' + location.hostname;
 	// We force the "Newsletters plan" link only if there is no plans already created
 	return alreadyHasTierPlans ? link : link + '#add-tier-plan';
 };


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In a separate calypso PR, we are updating the url of the screen where Monetize plans are created: https://github.com/Automattic/wp-calypso/pull/84574
* This PR updates related links to point at the new url

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) At a code level, make sure all the updated urls no match what is in this calypso PR: 

2) You can test the Launchpad endpoint: 
   - Run the bin commands below to load this branch in your sandbox.
   - Create a new newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
   - Sandbox public-api and the domain of your test site
   - Go to https://developer.wordpress.com/docs/api/console/
   - Select wp rest api and wpcom/v2, and enter this endpoint: `/sites/YOURDOMAIN/launchpad`
   - In the response, find the checklist item for 'newsletter_plan_created' and confirm the calypso_path has '/earn/payments/YOURDOMAIN#add-newsletter-payment-plan' (key part being /payments/)
   
 3) You can also test production behaviors. 
    - You can use the same set up as in step 2 if you did that already (load this branch in your sandbox, sandbox public-api, sandbox newsletter site). 
    - If it is not yet merged to trunk, checkout https://github.com/Automattic/wp-calypso/pull/84574 in your local calypso dev environment. 
    - Go to My Home, and confirm the launchpad task for 'Create paid newsletter' directs to the correct url (earn/payments/)>
    - Go to a post, try to force post access to for paid users. You'll get a modal popup that you need to create plans if you have not created any yet. Click the button and confirm it goes to the right url. 
