### PR TITLE
Stats: add passing select UTM parameters

### DIFF
--- a/projects/packages/stats/changelog/add-utm-tracking
+++ b/projects/packages/stats/changelog/add-utm-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: added passing select UTM parameters to Tracking Pixel requests.

--- a/projects/packages/stats/composer.json
+++ b/projects/packages/stats/composer.json
@@ -51,7 +51,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.8.x-dev"
+			"dev-trunk": "0.9.x-dev"
 		},
 		"textdomain": "jetpack-stats"
 	},

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -27,6 +27,18 @@ class Tracking_Pixel {
 	 */
 	const STATS_ARRAY_TO_STRING_FILTER = 'stats_array';
 
+	const TRACKED_UTM_PARAMETERS = array(
+		'utm_id',
+		'utm_source',
+		'utm_medium',
+		'utm_campaign',
+		'utm_term',
+		'utm_content',
+		'utm_source_platform',
+		'utm_creative_format',
+		'utm_marketing_tactic',
+	);
+
 	/**
 	 * Stats Build View Data.
 	 *
@@ -61,7 +73,16 @@ class Tracking_Pixel {
 		} else {
 			$post = '0';
 		}
-		return compact( 'v', 'blog', 'post', 'tz', 'srv' );
+		$view_data = compact( 'v', 'blog', 'post', 'tz', 'srv' );
+		foreach ( self::TRACKED_UTM_PARAMETERS as $utm_parameter ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET[ $utm_parameter ] ) && is_scalar( $_GET[ $utm_parameter ] ) ) {
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+				$view_data[ $utm_parameter ] = substr( (string) $_GET[ $utm_parameter ], 0, 255 );
+			}
+		}
+
+		return $view_data;
 	}
 
 	/**

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -258,6 +258,7 @@ _stq.push([ "clickTrackerInit", "%2$s", "%3$s" ]);',
 		 * @param array $kvs Array of options about the site and page you're on.
 		 */
 		$kvs = (array) apply_filters( self::STATS_ARRAY_TO_STRING_FILTER, $kvs );
+		$kvs = array_map( 'strval', $kvs );
 
 		// Encode into JSON object, and then encode it into a string that's safe to embed into Javascript.
 		// We will then use JSON.parse method in JS to read the array.

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -74,11 +74,15 @@ class Tracking_Pixel {
 			$post = '0';
 		}
 		$view_data = compact( 'v', 'blog', 'post', 'tz', 'srv' );
+		// Batcache removes some of the UTM params from $_GET, we need to extract them from uri directly instead.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- We're sanitizing individual params in the loop.
+		$url_query = wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ), PHP_URL_QUERY );
+		parse_str( (string) $url_query, $url_params );
 		foreach ( self::TRACKED_UTM_PARAMETERS as $utm_parameter ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- UTMs are standardized parameters coming from outside WordPress, adding nonce is not possible
-			if ( isset( $_GET[ $utm_parameter ] ) && is_scalar( $_GET[ $utm_parameter ] ) ) {
+			if ( isset( $url_params[ $utm_parameter ] ) && is_scalar( $url_params[ $utm_parameter ] ) ) {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- UTMs are standardized parameters coming from outside WordPress, adding nonce is not possible
-				$view_data[ $utm_parameter ] = substr( sanitize_textarea_field( wp_unslash( $_GET[ $utm_parameter ] ) ), 0, 255 );
+				$view_data[ $utm_parameter ] = substr( sanitize_textarea_field( wp_unslash( $url_params[ $utm_parameter ] ) ), 0, 255 );
 			}
 		}
 

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -75,10 +75,10 @@ class Tracking_Pixel {
 		}
 		$view_data = compact( 'v', 'blog', 'post', 'tz', 'srv' );
 		foreach ( self::TRACKED_UTM_PARAMETERS as $utm_parameter ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- UTMs are standardized parameters coming from outside WordPress, adding nonce is not possible
 			if ( isset( $_GET[ $utm_parameter ] ) && is_scalar( $_GET[ $utm_parameter ] ) ) {
-				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
-				$view_data[ $utm_parameter ] = substr( (string) $_GET[ $utm_parameter ], 0, 255 );
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- UTMs are standardized parameters coming from outside WordPress, adding nonce is not possible
+				$view_data[ $utm_parameter ] = substr( sanitize_textarea_field( wp_unslash( $_GET[ $utm_parameter ] ) ), 0, 255 );
 			}
 		}
 

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -99,7 +99,7 @@ class Tracking_Pixel {
 
 		return sprintf(
 			'_stq = window._stq || [];
-_stq.push([ "view", {%1$s} ]);
+_stq.push([ "view", JSON.parse(%1$s) ]);
 _stq.push([ "clickTrackerInit", "%2$s", "%3$s" ]);',
 			$data_stats_array,
 			$data['blog'],
@@ -257,13 +257,11 @@ _stq.push([ "clickTrackerInit", "%2$s", "%3$s" ]);',
 		 *
 		 * @param array $kvs Array of options about the site and page you're on.
 		 */
-		$kvs   = (array) apply_filters( self::STATS_ARRAY_TO_STRING_FILTER, $kvs );
-		$kvs   = array_map( 'addslashes', $kvs );
-		$jskvs = array();
-		foreach ( $kvs as $k => $v ) {
-			$jskvs[] = "$k:'$v'";
-		}
-		return implode( ',', $jskvs );
+		$kvs = (array) apply_filters( self::STATS_ARRAY_TO_STRING_FILTER, $kvs );
+
+		// Encode into JSON object, and then encode it into a string that's safe to embed into Javascript.
+		// We will then use JSON.parse method in JS to read the array.
+		return wp_json_encode( wp_json_encode( $kvs ) );
 	}
 
 	/**

--- a/projects/packages/stats/tests/php/test-tracking-pixel.php
+++ b/projects/packages/stats/tests/php/test-tracking-pixel.php
@@ -15,6 +15,15 @@ use WP_Query;
  * @covers \Automattic\Jetpack\Stats\Tracking_Pixel
  */
 class Test_Tracking_Pixel extends StatsBaseTestCase {
+	/**
+	 * Set up
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$_GET['utm_source'] = 'a_source';
+		$_GET['utm_id']     = 'some_id';
+	}
 
 	/**
 	 * Clean up the testing environment.
@@ -26,6 +35,7 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 		global $wp_the_query;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_the_query = new WP_Query();
+		$_GET         = array();
 	}
 
 	/**
@@ -39,11 +49,13 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 		$wp_the_query->queried_object = self::post( 7 );
 		$view_data                    = Tracking_Pixel::build_view_data();
 		$expected_view_data           = array(
-			'v'    => 'ext',
-			'blog' => 1234,
-			'post' => 7,
-			'tz'   => false,
-			'srv'  => 'example.org',
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => 7,
+			'tz'         => false,
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -57,11 +69,13 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 		add_option( 'gmt_offset', '5' );
 		$view_data          = Tracking_Pixel::build_view_data();
 		$expected_view_data = array(
-			'v'    => 'ext',
-			'blog' => 1234,
-			'post' => '0',
-			'tz'   => '5',
-			'srv'  => 'example.org',
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => '0',
+			'tz'         => '5',
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}

--- a/projects/packages/stats/tests/php/test-tracking-pixel.php
+++ b/projects/packages/stats/tests/php/test-tracking-pixel.php
@@ -21,8 +21,7 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$_GET['utm_source'] = 'a_source';
-		$_GET['utm_id']     = 'some_id';
+		$_SERVER['REQUEST_URI'] = 'index.html?utm_source=a_source&utm_id=some_id';
 	}
 
 	/**
@@ -34,8 +33,8 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 		parent::tear_down();
 		global $wp_the_query;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$wp_the_query = new WP_Query();
-		$_GET         = array();
+		$wp_the_query           = new WP_Query();
+		$_SERVER['REQUEST_URI'] = '';
 	}
 
 	/**

--- a/projects/packages/stats/tests/php/test-tracking-pixel.php
+++ b/projects/packages/stats/tests/php/test-tracking-pixel.php
@@ -136,9 +136,9 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 		$method->setAccessible( true );
 		$pixel_details = $method->invoke( new Tracking_Pixel(), $data );
 
-		$expected_pixel_details = "_stq = window._stq || [];
-_stq.push([ \"view\", {v:'ext',blog:'1234',post:'0',tz:'',srv:'replaced.com'} ]);
-_stq.push([ \"clickTrackerInit\", \"1234\", \"0\" ]);";
+		$expected_pixel_details = '_stq = window._stq || [];
+_stq.push([ "view", JSON.parse("{\"v\":\"ext\",\"blog\":\"1234\",\"post\":\"0\",\"tz\":\"\",\"srv\":\"replaced.com\"}") ]);
+_stq.push([ "clickTrackerInit", "1234", "0" ]);';
 
 		remove_filter( 'stats_array', array( $this, 'stats_array_filter_replace_srv' ) );
 		$this->assertSame( $expected_pixel_details, $pixel_details );

--- a/projects/plugins/jetpack/changelog/add-stats-passing-utm-parameters
+++ b/projects/plugins/jetpack/changelog/add-stats-passing-utm-parameters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2334,7 +2334,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "42f8cbf459a7aa8ad59218370eddd4177b1d0316"
+                "reference": "1ab549225e2ceb78c3e8c3efbb8a6508566a7749"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -2359,7 +2359,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 },
                 "textdomain": "jetpack-stats"
             },

--- a/projects/plugins/search/changelog/add-stats-passing-utm-parameters
+++ b/projects/plugins/search/changelog/add-stats-passing-utm-parameters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1292,7 +1292,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "42f8cbf459a7aa8ad59218370eddd4177b1d0316"
+                "reference": "1ab549225e2ceb78c3e8c3efbb8a6508566a7749"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1317,7 +1317,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 },
                 "textdomain": "jetpack-stats"
             },


### PR DESCRIPTION
## Proposed changes:
This PR adds select UTM parameters to the pixel requests send to wp.com, so that we can show more statistics to site owners.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
panfyZ-37z-p2

## Does this pull request change what data or activity we track or use?
It adds additional parameters to tracking, but we already mention tracking "visiting URL", which parameters are part of.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you are logged out
* Add `?utm_source=a_source&utm_medium=a_medium` to any page on your test website
* Verify that the request to pixel.wp.com includes the UTM parameters
* Add a plugin for AMP support, visit any post with `?amp=1&utm_source=test` added to URL, verify that the pixel URL includes UTM parameter