### PR TITLE
ci: Fix monorepo auto-tagger

### DIFF
--- a/.github/workflows/autotagger.yml
+++ b/.github/workflows/autotagger.yml
@@ -70,6 +70,7 @@ jobs:
           export GIT_COMMITTER_NAME=matticbot
           export GIT_COMMITTER_EMAIL=matticbot@users.noreply.github.com
 
+          EXIT=0
           echo "Creating tags..."
           TOPUSH=()
           for T in "${TAGS[@]}"; do
@@ -79,8 +80,22 @@ jobs:
           done
           if [[ ${#TOPUSH[@]} -gt 0 ]]; then
             echo "Pushing tags..."
-            git push origin "${TOPUSH[@]}"
-            echo "::notice::Created tags: ${TOPUSH[*]}"
+            # GitHub has a limit on the number of tags that can be updated in a single push. So do them in batches.
+            DONE=()
+            while [[ ${#TOPUSH[@]} -gt 0 ]]; do
+              BATCH=( "${TOPUSH[@]:0:5}" )
+              if git push origin "${BATCH[@]}"; then
+                DONE+=( "${BATCH[@]}" )
+              else
+                echo "::error::Failed to create tags: ${BATCH[*]}"
+                EXIT=1
+              fi
+              TOPUSH=( "${TOPUSH[@]:5}" )
+            done
+            if [[ ${#DONE[@]} -gt 0 ]]; then
+              echo "::notice::Created tags: ${DONE[*]}"
+            fi
           else
             echo "::notice::No tags needed creation."
           fi
+          exit $EXIT

--- a/.github/workflows/slack-workflow-failed.yml
+++ b/.github/workflows/slack-workflow-failed.yml
@@ -8,6 +8,7 @@ on:
       - Build Docker
       - Tests
       - Gardening
+      - Monorepo Auto-tagger
       - Post-Build
       - PR is up-to-date
       - Update Jetpack Staging Test Sites


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
GitHub has a limit on the number of tags that can be pushed in one command. While we could change the setting, it's probably better to work with it in the workflow and batch the tag pushes.

Let's also alert in Slack if the auto-tagging workflow fails.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Kind of tough to test. You'd want to create a fork lacking some tags, merge this, make sure your fork has the "Limit how many branches and tags can be updated in a single push" active, then push something that would tag releases of more than 5 projects.
