### PR TITLE
Jetpack AI: Include usage panel on block settings sidebar [PoC]

### DIFF
--- a/projects/plugins/jetpack/changelog/poc-jetpack-ai-include-usage-panel-on-block-settings-sidebar
+++ b/projects/plugins/jetpack/changelog/poc-jetpack-ai-include-usage-panel-on-block-settings-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Add Usage Panel to the block settings sidebar.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -27,6 +27,7 @@ import { useEffect, useRef } from 'react';
 /**
  * Internal dependencies
  */
+import UsagePanel from '../../plugins/ai-assistant-plugin/components/usage-panel';
 import ConnectPrompt from './components/connect-prompt';
 import ImageWithSelect from './components/image-with-select';
 import { promptTemplates } from './components/prompt-templates-control';
@@ -446,6 +447,13 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 						{ ...innerBlocks }
 					/>
 				) }
+				<InspectorControls>
+					<PanelBody title={ __( 'AI Assistant', 'jetpack' ) } initialOpen={ true }>
+						<PanelRow>
+							<UsagePanel />
+						</PanelRow>
+					</PanelBody>
+				</InspectorControls>
 
 				{ isPlaygroundVisible && (
 					<InspectorControls>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -448,7 +448,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					/>
 				) }
 				<InspectorControls>
-					<PanelBody title={ __( 'AI Assistant', 'jetpack' ) } initialOpen={ true }>
+					<PanelBody initialOpen={ true }>
 						<PanelRow>
 							<UsagePanel />
 						</PanelRow>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Include usage panel on block settings sidebar

<img width="300" alt="Screenshot 2023-11-28 at 13 25 59" src="https://github.com/Automattic/jetpack/assets/6760046/717c200a-f3e0-4215-aea4-499ddf0a8813">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a new JN site with this branch
* Go to the block editor
* Add an AI Assistant block
* Notice that the block settings sidebar now contains the usage panel

**Note:** this is just a proof of concept.

