### PR TITLE
Move/source sanitize to jetpack

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -369,7 +369,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 		} else {
 			$payload = array(
 				'type'   => $request['type'],
-				'source' => sanitize_text_field( wp_unslash( $request['source'] ) ),
+				'source' => $source,
 			);
 
 			// If we pass directly is_editable as null, it would break API argument validation.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -359,7 +359,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 */
 	public function get_status( \WP_REST_Request $request ) {
 		$product_type = $request['type'];
-		$source       = $request['source'];
+		$source       = sanitize_text_field( wp_unslash( $request['source'] ) );
 		$is_editable  = ! isset( $request['is_editable'] ) ? null : (bool) $request['is_editable'];
 
 		if ( $this->is_wpcom() ) {
@@ -369,7 +369,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 		} else {
 			$payload = array(
 				'type'   => $request['type'],
-				'source' => $source,
+				'source' => sanitize_text_field( wp_unslash( $request['source'] ) ),
 			);
 
 			// If we pass directly is_editable as null, it would break API argument validation.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -257,6 +257,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 * @return WP_Error|array ['products']
 	 */
 	public function list_products( WP_REST_Request $request ) {
+		$query       = null;
 		$is_editable = isset( $request['is_editable'] ) ? (bool) $request['is_editable'] : null;
 		$type        = isset( $request['type'] ) ? $request['type'] : null;
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -360,15 +360,13 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	public function get_status( \WP_REST_Request $request ) {
 		$product_type = $request['type'];
 
-		if ( ! empty( $_GET['source'] ) ) {
-		    $source = sanitize_text_field( wp_unslash( $_GET['source'] ) );
-		} elseif ( ! empty( $request['source'] ) ) {
-		    $source = sanitize_text_field( $request['source'] );
+		if ( ! empty( $request['source'] ) ) {
+			$source = sanitize_text_field( wp_unslash( $request['source'] ) );
 		} else {
-		    $source = 'gutenberg';
+			$source = 'gutenberg';
 		}
 
-		$is_editable  = ! isset( $request['is_editable'] ) ? null : (bool) $request['is_editable'];
+		$is_editable = ! isset( $request['is_editable'] ) ? null : (bool) $request['is_editable'];
 
 		if ( $this->is_wpcom() ) {
 			require_lib( 'memberships' );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -359,7 +359,15 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 */
 	public function get_status( \WP_REST_Request $request ) {
 		$product_type = $request['type'];
-		$source       = sanitize_text_field( wp_unslash( $request['source'] ) );
+
+		if ( ! empty( $_GET['source'] ) ) {
+		    $source = sanitize_text_field( wp_unslash( $_GET['source'] ) );
+		} elseif ( ! empty( $request['source'] ) ) {
+		    $source = sanitize_text_field( $request['source'] );
+		} else {
+		    $source = 'gutenberg';
+		}
+
 		$is_editable  = ! isset( $request['is_editable'] ) ? null : (bool) $request['is_editable'];
 
 		if ( $this->is_wpcom() ) {

--- a/projects/plugins/jetpack/changelog/move-source-sanitize-to-jetpack
+++ b/projects/plugins/jetpack/changelog/move-source-sanitize-to-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Moves the REST request `source` escaping from WPCOM to the Jetpack Memberships plugin for clarity.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/234
Companion diff: D130238-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This will move this sanitization to the Memberships endpoint in Jetpack (`members.php`) so this is clearer, and then it can be removed from WPCOM's `connected-accounts.php`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD