### PR TITLE
Jetpack Menu: Add a link to the Jetpack Manage to Jetpack menu

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-jetpack-manage-menu-item
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-manage-menu-item
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Display an "Jetpack Manage" menu item to connected users.
+Display a "Jetpack Manage" menu item to connected users.

--- a/projects/packages/my-jetpack/changelog/add-jetpack-manage-menu-item
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-manage-menu-item
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Display an "Jetpack Manage" menu item to connected users.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -79,6 +79,9 @@ class Initializer {
 		// Add "Activity Log" menu item.
 		Activitylog::init();
 
+		// Add "Jetpack Manage" menu item.
+		Jetpack_Manage::init();
+
 		/**
 		 * Fires after the My Jetpack package is initialized
 		 *

--- a/projects/packages/my-jetpack/src/class-jetpack-manage.php
+++ b/projects/packages/my-jetpack/src/class-jetpack-manage.php
@@ -39,8 +39,12 @@ class Jetpack_Manage {
 		}
 
 		// Do not display the menu if the user has <= 2 sites.
-		$number_of_sites = ( new Connection_Manager() )->get_connected_user_data( get_current_user_id() )['site_count'];
-		if ( $number_of_sites <= 2 ) {
+		$user_data = ( new Connection_Manager() )->get_connected_user_data( get_current_user_id() );
+		if ( ! isset( $user_data['site_count'] ) ) {
+			return;
+		}
+
+		if ( $user_data['site_count'] <= 2 ) {
 			return;
 		}
 

--- a/projects/packages/my-jetpack/src/class-jetpack-manage.php
+++ b/projects/packages/my-jetpack/src/class-jetpack-manage.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Manage the display of an "Jetpack Manage" menu item.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Redirect;
+
+/**
+ * Jetpack Manage features in My Jetpack.
+ */
+class Jetpack_Manage {
+	/**
+	 * Initialize the class and hooks needed.
+	 */
+	public static function init() {
+		add_action( 'admin_menu', array( self::class, 'add_submenu_jetpack' ) );
+	}
+
+	/**
+	 * The page to be added to submenu
+	 *
+	 * @return void|null|string The resulting page's hook_suffix
+	 */
+	public static function add_submenu_jetpack() {
+		// Only proceed if the user is connected to WordPress.com.
+		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
+			return;
+		}
+
+		// Do not display the menu on Multisite.
+		if ( is_multisite() ) {
+			return;
+		}
+
+		return Admin_Menu::add_menu(
+			__( 'Jetpack Manage', 'jetpack-my-jetpack' ),
+			_x( 'Jetpack Manage', 'product name shown in menu', 'jetpack-my-jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
+			'manage_options',
+			esc_url( Redirect::get_url( 'cloud-manage-dashboard-wp-menu' ) ),
+			null,
+			1
+		);
+	}
+}

--- a/projects/packages/my-jetpack/src/class-jetpack-manage.php
+++ b/projects/packages/my-jetpack/src/class-jetpack-manage.php
@@ -33,6 +33,11 @@ class Jetpack_Manage {
 			return;
 		}
 
+		// Do not display the menu if Jetpack plugin is not installed.
+		if ( ! class_exists( 'Jetpack' ) ) {
+			return;
+		}
+
 		// Do not display the menu on Multisite.
 		if ( is_multisite() ) {
 			return;
@@ -40,11 +45,7 @@ class Jetpack_Manage {
 
 		// Do not display the menu if the user has <= 2 sites.
 		$user_data = ( new Connection_Manager() )->get_connected_user_data( get_current_user_id() );
-		if ( ! isset( $user_data['site_count'] ) ) {
-			return;
-		}
-
-		if ( $user_data['site_count'] <= 2 ) {
+		if ( ! isset( $user_data['site_count'] ) || $user_data['site_count'] < 2 ) {
 			return;
 		}
 

--- a/projects/packages/my-jetpack/src/class-jetpack-manage.php
+++ b/projects/packages/my-jetpack/src/class-jetpack-manage.php
@@ -38,13 +38,19 @@ class Jetpack_Manage {
 			return;
 		}
 
+		// Do not display the menu if the user has <= 2 sites.
+		$number_of_sites = ( new Connection_Manager() )->get_connected_user_data( get_current_user_id() )['site_count'];
+		if ( $number_of_sites <= 2 ) {
+			return;
+		}
+
 		return Admin_Menu::add_menu(
 			__( 'Jetpack Manage', 'jetpack-my-jetpack' ),
 			_x( 'Jetpack Manage', 'product name shown in menu', 'jetpack-my-jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
 			'manage_options',
 			esc_url( Redirect::get_url( 'cloud-manage-dashboard-wp-menu' ) ),
 			null,
-			1
+			100
 		);
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/test-jetpack-manage.php
+++ b/projects/packages/my-jetpack/tests/php/test-jetpack-manage.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Test the Jetpack Manage features in My Jetpack.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use WorDBless\BaseTestCase;
+
+class Test_Jetpack_Manage extends BaseTestCase {
+	/**
+	 * Admin user id
+	 *
+	 * @var int
+	 */
+	protected $admin_id;
+
+	/**
+	 * Editor user id
+	 *
+	 * @var int
+	 */
+	protected $editor_id;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		$this->admin_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_user',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+
+		$this->editor_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_user_2',
+				'user_pass'  => 'dummy_pass_2',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test that the menu is not added when on multisite.
+	 */
+	public function test_add_submenu_jetpack_multisite() {
+		if ( is_multisite() ) {
+			$this->assertFalse( Jetpack_Manage::add_submenu_jetpack() );
+		}
+
+		$this->assertNotFalse( Jetpack_Manage::add_submenu_jetpack() );
+	}
+
+	/**
+	 * Test that the menu doesn't appear for non-admins.
+	 */
+	public function test_add_submenu_jetpack_editor() {
+		wp_set_current_user( $this->editor_id );
+
+		$this->assertNull( Jetpack_Manage::add_submenu_jetpack() );
+	}
+
+	/**
+	 * Test that the menu appears for admins.
+	 */
+	public function test_add_submenu_jetpack_admin() {
+		wp_set_current_user( $this->admin_id );
+
+		$this->assertNotFalse( Jetpack_Manage::add_submenu_jetpack() );
+	}
+}

--- a/projects/plugins/backup/changelog/add-jetpack-manage-menu-item
+++ b/projects/plugins/backup/changelog/add-jetpack-manage-menu-item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/changelog/add-jetpack-manage-menu-item
+++ b/projects/plugins/boost/changelog/add-jetpack-manage-menu-item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/add-jetpack-manage-menu-item
+++ b/projects/plugins/jetpack/changelog/add-jetpack-manage-menu-item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/changelog/add-jetpack-manage-menu-item
+++ b/projects/plugins/migration/changelog/add-jetpack-manage-menu-item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/changelog/add-jetpack-manage-menu-item
+++ b/projects/plugins/protect/changelog/add-jetpack-manage-menu-item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/changelog/add-jetpack-manage-menu-item
+++ b/projects/plugins/search/changelog/add-jetpack-manage-menu-item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/changelog/add-jetpack-manage-menu-item
+++ b/projects/plugins/social/changelog/add-jetpack-manage-menu-item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/changelog/add-jetpack-manage-menu-item
+++ b/projects/plugins/starter-plugin/changelog/add-jetpack-manage-menu-item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/changelog/add-jetpack-manage-menu-item
+++ b/projects/plugins/videopress/changelog/add-jetpack-manage-menu-item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+


### PR DESCRIPTION
## Proposed changes:

The Jetpack Manage might be useful for users managing multiple websites. This PR adds the link on the Jetpack menu for visibility. It will be displayed on all Jetpack plugins, as long as the user is connected to WordPress.com, and the site isn't multisite, as Jetpack Cloud isn't fully compatible with multisite installations yet.

![image](https://github.com/Automattic/jetpack/assets/1749918/1cd7e14a-7092-425b-b6a2-d7cb118d1f0b)

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1HpG7-pYl-p2

## Does this pull request change what data or activity we track or use?

* Yes, clicks on the link are tracked (see PCYsg-pY7-p2#monitoring )

## Testing instructions:

- Start with a brand new site (you can use the link below for spinning up a JN site), using Jetpack plugin only (the instructions aren't valid for standalone plugins, and the link shouldn't appear there)
- You should not see the "Jetpack Menu" menu item by default.
- Connect your site to WordPress.com.
- When you return to wp-admin, you should notice a "Jetpack Manage" link with an external icon next to it, on the last position.
- When clicking on the link, you should be redirected to `https://cloud.jetpack/dashboard?origin=wp-admin`
- You can try installing an additional Jetpack plugin, and the link position should not change.
- You can also try to launch a Multisite network; you should not see the "Jetpack Manage" menu item there.