### PR TITLE
Avoid a PHP Warning in invalid contact form payloads

### DIFF
--- a/projects/packages/forms/changelog/fix-warning-array-to-string
+++ b/projects/packages/forms/changelog/fix-warning-array-to-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid PHP warnings when form has to process malformed data.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -506,6 +506,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_input_field( $type, $id, $value, $class, $placeholder, $required, $extra_attrs = array() ) {
+		if ( ! is_string( $value ) ) {
+			$value = '';
+		}
+
 		$extra_attrs_string = '';
 
 		if ( ! empty( $this->field_styles ) ) {
@@ -608,6 +612,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_textarea_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		if ( ! is_string( $value ) ) {
+			$value = '';
+		}
+
 		$field  = $this->render_label( 'textarea', 'contact-form-comment-' . $id, $label, $required, $required_field_text );
 		$field .= "<textarea
 		                style='" . $this->field_styles . "'


### PR DESCRIPTION
## Proposed changes:

**Data type validation**

A Malformed POST input to a contact form can pass an array of data as the value for a textarea  (which is expected by some other field types), which ultimately causes a PHP Warning within `esc_textarea()`.

```
E_WARNING: htmlspecialchars() expects parameter 1 to be string, array given in wp-includes/formatting.php:4732
```

This simply discards non-stringy data when rendering an `<input>` or `<textarea>` element.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* See comment below

