### PR TITLE
renovate: Filter updates of PHP non-dev deps

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -81,5 +81,14 @@ module.exports = {
 			} )(),
 			enabled: false,
 		},
+		// PHP non-dev deps need to work with the oldest PHP versions we support.
+		{
+			matchDatasources: [ 'packagist' ],
+			matchDepTypes: [ 'require' ],
+			constraintsFiltering: 'strict',
+			constraints: {
+				php: `~${ versions.MIN_PHP_VERSION }.0`,
+			},
+		},
 	],
 };

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,16 +26,12 @@
 		// Monorepo packages are excluded in renovate-config.js, where we can read
 		// the list of them in code.
 
-		// We need to keep a wide version range to support PHP 7.0.
-		// Note for libraries used in plugins this will only work right for require-dev deps, not require.
+		// Widen PHP dev deps to maintain support for old PHP versions we still support.
+		// When we drop an old PHP version we'll manually go through and narrow any ranges.
+		// (non-dev deps are handled in renovate-config.js where we can read the correct value for `constraints.php`)
 		{
-			matchPackageNames: [
-				'johnkary/phpunit-speedtrap',
-				'symfony/console',
-				'symfony/process',
-				'wikimedia/at-ease',
-				'wikimedia/testing-access-wrapper',
-			],
+			matchDatasources: [ 'packagist' ],
+			matchDepTypes: [ 'require-dev' ],
 			rangeStrategy: 'widen',
 		},
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
For our non-dev PHP deps, we can't update if the upstream package has dropped support for the lowest PHP version we still support. Adjust renovate's config to filter those out.

Also, update the rule that sets `rangeStrategy: widen` for PHP dev deps to do it generally instead of depending on a list of specific deps. Too bad there's no "only widen if necessary for version support" option.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this in a forked repo, add any necessary secrets, and run it. Or just look at https://github.com/anomiex/jetpack/actions/runs/7022848363/job/19108043107 where I did that.