### PR TITLE
AI Assistant: add prompt to attributes

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-ai-prompt-to-attr
+++ b/projects/js-packages/ai-client/changelog/add-ai-prompt-to-attr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Client: add requesting state to attributes

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -97,7 +97,7 @@ export function AIControl(
 	const promptUserInputRef = useRef( null );
 	const loading = state === 'requesting' || state === 'suggesting';
 	const [ editRequest, setEditRequest ] = React.useState( false );
-	const [ lastValue, setLastValue ] = React.useState( '' );
+	const [ lastValue, setLastValue ] = React.useState( value || '' );
 
 	useEffect( () => {
 		if ( editRequest ) {

--- a/projects/plugins/jetpack/changelog/add-ai-prompt-to-attr
+++ b/projects/plugins/jetpack/changelog/add-ai-prompt-to-attr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Assistant: add userPrompt to block's attributes

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/block.json
@@ -50,6 +50,10 @@
 		"customSystemPrompt": {
 			"type": "string",
 			"default": ""
+		},
+		"userPrompt": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"example": {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/block.json
@@ -54,6 +54,10 @@
 		"userPrompt": {
 			"type": "string",
 			"default": ""
+		},
+		"requestingState": {
+			"type": "string",
+			"default": "init"
 		}
 	},
 	"example": {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -125,6 +125,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		tracks,
 		userPrompt: attributes.userPrompt,
 		requireUpgrade,
+		requestingState: attributes.requestingState,
 	} );
 
 	const connected = isUserConnected();
@@ -216,6 +217,10 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 
 		return () => clearInterval( interval );
 	}, [ promptPlaceholder, currentIndex ] );
+
+	useEffect( () => {
+		setAttributes( { requestingState } );
+	}, [ requestingState, setAttributes ] );
 
 	const saveImage = async image => {
 		if ( loadingImages ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -51,7 +51,6 @@ const isPlaygroundVisible =
 	window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-playground-visible' ];
 
 export default function AIAssistantEdit( { attributes, setAttributes, clientId, isSelected } ) {
-	const [ userPrompt, setUserPrompt ] = useState();
 	const [ errorData, setError ] = useState( {} );
 	const [ loadingImages, setLoadingImages ] = useState( false );
 	const [ resultImages, setResultImages ] = useState( [] );
@@ -124,7 +123,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		content: attributes.content,
 		setError,
 		tracks,
-		userPrompt,
+		userPrompt: attributes.userPrompt,
 		requireUpgrade,
 	} );
 
@@ -310,7 +309,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 
 	const handleChange = value => {
 		setErrorDismissed( true );
-		setUserPrompt( value );
+		setAttributes( { userPrompt: value } );
 	};
 
 	const handleSend = () => {
@@ -386,7 +385,9 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		setError( {} );
 
 		getImagesFromOpenAI(
-			userPrompt.trim() === '' ? __( 'What would you like to see?', 'jetpack' ) : userPrompt,
+			attributes.userPrompt.trim() === ''
+				? __( 'What would you like to see?', 'jetpack' )
+				: attributes.userPrompt,
 			setAttributes,
 			setLoadingImages,
 			setResultImages,
@@ -545,7 +546,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 							// Add a typing effect in the text area
 							for ( let i = 0; i < prompt.length; i++ ) {
 								setTimeout( () => {
-									setUserPrompt( prompt.slice( 0, i + 1 ) );
+									setAttributes( { userPrompt: prompt.slice( 0, i + 1 ) } );
 								}, 25 * i );
 							}
 						} }
@@ -556,7 +557,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 				<AIControl
 					ref={ aiControlRef }
 					disabled={ requireUpgrade || ! connected }
-					value={ userPrompt }
+					value={ attributes.userPrompt }
 					placeholder={ promptPlaceholder || __( 'Ask Jetpack AI', 'jetpack' ) }
 					onChange={ handleChange }
 					onSend={ handleSend }


### PR DESCRIPTION
PoC: add prompt to attributes instead of local state


## Proposed changes:
This PR moves the prompt to the attributes, allowing for the attribute to persist between reloads and drafts.

It now also stores the requestingState to keep consistency between reloads and action buttons behavior.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Load the editor, create an AI assistant block, look at the code editor to see the attribute `userPrompt` is set to the prompt you typed. Save draft and reload, see that your last prompt is still there.

See that, after reloading, the input action buttons remain consistent.