### PR TITLE
Update add subscribe block launchpad task url.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/subscribe-block-launchpad-task-url-update
+++ b/projects/packages/jetpack-mu-wpcom/changelog/subscribe-block-launchpad-task-url-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update url for launchpad task to add subscribe block to point to site editor with subscribe block docs open in the help center.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.1.0",
+	"version": "5.1.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.1.0';
+	const PACKAGE_VERSION = '5.1.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -576,7 +576,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_add_subscribe_block_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/site-editor/' . $data['site_slug_encoded'];
+				return '/site-editor/' . $data['site_slug_encoded'] . '/?canvas=edit&help-center=subscribe-block';
 			},
 		),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/wp-calypso/issues/84594

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update url for launchpad task to add subscribe block to point to site editor with subscribe block docs open in the help center.
* This is dependent on the Calypso PR [https://github.com/Automattic/wp-calypso/pull/84609.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- pdDOJh-2JD-p2
- pdDOJh-2Ee-p2#comment-2017

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the jetpack-downloader to apply the patch on your sandbox (See: PCYsg-Osp-p2)
* Sandbox public-api.wordpress.com.
* Go to `wordpress.com/subscribers/your-site.wordpress.com` on a site that does not have any subscribers and have not have a subscribe block added to the home page (test it on a newly created site).
* Clicking on "Add the Subscribe Block to your site" should take you to "your-site.wordpress.com/wp-admin/site-editor.php?canvas=edit&help-center=subscribe-block".
  * As long as the URL matches the above pattern, it's fine. The help center popup is done in another PR: https://github.com/Automattic/wp-calypso/pull/84609.