### PR TITLE
My Jetpack: do not display any notices from third-parties

### DIFF
--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -12,7 +12,7 @@
 
 	#wpbody-content {
 		& > .notice {
-			display: none;
+			display: none !important;
 		}
 	}
 	#wpwrap {

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-notices
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: do not display any notices from third-party services.


### PR DESCRIPTION
Fixes #34360

## Proposed changes:

This is a follow-up to #23093. #23093 mostly works, but some plugins add inline display styles to their notices to be able to style them further. That extra important should fix things.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Find the GoDaddy test site in P8oabR-1n-p2 (it's the first on the page).
* Log in, go to Jetpack > Beta > Jetpack and switch to this branch.
* Go to My Jetpack
    * You should not see any third-party notices at the top of the page.
