### PR TITLE
 Improving likes: add RTL support to likes popover

### DIFF
--- a/projects/plugins/jetpack/changelog/add-likes-rtl-support
+++ b/projects/plugins/jetpack/changelog/add-likes-rtl-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improving likes: add RTL support to likes popover

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -253,17 +253,26 @@ function JetpackLikesMessageListener( event ) {
 				}
 			} );
 
+			const containerStyle = getComputedStyle( container );
+			const isRtl = containerStyle.direction === 'rtl';
+
 			const el = document.querySelector( `*[name='${ data.parent }']` );
 			const rect = el.getBoundingClientRect();
 			const win = el.ownerDocument.defaultView;
 			const offset = {
 				top: rect.top + win.pageYOffset,
 				left: rect.left + win.pageXOffset,
+				right: rect.right + win.pageXOffset,
 			};
 
 			if ( newLayout ) {
-				container.style.left = offset.left + data.position.left + 'px';
 				container.style.top = offset.top + data.position.top - 1 + 'px';
+
+				if ( isRtl ) {
+					container.style.right = offset.right - data.position.left - 50 + 'px';
+				} else {
+					container.style.left = offset.left + data.position.left + 'px';
+				}
 			} else {
 				container.style.left = offset.left + data.position.left - 10 + 'px';
 				container.style.top = offset.top + data.position.top - 33 + 'px';

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -262,14 +262,17 @@ function JetpackLikesMessageListener( event ) {
 			const offset = {
 				top: rect.top + win.pageYOffset,
 				left: rect.left + win.pageXOffset,
-				right: rect.right + win.pageXOffset,
 			};
 
 			if ( newLayout ) {
 				container.style.top = offset.top + data.position.top - 1 + 'px';
 
 				if ( isRtl ) {
-					container.style.right = offset.right - data.position.left - 50 + 'px';
+					const visibleAvatarsCount = data && data.likers ? Math.min( data.likers.length, 5 ) : 0;
+					// 24px is the width of the avatar + 4px is the padding between avatars
+					container.style.left =
+						offset.left + data.position.left + 24 * visibleAvatarsCount + 4 + 'px';
+					container.style.transform = 'translateX(-100%)';
 				} else {
 					container.style.left = offset.left + data.position.left + 'px';
 				}

--- a/projects/plugins/jetpack/modules/likes/style.css
+++ b/projects/plugins/jetpack/modules/likes/style.css
@@ -172,6 +172,7 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 	margin: 0 !important;
 	padding: 0 !important;
 	position: static;
+	box-sizing: border-box;
 }
 
 #likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a img {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/84555

## Proposed changes:
* Add RTL support to likes popover
* Depends on https://github.com/Automattic/jetpack/pull/34308

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Follow the initial instructions from https://github.com/Automattic/jetpack/pull/34308
* Test using a site with RTL language
* The popover should be properly displayed in the RTL format
<img width="544" alt="image" src="https://github.com/Automattic/jetpack/assets/3113712/b83b29d9-158a-4185-824d-45ab9466c33b">
