### PR TITLE
Improvements to my Jetpack CTAs and Connection banner

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -90,7 +90,7 @@ export default function MyJetpackScreen() {
 	useConnectionWatcher();
 	// Check using the global state instead of Redux so it only has effect after refreshing the page
 	const welcomeBannerHasBeenDismissed =
-		window?.myJetpackInitialState?.welcomeBanner.hasBeenDismissed === '1';
+		window?.myJetpackInitialState?.welcomeBanner.hasBeenDismissed;
 	const isStatsModuleActive = window?.myJetpackInitialState?.isStatsModuleActive === '1';
 	const { message, options, clean } = useGlobalNotice();
 	const { hasConnectionError } = useConnectionErrorNotice();

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -139,7 +139,7 @@ export default function MyJetpackScreen() {
 							<ConnectionError />
 						</Col>
 					) }
-					{ message && (
+					{ message && welcomeBannerHasBeenDismissed && (
 						<Col>
 							<GlobalNotice message={ message } options={ options } clean={ clean } />
 						</Col>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -26,6 +26,7 @@ import useChatAvailability from '../../hooks/use-chat-availability';
 import useConnectionWatcher from '../../hooks/use-connection-watcher';
 import useGlobalNotice from '../../hooks/use-notice';
 import { useProduct } from '../../hooks/use-product';
+import useWelcomeBanner from '../../hooks/use-welcome-banner';
 import ConnectionsSection from '../connections-section';
 import IDCModal from '../idc-modal';
 import PlansSection from '../plans-section';
@@ -96,6 +97,7 @@ export default function MyJetpackScreen() {
 	const { jwt, isFetchingChatAuthentication } = useChatAuthentication();
 	const shouldShowZendeskChatWidget =
 		! isFetchingChatAuthentication && ! isFetchingChatAvailability && isAvailable && jwt;
+	const { hasBeenDismissed: welcomeBannerHasBeenDismissed } = useWelcomeBanner;
 
 	const { recordEvent } = useAnalytics();
 	const [ reloading, setReloading ] = useState( false );
@@ -132,7 +134,7 @@ export default function MyJetpackScreen() {
 							{ __( 'Discover all Jetpack Products', 'jetpack-my-jetpack' ) }
 						</Text>
 					</Col>
-					{ hasConnectionError && (
+					{ hasConnectionError && welcomeBannerHasBeenDismissed && (
 						<Col>
 							<ConnectionError />
 						</Col>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -26,7 +26,6 @@ import useChatAvailability from '../../hooks/use-chat-availability';
 import useConnectionWatcher from '../../hooks/use-connection-watcher';
 import useGlobalNotice from '../../hooks/use-notice';
 import { useProduct } from '../../hooks/use-product';
-import useWelcomeBanner from '../../hooks/use-welcome-banner';
 import ConnectionsSection from '../connections-section';
 import IDCModal from '../idc-modal';
 import PlansSection from '../plans-section';
@@ -89,6 +88,9 @@ const GlobalNotice = ( { message, options, clean } ) => {
  */
 export default function MyJetpackScreen() {
 	useConnectionWatcher();
+	// Check using the global state instead of Redux so it only has effect after refreshing the page
+	const welcomeBannerHasBeenDismissed =
+		window?.myJetpackInitialState?.welcomeBanner.hasBeenDismissed === '1';
 	const isStatsModuleActive = window?.myJetpackInitialState?.isStatsModuleActive === '1';
 	const { message, options, clean } = useGlobalNotice();
 	const { hasConnectionError } = useConnectionErrorNotice();
@@ -97,7 +99,6 @@ export default function MyJetpackScreen() {
 	const { jwt, isFetchingChatAuthentication } = useChatAuthentication();
 	const shouldShowZendeskChatWidget =
 		! isFetchingChatAuthentication && ! isFetchingChatAvailability && isAvailable && jwt;
-	const { hasBeenDismissed: welcomeBannerHasBeenDismissed } = useWelcomeBanner();
 
 	const { recordEvent } = useAnalytics();
 	const [ reloading, setReloading ] = useState( false );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -97,7 +97,7 @@ export default function MyJetpackScreen() {
 	const { jwt, isFetchingChatAuthentication } = useChatAuthentication();
 	const shouldShowZendeskChatWidget =
 		! isFetchingChatAuthentication && ! isFetchingChatAvailability && isAvailable && jwt;
-	const { hasBeenDismissed: welcomeBannerHasBeenDismissed } = useWelcomeBanner;
+	const { hasBeenDismissed: welcomeBannerHasBeenDismissed } = useWelcomeBanner();
 
 	const { recordEvent } = useAnalytics();
 	const [ reloading, setReloading ] = useState( false );

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -73,13 +73,13 @@ const ActionButton = ( {
 					size: 'small',
 					variant: 'primary',
 					weight: 'regular',
-					label: __( 'Purchase', 'jetpack-my-jetpack' ),
+					label: __( 'Learn more', 'jetpack-my-jetpack' ),
 					onClick: onAdd,
 				};
 			}
 			case PRODUCT_STATUSES.CAN_UPGRADE: {
 				const upgradeText = __( 'Upgrade', 'jetpack-my-jetpack' );
-				const purchaseText = __( 'Purchase', 'jetpack-my-jetpack' );
+				const purchaseText = __( 'Learn more', 'jetpack-my-jetpack' );
 				const buttonText = purchaseUrl || upgradeInInterstitial ? upgradeText : purchaseText;
 
 				return {
@@ -99,7 +99,7 @@ const ActionButton = ( {
 					size: 'small',
 					variant: 'primary',
 					weight: 'regular',
-					label: __( 'Start for free', 'jetpack-my-jetpack' ),
+					label: __( 'Learn more', 'jetpack-my-jetpack' ),
 					onClick: onAdd,
 				};
 			case PRODUCT_STATUSES.ACTIVE: {

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-improvements
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-improvements
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+To avoid overwhelming users with information, now that we have the welcome banner, we only display the connection message if the welcome banner has been dismissed, either by clicking on any CTA or the close button. We also updated some CTAs to be more consistent and clear for new users.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates the copy in some CTAs from "Purchase" and "Start for free" to "Learn more" to be consistent with the other CTAs that redirect to an interstitial, and add a check to only display the Connection banner if the Welcome banner has been dismissed. This way, the user isn't overwhelmed with information when they visit My Jetpack for the first time.

<img width="1505" alt="image" src="https://github.com/Automattic/jetpack/assets/5714212/725b5f0a-5089-40f6-a5e1-1f6a3c7a6a19">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch
* Visit WP Admin and go to My Jetpack without connecting Jetpack
* Confirm that the notice with the connection banner is not there, click to dismiss the Welcome banner, and confirm that the notice appears after you refresh the page
* Confirm that the buttons that redirect to interstitials are now labeled "Learn more"
