### PR TITLE
Launchpad: Fix the Save modal doesn't show after saving changes in the editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-launchpad-is-saving-site
+++ b/projects/plugins/jetpack/changelog/fix-launchpad-is-saving-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Launchpad: Fix the Save modal doesn't show after saving changes in the editor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/wp-calypso/issues/83390

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Show the “Save” modal after saving changes in the editor

![image](https://github.com/Automattic/jetpack/assets/13596067/912cd18f-43c8-424a-8002-210905b0d33e)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply https://github.com/Automattic/jetpack/pull/34415 to your sandbox first
  ```
  bin/jetpack-downloader test jetpack-mu-wpcom-plugin trunk
  ```
* Apply the changes to your sandbox as follows:
  ```
  bin/jetpack-downloader test jetpack fix/launchpad-is-saving-site
   ```
* Go to `/setup/assembler-first?flags=themes/assembler-first`
* Create a new site
* Sandbox your new site
* Finish the Assembler step
* Edit your homepage and save changes in the Site Editor
* Ensure the “Save” modal is shown after saving changes successfully
* Reset jetpack-mu-wpcom on your sandbox
  ```
  jetpack-downloader reset jetpack
  jetpack-downloader reset jetpack-mu-wpcom-plugin
  ```