### PR TITLE
Enable new like widget layout

### DIFF
--- a/projects/plugins/jetpack/changelog/add-enable-new-likes-layout
+++ b/projects/plugins/jetpack/changelog/add-enable-new-likes-layout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enable new like widget layout.

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -442,7 +442,7 @@ class Jetpack_Likes {
 		 *
 		 * @param bool $new_layout Enable the new Likes layout. False by default.
 		 */
-		$new_layout = apply_filters( 'likes_new_layout', false ) ? '&amp;n=1' : '';
+		$new_layout = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
 
 		$src      = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s', $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$name     = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -24,7 +24,7 @@ function jetpack_likes_master_iframe() {
 
 	$likes_locale = ( '' === $_locale || 'en' === $_locale ) ? '' : '&amp;lang=' . strtolower( $_locale );
 	/** This filter is documented in projects/plugins/jetpack/modules/likes.php */
-	$new_layout       = apply_filters( 'likes_new_layout', false ) ? '&amp;n=1' : '';
+	$new_layout       = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
 	$new_layout_class = $new_layout ? 'wpl-new-layout' : '';
 
 	$src = sprintf(


### PR DESCRIPTION

## Proposed changes:
Enables the new like widget layout

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Apply this PR
- Access your site through JT
- Enable likes in Jetpack > Settings > Sharing
- Verify that the iframes src contains &n=1. There is one where the likes are displayed, and then another one that calls https://widgets.wp.com/likes/master.html near the end of the HTML.