### PR TITLE
Jetpack Google Fonts: Clean up the dirty data when saving global styles

### DIFF
--- a/projects/plugins/jetpack/changelog/feat-google-fonts-clean-up-dirty-data
+++ b/projects/plugins/jetpack/changelog/feat-google-fonts-clean-up-dirty-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack Google Fonts: Clean up the old data when saving the user's global styles

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Tracking;
+
 /**
  * Gets the Google Fonts data
  *
@@ -201,6 +203,56 @@ function jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user( $
 }
 
 add_filter( 'wp_theme_json_data_user', 'jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user' );
+
+/**
+ * Filter out the font families from the jetpack-google-fonts provider when saving the user global styles.
+ *
+ * @param array $post_data The post data to filter.
+ * @return array The filtered post data.
+ */
+function jetpack_google_fonts_user_global_styles_pre_save( $post_data ) {
+	if ( $post_data['post_type'] !== 'wp_global_styles' ) {
+		return $post_data;
+	}
+
+	$post_content        = stripslashes( $post_data['post_content'] );
+	$raw_data            = json_decode( $post_content, true );
+	$json_decoding_error = json_last_error();
+	if ( JSON_ERROR_NONE !== $json_decoding_error ) {
+		return $post_data;
+	}
+
+	if ( empty( $raw_data['settings']['typography']['fontFamilies'] ) ) {
+		return $post_data;
+	}
+
+	$prev_count = count( $raw_data['settings']['typography']['fontFamilies'] );
+	$raw_data['settings']['typography']['fontFamilies'] = jetpack_google_fonts_filter_out_deprecated_font_data(
+		$raw_data['settings']['typography']['fontFamilies']
+	);
+
+	if ( $prev_count !== count( $raw_data['settings']['typography']['fontFamilies'] ) ) {
+		$tracking = new Tracking();
+		$tracking->record_user_event( 'jetpack_google_fonts_clean_up_dirty_data' );
+	}
+
+	/**
+	 * Clean up the empty properties
+	 */
+	if ( empty( $raw_data['settings']['typography']['fontFamilies'] ) ) {
+		unset( $raw_data['settings']['typography']['fontFamilies'] );
+	}
+
+	if ( empty( $raw_data['settings']['typography'] ) ) {
+		unset( $raw_data['settings']['typography'] );
+	}
+
+	$post_data['post_content'] = wp_json_encode( $raw_data );
+
+	return $post_data;
+}
+
+add_filter( 'wp_insert_post_data', 'jetpack_google_fonts_user_global_styles_pre_save' );
 
 if ( ! class_exists( 'Jetpack_Google_Font_Face' ) ) {
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/4535, https://github.com/Automattic/jetpack/pull/34306, pbxlJb-52N-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* The old Google Fonts data, such as the following, was inadvertently stored in the user's global styles. As a result, this PR proposes to clean up the dirty data when user saves the global styles on their site.
  ```json
  [
	{
		"fontFamily": "'Albert Sans'",
		"name": "Albert Sans",
		"slug": "albert-sans",
		"fontFace": {
			"albert-sans-100-900-italic": {
				"origin": "gutenberg_wp_fonts_api",
				"provider": "jetpack-google-fonts",
				"fontFamily": "Albert Sans",
				"fontStyle": "italic",
				"fontWeight": "100 900",
				"fontDisplay": "fallback"
			},
			"albert-sans-100-900-normal": {
				"origin": "gutenberg_wp_fonts_api",
				"provider": "jetpack-google-fonts",
				"fontFamily": "Albert Sans",
				"fontStyle": "normal",
				"fontWeight": "100 900",
				"fontDisplay": "fallback"
			}
		}
	}
  ]
  ```
* This PR adds a new hook to filter out those data from user global styles to resolve the issue

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to WoA site
* Go to the Site Editor
* Update the global styles first
* Open the DevTool, and find the request from the previous step
* Copy the request as followed, `/wp-json/wp/v2/global-styles/<global_styles_id>`.
  ![image](https://github.com/Automattic/jetpack/assets/13596067/e646c576-7f1d-4349-8486-82a6bdfd7421)
* Trigger the code with the body below on the console to insert the dirty data. Note that you have to replace the `<global_styles_id>` with the real id on your site.
  ```
  `{"id":<global_styles_id>,"styles":{},"settings":{"typography":{"fontFamilies":{"theme":[{"fontFamily":"'Albert Sans'","name":"Albert Sans","slug":"albert-sans","fontFace":{"albert-sans-100-900-italic":{"origin":"gutenberg_wp_fonts_api","provider":"jetpack-google-fonts","fontFamily":"Albert Sans","fontStyle":"italic","fontWeight":"100 900","fontDisplay":"fallback"},"albert-sans-100-900-normal":{"origin":"gutenberg_wp_fonts_api","provider":"jetpack-google-fonts","fontFamily":"Albert Sans","fontStyle":"normal","fontWeight":"100 900","fontDisplay":"fallback"}}}]}}}}`
  ```
* Refresh the page
* Ensure the user's global styles have the above dirty data
* Install changes from this PR by Jetpack Beta Tester
* Update the global styles in the Editor and save
* Ensure the dirty data is gone