### PR TITLE
CLI: Try using enquirer to handle autocomplete prompts for changelog add

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3820,6 +3820,9 @@ importers:
       configstore:
         specifier: 5.0.1
         version: 5.0.1
+      enquirer:
+        specifier: 2.4.1
+        version: 2.4.1
       envfile:
         specifier: 6.17.0
         version: 6.17.0
@@ -13691,6 +13694,11 @@ packages:
       allure-js-commons: 2.9.2
     dev: true
 
+  /ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+    dev: false
+
   /ansi-escapes@3.2.0:
     resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
     engines: {node: '>=4'}
@@ -15811,6 +15819,14 @@ packages:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  /enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
+    dev: false
 
   /entities@2.1.0:
     resolution: {integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==}

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -747,8 +747,7 @@ async function promptChangelog( argv, needChangelog, types ) {
 		validate: input => {
 			const fileExists = doesFilenameExist( input, needChangelog );
 			if ( fileExists ) {
-				console.log( chalk.red( 'Please choose another file name.' ) );
-				return 'Please choose another file name, or delete the file manually.';
+				return 'Filename exists already. Please choose another file name, or delete the file existing manually.';
 			}
 			return true;
 		},

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -779,9 +779,8 @@ async function promptChangelog( argv, needChangelog, types ) {
 		type: 'autocomplete',
 		name: 'type',
 		message: 'Type of change.',
-		suggest: ( input, typeChoices = choices.map( choice => choice.value ) ) => {
-			return Promise.resolve( typeChoices.filter( choice => choice.value.startsWith( input ) ) );
-		},
+		suggest: ( input, choices ) => choices.filter( choice => choice.value.startsWith( input ) ),
+		highlight: v => v,
 		choices: choices,
 	} );
 

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -341,14 +341,6 @@ async function changelogAdd( argv ) {
 		return;
 	}
 
-	console.log(
-		chalk.yellow(
-			"When writing your changelog entry, please use the format 'Subject: change description.'\n" +
-				'Here is an example of a good changelog entry:\n' +
-				'  Sitemaps: ensure that the Home URL is slashed on subdirectory websites.\n'
-		)
-	);
-
 	if ( promptConfirm.separateChangelogFiles ) {
 		uniqueProjects.unshift( ...defaultProjects.splice( 0 ) );
 	}
@@ -783,6 +775,14 @@ async function promptChangelog( argv, needChangelog, types ) {
 		highlight: v => v,
 		choices: typeChoices,
 	} );
+
+	console.log(
+		chalk.yellow(
+			"When writing your changelog entry, please use the format 'Subject: change description.'\n" +
+				'Here is an example of a good changelog entry:\n' +
+				'  Sitemaps: ensure that the Home URL is slashed on subdirectory websites.\n'
+		)
+	);
 
 	// Get the entry, if it's a patch type it can be left blank.
 	let entryResponse;

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -370,8 +370,7 @@ async function changelogAdd( argv ) {
 
 	for ( const proj of uniqueProjects ) {
 		console.log( chalk.green( `Running changelogger for ${ proj }!` ) );
-		const projArray = [ proj ];
-		const response = await promptChangelog( argv, projArray, projectChangeTypes[ proj ] );
+		const response = await promptChangelog( argv, [ proj ], projectChangeTypes[ proj ] );
 		argv = await formatAutoArgs( proj, argv, response );
 		await changelogArgs( argv );
 	}

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -4,6 +4,7 @@ import path from 'path';
 import process from 'process';
 import { fileURLToPath } from 'url';
 import chalk from 'chalk';
+import enquirer from 'enquirer';
 import inquirer from 'inquirer';
 import { readComposerJson } from '../helpers/json.js';
 import { normalizeProject } from '../helpers/normalizeArgv.js';
@@ -13,7 +14,7 @@ import { runCommand } from '../helpers/runCommand.js';
 import { chalkJetpackGreen } from '../helpers/styling.js';
 
 let changeloggerPath = null;
-
+const { prompt } = enquirer;
 /**
  * Comand definition for changelog subcommand.
  *
@@ -369,7 +370,8 @@ async function changelogAdd( argv ) {
 
 	for ( const proj of uniqueProjects ) {
 		console.log( chalk.green( `Running changelogger for ${ proj }!` ) );
-		const response = await promptChangelog( argv, proj, projectChangeTypes[ proj ] );
+		const projArray = [ proj ];
+		const response = await promptChangelog( argv, projArray, projectChangeTypes[ proj ] );
 		argv = await formatAutoArgs( proj, argv, response );
 		await changelogArgs( argv );
 	}
@@ -623,6 +625,7 @@ function doesFilenameExist( fileName, needChangelog ) {
 			fileURLToPath( new URL( './', import.meta.url ) ),
 			`../../../projects/${ proj }/changelog/${ fileName }`
 		);
+
 		try {
 			if ( fs.existsSync( projPath ) ) {
 				console.log(
@@ -734,72 +737,94 @@ async function promptChangelog( argv, needChangelog, types ) {
 		value,
 		name: `[${ value.padEnd( maxLength, ' ' ) }] ${ name }`,
 	} ) );
-	const commands = await inquirer.prompt( [
-		{
-			type: 'string',
-			name: 'changelogName',
-			message: 'Name your changelog file:',
-			default: gitBranch,
-			validate: input => {
-				const fileExists = doesFilenameExist( input, needChangelog );
-				if ( fileExists ) {
-					return 'Please choose another file name, or delete the file manually.';
-				}
-				return true;
+
+	// Get the changelog name.
+	const { changelogName } = await prompt( {
+		type: 'input',
+		name: 'changelogName',
+		message: 'Name your changelog file:',
+		default: gitBranch,
+		validate: input => {
+			const fileExists = doesFilenameExist( input, needChangelog );
+			if ( fileExists ) {
+				console.log( chalk.red( 'Please choose another file name.' ) );
+				return 'Please choose another file name, or delete the file manually.';
+			}
+			return true;
+		},
+	} );
+
+	// Get the significance.
+	const { significance } = await prompt( {
+		type: 'autocomplete',
+		name: 'significance',
+		message: 'Significance of the change, in the style of semantic versioning.',
+		choices: [
+			{
+				value: 'patch',
+				name: '[patch] Backwards-compatible bug fixes.',
 			},
-		},
-		{
-			type: 'list',
-			name: 'significance',
-			message: 'Significance of the change, in the style of semantic versioning.',
-			choices: [
-				{
-					value: 'patch',
-					name: '[patch] Backwards-compatible bug fixes.',
-				},
-				{
-					value: 'minor',
-					name: '[minor] Added (or deprecated) functionality in a backwards-compatible manner.',
-				},
-				{
-					value: 'major',
-					name: '[major] Broke backwards compatibility in some way.',
-				},
-			],
-		},
-		{
-			type: 'list',
-			name: 'type',
-			message: 'Type of change.',
-			choices: choices,
-		},
-		{
-			type: 'string',
-			name: 'entry',
-			message: 'Changelog entry. May be left empty if this change is particularly insignificant.',
-			when: answers => answers.significance === 'patch',
-		},
-		{
-			type: 'string',
-			name: 'comment',
-			message:
-				'You omitted the changelog entry, which is fine. But please comment as to why no entry is needed.',
-			when: answers => answers.significance === 'patch' && answers.entry === '',
-		},
-		{
-			type: 'string',
+			{
+				value: 'minor',
+				name: '[minor] Added (or deprecated) functionality in a backwards-compatible manner.',
+			},
+			{
+				value: 'major',
+				name: '[major] Broke backwards compatibility in some way.',
+			},
+		],
+	} );
+
+	// Get the type of change.
+	const { type } = await prompt( {
+		type: 'autocomplete',
+		name: 'type',
+		message: 'Type of change.',
+		choices: choices,
+	} );
+
+	// Get the entry, if it's a patch type it can be left blank.
+	let entryResponse;
+	if ( significance !== 'patch' ) {
+		entryResponse = await prompt( {
+			type: 'input',
 			name: 'entry',
 			message: 'Changelog entry. May not be empty.',
-			when: answers => answers.significance === 'minor' || 'major',
 			validate: input => {
 				if ( ! input || ! input.trim() ) {
 					return `Changelog entry can't be blank`;
 				}
 				return true;
 			},
-		},
-	] );
-	return { ...commands };
+		} );
+	} else {
+		entryResponse = await prompt( {
+			type: 'input',
+			name: 'entry',
+			message: 'Changelog entry. May be left empty if this change is particularly insignificant.',
+		} );
+	}
+	const { entry } = entryResponse;
+
+	// Get the comment if the entry is left blank for a patch level change.
+	let commentResponse;
+	if ( entry === '' ) {
+		commentResponse = await prompt( {
+			type: 'input',
+			name: 'comment',
+			message:
+				'You omitted the changelog entry, which is fine. But please comment as to why no entry is needed.',
+		} );
+	}
+	const { comment } = commentResponse || {};
+
+	return {
+		changelogName,
+		significance,
+		type,
+		entry,
+		comment,
+	};
 }
 
 /**

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -732,7 +732,7 @@ async function promptChangelog( argv, needChangelog, types ) {
 		.trim()
 		.replace( /\//g, '-' );
 	const maxLength = Object.keys( types ).reduce( ( a, v ) => ( v.length > a ? v.length : a ), 0 );
-	const choices = Object.entries( types ).map( ( [ value, name ] ) => ( {
+	const typeChoices = Object.entries( types ).map( ( [ value, name ] ) => ( {
 		value,
 		name: `[${ value.padEnd( maxLength, ' ' ) }] ${ name }`,
 	} ) );
@@ -781,7 +781,7 @@ async function promptChangelog( argv, needChangelog, types ) {
 		message: 'Type of change.',
 		suggest: ( input, choices ) => choices.filter( choice => choice.value.startsWith( input ) ),
 		highlight: v => v,
-		choices: choices,
+		choices: typeChoices,
 	} );
 
 	// Get the entry, if it's a patch type it can be left blank.

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -737,7 +737,6 @@ async function promptChangelog( argv, needChangelog, types ) {
 		value,
 		name: `[${ value.padEnd( maxLength, ' ' ) }] ${ name }`,
 	} ) );
-
 	// Get the changelog name.
 	const { changelogName } = await prompt( {
 		type: 'input',
@@ -758,6 +757,11 @@ async function promptChangelog( argv, needChangelog, types ) {
 		type: 'autocomplete',
 		name: 'significance',
 		message: 'Significance of the change, in the style of semantic versioning.',
+		suggest: ( input, significanceChoices = [ 'patch', 'minor', 'majo' ] ) => {
+			return Promise.resolve(
+				significanceChoices.filter( choice => choice.value.startsWith( input ) )
+			);
+		},
 		choices: [
 			{
 				value: 'patch',
@@ -779,6 +783,9 @@ async function promptChangelog( argv, needChangelog, types ) {
 		type: 'autocomplete',
 		name: 'type',
 		message: 'Type of change.',
+		suggest: ( input, typeChoices = choices.map( choice => choice.value ) ) => {
+			return Promise.resolve( typeChoices.filter( choice => choice.value.startsWith( input ) ) );
+		},
 		choices: choices,
 	} );
 

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -756,11 +756,8 @@ async function promptChangelog( argv, needChangelog, types ) {
 		type: 'autocomplete',
 		name: 'significance',
 		message: 'Significance of the change, in the style of semantic versioning.',
-		suggest: ( input, significanceChoices = [ 'patch', 'minor', 'major' ] ) => {
-			return Promise.resolve(
-				significanceChoices.filter( choice => choice.value.startsWith( input ) )
-			);
-		},
+		suggest: ( input, choices ) => choices.filter( choice => choice.value.startsWith( input ) ),
+		highlight: v => v,
 		choices: [
 			{
 				value: 'patch',

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -757,7 +757,7 @@ async function promptChangelog( argv, needChangelog, types ) {
 		type: 'autocomplete',
 		name: 'significance',
 		message: 'Significance of the change, in the style of semantic versioning.',
-		suggest: ( input, significanceChoices = [ 'patch', 'minor', 'majo' ] ) => {
+		suggest: ( input, significanceChoices = [ 'patch', 'minor', 'major' ] ) => {
 			return Promise.resolve(
 				significanceChoices.filter( choice => choice.value.startsWith( input ) )
 			);

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -25,9 +25,9 @@
 		"@octokit/rest": "19.0.13",
 		"chalk": "4.1.2",
 		"configstore": "5.0.1",
+		"enquirer": "2.4.1",
 		"envfile": "6.17.0",
 		"execa": "7.0.0",
-		"tmp": "0.2.1",
 		"glob": "7.1.6",
 		"ignore": "5.1.8",
 		"inquirer": "7.3.3",
@@ -42,6 +42,7 @@
 		"process": "0.11.10",
 		"semver": "7.5.2",
 		"sprintf-js": "1.1.2",
+		"tmp": "0.2.1",
 		"yargs": "17.6.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

An alternative to https://github.com/Automattic/jetpack/pull/34381

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Uses enquirer instead of inquirer to handle autocompletion when searching for changes.

This just handles the prompts for the `jetpack changelog add` command, and doesn't replace inquirer everywhere. If this is the direction we want to go later, we can look into that.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pf4qpu-9d-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Put the changelogger through its paces:

Try using `jetpack changelog add` and specify a project, or make some changes to projects and use `jetpack changelog add` to make sure everything works and the changelogger is put through its paces. 