### PR TITLE
Email preview: fix sending preview if content in the editor is different from latest in the database

### DIFF
--- a/projects/plugins/jetpack/changelog/update-email-preview-save-draft
+++ b/projects/plugins/jetpack/changelog/update-email-preview-save-draft
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix sending email preview if content in the editor is different from latest in the database.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -11,7 +11,8 @@ import {
 	TextControl,
 	Icon,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import './email-preview.scss';
@@ -23,15 +24,23 @@ export default function EmailPreview( { isModalOpen, closeModal } ) {
 	const [ emailSending, setEmailSending ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( false );
 	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId() );
+	const { __unstableSaveForPreview } = useDispatch( editorStore );
 	const [ isSmall ] = useBreakpointMatch( 'sm' );
 	const { tracks } = useAnalytics();
 
-	const sendEmailPreview = () => {
+	const sendEmailPreview = async () => {
 		tracks.recordEvent( 'jetpack_send_email_preview', {
 			post_id: postId,
 		} );
 
 		setEmailSending( true );
+
+		// Save post revision so that we send what they see in the editor, and not what previous draft/revision might've saved
+		// Introduced at GB 16.3 at https://github.com/WordPress/gutenberg/pull/44971
+		if ( typeof __unstableSaveForPreview === 'function' ) {
+			await __unstableSaveForPreview();
+		}
+
 		apiFetch( {
 			path: '/wpcom/v2/send-email-preview/',
 			method: 'POST',

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -37,7 +37,7 @@ export default function EmailPreview( { isModalOpen, closeModal } ) {
 
 		// Save post revision so that we send what they see in the editor, and not what previous draft/revision might've saved
 		// Introduced at GB 16.3 at https://github.com/WordPress/gutenberg/pull/44971
-		// @todo Remove the `if` check and `else` branch once WP 6.4 is the minimum supported version
+		// @todo Remove the `if` check once WP 6.4 is the minimum supported version
 		if ( typeof __unstableSaveForPreview === 'function' ) {
 			await __unstableSaveForPreview();
 		}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -37,6 +37,7 @@ export default function EmailPreview( { isModalOpen, closeModal } ) {
 
 		// Save post revision so that we send what they see in the editor, and not what previous draft/revision might've saved
 		// Introduced at GB 16.3 at https://github.com/WordPress/gutenberg/pull/44971
+		// @todo Remove the `if` check and `else` branch once WP 6.4 is the minimum supported version
 		if ( typeof __unstableSaveForPreview === 'function' ) {
 			await __unstableSaveForPreview();
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fire auto-save before sending the email preview. Ensures the preview email has latest content from the post, instead of what might've been saved by editor previously.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post; good to test without saving it first as a draft, as well as saving it as a draft
* If you save a draft, go ahead and modify the text some more. Using numbers in content makes testing easy.
* Hit publish, hit "Send test email"
* Note auto-save kick on the background
* See that you get the email with latest content
* Without the change, latest unsaved changes aren't in the email