### PR TITLE
AI Assistant: improve spacing and sizes for block and action buttons

### DIFF
--- a/projects/js-packages/ai-client/changelog/change-ai-handle-multiple-lines
+++ b/projects/js-packages/ai-client/changelog/change-ai-handle-multiple-lines
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Address spacing and sizing issues on the AI Assistant block

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -263,7 +263,7 @@ export function AIControl(
 					</div>
 				) }
 			</div>
-			{ showGuideLine && <GuidelineMessage /> }
+			{ showGuideLine && ! loading && ! editRequest && <GuidelineMessage /> }
 		</div>
 	);
 }

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { PlainText } from '@wordpress/block-editor';
-import { Button } from '@wordpress/components';
+import { Button, ButtonGroup } from '@wordpress/components';
 import { useKeyboardShortcut } from '@wordpress/compose';
 import {
 	forwardRef,
@@ -182,7 +182,7 @@ export function AIControl(
 									<Button
 										className="jetpack-components-ai-control__controls-prompt_button"
 										onClick={ () => setEditRequest( false ) }
-										variant="tertiary"
+										variant="secondary"
 										label={ __( 'Cancel', 'jetpack-ai-client' ) }
 									>
 										{ showButtonLabels ? (
@@ -226,30 +226,32 @@ export function AIControl(
 
 				{ showAccept && ! editRequest && value?.length > 0 && (
 					<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
-						<Button
-							className="jetpack-components-ai-control__controls-prompt_button"
-							label={ __( 'Back to edit', 'jetpack-ai-client' ) }
-							onClick={ () => setEditRequest( true ) }
-							tooltipPosition="top"
-						>
-							<Icon icon={ arrowLeft } />
-						</Button>
-						<Button
-							className="jetpack-components-ai-control__controls-prompt_button"
-							label={ __( 'Discard', 'jetpack-ai-client' ) }
-							onClick={ discardHandler }
-							tooltipPosition="top"
-						>
-							<Icon icon={ trash } />
-						</Button>
-						<Button
-							className="jetpack-components-ai-control__controls-prompt_button"
-							label={ __( 'Regenerate', 'jetpack-ai-client' ) }
-							onClick={ () => onSend?.( value ) }
-							tooltipPosition="top"
-						>
-							<Icon icon={ reusableBlock } />
-						</Button>
+						<ButtonGroup>
+							<Button
+								className="jetpack-components-ai-control__controls-prompt_button"
+								label={ __( 'Back to edit', 'jetpack-ai-client' ) }
+								onClick={ () => setEditRequest( true ) }
+								tooltipPosition="top"
+							>
+								<Icon icon={ arrowLeft } />
+							</Button>
+							<Button
+								className="jetpack-components-ai-control__controls-prompt_button"
+								label={ __( 'Discard', 'jetpack-ai-client' ) }
+								onClick={ discardHandler }
+								tooltipPosition="top"
+							>
+								<Icon icon={ trash } />
+							</Button>
+							<Button
+								className="jetpack-components-ai-control__controls-prompt_button"
+								label={ __( 'Regenerate', 'jetpack-ai-client' ) }
+								onClick={ () => onSend?.( value ) }
+								tooltipPosition="top"
+							>
+								<Icon icon={ reusableBlock } />
+							</Button>
+						</ButtonGroup>
 						<Button
 							className="jetpack-components-ai-control__controls-prompt_button"
 							onClick={ onAccept }

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -8,14 +8,17 @@
 	box-shadow: 0px 12px 15px 0px rgba(0, 0, 0, 0.12), 0px 3px 9px 0px rgba(0, 0, 0, 0.12), 0px 1px 3px 0px rgba(0, 0, 0, 0.15);
 	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	width: 100%;
+	border-radius: 6px;
+	border: 1px solid var(--gutenberg-gray-400, #CCC);
 }
 
 .jetpack-components-ai-control__wrapper {
 	display: flex;
-	padding: 12px 14px;
-	gap: 8px;
-	align-items: center;
+	padding: 8px 8px 8px var(--grid-unit-15, 12px);
+	align-items: flex-end;
 	box-sizing: border-box;
+	border-radius: 6px 6px 0 0;
+	gap: 6px;
 
 	&.is-transparent {
 		opacity: 0.4;
@@ -23,10 +26,9 @@
 }
 
 .jetpack-components-ai-control__input-wrapper {
-	position: relative;
 	display: flex;
 	flex-grow: 1;
-	width: 100%;
+	align-self: center;
 
 	textarea.jetpack-components-ai-control__input {
 		background-color: var( --jp-white );
@@ -67,14 +69,20 @@
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 600;
-	line-height: 16px;
+	line-height: 1em;
 	user-select: none;
 	white-space: nowrap;
 	display: flex;
 	align-items: center;
+	gap: 8px;
 
 	.components-button.is-small:not(.has-label) {
 		padding: 0;
+	}
+
+	.components-button {
+		box-shadow: none;
+		padding: 6px 8px;
 	}
 }
 
@@ -89,24 +97,25 @@
 
 .jetpack-ai-assistant__message {
 	display: flex;
-    line-height: 28px;
-    font-size: 12px;
-    align-self: center;
-    align-items: center;
-    background-color: var( --jp-white-off );
-    padding: 0 12px;
+	line-height: 28px;
+	font-size: 12px;
+	align-self: center;
+	align-items: center;
+	background-color: var( --jp-white-off );
+	padding: 0 12px;
+	border-radius: 0 0 6px 6px;
 
-    > svg {
-        fill: var( --jp-gray-40 );
-    }
+	> svg {
+		fill: var( --jp-gray-40 );
+	}
 
-    .jetpack-ai-assistant__message-content {
-        flex-grow: 2;
-        margin: 0 8px;
-        color: var( --jp-gray-70 );
+	.jetpack-ai-assistant__message-content {
+		flex-grow: 2;
+		margin: 0 8px;
+		color: var( --jp-gray-50 );
 
-        .components-external-link {
-            color: var( --jp-gray-50 );
-        }
-    }
+		.components-external-link {
+			color: var( --jp-gray-50 );
+		}
+	}
 }

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -82,7 +82,7 @@
 		padding: 0;
 	}
 
-	.components-button {
+	.components-button-group .components-button {
 		box-shadow: none;
 		padding: 6px 8px;
 	}

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -29,6 +29,8 @@
 	display: flex;
 	flex-grow: 1;
 	align-self: center;
+	min-height: 36px; // need compat height with buttons wrapper
+	align-items: center;
 
 	textarea.jetpack-components-ai-control__input {
 		background-color: var( --jp-white );

--- a/projects/js-packages/ai-client/src/components/ai-status-indicator/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-status-indicator/style.scss
@@ -1,12 +1,19 @@
 @import '@automattic/jetpack-base-styles/style';
 
 .jetpack-ai-status-indicator__icon-wrapper {
-	transition: opacity 0.3s ease-in-out, width 0.5s;
+	transition: opacity 0.25s ease-in-out, width 0.25s;
 	width: 0;
 	opacity: 0;
+	align-self: baseline;
+
+	> svg {
+		height: 24px;
+		width: 24px;
+		margin: 6px 0 0;
+	}
 
 	&.is-requesting, &.is-suggesting {
 		opacity: 1;
-		width: 38px;
+		width: 24px;
 	}
 }

--- a/projects/plugins/jetpack/changelog/change-ai-handle-multiple-lines
+++ b/projects/plugins/jetpack/changelog/change-ai-handle-multiple-lines
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Assistant: improve UI spacings and sizes on block and action buttons


### PR DESCRIPTION
Address design/styling issues on the AI Assistant block

Fixes #34336 
Fixes https://github.com/Automattic/jetpack-roadmap/issues/896

## Proposed changes:
This PR changes some of the styles to better adjust to the designs.

- [x] Adjust vertical behavior when prompt turns into multiline
- [x] Add border and border radius to the ~input box~ block 
- [x] Adjust spacing between buttons and icons
- [x] Avoid height jumping when displaying buttons
- [x] Increase the speed of the animation to show the spinner
- [x] Hide the extra info when editing a prompt or when it's generating
- [x] Adjust font color of the extra info

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-pBB-p2
p1701702051720109-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a post and insert an AI Assistant block, check the list and compare to designs (mentioned on the issues)