### PR TITLE
cli: Update test for node 20.10 fixing a bug

### DIFF
--- a/tools/cli/tests/unit/helpers/filter-stream.test.js
+++ b/tools/cli/tests/unit/helpers/filter-stream.test.js
@@ -1,6 +1,7 @@
 import { once } from 'events';
 import { promisify } from 'util';
 import { jest } from '@jest/globals';
+import semver from 'semver';
 import FilterStream from '../../../helpers/filter-stream.js';
 
 describe( 'FilterStream', () => {
@@ -145,6 +146,9 @@ describe( 'FilterStream', () => {
 		ts.end( endfn );
 		await expect( errorEvent ).resolves.toEqual( [ new Error( 'nope!' ) ] );
 		// For some reason the end() callback is never called when there's an error. Only the error event.
-		expect( endfn ).not.toHaveBeenCalled();
+		// But this was apparently fixed in 20.10.0.
+		expect( endfn ).toHaveBeenCalledTimes(
+			semver.satisfies( process.versions.node, '>= 20.10.0' ) ? 1 : 0
+		);
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Until Node 20.10, the callback passed to a stream filter's `.end()` function would not be called if the stream raises an error. We had a test checking that behavior.

Now it is called, so the test needs updating. For now we'll introduce a version check so we don't have to bump the node version for everything.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1701284596881729/1701274551.950879-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the test with both node 20.9.0 and 20.10.0, it should pass with either one.