### PR TITLE
AI Assistant: add suggestions actions

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-ai-suggestions-actions
+++ b/projects/js-packages/ai-client/changelog/add-ai-suggestions-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Client: add internal state management to toggle editing last prompt. Add discard handler prop

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -74,6 +74,7 @@ export function AIControl(
 		onSend = noop,
 		onStop = noop,
 		onAccept = noop,
+		onDiscard = noop,
 	}: {
 		disabled?: boolean;
 		value: string;
@@ -216,7 +217,7 @@ export function AIControl(
 						<Button
 							className="jetpack-components-ai-control__controls-prompt_button"
 							label={ __( 'Discard', 'jetpack-ai-client' ) }
-							onClick={ noop }
+							onClick={ () => onDiscard?.() }
 						>
 							<Icon icon={ trash } />
 						</Button>

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -6,7 +6,15 @@ import { Button } from '@wordpress/components';
 import { useKeyboardShortcut } from '@wordpress/compose';
 import { forwardRef, useImperativeHandle, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, closeSmall, check, arrowUp } from '@wordpress/icons';
+import {
+	Icon,
+	closeSmall,
+	check,
+	arrowUp,
+	arrowLeft,
+	trash,
+	reusableBlock,
+} from '@wordpress/icons';
 import classNames from 'classnames';
 import React from 'react';
 /**
@@ -160,8 +168,29 @@ export function AIControl(
 					</div>
 				) }
 
-				{ showAccept && (
+				{ showAccept && value?.length > 0 && (
 					<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
+						<Button
+							className="jetpack-components-ai-control__controls-prompt_button"
+							label={ __( 'Back to edit', 'jetpack-ai-client' ) }
+							onClick={ noop }
+						>
+							<Icon icon={ arrowLeft } />
+						</Button>
+						<Button
+							className="jetpack-components-ai-control__controls-prompt_button"
+							label={ __( 'Discard', 'jetpack-ai-client' ) }
+							onClick={ noop }
+						>
+							<Icon icon={ trash } />
+						</Button>
+						<Button
+							className="jetpack-components-ai-control__controls-prompt_button"
+							label={ __( 'Regenerate', 'jetpack-ai-client' ) }
+							onClick={ () => onSend?.( value ) }
+						>
+							<Icon icon={ reusableBlock } />
+						</Button>
 						<Button
 							className="jetpack-components-ai-control__controls-prompt_button"
 							onClick={ onAccept }

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -63,6 +63,21 @@
 	}
 }
 
+.jetpack-components-ai-control__controls-prompt_button_wrapper {
+	text-transform: uppercase;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 16px;
+	user-select: none;
+	white-space: nowrap;
+	display: flex;
+	align-items: center;
+
+	.components-button.is-small:not(.has-label) {
+		padding: 0;
+	}
+}
+
 .jetpack-components-ai-control__controls-prompt_button {
 	&:disabled {
 		opacity: 0.6;

--- a/projects/plugins/jetpack/changelog/add-ai-suggestions-actions
+++ b/projects/plugins/jetpack/changelog/add-ai-suggestions-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Pass down tryAgain handler to AI Control

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -561,6 +561,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					onSend={ handleSend }
 					onStop={ handleStopSuggestion }
 					onAccept={ handleAccept }
+					onDiscard={ handleTryAgain }
 					state={ requestingState }
 					isTransparent={ requireUpgrade || ! connected }
 					showButtonLabels={ ! isMobileViewport }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -333,7 +333,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 			 * - Create blocks from HTML code
 			 */
 			const HTML = markdownConverter
-				.render( attributes.content )
+				.render( attributes.content || '' )
 				// Fix list indentation
 				.replace( /<li>\s+<p>/g, '<li>' )
 				.replace( /<\/p>\s+<\/li>/g, '</li>' );
@@ -360,7 +360,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 
 	const handleAcceptTitle = () => {
 		if ( isInBlockEditor ) {
-			editPost( { title: attributes.content.trim() } );
+			editPost( { title: attributes.content ? attributes.content.trim() : '' } );
 			removeBlock( clientId );
 		} else {
 			handleAcceptContent();
@@ -565,7 +565,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					state={ requestingState }
 					isTransparent={ requireUpgrade || ! connected }
 					showButtonLabels={ ! isMobileViewport }
-					showAccept={ contentIsLoaded && ! isWaitingState }
+					showAccept={ requestingState !== 'init' && contentIsLoaded && ! isWaitingState }
 					acceptLabel={ acceptLabel }
 					showGuideLine={ contentIsLoaded }
 				/>


### PR DESCRIPTION
Once a request receives some suggestions, we show a new set of buttons for secondary actions

Fixes #34334 
Fixes #34335 

## Proposed changes:
This PR adds some more internal state management to be able to show secondary actions. One of them being a sort of "back to edit" the prompt, which should better differentiate upon what are the actions being taken (prompt vs suggestion)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-pBB-p2
p1701359106545339-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Spin up a JN instance and use the editor to see the new button actions on the AI Assistant. 

NOTE: the forms extension doesn't go into these actions since it's designed to work on a more contextual way, allowing to simple ask modifications on the achieved output/suggestion.