### PR TITLE
Improving likes: Update copy & translations for popover

### DIFF
--- a/projects/plugins/jetpack/changelog/update-likes-popover-copy
+++ b/projects/plugins/jetpack/changelog/update-likes-popover-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -33,8 +33,13 @@ function jetpack_likes_master_iframe() {
 		$new_layout
 	);
 
-	/* translators: The value of %d is not available at the time of output */
-	$likers_text = wp_kses( __( '<span>%d</span> bloggers like this:', 'jetpack' ), array( 'span' => array() ) );
+	if ( $new_layout ) {
+		/* translators: The value of %d is not available at the time of output */
+		$likers_text = wp_kses( __( '<span>%d</span> likes', 'jetpack' ), array( 'span' => array() ) );
+	} else {
+		/* translators: The value of %d is not available at the time of output */
+		$likers_text = wp_kses( __( '<span>%d</span> bloggers like this:', 'jetpack' ), array( 'span' => array() ) );
+	}
 	?>
 	<iframe src='<?php echo esc_url( $src ); ?>' scrolling='no' id='likes-master' name='likes-master' style='display:none;'></iframe>
 	<div id='likes-other-gravatars'><div class="likes-text"><?php echo $likers_text; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/84425

## Proposed changes:

* Update copy & translations for likes popover
* Depends on https://github.com/Automattic/jetpack/pull/34308

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your local
* Start a site with JurassicTube
* Enable likes in Jetpack > Settings > Sharing
* Open a post with likes and click to see the popover, check if the label changed to `%d likes`
<img width="292" alt="Screenshot 2023-11-28 at 20 01 11" src="https://github.com/Automattic/jetpack/assets/3113712/d336c628-a95d-41ad-bc88-59cf9a89fe04">

