### PR TITLE
DRAFT: Launchpad: Add source to stripe connect task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-earn-launchpad-stripe-return
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-earn-launchpad-stripe-return
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: Add source to Earn stripe task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -504,7 +504,8 @@ function wpcom_launchpad_get_task_definitions() {
 				if ( function_exists( 'get_memberships_connected_account_redirect' ) ) {
 					return get_memberships_connected_account_redirect(
 						get_current_user_id(),
-						get_current_blog_id()
+						get_current_blog_id(),
+						'earn-launchpad'
 					);
 				}
 				return '/earn/payments/' . $data['site_slug_encoded'];


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a source param when invoking get_memberships_connected_account_redirect(). This will get passed to the stripe return URL, and allow us to ensure users are directly returned to the Monetize > Home/Launchpad. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Will add when ready for testing.

