### PR TITLE
Contact Form: add visible focus state to radio buttons and checkboxes

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-chexkbox-radio-focus
+++ b/projects/packages/forms/changelog/fix-contact-form-chexkbox-radio-focus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: add focus state to radio buttons and checkboxes

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -565,7 +565,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	--field-padding: calc(var(--label-left) - var(--jetpack--contact-form--border-size));
 }
 
-.contact-form .is-style-animated .grunion-field-wrap input {
+.contact-form .is-style-animated .grunion-field-wrap input:not([type="checkbox"]):not([type="radio"]) {
 	outline: none;
 }
 
@@ -634,17 +634,15 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .grunion-field-wrap input.checkbox-multiple,
 .contact-form .grunion-field-wrap input.radio {
 	align-items: center;
-	all: initial;
 	appearance: none;
 	color: var(--jetpack--contact-form--text-color);
-	display: flex !important;
 	border: none;
 	font-size: var(--jetpack--contact-form--font-size);
 	font-family: var(--jetpack--contact-form--font-family);
 	height: var(--jetpack--contact-form--font-size);
 	justify-content: center;
 	margin: 0 10px 0 0;
-	outline: none;
+	padding: 0;
 	position: relative;
 	width: var(--jetpack--contact-form--font-size);
 }
@@ -689,11 +687,11 @@ on production builds, the attributes are being reordered, causing side-effects
 	border-radius: 50%;
 	content: '';
 	height: 0.5em;
-	margin-left: 50%;
-	margin-top: 50%;
 	position: absolute;
 	transform: translate(-50%, -50%);
 	width: 0.5em;
+	top: calc(var(--jetpack--contact-form--font-size) / 2);
+	inset-inline-start: calc(var(--jetpack--contact-form--font-size) / 2);
 }
 
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-checkbox-multiple-label,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

Enable the default focus state on the checkboxes and radio buttons in _Contact Form_. This is essential for keyboard users, for instance.

|Before|After|
|-|-|
|<img width="232" alt="" src="https://github.com/Automattic/jetpack/assets/1620183/4a17ec0a-fa8e-4433-bebf-ca11f49897f4">|<img width="235" alt="" src="https://github.com/Automattic/jetpack/assets/1620183/58a49a9a-b630-4ea9-8de2-240514e3d589">|
|<img width="155" alt="" src="https://github.com/Automattic/jetpack/assets/1620183/cd6e1d5c-8813-4f0d-9fc9-3dac6466e0ec">|<img width="146" alt="" src="https://github.com/Automattic/jetpack/assets/1620183/608cee3d-14c9-48e7-b873-ae3734371544">|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-87-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Create a new post
- Add a Contact form block to the post
- Add a Multiple Choice and Single Choice fields
- Visit the post preview
- Navigate through the form with the Tab key of your keyboard
- Notice the checkboxes and radio buttons have a visible focus state
- Repeat the above for all block styles: _Default_, _Outlined_, and _Animated_

