### PR TITLE
Related Posts Block: Fix Thumbnails Opening in Same Tab

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-thumbnails
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-thumbnails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Related Posts block: fix thumbnails opening in the same tab.

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/edit.js
@@ -100,13 +100,16 @@ function RelatedPostsEditItem( props ) {
 				{ props.post.title }
 			</a>
 			{ props.displayThumbnails && props.post.img && props.post.img.src && (
-				<a className="jp-related-posts-i2__post-img-link" href={ props.post.url }>
+				<a
+					className="jp-related-posts-i2__post-img-link"
+					href={ props.post.url }
+					target="_blank"
+					rel="nofollow noopener noreferrer"
+				>
 					<img
 						className="jp-related-posts-i2__post-img"
 						src={ props.post.img.src }
 						alt={ props.post.title }
-						rel="nofollow noopener noreferrer"
-						target="_blank"
 					/>
 				</a>
 			) }


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This has been bugging me a little whenever using the Related Posts block; the thumbnails open in the same tab when you click it, even though the post titles don't. Since these images can be big, it's pretty easy to do accidentally, and it means that you'd need to reload the Editor. It also means relying on the browser's alert notice in order to avoid lost content. 

From the code, it looks like a bug whereby the attributes need to be applied to the link rather than the image. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Insert the Related Posts block
2. Select "Display thumbnails" in Block Settings
3. Click the thumbnail in the Editor
4. Confirm that it opens in a new tab rather than the same tab 

