### PR TITLE
Jetpack Social | Disable Quick Share for Scheduled posts

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-disable-quick-share-for-sched-posts
+++ b/projects/js-packages/publicize-components/changelog/update-disable-quick-share-for-sched-posts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Disabled quick share for scheduled posts

--- a/projects/js-packages/publicize-components/src/components/post-publish-one-click-sharing/index.js
+++ b/projects/js-packages/publicize-components/src/components/post-publish-one-click-sharing/index.js
@@ -1,7 +1,9 @@
 import { Text, ThemeProvider } from '@automattic/jetpack-components';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { store as editorStore } from '@wordpress/editor';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import OneClickSharingModal from '../one-click-sharing-modal';
@@ -13,6 +15,12 @@ const PostPublishOneClickSharing = () => {
 
 	const openModal = useCallback( () => setIsModalOpened( true ), [] );
 	const closeModal = useCallback( () => setIsModalOpened( false ), [] );
+
+	const { isCurrentPostPublished } = useSelect( select => select( editorStore ), [] );
+
+	if ( ! isCurrentPostPublished() ) {
+		return null;
+	}
 
 	return (
 		<PluginPostPublishPanel


### PR DESCRIPTION
Right now the quick share is enabled for scheduled posts which should not be the case.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable Quick Share for Scheduled posts

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post
* Schedule it
* On post publish sidebar, confirm that quick share panel is not displayed.

