### PR TITLE
My Jetpack: Do not set quantity when selling the current, unlimited tier

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -285,6 +285,9 @@ export function JetpackAIInterstitial() {
 	const { hasRequiredPlan } = detail;
 	const ctaLabel = hasRequiredPlan ? __( 'Upgrade Jetpack AI', 'jetpack-my-jetpack' ) : null;
 
+	// Decide the quantity value for the upgrade, but ignore the unlimited tier.
+	const quantity = nextTier?.value !== 1 ? nextTier?.value : null;
+
 	return (
 		<ProductInterstitial
 			slug="jetpack-ai"
@@ -292,7 +295,7 @@ export function JetpackAIInterstitial() {
 			imageContainerClassName={ styles.aiImageContainer }
 			ctaButtonLabel={ ctaLabel }
 			hideTOS={ true }
-			quantity={ nextTier.value }
+			quantity={ quantity }
 			directCheckout={ hasRequiredPlan }
 		>
 			<img src={ jetpackAiImage } alt="Jetpack AI" />

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-do-not-set-quantity-for-unlimited-tier
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-do-not-set-quantity-for-unlimited-tier
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix checkout error while selling the unlimited Jetpack AI plan.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34317.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Do not set the quantity for Jetpack AI when selling the current, unlimited plan; the current plan is set as a product without quantities, so we need to remove the quantity property on the checkout URL when selling it to prevent the checkout from complaining about it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a new Jurassic Ninja site running this branch
* Connect the site then go to the My Jetpack page
* Scroll to the Jetpack AI card and click "Purchase"; this will open the product interstitial
* Click the button to buy it
* Confirm that, when you land on the checkout page, the error message from the issue is gone

