### PR TITLE
Refactor `proxy_request_to_wpcom_as_user` to match behaviour of wpcom

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php
@@ -54,11 +54,11 @@ trait WPCOM_REST_API_Proxy_Request_Trait {
 		}
 
 		$response_status = wp_remote_retrieve_response_code( $response );
-		$response_body   = json_decode( wp_remote_retrieve_body( $response ) );
+		$response_body   = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		if ( $response_status >= 400 ) {
-			$code    = isset( $response_body->code ) ? $response_body->code : 'unknown_error';
-			$message = isset( $response_body->message ) ? $response_body->message : __( 'An unknown error occurred.', 'jetpack' );
+			$code    = isset( $response_body['code'] ) ? $response_body['code'] : 'unknown_error';
+			$message = isset( $response_body['message'] ) ? $response_body['message'] : __( 'An unknown error occurred.', 'jetpack' );
 
 			return new WP_Error( $code, $message, array( 'status' => $response_status ) );
 		}

--- a/projects/plugins/jetpack/changelog/fix-proxy-return-arrays
+++ b/projects/plugins/jetpack/changelog/fix-proxy-return-arrays
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: technically just refactoring as there is no change to behaviour of any APIs
+
+


### PR DESCRIPTION
In https://github.com/Automattic/jetpack/pull/34041 I discovered that behaviour of calling the blogging-prompts api from php code was different on self hosted sites than it is on wpcom.

This is because on wpcom, associative array objects are returned, wheras on self hosted sites, stdClass type objects are used. This is due to the default behavior of `json_decode()`, by default it returns stdClass wheras passing a second argument to true produces and array (changed in this diff).

In the [memberships api](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php#L433) we already return associative array objects. In blogging-prompts I'm https://github.com/Automattic/jetpack/pull/34041

To make things consistent, this change updates the newsletters and email preview code to use the same pattern.

This change only affects callers running within PHP code. If the API is called remotely (from JavaScript), then objects will be converted to JSON anyway, and the API will behave identically.

As it turns out, none of the endpoints affected by this change are currently referenced by PHP. That makes this change functionally just a refactor. (at least within Jetpack as far as I can tell, is there anything else that I might need to check?).

## Does this pull request change what data or activity we track or use?

No

### Testing instructions.
I've tested that these endpoints return the same structure of JSON

```
POST /wp-json/wpcom/v2/send-email-preview
{
	"id": "$post_id"
}

GET /wp-json/wpcom/v2/newsletter-categories

GET /wp-json/wpcom/v2/newsletter-categories/count
```

And they are not referenced by PHP code (at least within jetpack, is it possible this could have cross plugin effects I need to test for?)