### PR TITLE
AI Client: change AI control shadow depth

### DIFF
--- a/projects/js-packages/ai-client/changelog/change-ai-control-shadow-depth
+++ b/projects/js-packages/ai-client/changelog/change-ai-control-shadow-depth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Assistant: change shadow for a better sense of depth

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.2.0",
+	"version": "0.2.1-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -5,7 +5,7 @@
 .jetpack-components-ai-control__container {
 	color: var( --jp-gray-80 );
 	background-color: var( --jp-white );
-	box-shadow: var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 0px 1px, var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 8px;
+	box-shadow: 0px 12px 15px 0px rgba(0, 0, 0, 0.12), 0px 3px 9px 0px rgba(0, 0, 0, 0.12), 0px 1px 3px 0px rgba(0, 0, 0, 0.15);
 	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	width: 100%;
 }
@@ -83,12 +83,12 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	
+
 	.input-icon {
 		// Brand green regardless of theme
 		color: var( --jp-green-40 );
 	}
-	
+
 	.input-spinner {
 		margin: 0;
 		width: 24px;


### PR DESCRIPTION
Adjust AI Assistant shadow for a better sense of depth and decoupling

Fixes #34331 

## Proposed changes:
This PR changes the shadow to match the designs seen on Figma file: gG1smMHbNGas0qwP9y6RwK-fi-7531%3A1227

<img width="669" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/6ad29e99-3646-40d7-80db-fc66b29ad4dd">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1701184924339369-slack-C02TQF5VAJD
p1HpG7-pBB-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use the link to create a JN instance, go to editor and create an AI Assistant block, see the new shadows match those in designs