### PR TITLE
Fix warnings from jetpack-mu-wpcom coming soon filter

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-warnings-from-jetpack-mu-wpcom-coming-soon-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-warnings-from-jetpack-mu-wpcom-coming-soon-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added type check to prevent unnecessary warnings in Coming Soon logic

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.1.0",
+	"version": "5.1.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.1.0';
+	const PACKAGE_VERSION = '5.1.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
@@ -170,7 +170,7 @@ add_filter( 'site_settings_endpoint_get', __NAMESPACE__ . '\add_public_coming_so
  * @return mixed
  */
 function add_public_coming_soon_to_settings_endpoint_post( $input, $unfiltered_input ) {
-	if ( array_key_exists( 'wpcom_public_coming_soon', $unfiltered_input ) ) {
+	if ( is_array( $unfiltered_input ) && array_key_exists( 'wpcom_public_coming_soon', $unfiltered_input ) ) {
 		$input['wpcom_public_coming_soon'] = (int) $unfiltered_input['wpcom_public_coming_soon'];
 	}
 	return $input;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds an `is_array()` check to a coming soon filter to prevent PHP warnings when the incoming argument is not an array. On WordPress.com, we're seeing cases where the incoming `$unfiltered_input` argument is null

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I think it should be sufficient to handle this one via inspection, as we shouldn't be calling `array_key_exists()` if we don't have an array argument.