### PR TITLE
Jetpack Social | Fix admin page connections UI

### DIFF
--- a/projects/plugins/social/changelog/fix-social-admin-page
+++ b/projects/plugins/social/changelog/fix-social-admin-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed broken connections UI

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -18,6 +18,7 @@ import StatCards from '../stat-cards';
 import styles from './styles.module.scss';
 
 const Header = () => {
+	const connectionData = window.jetpackSocialInitialState.connectionData ?? {};
 	const {
 		connectionsAdminUrl,
 		hasConnections,
@@ -31,8 +32,8 @@ const Header = () => {
 	} = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID );
 		return {
-			connectionsAdminUrl: store.getConnectionsAdminUrl(),
-			hasConnections: store.hasConnections(),
+			connectionsAdminUrl: connectionData.adminUrl,
+			hasConnections: Object.keys( connectionData.connections || {} ).length > 0,
 			hasPaidPlan: select( SOCIAL_STORE_ID ).hasPaidPlan(),
 			isModuleEnabled: store.isModuleEnabled(),
 			isShareLimitEnabled: select( SOCIAL_STORE_ID ).isShareLimitEnabled(),


### PR DESCRIPTION
In #34064, we made some changes to the store and thus admin page doesn't know anything about the connections and it always says "Connect accounts" even if there are accounts connected.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the admin header to feed it the data from initial state.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jetpack Social - `jetpack install plugins/social`
* Remove all the Social Media connections for the site
* Goto Social admin page - `/wp-admin/admin.php?page=jetpack-social`
* Confirm that you see the "Connect accounts" button
* Now connect one or more social media accounts for the site
* Reload the admin page
* Confirm that you no longer see the "Connect accounts" button

| BEFORE | AFTER |
|--------|--------|
| <img width="484" alt="Screenshot 2023-11-30 at 5 54 02 PM" src="https://github.com/Automattic/jetpack/assets/18226415/35a641d0-4bad-4e59-a5df-3fa934e7cd2a"> | <img width="536" alt="Screenshot 2023-11-30 at 5 51 46 PM" src="https://github.com/Automattic/jetpack/assets/18226415/fdc23083-1a76-4903-95ec-3c37595fe2af"> | 

