### PR TITLE
Release jetpack-mu-wpcom 5.1.1.

### DIFF
--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.4] - 2023-11-30
+### Changed
+- Internal updates.
+
 ## [4.0.3] - 2023-11-24
 
 ## [4.0.2] - 2023-11-21
@@ -196,6 +200,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[4.0.4]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.3...4.0.4
 [4.0.3]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.2...4.0.3
 [4.0.2]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.0...4.0.1

--- a/projects/packages/changelogger/changelog/renovate-mediawiki-mediawiki-codesniffer-42.x
+++ b/projects/packages/changelogger/changelog/renovate-mediawiki-mediawiki-codesniffer-42.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix `MediaWiki.PHPUnit.MockBoilerplate` sniffs in tests. No change to the package itself.
-
-

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.0.4-alpha';
+	const VERSION = '4.0.4';
 
 	/**
 	 * Constructor.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2023-11-30
+### Changed
+- Update url for launchpad task to add subscribe block to point to site editor with subscribe block docs open in the help center. [#34329]
+
+### Fixed
+- Added type check to prevent unnecessary warnings in Coming Soon logic [#34322]
+- Earn: Update link to plans page. [#34316]
+
 ## [5.1.0] - 2023-11-24
 ### Added
 - Added dynamic titles to task lists. [#34244]
@@ -450,6 +458,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.1.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.1.0...v5.1.1
 [5.1.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.0.0...v5.1.0
 [5.0.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.18.0...v5.0.0
 [4.18.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.17.0...v4.18.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-warnings-from-jetpack-mu-wpcom-coming-soon-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-warnings-from-jetpack-mu-wpcom-coming-soon-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Added type check to prevent unnecessary warnings in Coming Soon logic

--- a/projects/packages/jetpack-mu-wpcom/changelog/renovate-mediawiki-mediawiki-codesniffer-42.x
+++ b/projects/packages/jetpack-mu-wpcom/changelog/renovate-mediawiki-mediawiki-codesniffer-42.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix `MediaWiki.PHPUnit.MockBoilerplate` sniffs in tests. No change to the package itself.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/subscribe-block-launchpad-task-url-update
+++ b/projects/packages/jetpack-mu-wpcom/changelog/subscribe-block-launchpad-task-url-update
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update url for launchpad task to add subscribe block to point to site editor with subscribe block docs open in the help center.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-earn-plans-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-earn-plans-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Earn: Update link to plans page.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.1.1-alpha",
+	"version": "5.1.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.1.1-alpha';
+	const PACKAGE_VERSION = '5.1.1';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.3 - 2023-11-30
+### Changed
+- Internal updates.
+
 ## 2.0.2 - 2023-11-24
 
 ## 2.0.1 - 2023-11-21

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_2"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_3"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.2
+ * Version: 2.0.3
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This releases jetpack-mu-wpcom 5.1.1.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

