### PR TITLE
Removed feature flag for new likes layout

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-likes-improvement-feature-flags
+++ b/projects/plugins/jetpack/changelog/remove-likes-improvement-feature-flags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove feature flag for new like widget layout.

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -62,17 +62,6 @@ function render_block( $attr, $content, $block ) {
 		return;
 	}
 
-	/**
-	 * Enable an alternate Likes layout.
-	 *
-	 * @since 12.9
-	 *
-	 * @module likes
-	 *
-	 * @param bool $new_layout Enable the new Likes layout. False by default.
-	 */
-	$new_layout = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
-
 	add_action( 'wp_footer', __NAMESPACE__ . '\render_iframe', 25 );
 
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -95,7 +84,7 @@ function render_block( $attr, $content, $block ) {
 		$bloginfo     = get_blog_details( (int) $blog_id );
 		$domain       = $bloginfo->domain;
 		$reblog_param = $show_reblog_button ? '&amp;reblog=1' : '';
-		$src          = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout, $reblog_param );
+		$src          = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s&amp;block=1%7$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $reblog_param );
 
 		// provide the mapped domain when needed
 		if ( isset( $_SERVER['HTTP_HOST'] ) && strpos( sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ), '.wordpress.com' ) === false ) {
@@ -107,7 +96,7 @@ function render_block( $attr, $content, $block ) {
 		$url       = home_url();
 		$url_parts = wp_parse_url( $url );
 		$domain    = $url_parts['host'];
-		$src       = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src       = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s&amp;block=1', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid );
 	}
 
 	$name    = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -432,19 +432,8 @@ class Jetpack_Likes {
 		* If the same post appears more then once on a page the page goes crazy
 		* we need a slightly more unique id / name for the widget wrapper.
 		*/
-		$uniqid = uniqid();
-		/**
-		 * Enable an alternate Likes layout.
-		 *
-		 * @since 12.9
-		 *
-		 * @module likes
-		 *
-		 * @param bool $new_layout Enable the new Likes layout. False by default.
-		 */
-		$new_layout = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
-
-		$src      = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$uniqid   = uniqid();
+		$src      = sprintf( 'https://widgets.wp.com/likes/?ver=%1ss#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid );
 		$name     = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$wrapper  = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$headline = sprintf(

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -34,6 +34,6 @@ function jetpack_likes_master_iframe() {
 		$likers_text = wp_kses( '<span>%d</span>', array( 'span' => array() ) );
 	?>
 	<iframe src='<?php echo esc_url( $src ); ?>' scrolling='no' id='likes-master' name='likes-master' style='display:none;'></iframe>
-	<div id='likes-other-gravatars' class='<?php echo esc_attr( 'wpl-new-layout' ); ?>' role="dialog" aria-hidden="true" tabindex="-1"><div class="likes-text"><?php echo $likers_text; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>
+	<div id='likes-other-gravatars' class='wpl-new-layout' role="dialog" aria-hidden="true" tabindex="-1"><div class="likes-text"><?php echo $likers_text; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>
 	<?php
 }

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -23,26 +23,17 @@ function jetpack_likes_master_iframe() {
 	$_locale   = isset( $gp_locale->slug ) ? $gp_locale->slug : '';
 
 	$likes_locale = ( '' === $_locale || 'en' === $_locale ) ? '' : '&amp;lang=' . strtolower( $_locale );
-	/** This filter is documented in projects/plugins/jetpack/modules/likes.php */
-	$new_layout       = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
-	$new_layout_class = $new_layout ? 'wpl-new-layout' : '';
 
 	$src = sprintf(
-		'https://widgets.wp.com/likes/master.html?ver=%1$s#ver=%1$s%2$s%3$s',
+		'https://widgets.wp.com/likes/master.html?ver=%1$s#ver=%1$s%2$s',
 		$version,
-		$likes_locale,
-		$new_layout
+		$likes_locale
 	);
 
-	if ( $new_layout ) {
 		// The span content is replaced by queuehandler when showOtherGravatars is called.
 		$likers_text = wp_kses( '<span>%d</span>', array( 'span' => array() ) );
-	} else {
-		/* translators: The value of %d is not available at the time of output */
-		$likers_text = wp_kses( __( '<span>%d</span> bloggers like this:', 'jetpack' ), array( 'span' => array() ) );
-	}
 	?>
 	<iframe src='<?php echo esc_url( $src ); ?>' scrolling='no' id='likes-master' name='likes-master' style='display:none;'></iframe>
-	<div id='likes-other-gravatars' class='<?php echo esc_attr( $new_layout_class ); ?>' role="dialog" aria-hidden="true" tabindex="-1"><div class="likes-text"><?php echo $likers_text; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>
+	<div id='likes-other-gravatars' class='<?php echo esc_attr( 'wpl-new-layout' ); ?>' role="dialog" aria-hidden="true" tabindex="-1"><div class="likes-text"><?php echo $likers_text; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>
 	<?php
 }

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -212,22 +212,14 @@ function JetpackLikesMessageListener( event ) {
 				break;
 			}
 
-			const newLayout = container.classList.contains( 'wpl-new-layout' );
-
 			const list = container.querySelector( 'ul' );
 
 			container.style.display = 'none';
 			list.innerHTML = '';
 
-			if ( newLayout ) {
-				container
-					.querySelectorAll( '.likes-text span' )
-					.forEach( item => ( item.textContent = data.totalLikesLabel ) );
-			} else {
-				container
-					.querySelectorAll( '.likes-text span' )
-					.forEach( item => ( item.textContent = data.total ) );
-			}
+			container
+				.querySelectorAll( '.likes-text span' )
+				.forEach( item => ( item.textContent = data.totalLikesLabel ) );
 
 			( data.likers || [] ).forEach( async ( liker, index ) => {
 				if ( liker.profile_URL.substr( 0, 4 ) !== 'http' ) {
@@ -238,32 +230,19 @@ function JetpackLikesMessageListener( event ) {
 				const element = document.createElement( 'li' );
 				list.append( element );
 
-				if ( newLayout ) {
-					element.innerHTML = `
-					<a href="${ encodeURI( liker.profile_URL ) }" rel="nofollow" target="_parent" class="wpl-liker">
-						<img src="${ liker.avatar_URL }"
-							alt=""
-							style="width: 28px; height: 28px;" />
-						<span></span>
-					</a>
+				element.innerHTML = `
+				<a href="${ encodeURI( liker.profile_URL ) }" rel="nofollow" target="_parent" class="wpl-liker">
+					<img src="${ liker.avatar_URL }"
+						alt=""
+						style="width: 28px; height: 28px;" />
+					<span></span>
+				</a>
 				`;
-				} else {
-					element.innerHTML = `
-					<a href="${ encodeURI( liker.profile_URL ) }" rel="nofollow" target="_parent" class="wpl-liker">
-						<img src="${ liker.avatar_URL }"
-							alt=""
-							style="width: 30px; height: 30px; padding-right: 3px;" />
-					</a>
-				`;
-				}
 
 				// Add some extra attributes through native methods, to ensure strings are sanitized.
 				element.classList.add( liker.css_class );
 				element.querySelector( 'img' ).alt = data.avatarAltTitle.replace( '%s', liker.name );
-
-				if ( newLayout ) {
-					element.querySelector( 'span' ).innerText = liker.name;
-				}
+				element.querySelector( 'span' ).innerText = liker.name;
 
 				if ( index === data.likers.length - 1 ) {
 					element.addEventListener( 'keydown', e => {
@@ -293,22 +272,17 @@ function JetpackLikesMessageListener( event ) {
 				};
 
 				let containerLeft = 0;
-				if ( newLayout ) {
-					container.style.top = offset.top + data.position.top - 1 + 'px';
+				container.style.top = offset.top + data.position.top - 1 + 'px';
 
-					if ( isRtl ) {
-						const visibleAvatarsCount = data && data.likers ? Math.min( data.likers.length, 5 ) : 0;
-						// 24px is the width of the avatar + 4px is the padding between avatars
-						containerLeft = offset.left + data.position.left + 24 * visibleAvatarsCount + 4;
-						container.style.transform = 'translateX(-100%)';
-					} else {
-						containerLeft = offset.left + data.position.left;
-					}
-					container.style.left = containerLeft + 'px';
+				if ( isRtl ) {
+					const visibleAvatarsCount = data && data.likers ? Math.min( data.likers.length, 5 ) : 0;
+					// 24px is the width of the avatar + 4px is the padding between avatars
+					containerLeft = offset.left + data.position.left + 24 * visibleAvatarsCount + 4;
+					container.style.transform = 'translateX(-100%)';
 				} else {
-					container.style.left = offset.left + data.position.left - 10 + 'px';
-					container.style.top = offset.top + data.position.top - 33 + 'px';
+					containerLeft = offset.left + data.position.left;
 				}
+				container.style.left = containerLeft + 'px';
 
 				// Container width - padding
 				const initContainerWidth = data.width - 20;
@@ -319,35 +293,21 @@ function JetpackLikesMessageListener( event ) {
 					height = 204;
 				}
 
-				if ( ! newLayout ) {
-					// Avatars + padding
-					const containerWidth = rowLength * 37 + 13;
-					container.style.height = height + 'px';
-					container.style.width = containerWidth + 'px';
-
-					const listWidth = rowLength * 37;
-					list.style.width = listWidth + 'px';
-				}
-
 				// If the popup is overflows viewport width, we should show it on the next line
-				if ( newLayout ) {
-					// Push it offscreen to calculated rendered width
-					container.style.left = '-9999px';
-					container.style.display = 'block';
+				// Push it offscreen to calculated rendered width
+				container.style.left = '-9999px';
+				container.style.display = 'block';
 
-					// If the popup exceeds the viewport width,
-					// flip the position of the popup.
-					const containerWidth = container.offsetWidth;
-					const containerRight = containerLeft + containerWidth;
-					if ( containerRight > win.innerWidth ) {
-						containerLeft = rect.right - containerWidth;
-					}
-
-					// Set the container left
-					container.style.left = containerLeft + 'px';
-				} else {
-					container.style.display = 'block';
+				// If the popup exceeds the viewport width,
+				// flip the position of the popup.
+				const containerWidth = container.offsetWidth;
+				const containerRight = containerLeft + containerWidth;
+				if ( containerRight > win.innerWidth ) {
+					containerLeft = rect.right - containerWidth;
 				}
+
+				// Set the container left
+				container.style.left = containerLeft + 'px';
 				container.setAttribute( 'aria-hidden', 'false' );
 			};
 


### PR DESCRIPTION
> [!CAUTION]
> ☢️☢️☢️ IMPORTANT: DON'T MERGE YET ☢️☢️☢️

Fixes https://github.com/Automattic/wp-calypso/issues/84422

## Proposed changes:
This PR removes the feature flag for the new layout of the Likes widget.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Not relevant

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply this PR
- Connect your site through JT
- Enable likes in Jetpack > Settings > Sharing
- Enter your site in JT and go to a post with likes.
- Check the iframe URL of the Likes widget. It shouldn't have any `&n=` parameter at all.
- Look for another call to `https://widgets.wp.com/likes/master.html` in the HTML code and check that there is no `&n=` parameter there.

