### PR TITLE
Internal release: remove Launchpad task for domain email verification

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-confirm-domain-email-launchpad-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-confirm-domain-email-launchpad-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed Launchpad task for domain email verification.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -49,7 +49,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.5.x-dev"
+			"dev-trunk": "5.6.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.5.0",
+	"version": "5.6.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.5.0';
+	const PACKAGE_VERSION = '5.6.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -140,15 +140,6 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/me/account';
 			},
 		),
-		'verify_domain_email'                => array(
-			'get_title'           => function () {
-				return __( 'Verify domain email address', 'jetpack-mu-wpcom' );
-			},
-			'is_visible_callback' => 'wpcom_launchpad_is_domain_email_unverified',
-			'get_calypso_path'    => function ( $task, $default, $data ) {
-				return '/domains/manage/' . $data['site_slug_encoded'];
-			},
-		),
 
 		// Newsletter pre-launch tasks.
 		'first_post_published_newsletter'    => array(
@@ -1333,21 +1324,6 @@ function wpcom_launchpad_is_email_verified() {
 	}
 
 	return ! Email_Verification::is_email_unverified();
-}
-
-/**
- * Callback for email verification visibility when the user has a
- * custom domain.
- *
- * @return bool True if email is unverified, false otherwise.
- */
-function wpcom_launchpad_is_domain_email_unverified() {
-	// TODO: handle the edge case where an Atomic user can be unverified.
-	if ( ! class_exists( 'Email_Verification' ) ) {
-		return false;
-	}
-
-	return Email_Verification::is_domain_email_unverified();
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -30,7 +30,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'verify_domain_email',
 				'setup_general',
 				'design_selected',
 				'plan_selected',
@@ -45,7 +44,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'verify_domain_email',
 				'plan_selected',
 				'setup_free',
 				'design_selected',
@@ -61,7 +59,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'verify_domain_email',
 				'design_selected',
 				'setup_link_in_bio',
 				'plan_selected',
@@ -75,7 +72,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'verify_domain_email',
 				'design_selected',
 				'setup_link_in_bio',
 				'plan_selected',
@@ -105,7 +101,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'verify_domain_email',
 				'videopress_setup',
 				'plan_selected',
 				'videopress_upload',
@@ -118,7 +113,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'verify_domain_email',
 				'setup_write',
 				'design_selected',
 				'plan_selected',
@@ -132,7 +126,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'verify_domain_email',
 				'first_post_published',
 				'setup_blog',
 				'domain_upsell',
@@ -146,7 +139,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'verify_domain_email',
 				'design_completed',
 				'setup_blog',
 				'domain_upsell',

--- a/projects/plugins/mu-wpcom-plugin/changelog/remove-confirm-domain-email-launchpad-task
+++ b/projects/plugins/mu-wpcom-plugin/changelog/remove-confirm-domain-email-launchpad-task
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_8"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_9_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "67196edaad741f50bdaa56fbe52cb9c61a583c04"
+                "reference": "43d5ead5b622ced2b8af330fc4fe39696218d946"
             },
             "require": {
                 "php": ">=7.0"
@@ -33,7 +33,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.5.x-dev"
+                    "dev-trunk": "5.6.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.8
+ * Version: 2.0.9-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.8",
+	"version": "2.0.9-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Reverts https://github.com/Automattic/jetpack/pull/33373
See Nov 30 Dotcom Walkthrough discussion. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the Launchpad task for domain email verification

## Why?

There is a good argument for keeping this and reworking it, but we already have some nags, and this hasn't proved effective, so let's remove it entirely. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin remove/confirm-domain-email-launchpad-task` on your sandbox
* Buy a domain with an unverified email address on the following flows:
    * Free
    * Link in Bio
    * Videopress
    * Write
    * Start writing
    * Design first
* Verify there is no longer a Launchpad task for each

