### PR TITLE
FollowingEndpoint: change permission check

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-following.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-following.php
@@ -48,7 +48,7 @@ class WPCOM_REST_API_V2_Endpoint_Following extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_following' ),
-					'permission_callback' => array( $this, 'permission_check' ),
+					'permission_callback' => 'is_user_logged_in',
 					'args'                => array(
 						'ignore_user_blogs' => array(
 							'type' => 'boolean',
@@ -78,15 +78,6 @@ class WPCOM_REST_API_V2_Endpoint_Following extends WP_REST_Controller {
 				),
 			)
 		);
-	}
-
-	/**
-	 * Check if user has edit post permission.
-	 *
-	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
-	 */
-	public function permission_check() {
-		return current_user_can( 'edit_posts' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-following.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-following.php
@@ -65,7 +65,7 @@ class WPCOM_REST_API_V2_Endpoint_Following extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_recommendations' ),
-					'permission_callback' => array( $this, 'permission_check' ),
+					'permission_callback' => 'is_user_logged_in',
 					'args'                => array(
 						'number' => array(
 							'type'              => 'number',

--- a/projects/plugins/jetpack/changelog/fix-following-api-perm
+++ b/projects/plugins/jetpack/changelog/fix-following-api-perm
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The endpoint for retrieving the user's subscriptions and site recommendations is not a site-specific one. But the permission check was a site-specific one. This PR ensures that we have the same permission checks like other related endpoints.
* The issue is most obvious for free users on wpcom. When the permission check runs the current site is the public API 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR to your sandbox
* Go to https://developer.wordpress.com/docs/api/console/
* Login with free wp user:

Ensure that responses are returned for:
```
 wpcom/v2/following/mine
 wpcom/v2/following/recommendations
```
