### PR TITLE
Add page view events to WooCommerce Checkout flow.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-page-view-events-for-wc-checkout-flow
+++ b/projects/plugins/jetpack/changelog/add-page-view-events-for-wc-checkout-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add page view tracking for WooCommerce Checkout Flow

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Assets;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -12,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require __DIR__ . '/classes/class-jetpack-woocommerce-analytics-trait.php';
 require_once __DIR__ . '/classes/class-jetpack-woocommerce-analytics-universal.php';
 require_once __DIR__ . '/classes/class-jetpack-woocommerce-analytics-my-account.php';
+require_once __DIR__ . '/classes/class-jetpack-woocommerce-analytics-checkout-flow.php';
 
 /**
  * Class Jetpack_WooCommerce_Analytics
@@ -39,6 +42,13 @@ class Jetpack_WooCommerce_Analytics {
 	 * @var Static property to hold concrete analytics implementation that does the work.
 	 */
 	private static $myaccount = false;
+
+	/**
+	 * Instance of the Checkout Flow functions
+	 *
+	 * @var Static property to hold concrete analytics implementation that does the work.
+	 */
+	private static $views = false;
 
 	/**
 	 * WooCommerce Analytics is only available to Jetpack connected WooCommerce stores with both plugins set to active
@@ -77,8 +87,37 @@ class Jetpack_WooCommerce_Analytics {
 	 * @return void
 	 */
 	private function __construct() {
+		// loading _wca.
+		add_action( 'wp_head', array( $this, 'wp_head_top' ), 1 );
+
+		// loading s.js.
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_tracking_script' ) );
+
 		self::$analytics = new Jetpack_WooCommerce_Analytics_Universal();
 		self::$myaccount = new Jetpack_WooCommerce_Analytics_My_Account();
+		self::$views     = new Jetpack_WooCommerce_Analytics_Checkout_Flow();
+	}
+
+		/**
+		 * Make _wca available to queue events
+		 */
+	public function wp_head_top() {
+		if ( is_cart() || is_checkout() || is_checkout_pay_page() || is_order_received_page() || is_add_payment_method_page() ) {
+			echo '<script>window._wca_prevent_referrer = true;</script>' . "\r\n";
+		}
+		echo '<script>window._wca = window._wca || [];</script>' . "\r\n";
+	}
+
+	/**
+	 * Place script to call s.js, Store Analytics.
+	 */
+	public function enqueue_tracking_script() {
+		$filename = sprintf(
+			'https://stats.wp.com/s-%d.js',
+			gmdate( 'YW' )
+		);
+
+		Assets::enqueue_async_script( 'woocommerce-analytics', esc_url( $filename ), esc_url( $filename ), array(), null, false );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Jetpack_WooCommerce_Analytics_Checkout_Flow
+ *
+ * @package automattic/jetpack
+ * @author Automattic
+ */
+
+/**
+ * Bail if accessed directly
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Jetpack_WooCommerce_Analytics_Checkout_Flow
+ * Class that handles all page view events for the checkout flow (from product view to order confirmation view)
+ */
+class Jetpack_WooCommerce_Analytics_Checkout_Flow {
+
+	use Jetpack_WooCommerce_Analytics_Trait;
+
+	/**
+	 * Jetpack_WooCommerce_Analytics_Checkout_Flow constructor.
+	 */
+	public function __construct() {
+		$this->find_cart_checkout_content_sources();
+
+		// single product page view.
+		add_action( 'woocommerce_after_single_product', array( $this, 'capture_product_view' ) );
+
+		// order confirmed page view
+		add_action( 'woocommerce_thankyou', array( $this, 'capture_order_confirmation_view' ), 10, 1 );
+
+		// cart page view
+		add_action( 'wp_footer', array( $this, 'capture_cart_view' ) );
+
+		// checkout page view
+		add_action( 'wp_footer', array( $this, 'capture_checkout_view' ) );
+	}
+
+		/**
+		 * Track a product page view
+		 */
+	public function capture_product_view() {
+		global $product;
+		if ( ! $product instanceof WC_Product ) {
+			return;
+		}
+
+		$this->record_event(
+			'woocommerceanalytics_product_view',
+			array(),
+			$product->get_id()
+		);
+	}
+
+	/**
+	 * Track the order confirmation page view
+	 */
+	public function capture_order_confirmation_view() {
+		$order_id = absint( get_query_var( 'order-received' ) );
+		if ( ! $order_id ) {
+			return;
+		}
+
+		if ( ! is_order_received_page() ) {
+			return;
+		}
+
+		$this->record_event(
+			'woocommerceanalytics_order_confirmation_view',
+			array()
+		);
+	}
+
+	/**
+	 * Track the cart page view
+	 */
+	public function capture_cart_view() {
+		if ( ! is_cart() ) {
+			return;
+		}
+		$this->record_event(
+			'woocommerceanalytics_cart_view',
+			array()
+		);
+	}
+
+	/**
+	 * Track the checkout page view
+	 */
+	public function capture_checkout_view() {
+		if ( ! is_checkout() ) {
+			return;
+		}
+
+		// Order received page is also a checkout page, so we need to bail out if we are on that page.
+		if ( is_order_received_page() ) {
+			return;
+		}
+
+		$this->record_event(
+			'woocommerceanalytics_checkout_view',
+			array()
+		);
+	}
+}

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
@@ -201,7 +201,7 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 			'create_account'         => $create_account,
 			'guest_checkout'         => $guest_checkout,
 			'express_checkout'       => 'null', // TODO: not solved yet.
-			'number_products'        => $cart->get_cart_contents_count(),
+			'products_count'         => $cart->get_cart_contents_count(),
 			'order_value'            => $cart->get_cart_contents_total(),
 			'shipping_options_count' => 'null', // TODO: not solved yet.
 			'coupon_used'            => $coupon_used,

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
@@ -26,6 +26,8 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 	 */
 	public function __construct() {
 		$this->find_cart_checkout_content_sources();
+		$this->additional_blocks_on_cart_page     = $this->get_additional_blocks_on_page( 'cart' );
+		$this->additional_blocks_on_checkout_page = $this->get_additional_blocks_on_page( 'checkout' );
 
 		// single product page view.
 		add_action( 'woocommerce_after_single_product', array( $this, 'capture_product_view' ) );
@@ -69,9 +71,35 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 			return;
 		}
 
+		$order = wc_get_order( $order_id );
+
+		$coupons     = $order->get_coupons();
+		$coupon_used = 0;
+		if ( is_countable( $coupons ) ) {
+			$coupon_used = count( $coupons ) ? 1 : 0;
+		}
+
+		if ( is_object( WC()->session ) ) {
+			$create_account = true === WC()->session->get( 'wc_checkout_createaccount_used' ) ? 'Yes' : 'No';
+		} else {
+			$create_account = 'No';
+		}
+
 		$this->record_event(
 			'woocommerceanalytics_order_confirmation_view',
-			array()
+			array(
+				'coupon_used'      => $coupon_used,
+				'create_account'   => $create_account,
+				'express_checkout' => 'null', // TODO: not solved yet.
+				'guest_checkout'   => $order->get_customer_id() ? 'No' : 'Yes',
+				'oi'               => $order->get_id(),
+				'order_value'      => $order->get_total(),
+				'payment_option'   => $order->get_payment_method(),
+				'products_count'   => $order->get_item_count(),
+				'products'         => $this->format_items_to_json( $order->get_items() ),
+				'order_note'       => $order->get_customer_note(),
+				'shipping_option'  => $order->get_shipping_method(),
+			)
 		);
 	}
 
@@ -82,9 +110,13 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 		if ( ! is_cart() ) {
 			return;
 		}
+
 		$this->record_event(
 			'woocommerceanalytics_cart_view',
-			array()
+			array_merge(
+				$this->get_cart_checkout_shared_data(),
+				array()
+			)
 		);
 	}
 
@@ -103,7 +135,79 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 
 		$this->record_event(
 			'woocommerceanalytics_checkout_view',
-			array()
+			array_merge(
+				$this->get_cart_checkout_shared_data(),
+				array()
+			)
 		);
+	}
+
+	/**
+	 * Format Cart Items or Order Items to an array
+	 *
+	 * @param array|WC_Order_Item[] $items Cart Items or Order Items.
+	 */
+	protected function format_items_to_json( $items ) {
+		$products = array();
+
+		foreach ( $items as $item ) {
+			if ( $item instanceof WC_Order_Item_Product ) {
+				$product = wc_get_product( $item->get_product_id() );
+			} else {
+				$product = $item['data'];
+			}
+			$data = $this->get_product_details( $product );
+			if ( $item instanceof WC_Order_Item_Product ) {
+				$data['pq'] = $item->get_quantity();
+			} else {
+				$data['pq'] = $item['quantity'];
+			}
+			$products[] = $data;
+		}
+
+		return wp_json_encode( $products );
+	}
+
+	/**
+	 * Get Cart/Checkout page view shared data
+	 */
+	protected function get_cart_checkout_shared_data() {
+		$cart = WC()->cart;
+
+		$guest_checkout = ucfirst( get_option( 'woocommerce_enable_guest_checkout', 'No' ) );
+		$create_account = ucfirst( get_option( 'woocommerce_enable_signup_and_login_from_checkout', 'No' ) );
+
+		$coupons     = $cart->get_coupons();
+		$coupon_used = 0;
+		if ( is_countable( $coupons ) ) {
+			$coupon_used = count( $coupons ) ? 1 : 0;
+		}
+
+		$enabled_payment_options = array_filter(
+			WC()->payment_gateways->get_available_payment_gateways(),
+			function ( $payment_gateway ) {
+				if ( ! $payment_gateway instanceof WC_Payment_Gateway ) {
+					return false;
+				}
+
+				return $payment_gateway->is_available();
+			}
+		);
+
+		$enabled_payment_options = array_keys( $enabled_payment_options );
+
+		$shared_data = array(
+			'products'               => $this->format_items_to_json( $cart->get_cart() ),
+			'create_account'         => $create_account,
+			'guest_checkout'         => $guest_checkout,
+			'express_checkout'       => 'null', // TODO: not solved yet.
+			'number_products'        => $cart->get_cart_contents_count(),
+			'order_value'            => $cart->get_cart_contents_total(),
+			'shipping_options_count' => 'null', // TODO: not solved yet.
+			'coupon_used'            => $coupon_used,
+			'payment_options'        => $enabled_payment_options,
+		);
+
+		return $shared_data;
 	}
 }

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -45,14 +45,14 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	 *
 	 * @var array
 	 */
-	private $additional_blocks_on_cart_page;
+	protected $additional_blocks_on_cart_page;
 
 	/**
 	 * Tracks any additional blocks loaded on the Checkout page.
 	 *
 	 * @var array
 	 */
-	private $additional_blocks_on_checkout_page;
+	protected $additional_blocks_on_checkout_page;
 
 	/**
 	 * Gets the content of the cart/checkout page or where the cart/checkout page is ultimately derived from if using a template.
@@ -243,11 +243,11 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		 */
 	public function get_product_details( $product ) {
 		return array(
-			'id'       => $product->get_id(),
-			'name'     => $product->get_title(),
-			'category' => $this->get_product_categories_concatenated( $product ),
-			'price'    => $product->get_price(),
-			'type'     => $product->get_type(),
+			'pi' => $product->get_id(),
+			'pn' => $product->get_title(),
+			'pc' => $this->get_product_categories_concatenated( $product ),
+			'pp' => $product->get_price(),
+			'pt' => $product->get_type(),
 		);
 	}
 
@@ -319,11 +319,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		$js = "{'_en': '" . esc_js( $event_name ) . "'";
 
 		if ( isset( $product_details ) ) {
-				$js .= ",'pi': '" . esc_js( $product_id ) . "'";
-				$js .= ",'pn': '" . esc_js( $product_details['name'] ) . "'";
-				$js .= ",'pc': '" . esc_js( $product_details['category'] ) . "'";
-				$js .= ",'pp': '" . esc_js( $product_details['price'] ) . "'";
-				$js .= ",'pt': '" . esc_js( $product_details['type'] ) . "'";
+				$all_props = array_merge( $all_props, $product_details );
 		}
 
 		$js .= ',' . $this->render_properties_as_js( $all_props ) . '}';
@@ -343,6 +339,72 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 			return $blogid . ':' . $userid;
 		}
 		return 'null';
+	}
+
+	/**
+	 * Gets the IDs of additional blocks on the Cart/Checkout pages or templates.
+	 *
+	 * @param string $cart_or_checkout Whether to get blocks on the cart or checkout page.
+	 * @return array All inner blocks on the page.
+	 */
+	public function get_additional_blocks_on_page( $cart_or_checkout = 'cart' ) {
+
+		$additional_blocks_on_page_transient_name = 'jetpack_woocommerce_analytics_additional_blocks_on_' . $cart_or_checkout . '_page';
+		$additional_blocks_on_page                = get_transient( $additional_blocks_on_page_transient_name );
+
+		if ( false !== $additional_blocks_on_page ) {
+			return $additional_blocks_on_page;
+		}
+
+		$content = $this->cart_content_source;
+
+		if ( 'checkout' === $cart_or_checkout ) {
+			$content = $this->checkout_content_source;
+		}
+
+		$parsed_blocks = parse_blocks( $content );
+		$other_blocks  = array_filter(
+			$parsed_blocks,
+			function ( $block ) use ( $cart_or_checkout ) {
+				if ( ! isset( $block['blockName'] ) ) {
+					return false;
+				}
+				if ( 'woocommerce/classic-shortcode' === $block['blockName'] ) {
+					return false;
+				}
+				if ( 'core/shortcode' === $block['blockName'] ) {
+					return false;
+				}
+				if ( 'checkout' === $cart_or_checkout && 'woocommerce/checkout' !== $block['blockName'] ) {
+					return true;
+				}
+				if ( 'cart' === $cart_or_checkout && 'woocommerce/cart' !== $block['blockName'] ) {
+					return true;
+				}
+				return false;
+			}
+		);
+
+		$all_inner_blocks = array();
+
+		// Loop over each "block group". In templates the blocks are grouped up.
+		foreach ( $other_blocks as $block ) {
+
+			// This check is necessary because sometimes this is null when using templates.
+			if ( ! empty( $block['blockName'] ) ) {
+				$all_inner_blocks[] = $block['blockName'];
+			}
+
+			if ( ! isset( $block['innerBlocks'] ) || ! is_array( $block['innerBlocks'] ) || 0 === count( $block['innerBlocks'] ) ) {
+				continue;
+			}
+
+			foreach ( $block['innerBlocks'] as $inner_content ) {
+				$all_inner_blocks = array_merge( $all_inner_blocks, $this->get_inner_blocks( $inner_content ) );
+			}
+		}
+		set_transient( $additional_blocks_on_page_transient_name, $all_inner_blocks, DAY_IN_SECONDS );
+		return $all_inner_blocks;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -369,18 +369,23 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 				if ( ! isset( $block['blockName'] ) ) {
 					return false;
 				}
+
 				if ( 'woocommerce/classic-shortcode' === $block['blockName'] ) {
 					return false;
 				}
+				
 				if ( 'core/shortcode' === $block['blockName'] ) {
 					return false;
 				}
+				
 				if ( 'checkout' === $cart_or_checkout && 'woocommerce/checkout' !== $block['blockName'] ) {
 					return true;
 				}
+				
 				if ( 'cart' === $cart_or_checkout && 'woocommerce/cart' !== $block['blockName'] ) {
 					return true;
 				}
+				
 				return false;
 			}
 		);

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -29,6 +29,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 */
 	public function __construct() {
 		$this->find_cart_checkout_content_sources();
+		$this->additional_blocks_on_cart_page     = $this->get_additional_blocks_on_page( 'cart' );
+		$this->additional_blocks_on_checkout_page = $this->get_additional_blocks_on_page( 'checkout' );
 
 		// add to carts from non-product pages or lists -- search, store etc.
 		add_action( 'wp_head', array( $this, 'loop_session_events' ), 2 );
@@ -52,6 +54,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart_via_quantity' ), 10, 1 );
 
 		add_filter( 'woocommerce_checkout_posted_data', array( $this, 'save_checkout_post_data' ), 10, 1 );
+
+		add_action( 'woocommerce_created_customer', array( $this, 'capture_created_customer' ), 10, 2 );
 	}
 
 	/**
@@ -181,9 +185,6 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	public function checkout_process() {
 		$cart = WC()->cart->get_cart();
 
-		$this->additional_blocks_on_cart_page     = $this->get_additional_blocks_on_page( 'cart' );
-		$this->additional_blocks_on_checkout_page = $this->get_additional_blocks_on_page( 'checkout' );
-
 		$guest_checkout = ucfirst( get_option( 'woocommerce_enable_guest_checkout', 'No' ) );
 		$create_account = ucfirst( get_option( 'woocommerce_enable_signup_and_login_from_checkout', 'No' ) );
 
@@ -237,8 +238,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 					array(
 						'pq'               => $cart_item['quantity'],
 						'payment_options'  => $enabled_payment_options,
-						'guest_checkout'   => 'Yes' === $guest_checkout ? 'Y' : 'N',
-						'create_account'   => 'Yes' === $create_account ? 'Y' : 'N',
+						'guest_checkout'   => $guest_checkout,
+						'create_account'   => $create_account,
 						'express_checkout' => 'null',
 						'shipping_option'  => $this->get_shipping_option_for_item( $cart_item_key ),
 						'products_count'   => $products_count,
@@ -269,8 +270,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 					array(
 						'pq'               => $cart_item['quantity'],
 						'payment_options'  => $enabled_payment_options,
-						'guest_checkout'   => 'Yes' === $guest_checkout ? 'Y' : 'N',
-						'create_account'   => 'Yes' === $create_account ? 'Y' : 'N',
+						'guest_checkout'   => $guest_checkout,
+						'create_account'   => $create_account,
 						'express_checkout' => 'null',
 						'shipping_option'  => $this->get_shipping_option_for_item( $cart_item_key ),
 						'products_count'   => $products_count,
@@ -291,9 +292,6 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	public function order_process( $order_id ) {
 		$order = wc_get_order( $order_id );
 
-		$this->additional_blocks_on_cart_page     = $this->get_additional_blocks_on_page( 'cart' );
-		$this->additional_blocks_on_checkout_page = $this->get_additional_blocks_on_page( 'checkout' );
-
 		if (
 			! $order
 			|| ! $order instanceof WC_Order
@@ -304,7 +302,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		$payment_option = $order->get_payment_method();
 
 		if ( is_object( WC()->session ) ) {
-			$create_account = true === WC()->session->get( 'wc_checkout_createaccount_used' ) ? 'Y' : 'N';
+			$create_account = true === WC()->session->get( 'wc_checkout_createaccount_used' ) ? 'Yes' : 'No';
 		} else {
 			$create_account = 'No';
 		}
@@ -402,72 +400,6 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	}
 
 	/**
-	 * Gets the IDs of additional blocks on the Cart/Checkout pages or templates.
-	 *
-	 * @param string $cart_or_checkout Whether to get blocks on the cart or checkout page.
-	 * @return array All inner blocks on the page.
-	 */
-	public function get_additional_blocks_on_page( $cart_or_checkout = 'cart' ) {
-
-		$additional_blocks_on_page_transient_name = 'jetpack_woocommerce_analytics_additional_blocks_on_' . $cart_or_checkout . '_page';
-		$additional_blocks_on_page                = get_transient( $additional_blocks_on_page_transient_name );
-
-		if ( false !== $additional_blocks_on_page ) {
-			return $additional_blocks_on_page;
-		}
-
-		$content = $this->cart_content_source;
-
-		if ( 'checkout' === $cart_or_checkout ) {
-			$content = $this->checkout_content_source;
-		}
-
-		$parsed_blocks = parse_blocks( $content );
-		$other_blocks  = array_filter(
-			$parsed_blocks,
-			function ( $block ) use ( $cart_or_checkout ) {
-				if ( ! isset( $block['blockName'] ) ) {
-					return false;
-				}
-				if ( 'woocommerce/classic-shortcode' === $block['blockName'] ) {
-					return false;
-				}
-				if ( 'core/shortcode' === $block['blockName'] ) {
-					return false;
-				}
-				if ( 'checkout' === $cart_or_checkout && 'woocommerce/checkout' !== $block['blockName'] ) {
-					return true;
-				}
-				if ( 'cart' === $cart_or_checkout && 'woocommerce/cart' !== $block['blockName'] ) {
-					return true;
-				}
-				return false;
-			}
-		);
-
-		$all_inner_blocks = array();
-
-		// Loop over each "block group". In templates the blocks are grouped up.
-		foreach ( $other_blocks as $block ) {
-
-			// This check is necessary because sometimes this is null when using templates.
-			if ( ! empty( $block['blockName'] ) ) {
-				$all_inner_blocks[] = $block['blockName'];
-			}
-
-			if ( ! isset( $block['innerBlocks'] ) || ! is_array( $block['innerBlocks'] ) || 0 === count( $block['innerBlocks'] ) ) {
-				continue;
-			}
-
-			foreach ( $block['innerBlocks'] as $inner_content ) {
-				$all_inner_blocks = array_merge( $all_inner_blocks, $this->get_inner_blocks( $inner_content ) );
-			}
-		}
-		set_transient( $additional_blocks_on_page_transient_name, $all_inner_blocks, DAY_IN_SECONDS );
-		return $all_inner_blocks;
-	}
-
-	/**
 	 * Track adding items to the cart.
 	 *
 	 * @param string $cart_item_key Cart item key.
@@ -544,5 +476,21 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			}
 		}
 		return $data;
+	}
+
+	/**
+	 * Capture the create account event. Similar to save_checkout_post_data but works with Store API.
+	 *
+	 * @param int   $customer_id Customer ID.
+	 * @param array $new_customer_data New customer data.
+	 */
+	public function capture_created_customer( $customer_id, $new_customer_data ) {
+		$session = WC()->session;
+		if ( is_object( $session ) ) {
+			if ( str_contains( $new_customer_data['source'], 'store-api' ) ) {
+				$session->set( 'wc_checkout_createaccount_used', true );
+				$session->save_data();
+			}
+		}
 	}
 }


### PR DESCRIPTION
NOTE: This should be merged until https://github.com/woocommerce/woocommerce-blocks/pull/12010 is merged and assigned a version, since we will use that version to gate keep the work here.

This is part of our work here https://github.com/woocommerce/woocommerce-blocks/pull/12010 to move page view events from WooCommerce Blocks to Jetpack, this ensures all shopper events live together and also now support classic cart/checkout views.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a live, Jetpack connected website, install WooCommerce. It would be good to install WooCommerce Blocks from this link [to avoid duplicate events.](https://github.com/woocommerce/woocommerce-blocks/pull/12010#issuecomment-1836325302)
* Using a block theme and running Checkout Block and Cart Block.
* Open Tracks Vigilante
* View a product page, add it to cart, and visit Cart page and then Checkout.
* Make sure the product_view and cart_view events fire.
* Make sure all data is present, checkout_view should be similar to product_checkout.
* Place the order, make sure the order_view event fire, it should be similar to product_purchase (with main different being that products is an array).
* Do the flow again, now with Cart shortcode and Checkout shortcode.
* The same events should fire with the same data.
* Do the flow again but in a classic theme.

