### PR TITLE
(Jetpack)(PHP8)(GB 17.1.3) Make the check around `$google_fonts_data`'s array more resilient and return early if key or value is not of the right type

### DIFF
--- a/projects/plugins/jetpack/changelog/make-load-google-fonts-more-resilient
+++ b/projects/plugins/jetpack/changelog/make-load-google-fonts-more-resilient
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Google Fonts: resolve occasional bug resulting in PHP 8 with latest Gutenberg.

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -112,7 +112,7 @@ function jetpack_get_theme_fonts_map() {
  */
 function jetpack_register_google_fonts_to_theme_json( $theme_json ) {
 	$google_fonts_data = jetpack_get_google_fonts_data();
-	if ( ! $google_fonts_data ) {
+	if ( ! $google_fonts_data || ! isset( $google_fonts_data['fontFamilies'] ) || ! is_array( $google_fonts_data['fontFamilies'] ) ) {
 		return $theme_json;
 	}
 

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -46,7 +46,9 @@ function jetpack_get_google_fonts_data() {
 		}
 	}
 
-	return $data;
+	if ( is_array( $data ) && is_array( $data['fontFamilies'] ) ) {
+		return $data;
+	}
 }
 
 /**
@@ -56,15 +58,11 @@ function jetpack_get_google_fonts_data() {
  * @return object[] The map of the the available Google Fonts.
  */
 function jetpack_get_available_google_fonts_map( $google_fonts_data ) {
-	$font_families = isset( $google_fonts_data ) && isset( $google_fonts_data['fontFamilies'] )
-		? $google_fonts_data['fontFamilies']
-		: array();
-
 	$jetpack_google_fonts_list = array_map(
 		function ( $font_family ) {
 			return $font_family['name'];
 		},
-		$font_families
+		$google_fonts_data['fontFamilies']
 	);
 
 	/** This filter is documented in modules/google-fonts/wordpress-6.3/load-google-fonts.php */
@@ -112,7 +110,7 @@ function jetpack_get_theme_fonts_map() {
  */
 function jetpack_register_google_fonts_to_theme_json( $theme_json ) {
 	$google_fonts_data = jetpack_get_google_fonts_data();
-	if ( ! $google_fonts_data || ! isset( $google_fonts_data['fontFamilies'] ) || ! is_array( $google_fonts_data['fontFamilies'] ) ) {
+	if ( ! $google_fonts_data ) {
 		return $theme_json;
 	}
 


### PR DESCRIPTION
## Proposed changes:

We've found that in some circumstances (which I couldn't pinpoint yet, exactly) when using PHP8 and Gutenberg 17.1.3+, the `$google_fonts_data['fontFamilies']` would be `null` and cause a fatal. The actual changeset in GB that triggers it (when PHP8 is being used) is this https://github.com/WordPress/gutenberg/pull/55240.This adds a more resilient guard around it, extending the current one, and return early if the shape is not correct.

See p1701220768492429-slack-CDLH4C1UZ and p1701369236916389-slack-C05Q5HSS013 for more context and info.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Steps to reproduce are tricky, see p1701220768492429-slack-CDLH4C1UZ for more info. It needs some WPCOM-specific builds that might not be available in this repo.