### PR TITLE
Launchpad: Add the tasks for new assembler-first flow

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-assembler-first-launchpad-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-assembler-first-launchpad-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: Add tasks for the new assembler-first flow

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -242,6 +242,22 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'share_site',
 			),
 		),
+		'assembler-first'        => array(
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
+			'task_ids'            => array(
+				'verify_domain_email',
+				'plan_selected',
+				'setup_free',
+				'design_selected',
+				'domain_upsell',
+				'first_post_published',
+				'design_edited',
+				'site_launched',
+			),
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
+		),
 	);
 
 	$extended_task_list_definitions = apply_filters( 'wpcom_launchpad_extended_task_list_definitions', array() );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/pull/84688

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the tasks for the new assembler-first flow as follows:

<img width="394" alt="image" src="https://github.com/Automattic/jetpack/assets/13596067/209b7ca0-e71d-4f91-8ed7-2ed25f0d9781">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync the changes to your sandbox
  ```
  bin/jetpack-downloader test jetpack-mu-wpcom-plugin feat/assembler-first-launchpad-task
  ```
* Follow the instructions https://github.com/Automattic/wp-calypso/pull/84688 to create a new site with the assembler-first flow
* Go to the launchpad, `/setup/assembler-first/launchpad?siteSlug=<your_site>`
* Ensure you're able to the tasks mentioned above