### PR TITLE
Improving likes: fix popover closing area

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-close-likes-popover
+++ b/projects/plugins/jetpack/changelog/fix-close-likes-popover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Improving likes: fix popover closing area

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -200,6 +200,18 @@ function JetpackLikesMessageListener( event ) {
 			}
 			break;
 
+		case 'hideOtherGravatars': {
+			const container = document.querySelector( '#likes-other-gravatars' );
+			if ( ! container ) {
+				break;
+			}
+
+			if ( container.style.display === 'block' ) {
+				container.style.display = 'none';
+			}
+			break;
+		}
+
 		case 'showOtherGravatars': {
 			const container = document.querySelector( '#likes-other-gravatars' );
 			if ( ! container ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/wp-calypso/issues/84754

## Proposed changes:

The issue originated from clicks within the iframe, which are not part of the parent document containing the popover's close listener. To address this, I added a click event to the iframe area to handle popover hiding. The Jetpack side of this fix adds a new `hideOtherGravatars` event that is called by the `likes-rest-nojquery.js` when the click happens inside the iframe.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
This PR should be tested together with D130695-code.

* Apply this PR to your local
* Start a site with JurassicTube
* Enable likes in Jetpack > Settings > Sharing
* Open a post with likes and click to see the popover
* Click anywhere in the highlighted area below, it should close the popover

<img width="696" alt="Screenshot 2023-12-01 at 17 13 13" src="https://github.com/Automattic/jetpack/assets/3113712/77d570f3-41f5-4bc5-b1b1-d693fbf4a2f0">