### PR TITLE
cli: Avoid node bug in process plumbing

### DIFF
--- a/tools/cli/helpers/list-project-files.js
+++ b/tools/cli/helpers/list-project-files.js
@@ -15,26 +15,25 @@ export async function* listProjectFiles( src, spawn ) {
 	//    ls-files --ignored | check-attr production-include | filter
 	//  } | check-attr production-exclude | filter
 
-	const lsFiles = spawn( 'git', [ '-c', 'core.quotepath=off', 'ls-files' ], {
+	// If any of the execa promises reject during the `yield*`, node will decide they're "unhandled" and exit ignoring any
+	// parent catch. So we need to catch any errors manually, then re-throw them after.
+	let err;
+	const promises = [];
+	const doSpawn = ( cmd, args, options ) => {
+		const proc = spawn( cmd, args, options );
+		promises.push( proc.catch( e => ( err ||= e ) ) );
+		return proc;
+	};
+
+	// Create the `ls-files` process.
+	const lsFiles = doSpawn( 'git', [ '-c', 'core.quotepath=off', 'ls-files' ], {
 		cwd: src,
 		stdio: [ 'ignore', 'pipe', null ],
 		buffer: false,
 	} );
-	const lsIgnoredFiles = spawn(
-		'git',
-		[ '-c', 'core.quotepath=off', 'ls-files', '--others', '--ignored', '--exclude-standard' ],
-		{ cwd: src, stdio: [ 'ignore', 'pipe', null ], buffer: false }
-	);
-	const checkAttrInclude = spawn(
-		'git',
-		[ '-c', 'core.quotepath=off', 'check-attr', '--stdin', 'production-include' ],
-		{
-			cwd: src,
-			stdio: [ lsIgnoredFiles.stdout, 'pipe', null ],
-			buffer: false,
-		}
-	);
-	const checkAttrExclude = spawn(
+
+	// Create the `| check-attr production-exclude | filter` part.
+	const checkAttrExclude = doSpawn(
 		'git',
 		[ '-c', 'core.quotepath=off', 'check-attr', '--stdin', 'production-exclude' ],
 		{
@@ -43,39 +42,51 @@ export async function* listProjectFiles( src, spawn ) {
 			buffer: false,
 		}
 	);
-	const filterProductionInclude = new FilterStream(
-		s => s.match( /^(.*): production-include: (?!unspecified|unset)/ )?.[ 1 ]
-	);
+
 	const filterProductionExclude = new FilterStream(
 		s => s.match( /^(.*): production-exclude: (?:unspecified|unset)/ )?.[ 1 ]
 	);
 
-	// Pipe lsFiles to checkAttrExclude first, then lsIgnoredFiles+checkAttrInclude+filterProductionInclude after that.
+	// Only after the `ls-files` part finishes can we create the `ls-files --ignored | check-attr production-include | filter` part
+	// and then connect it to the `| check-attr production-exclude | filter` part.
+	// If we create it earlier, and it finishes first, node loses all the output.
 	lsFiles.stdout.on( 'end', () => {
-		// prettier-ignore
+		const lsIgnoredFiles = doSpawn(
+			'git',
+			[ '-c', 'core.quotepath=off', 'ls-files', '--others', '--ignored', '--exclude-standard' ],
+			{ cwd: src, stdio: [ 'ignore', 'pipe', null ], buffer: false }
+		);
+
+		const checkAttrInclude = doSpawn(
+			'git',
+			[ '-c', 'core.quotepath=off', 'check-attr', '--stdin', 'production-include' ],
+			{
+				cwd: src,
+				stdio: [ lsIgnoredFiles.stdout, 'pipe', null ],
+				buffer: false,
+			}
+		);
+
+		const filterProductionInclude = new FilterStream(
+			s => s.match( /^(.*): production-include: (?!unspecified|unset)/ )?.[ 1 ]
+		);
+
 		checkAttrInclude.stdout
 			.pipe( filterProductionInclude )
 			.pipe( checkAttrExclude.stdin, { end: true } );
 	} );
+
+	// Connect the `ls-files` part to the `| check-attr production-exclude | filter` part.
 	lsFiles.stdout.pipe( checkAttrExclude.stdin, { end: false } );
 
-	const rl = readline.createInterface( {
+	// Yield the output of the `check-attr production-exclude | filter` part line by line.
+	yield* readline.createInterface( {
 		input: checkAttrExclude.stdout.pipe( filterProductionExclude ),
 		crlfDelay: Infinity,
 	} );
 
-	// Apparently if any of the execa promises reject during the `yield*`, node will decide they're "unhandled" and exit ignoring any
-	// parent catch. So we need to catch any errors manually, then re-throw them after.
-	let err;
-	for ( const proc of [ lsFiles, lsIgnoredFiles, checkAttrInclude, checkAttrExclude ] ) {
-		proc.catch( e => ( err ||= e ) );
-	}
-
-	// Return each line from the generator.
-	yield* rl;
-
-	// Wait for processes, then rethrow any error.
-	await Promise.all( [ lsFiles, lsIgnoredFiles, checkAttrInclude, checkAttrExclude ] );
+	// Wait for all the promises created above, then rethrow any error.
+	await Promise.all( promises );
 	if ( err ) {
 		throw err;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In `listProjectFiles` we first run `git ls-files` and process its output, then run a second `git ls-files` with different options and piped to `git check-attr` and process its output.

To keep the promise handling less confusing, we create all those processes at once and only attach the second pipe's output to the processor after the first pipe finishes.

But it seems Node has a bug (or at least unexpected behavior) where it throws away its internal stream buffer for the second pipe's output if the final process exits before the first pipe finishes.

The most logical (if not the most straightforward to code) way to handle that is to not even create the second pipe until the first one finishes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
I think this is the cause of p1701368080443519/1701367288.275599-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build working?