### PR TITLE
Admin Page: fix nav menu when Activity Log menu isn't available

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -647,8 +647,12 @@ class Main extends React.Component {
 
 		if ( this.props.isWoaSite ) {
 			window.wpNavMenuClassChange( { dashboard: 1, settings: 1 } );
-		} else if ( ! this.props.showMyJetpack ) {
+		} else if ( ! this.props.isLinked && ! this.props.showMyJetpack ) {
 			window.wpNavMenuClassChange( { dashboard: 1, settings: 2 } );
+		} else if ( ! this.props.isLinked && this.props.showMyJetpack ) {
+			window.wpNavMenuClassChange( { myJetpack: 1, dashboard: 2, settings: 3 } );
+		} else if ( this.props.isLinked && ! this.props.showMyJetpack ) {
+			window.wpNavMenuClassChange( { activityLog: 1, dashboard: 2, settings: 3 } );
 		} else {
 			window.wpNavMenuClassChange();
 		}

--- a/projects/plugins/jetpack/changelog/fix-menu-focus-activitylog
+++ b/projects/plugins/jetpack/changelog/fix-menu-focus-activitylog
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Admin Page: fix the focus on the admin navigation menu when the Activity Log menu is not available.
+
+


### PR DESCRIPTION
Follow-up to #34174

## Proposed changes:

We want to ensure that the admin navigation menu focus will always be correct, regardless of your site's status:

- Can the "My Jetpack" menu be displayed?
- Can the "Activity Log" menu be displayed?

<img width="179" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/c12cc50b-25f7-4c2f-b111-a16f9a1d6f63">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a brand new site, using one of the plugins (either Jetpack or
 standalone)
* You should not see any "Activity Log" menu item by default.
* Connect your site to WordPress.com. 
    * During the connection process, stop before you're asked to connect your user, and come back to wp-admin.
* When you come back to wp-admin, you should not see any "Activity Log" menu item.
    * Navigating between the different Jetpack menu pages, the menu focus should be correct.
* Go to the Jetpack menu, and follow the prompts to connect your user to WordPress.com.
* When you come back to wp-admin, you should notice an "Activity Log" link with an external icon next to it, right below "My Jetpack".
    * Focus when switching from one Jetpack menu to the next should be correct.
