### PR TITLE
Improving likes: fix wrong like count in dialog after liking

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-likes-count
+++ b/projects/plugins/jetpack/changelog/fix-likes-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix wrong like count in dialog after liking

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -35,8 +35,8 @@ function jetpack_likes_master_iframe() {
 	);
 
 	if ( $new_layout ) {
-		/* translators: The value of %d is not available at the time of output */
-		$likers_text = wp_kses( __( '<span>%d</span> likes', 'jetpack' ), array( 'span' => array() ) );
+		// The span content is be replaced by queuehandler when showOtherGravatars is called.
+		echo wp_kses( '<span>%d</span>', array( 'span' => array() ) );
 	} else {
 		/* translators: The value of %d is not available at the time of output */
 		$likers_text = wp_kses( __( '<span>%d</span> bloggers like this:', 'jetpack' ), array( 'span' => array() ) );

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -35,7 +35,7 @@ function jetpack_likes_master_iframe() {
 	);
 
 	if ( $new_layout ) {
-		// The span content is be replaced by queuehandler when showOtherGravatars is called.
+		// The span content is replaced by queuehandler when showOtherGravatars is called.
 		$likers_text = wp_kses( '<span>%d</span>', array( 'span' => array() ) );
 	} else {
 		/* translators: The value of %d is not available at the time of output */

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -36,7 +36,7 @@ function jetpack_likes_master_iframe() {
 
 	if ( $new_layout ) {
 		// The span content is be replaced by queuehandler when showOtherGravatars is called.
-		echo wp_kses( '<span>%d</span>', array( 'span' => array() ) );
+		$likers_text = wp_kses( '<span>%d</span>', array( 'span' => array() ) );
 	} else {
 		/* translators: The value of %d is not available at the time of output */
 		$likers_text = wp_kses( __( '<span>%d</span> bloggers like this:', 'jetpack' ), array( 'span' => array() ) );

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -213,9 +213,15 @@ function JetpackLikesMessageListener( event ) {
 			container.style.display = 'none';
 			list.innerHTML = '';
 
-			container
-				.querySelectorAll( '.likes-text span' )
-				.forEach( item => ( item.textContent = data.total ) );
+			if ( newLayout ) {
+				container
+					.querySelectorAll( '.likes-text span' )
+					.forEach( item => ( item.textContent = data.totalLikesLabel ) );
+			} else {
+				container
+					.querySelectorAll( '.likes-text span' )
+					.forEach( item => ( item.textContent = data.total ) );
+			}
 
 			( data.likers || [] ).forEach( liker => {
 				if ( liker.profile_URL.substr( 0, 4 ) !== 'http' ) {


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/84655

## Proposed changes:

* Fixes wrong like count in dialog after liking

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Apply this PR to your local
* Start a site with JurassicTube
* Enable likes in Jetpack > Settings > Sharing
* Open a post with 1 like and click to see the popover, check if the label is `1 like`
* Like the post, open the popover again, check if the count was incremented
* Remove the like, open the popover again, and check if the count was decremented

<img width="371" alt="image" src="https://github.com/Automattic/jetpack/assets/3113712/344db44e-0f4b-4afc-9940-c7087e5157a0">

