### PR TITLE
Subs / Masterbar: allow all admins to toggle the feature on / off

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -91,6 +91,9 @@ function SubscriptionsSettings( props ) {
 		);
 	};
 
+	const isDisabled =
+		! isSubscriptionsActive || unavailableInOfflineMode || isSavingAnyOption( [ 'subscriptions' ] );
+
 	return (
 		<SettingsCard { ...props } hideButton module="subscriptions">
 			<SettingsGroup
@@ -119,11 +122,7 @@ function SubscriptionsSettings( props ) {
 					<FormFieldset>
 						<ToggleControl
 							checked={ isSubscriptionsActive && isStbEnabled }
-							disabled={
-								! isSubscriptionsActive ||
-								unavailableInOfflineMode ||
-								isSavingAnyOption( [ 'subscriptions' ] )
-							}
+							disabled={ isDisabled }
 							toggling={ isSavingAnyOption( [ 'stb_enabled' ] ) }
 							onChange={ handleSubscribeToBlogToggleChange }
 							label={ __(
@@ -133,11 +132,7 @@ function SubscriptionsSettings( props ) {
 						/>
 						<ToggleControl
 							checked={ isSubscriptionsActive && isStcEnabled }
-							disabled={
-								! isSubscriptionsActive ||
-								unavailableInOfflineMode ||
-								isSavingAnyOption( [ 'subscriptions' ] )
-							}
+							disabled={ isDisabled }
 							toggling={ isSavingAnyOption( [ 'stc_enabled' ] ) }
 							onChange={ handleSubscribeToCommentToggleChange }
 							label={ __(
@@ -147,11 +142,7 @@ function SubscriptionsSettings( props ) {
 						/>
 						<ToggleControl
 							checked={ isSubscriptionsActive && isSmEnabled }
-							disabled={
-								! isSubscriptionsActive ||
-								unavailableInOfflineMode ||
-								isSavingAnyOption( [ 'subscriptions' ] )
-							}
+							disabled={ isDisabled }
 							toggling={ isSavingAnyOption( [ 'sm_enabled' ] ) }
 							onChange={ handleSubscribeModalToggleChange }
 							label={ __( 'Enable subscriber pop-up', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -122,8 +122,7 @@ function SubscriptionsSettings( props ) {
 							disabled={
 								! isSubscriptionsActive ||
 								unavailableInOfflineMode ||
-								isSavingAnyOption( [ 'subscriptions' ] ) ||
-								! isLinked
+								isSavingAnyOption( [ 'subscriptions' ] )
 							}
 							toggling={ isSavingAnyOption( [ 'stb_enabled' ] ) }
 							onChange={ handleSubscribeToBlogToggleChange }
@@ -137,8 +136,7 @@ function SubscriptionsSettings( props ) {
 							disabled={
 								! isSubscriptionsActive ||
 								unavailableInOfflineMode ||
-								isSavingAnyOption( [ 'subscriptions' ] ) ||
-								! isLinked
+								isSavingAnyOption( [ 'subscriptions' ] )
 							}
 							toggling={ isSavingAnyOption( [ 'stc_enabled' ] ) }
 							onChange={ handleSubscribeToCommentToggleChange }
@@ -152,8 +150,7 @@ function SubscriptionsSettings( props ) {
 							disabled={
 								! isSubscriptionsActive ||
 								unavailableInOfflineMode ||
-								isSavingAnyOption( [ 'subscriptions' ] ) ||
-								! isLinked
+								isSavingAnyOption( [ 'subscriptions' ] )
 							}
 							toggling={ isSavingAnyOption( [ 'sm_enabled' ] ) }
 							onChange={ handleSubscribeModalToggleChange }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -108,7 +108,7 @@ function SubscriptionsSettings( props ) {
 			>
 				<ModuleToggle
 					slug="subscriptions"
-					disabled={ unavailableInOfflineMode || ! isLinked }
+					disabled={ unavailableInOfflineMode }
 					activated={ isSubscriptionsActive }
 					toggling={ isSavingAnyOption( 'subscriptions' ) }
 					toggleModule={ toggleModuleNow }

--- a/projects/plugins/jetpack/_inc/client/writing/masterbar.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/masterbar.jsx
@@ -11,8 +11,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 	class extends Component {
 		render() {
 			const isActive = this.props.getOptionValue( 'masterbar' ),
-				unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'masterbar' ),
-				isLinked = this.props.isLinked;
+				unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'masterbar' );
 
 			return (
 				<SettingsCard
@@ -41,7 +40,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 						</p>
 						<ModuleToggle
 							slug="masterbar"
-							disabled={ unavailableInOfflineMode || ! isLinked }
+							disabled={ unavailableInOfflineMode }
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
 							toggleModule={ this.props.toggleModuleNow }

--- a/projects/plugins/jetpack/changelog/update-subs-masterbar-islinked
+++ b/projects/plugins/jetpack/changelog/update-subs-masterbar-islinked
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: display the Subscriptions and WordPress.com Toolbar controls even when your user is not connected to WordPress.com yet.


### PR DESCRIPTION
## Proposed changes:

See https://github.com/Automattic/jetpack/pull/34203#issuecomment-1831628558

All admins should be able to toggle features on and off, just like they can under Jetpack > Settings > Modules.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's connected to WordPress.com.
* Go to Jetpack > Settings
* Enable the WordPress.com Toolbar and Subscripions features.
* Go to Users > Add New and create a new admin.
* In a new browser, log in with that user.
* Go to Jetpack > Settings 
    * You should be able to turn the WordPress.com Toolbar and Subscripions features off.
