### PR TITLE
EU Cookie Widget: move away from deprecated jQuery method

### DIFF
--- a/projects/plugins/jetpack/changelog/y
+++ b/projects/plugins/jetpack/changelog/y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+EU Cookie Widget: move away from deprecated jQuery method

--- a/projects/plugins/jetpack/modules/widgets/eu-cookie-law/eu-cookie-law-admin.js
+++ b/projects/plugins/jetpack/modules/widgets/eu-cookie-law/eu-cookie-law-admin.js
@@ -3,7 +3,7 @@
 ( function ( $ ) {
 	var $document = $( document );
 
-	$document.on( 'ready', function () {
+	$document.ready( function () {
 		var maybeShowNotice = function ( e, policyUrl ) {
 			var $policyUrl = $( policyUrl || this ).closest( '.eu-cookie-law-widget-policy-url' );
 


### PR DESCRIPTION
Fixes #34361

## Proposed changes:

`$(document).on( "ready", handler )` was deprecated as of jQuery 1.8, and replaced by `.ready()`:
See https://api.jquery.com/ready/

Some folks have pointed out the following notice:

```
JQUERY MIGRATE reports
‘ready’ event is deprecated
```

I haven't been able to reproduce the issue, I *think* it may be limited to sites that enqueue a custom version of jQuery maybe?

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1701266347186179-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings, and enable the Widgets feature.
* Go to Appearance > Themes and add a new classic theme like Twenty Ten
* Go to Plugins > Add New and install the Classic Widgets plugin
* Go to Appearance > Customize > Widgets and add the Cookie Consent widget to your site
    * You shouldn't see any warnings in the console.
    * The widget should continue to work as expected.
