### PR TITLE
Protect: Fix Popover component inline styling

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-popover-component-inline-styling
+++ b/projects/plugins/protect/changelog/fix-protect-popover-component-inline-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Popover component styling

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -68,7 +68,7 @@ const FirewallSubheadingPopover = ( {
 		>
 			<Icon icon={ help } />
 			{ showPopover && (
-				<Popover noArrow={ false } offset={ 5 }>
+				<Popover noArrow={ false } offset={ 5 } inline={ true }>
 					<Text className={ styles[ 'popover-text' ] } variant={ 'body-small' }>
 						{ children }
 					</Text>

--- a/projects/plugins/protect/src/js/components/firewall-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-page/index.jsx
@@ -455,7 +455,7 @@ const FirewallPage = () => {
 						disabled={ ! isEnabled || formIsSubmitting || ! canToggleAutomaticRules }
 					/>
 					{ hasRequiredPlan && upgradeIsSeen === false && (
-						<Popover noArrow={ false } offset={ 8 } position={ 'top right' }>
+						<Popover noArrow={ false } offset={ 8 } position={ 'top right' } inline={ true }>
 							<div className={ styles.popover }>
 								<div className={ styles.popover__header }>
 									<Text className={ styles.popover__title } variant={ 'title-small' }>

--- a/projects/plugins/protect/src/js/components/navigation/badge.jsx
+++ b/projects/plugins/protect/src/js/components/navigation/badge.jsx
@@ -72,7 +72,7 @@ const ItemBadge = ( { count, checked } ) => {
 		>
 			{ badgeElement }
 			{ showPopover && (
-				<Popover noArrow={ false }>
+				<Popover noArrow={ false } inline={ true }>
 					<Text variant="body-small" className={ styles[ 'popover-text' ] }>
 						{ popoverText }
 					</Text>

--- a/projects/plugins/protect/src/js/components/navigation/index.jsx
+++ b/projects/plugins/protect/src/js/components/navigation/index.jsx
@@ -2,7 +2,6 @@ import { Text } from '@automattic/jetpack-components';
 import { Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
-import classNames from 'classnames';
 import React, { useState, useRef, useCallback } from 'react';
 import NavigationGroup from './group';
 import NavigationItem from './item';
@@ -34,15 +33,15 @@ const NavigationDropdown = ( { children, data } ) => {
 				<Text>{ label }</Text>
 			</div>
 			<Icon icon={ listOpen ? chevronUp : chevronDown } size={ 32 } />
-			<Popover
-				position="bottom center"
-				anchorRef={ ref?.current }
-				className={ classNames( {
-					[ styles[ 'navigation-dropdown-open' ] ]: listOpen,
-					[ styles[ 'navigation-dropdown-closed' ] ]: ! listOpen,
-				} ) }
-			>
-				<div style={ { width: ref?.current?.getBoundingClientRect?.()?.width } }>{ children }</div>
+			<Popover position="bottom center" anchorRef={ ref?.current } inline={ true }>
+				<div
+					style={ {
+						display: listOpen ? 'block' : 'none',
+						width: ref?.current?.getBoundingClientRect?.()?.width,
+					} }
+				>
+					{ children }
+				</div>
 			</Popover>
 		</button>
 	);

--- a/projects/plugins/protect/src/js/components/navigation/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/navigation/styles.module.scss
@@ -140,12 +140,4 @@
 	&-icon {
 		margin-right: var( --spacing-base ); // 8px
 	}
-
-	&-open {
-		display: block;
-	}
-
-	&-closed {
-		display: none;
-	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Description:
With a recent update to the WordPress core `Popover` component, the 4 instances we have in the Protect UI are no longer inheriting styling appropriately. To fix this we must pass an additional `inline` property that will force the component to render inline.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add the `inline` prop to each of 4 affected locations in the Protect UI:
- Within the `NavigationDropDown` component in the Protect navigation list in mobile view
- Within the `ItemBadge` component in the Protect navigation list that displays on hover
- Within the `FirewallHeader` component without an upgrade with manual rules enabled when hovering over the tooltip
- Within the `FirewallPage` component immediately after processing an upgrade

Update the `NavigationDropDown` component styling so that they are not overridden by the main `Popover` components' primary CSS

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- Automattic/jetpack-scan-team#805

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Checkout this branch
* Start up your Jurassic Tube
* Enable the Jetpack Debug Tool, add the Protect Helper, and add various vulnerabilities
* Enable Protect and allow the initial Scan to complete
* Preview the page in mobile view and verify that the navigation drop-down popover displays and functions accordingly
* Return to desktop view, hover over a navigation drop-down item badge, and verify that the popover displays accordingly
* Proceed to the Firewall tab and enable Manual rules
* Verify that the popover displays accordingly when hovering over the tooltip in the header
* Upgrade to a scan subscription and verify that the upgrade messaging popover in the firewall page displays accordingly
* Ensure no regressions are introduced

## Pictures:

Item 1
- No styling
- Stuck open
- Toggle doesn't expand/collapse Popover

Before:
![Screen Capture on 2023-12-01 at 09-49-27](https://github.com/Automattic/jetpack/assets/43220201/fbc85d24-ada6-4b1d-8e27-1dced7fc043f)

After:
![Screen Capture on 2023-12-01 at 09-47-19](https://github.com/Automattic/jetpack/assets/43220201/f3c6b0d0-fa8e-42d6-9946-ece91f3ff78d)

Item 2
- No styling

Before:
![robtmx.png](https://github.com/Automattic/jetpack/assets/43220201/5b7088b6-670b-44d0-bf21-032bb6661f9e)
After:
![aACqKC.png](https://github.com/Automattic/jetpack/assets/43220201/a425a9b4-1c36-49d2-9ca3-66d5cd77c815)

Item 3
- No styling

Before:
![1icAQN.png](https://github.com/Automattic/jetpack/assets/43220201/02678834-65ec-4912-905b-0fdec9ec95dc)

After:
![RbeBkw.png](https://github.com/Automattic/jetpack/assets/43220201/52433eea-f4a8-4185-a430-4bf6402b1c3c)

Item 4
- No styling

Before:
![5txgbW.png](https://github.com/Automattic/jetpack/assets/43220201/ade34558-28f6-45c4-8051-1db4b9fbfbc1)

After:
![muttf0.png](https://github.com/Automattic/jetpack/assets/43220201/abe6c426-e1bb-4dc3-b1c1-bc348ce46aad)