### PR TITLE
Subscriptions: add a filter to control email sending for posts

### DIFF
--- a/projects/plugins/jetpack/changelog/add-filter-should-send-email
+++ b/projects/plugins/jetpack/changelog/add-filter-should-send-email
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriptions: add a filter to control email sending for posts

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -300,7 +300,17 @@ class Jetpack_Subscriptions {
 			$should_email = false;
 		}
 
-		return $should_email;
+		/**
+		 * Control whether the post should be sent to subscribers as an email.
+		 *
+		 * @module subscriptions
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool   $should_email If the post should be emailed to subscribers.
+		 * @param object $post A post object.
+		 */
+		return apply_filters( 'jetpack_should_email_post_to_subscribers', $should_email, $post );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `jetpack_should_email_post_to_subscribers` filter to control if the post should be sent out to subscribers as an email. Allows custom-built features on top of subscriptions, in addition to existing category-based filters.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up subscriptions for your blog, subscribe to the blog as well. Remember to confirm subscription.
* Create a post; it gets sent to subscribers correctly.
* Add a `mu-plugin` script:
```php
function my_jetpack_should_email_post_to_subscribers( $should_email, $post ) {
	l( '🍎 My sending filter:', $should_email, $post );

	if ( str_ends_with( $post->post_title, 'blog' ) ) {
		return false;
	}

	return $should_email;
}
add_filter( 'jetpack_should_email_post_to_subscribers', 'my_jetpack_should_email_post_to_subscribers', 10, 2 );
```
* You can see the post logged with `jetpack docker tail`
* Write a new post ending the title with "blog" - see how email doesn't get sent

