### PR TITLE
Adds Creator as an upsell to the Newsletter recommendation card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
@@ -28,6 +28,21 @@ export function buildInitialState() {
 							url: 'https://cloud.jetpack.com/pricing#backup-storage-limits-faq',
 						},
 					},
+					creator: {
+						title: 'Jetpack Creator',
+						slug: 'jetpack_creator_yearly',
+						description:
+							'Craft stunning content, boost your subscriber base, and monetize your online presence.',
+						show_promotion: false,
+						discount_percent: 50,
+						included_in_plans: [ 'complete' ],
+						features: [
+							'Unlimited subscriber imports',
+							'Earn more from your content',
+							'Accept payments with PayPal',
+							'Earn with WordAds',
+						],
+					},
 					scan: {
 						title: 'Jetpack Scan',
 						slug: 'jetpack_scan',

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
@@ -33,14 +33,14 @@ export function buildInitialState() {
 						slug: 'jetpack_creator_yearly',
 						description:
 							'Craft stunning content, boost your subscriber base, and monetize your online presence.',
-						show_promotion: false,
+						show_promotion: true,
 						discount_percent: 50,
 						included_in_plans: [ 'complete' ],
 						features: [
 							'Unlimited subscriber imports',
 							'Earn more from your content',
 							'Accept payments with PayPal',
-							'Earn with WordAds',
+							'Increase earnings with WordAds',
 						],
 					},
 					scan: {

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -7,6 +7,7 @@ import {
 	PLAN_JETPACK_VIDEOPRESS,
 	PLAN_JETPACK_ANTI_SPAM,
 	PLAN_JETPACK_BACKUP_T1_YEARLY,
+	PLAN_JETPACK_CREATOR_YEARLY,
 } from 'lib/plans/constants';
 import {
 	getSiteAdminUrl,
@@ -719,6 +720,18 @@ export const getProductCardData = ( state, productSlug ) => {
 				productCardCtaText: __( 'Get Jetpack Security', 'jetpack' ),
 				productCardList: products.security ? products.security.features : [],
 				productCardIcon: '/recommendations/cloud-icon.svg',
+			};
+		// Creator Plan
+		case PLAN_JETPACK_CREATOR_YEARLY:
+			return {
+				productCardTitle: __( 'Grow and monetize your audience', 'jetpack' ),
+				productCardCtaLink: getRedirectUrl( 'jetpack-recommendations-product-checkout', {
+					site: siteRawUrl,
+					path: productSlug,
+				} ),
+				productCardCtaText: __( 'Get Jetpack Creator', 'jetpack' ),
+				productCardList: products.creator ? products.creator.features : [],
+				productCardIcon: '/recommendations/creator-icon.svg',
 			};
 		case PLAN_JETPACK_ANTI_SPAM:
 			return {

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -5,6 +5,7 @@ import {
 	PLAN_JETPACK_VIDEOPRESS,
 	PLAN_JETPACK_ANTI_SPAM,
 	PLAN_JETPACK_BACKUP_T1_YEARLY,
+	PLAN_JETPACK_CREATOR_YEARLY,
 	getPlanClass,
 } from 'lib/plans/constants';
 import { assign, difference, get, isArray, isEmpty, mergeWith, union } from 'lodash';
@@ -62,6 +63,7 @@ import {
 	getSitePurchases,
 	hasActiveProductPurchase,
 	hasActiveSecurityPurchase,
+	hasActiveCreatorPurchase,
 	siteHasFeature,
 	isFetchingSiteData,
 	hasActiveAntiSpamPurchase,
@@ -549,6 +551,11 @@ export const getProductSlugForStep = ( state, step ) => {
 				! isJetpackPlanWithBackup( getSitePlan( state ) )
 			) {
 				return PLAN_JETPACK_BACKUP_T1_YEARLY;
+			}
+			break;
+		case 'newsletter':
+			if ( ! hasActiveCreatorPurchase( state ) ) {
+				return PLAN_JETPACK_CREATOR_YEARLY;
 			}
 			break;
 		case 'anti-spam':

--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -5,6 +5,7 @@ import {
 	isJetpackBoost,
 	isJetpackProduct,
 	isJetpackSearch,
+	isJetpackCreator,
 	isJetpackSecurityBundle,
 	isJetpackAntiSpam,
 	isSecurityComparableJetpackLegacyPlan,
@@ -430,6 +431,31 @@ export function getActiveSearchPurchase( state ) {
 export function hasActiveSearchPurchase( state ) {
 	return (
 		!! getActiveSearchPurchase( state ) ||
+		'is-complete-plan' === getPlanClass( getSitePlan( state ).product_slug )
+	);
+}
+
+/**
+ * Searches active products for Creator product
+ *
+ * @param {object} state - Global state tree
+ * @returns {object}       An active Creator product if one was found, undefined otherwise.
+ */
+export function getActiveCreatorPurchase( state ) {
+	return find( getActiveProductPurchases( state ), product =>
+		isJetpackCreator( product.product_slug )
+	);
+}
+
+/**
+ * Determines if the site has an active Creator product purchase
+ *
+ * @param {object} state - Global state tree
+ * @returns {boolean}      True if the site has an active Creator product purchase, false otherwise.
+ */
+export function hasActiveCreatorPurchase( state ) {
+	return (
+		!! getActiveCreatorPurchase( state ) ||
 		'is-complete-plan' === getPlanClass( getSitePlan( state ).product_slug )
 	);
 }

--- a/projects/plugins/jetpack/changelog/add-creator-promo-newsletter-recommend
+++ b/projects/plugins/jetpack/changelog/add-creator-promo-newsletter-recommend
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adds a product upsell for Creator to the Newsletter recommendation card

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6766,6 +6766,21 @@ endif;
 			),
 		);
 
+		$products['creator'] = array(
+			'title'             => __( 'Jetpack Creator', 'jetpack' ),
+			'slug'              => 'jetpack_creator_yearly',
+			'description'       => __( 'Craft stunning content, boost your subscriber base, and monetize your online presence.', 'jetpack' ),
+			'show_promotion'    => true,
+			'discount_percent'  => 50,
+			'included_in_plans' => array( 'complete' ),
+			'features'          => array(
+				_x( 'Unlimited subscriber imports', 'Creator Product Feature', 'jetpack' ),
+				_x( 'Earn more from your content', 'Creator Product Feature', 'jetpack' ),
+				_x( 'Accept payments with PayPal', 'Creator Product Feature', 'jetpack' ),
+				_x( 'Increase earnings with WordAds', 'Creator Product Feature', 'jetpack' ),
+			),
+		);
+
 		$products['scan'] = array(
 			'title'             => __( 'Jetpack Scan', 'jetpack' ),
 			'slug'              => 'jetpack_scan',

--- a/projects/plugins/jetpack/images/recommendations/creator-icon.svg
+++ b/projects/plugins/jetpack/images/recommendations/creator-icon.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="56px" height="58px" viewBox="0 0 56 58" version="1.1">
+<defs>
+<filter id="alpha" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
+  <feColorMatrix type="matrix" in="SourceGraphic" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+</filter>
+<image id="image7" width="56" height="58" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADgAAAA6CAYAAADlTpoVAAAABmJLR0QA/wD/AP+gvaeTAAACzUlEQVRoge2ZTUhUURiG3zPXnwayRFOjtBQDCbSfWbgJ3YSUlNYiIvqRAhkyijSLohDaJEG0qKBFRFDuKqQIIyJNNApM3YhIioROujCGYjR/7s98bZygqXDud840C88D3/J573k5587cuQNoNBqNRrN8EfEMJxgCJnwQdhVERhEosB64lw1s+wHcmITImoBzpwMzla9E5vtQPNeiFAoc8pK18xLZ/nGyDVp6shfIOvqMzPqtiV77ktDCgyNk13yJrVj0eB2yNz+iUPeaRPf4A3psGGR1X+cVix7/OJl5vkR3+gX1GslklbWpKReZ4hBZ+eWJ7gYAILvurtpykSkL0vzaTYktZxr++JRbHKtlgEYaUrnr80iV+zadDk95s0zGkojjxcifP8PVpQpiZddloCtTKiMWRN8VCp1lXYddkEYaUiEunuT67uhLx4qcGo7J38GCYAUwlMb23SLO7+doEkfUrOK7DETGDs4DAL8gHStluyzmDHhD291a/ILi2ka2y4WqC9wqEkd08P/dfxGEf5VbRaJg0QzfZUKnZt0qEvfgvq9sl33NtKBbRWIHH37mu1xah9waEgXz3vJdDiUhPL8w6NaSOKLDr9kui7GX4qDjuLXYBUVKoB80+oHru4Y673M0uYdtUXpTyo8V6u9Bsq+Do8oVTAq2gnLeSGXExLlGAYc4plRBAYdgF9YCJfF75Ud7X4jk9ndcXW4HAQhv9xjCWfWyOf+ECprilh3zGmAIsloG1L+uuO36ey8a6R0EFo8qTj9RkfU77SOyCUoKAgDCncPKsiKI1ZOyEeoKepoDyrIihD/1yEaoKzi85SNQofABvHIK08ZTdXkKILPihJoPGK9D9u7qRPf5K2Teqic7d45f7vAE2XV7VK0nLv8P0uyGXCQ1HoBnqhAYTYlNqv0OsasXU1fbxLom1z9sNRqNRqPRaDQajUajWVb8BKnlqnNkL1PaAAAAAElFTkSuQmCC"/>
+<mask id="mask0">
+  <g filter="url(#alpha)">
+<use xlink:href="#image7"/>
+  </g>
+</mask>
+<clipPath id="clip1">
+  <rect x="0" y="0" width="56" height="58"/>
+</clipPath>
+<g id="surface6" clip-path="url(#clip1)">
+<path style=" stroke:none;fill-rule:nonzero;fill:white;fill-opacity:1;" d="M 41.039062 30.84375 L 43.957031 32.761719 Z M 39.972656 22.773438 C 39.972656 25.050781 39.289062 27.160156 38.117188 28.921875 L 43.957031 32.761719 C 45.863281 29.894531 46.972656 26.457031 46.972656 22.773438 Z M 28.734375 11.601562 C 34.941406 11.601562 39.972656 16.601562 39.972656 22.773438 L 46.972656 22.773438 C 46.972656 12.757812 38.808594 4.640625 28.734375 4.640625 Z M 17.5 22.773438 C 17.5 16.601562 22.53125 11.601562 28.734375 11.601562 L 28.734375 4.640625 C 18.664062 4.640625 10.5 12.757812 10.5 22.773438 Z M 19.9375 29.71875 C 18.410156 27.8125 17.5 25.402344 17.5 22.773438 L 10.5 22.773438 C 10.5 27.03125 11.980469 30.957031 14.457031 34.050781 Z M 33.859375 37.121094 L 23.667969 37.121094 L 23.667969 44.078125 L 33.859375 44.078125 Z M 15.167969 35.625 C 15.167969 40.296875 18.972656 44.078125 23.667969 44.078125 L 23.667969 37.121094 C 22.839844 37.121094 22.167969 36.453125 22.167969 35.625 Z M 14.457031 34.050781 C 15.003906 34.734375 15.167969 35.28125 15.167969 35.625 L 22.167969 35.625 C 22.167969 33.21875 21.113281 31.1875 19.9375 29.71875 Z M 33.859375 44.078125 C 39 44.078125 43.167969 39.9375 43.167969 34.824219 L 36.167969 34.824219 C 36.167969 36.09375 35.132812 37.121094 33.859375 37.121094 Z M 38.117188 28.921875 C 37.109375 30.441406 36.167969 32.464844 36.167969 34.824219 L 43.167969 34.824219 C 43.167969 34.320312 43.375 33.632812 43.957031 32.761719 Z M 38.117188 28.921875 "/>
+</g>
+</defs>
+<g id="surface1">
+<use xlink:href="#surface6" mask="url(#mask0)"/>
+<path style="fill:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke:white;stroke-opacity:1;stroke-miterlimit:4;" d="M 9 18.75 L 15.999442 18.75 " transform="matrix(2.333333,0,0,2.32,0,0)"/>
+<path style="fill:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke:white;stroke-opacity:1;stroke-miterlimit:4;" d="M 11.000558 20.750269 L 14.000558 20.750269 " transform="matrix(2.333333,0,0,2.32,0,0)"/>
+</g>
+</svg>


### PR DESCRIPTION
## Proposed changes:
This adds the new Creator plan as an upsell to the side of the Newsletter recommendation card.

## Jetpack product discussion
pf9WZf-9v-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to this route `/wp-admin/admin.php?page=jetpack#/recommendations/newsletter` without Creator purchased it should show an upsell
<img width="1060" alt="Screenshot 2023-11-28 at 22 22 21" src="https://github.com/Automattic/jetpack/assets/4077604/df2cc033-0b6d-4266-9efb-bebe8eb3021a">

* Go to the same route once purchased, it'll show the illustration screenshot to activate the feature
<img width="1060" alt="Screenshot 2023-11-28 at 22 22 31" src="https://github.com/Automattic/jetpack/assets/4077604/5a7948c1-7053-4693-aa75-e45306f45a4b">

