### PR TITLE
AI Assistant: change main action buttons style and behavior

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -254,7 +254,7 @@ export default function AiAssistantBar( {
 				<AIControl
 					ref={ inputRef }
 					disabled={ siteRequireUpgrade || ! connected }
-					value={ isLoading ? undefined : inputValue }
+					value={ inputValue }
 					placeholder={ isLoading ? loadingPlaceholder : placeholder }
 					onChange={ setInputValue }
 					onSend={ handleSend }


### PR DESCRIPTION
Address new design for the AI Assistant block. This is a mult-step change to be followed up.

Fixes #34332 
Fixes #34333 

## Proposed changes:
This PR addresses style changes on the buttons as well as their behavior:
- change "Send" in favor of "Generate"
- do not show main button while there is no content/prompt
- change "Stop" (ESC) in favor of simply "Stop"
- change AI "loading" icon for Spinner component, animate and show only when request is happening
- remove button's icons, let them show when on mobile view

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-pBB-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a JN instance and verify the changes in the description and design post. There's still work to do and this will not be merged until all changes are ready on next iterations.