### PR TITLE
CRM: Resolves 3390 - bypass errant codeception dependency

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3390-bypass_errant-dependency
+++ b/projects/plugins/crm/changelog/fix-crm-3390-bypass_errant-dependency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Skip codeception/module-db 3.1.1 dependency
+
+

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -7,7 +7,7 @@
 		"codeception/module-asserts": "^2.0 || ^3.0",
 		"codeception/module-phpbrowser": "^2.0 || ^3.0",
 		"codeception/module-webdriver": "^2.0 || ^3.0 || ^4.0",
-		"codeception/module-db": "^2.0 || ^3.0",
+		"codeception/module-db": "^2.0 || 3.1.0 || ^3.1.2",
 		"codeception/module-filesystem": "^2.0 || ^3.0",
 		"codeception/util-universalframework": "^1.0",
 		"yoast/phpunit-polyfills": "1.1.0"

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67351edadc6babc9b0488251d82b9dd3",
+    "content-hash": "87a6ff75df5bc0edb428f4035f72e0c3",
     "packages": [
         {
             "name": "automattic/jetpack-assets",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3390 - bypass errant codeception dependency

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This updates `composer.json` to avoid v3.1.1 of `codeception/module-db`.

External dependency bug report: Codeception/module-db#64

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Switch to PHP 8.0
2. Update composer dependencies: `composer update`
3. Run tests: `composer tests`

In `trunk`, one gets this error:
```
[TypeError] Codeception\Lib\Driver\Db::isBinary(): Argument #1 ($string) must be of type string, float given, called in /vendor/codeception/module-db/src/Codeception/Lib/Driver/Db.php on line 297  
```

In the `fix/crm/3390-bypass_errant-dependency` branch, the tests complete successfully.