### PR TITLE
Fix/css changes like avatar

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-css-changes-like-avatar
+++ b/projects/plugins/jetpack/changelog/fix-css-changes-like-avatar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Removed like avatar border inside the popup

--- a/projects/plugins/jetpack/modules/likes/style.css
+++ b/projects/plugins/jetpack/modules/likes/style.css
@@ -177,7 +177,7 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 
 #likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a img {
 	background: none;
-	border: 1px solid #fff;;
+	border: none;
 	border-radius: 50%;
 	margin: 0 !important;
 	padding: 1px !important;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/84752

## Proposed changes:

The white border in the avatars in the like section was there to make a clear separation between avatars:
![image](https://github.com/Automattic/jetpack/assets/3832570/20ff2c3e-02c7-4d16-b2b4-0d81e7294d64)


This border loses meaning in the popup, where each avatar is displayed in its own line, so no visual separation is needed:
![image](https://github.com/Automattic/jetpack/assets/3832570/0c9b70f1-3e39-4263-9382-2fc833c1a86b)
👆 example with a black background. You can still see the white border.

This patch removes the border completely from the like avatars inside the popup while maintaining it in the avatars outside the popup:
![popup](https://github.com/Automattic/jetpack/assets/3832570/37eab9ef-5368-4317-8164-9e004907a9d9)
👆 example with a gray background. No need for the white background anymore.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Not applicable.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

- Apply this PR.
- Start your docker and build Jetpack.
- Connect to your JT site.
- Go to a blog post on your sandboxed site with likes on it.
- Click on the "x likes" link and check that the white border is not there inside the popup. You may change temporally the white background of the popup in order to test this.
**Note**: the avatars inside the popup should be rounded. The ones outside the popup (before clicking on "x likes") will still be squared, as that's outside the scope of this PR.


