### PR TITLE
AI Assistant: fix block to bottom when content exceeds the viewport height

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-ai-assistant-fix-to-bottom
+++ b/projects/js-packages/ai-client/changelog/add-ai-assistant-fix-to-bottom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Assistant: make container fix to bottom when content is too large to fit the viewport

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -155,115 +155,117 @@ export function AIControl(
 	);
 
 	return (
-		<div className="jetpack-components-ai-control__container">
-			<div
-				className={ classNames( 'jetpack-components-ai-control__wrapper', {
-					'is-transparent': isTransparent,
-				} ) }
-			>
-				<AiStatusIndicator state={ state } />
+		<div className="jetpack-components-ai-control__container-wrapper">
+			<div className="jetpack-components-ai-control__container">
+				<div
+					className={ classNames( 'jetpack-components-ai-control__wrapper', {
+						'is-transparent': isTransparent,
+					} ) }
+				>
+					<AiStatusIndicator state={ state } />
 
-				<div className="jetpack-components-ai-control__input-wrapper">
-					<PlainText
-						value={ value }
-						onChange={ changeHandler }
-						placeholder={ placeholder }
-						className="jetpack-components-ai-control__input"
-						disabled={ loading || disabled }
-						ref={ promptUserInputRef }
-					/>
-				</div>
+					<div className="jetpack-components-ai-control__input-wrapper">
+						<PlainText
+							value={ value }
+							onChange={ changeHandler }
+							placeholder={ placeholder }
+							className="jetpack-components-ai-control__input"
+							disabled={ loading || disabled }
+							ref={ promptUserInputRef }
+						/>
+					</div>
 
-				{ ( ! showAccept || editRequest ) && value?.length > 0 && (
-					<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
-						{ ! loading ? (
-							<>
-								{ editRequest && (
+					{ ( ! showAccept || editRequest ) && value?.length > 0 && (
+						<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
+							{ ! loading ? (
+								<>
+									{ editRequest && (
+										<Button
+											className="jetpack-components-ai-control__controls-prompt_button"
+											onClick={ () => setEditRequest( false ) }
+											variant="secondary"
+											label={ __( 'Cancel', 'jetpack-ai-client' ) }
+										>
+											{ showButtonLabels ? (
+												__( 'Cancel', 'jetpack-ai-client' )
+											) : (
+												<Icon icon={ closeSmall } />
+											) }
+										</Button>
+									) }
+
 									<Button
 										className="jetpack-components-ai-control__controls-prompt_button"
-										onClick={ () => setEditRequest( false ) }
-										variant="secondary"
-										label={ __( 'Cancel', 'jetpack-ai-client' ) }
+										onClick={ sendRequest }
+										variant="primary"
+										disabled={ ! value?.length || disabled }
+										label={ __( 'Send request', 'jetpack-ai-client' ) }
 									>
 										{ showButtonLabels ? (
-											__( 'Cancel', 'jetpack-ai-client' )
+											__( 'Generate', 'jetpack-ai-client' )
 										) : (
-											<Icon icon={ closeSmall } />
+											<Icon icon={ arrowUp } />
 										) }
 									</Button>
-								) }
-
+								</>
+							) : (
 								<Button
 									className="jetpack-components-ai-control__controls-prompt_button"
-									onClick={ sendRequest }
-									variant="primary"
-									disabled={ ! value?.length || disabled }
-									label={ __( 'Send request', 'jetpack-ai-client' ) }
+									onClick={ onStop }
+									variant="secondary"
+									label={ __( 'Stop request', 'jetpack-ai-client' ) }
 								>
 									{ showButtonLabels ? (
-										__( 'Generate', 'jetpack-ai-client' )
+										__( 'Stop', 'jetpack-ai-client' )
 									) : (
-										<Icon icon={ arrowUp } />
+										<Icon icon={ closeSmall } />
 									) }
 								</Button>
-							</>
-						) : (
-							<Button
-								className="jetpack-components-ai-control__controls-prompt_button"
-								onClick={ onStop }
-								variant="secondary"
-								label={ __( 'Stop request', 'jetpack-ai-client' ) }
-							>
-								{ showButtonLabels ? (
-									__( 'Stop', 'jetpack-ai-client' )
-								) : (
-									<Icon icon={ closeSmall } />
-								) }
-							</Button>
-						) }
-					</div>
-				) }
+							) }
+						</div>
+					) }
 
-				{ showAccept && ! editRequest && value?.length > 0 && (
-					<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
-						<ButtonGroup>
+					{ showAccept && ! editRequest && value?.length > 0 && (
+						<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
+							<ButtonGroup>
+								<Button
+									className="jetpack-components-ai-control__controls-prompt_button"
+									label={ __( 'Back to edit', 'jetpack-ai-client' ) }
+									onClick={ () => setEditRequest( true ) }
+									tooltipPosition="top"
+								>
+									<Icon icon={ arrowLeft } />
+								</Button>
+								<Button
+									className="jetpack-components-ai-control__controls-prompt_button"
+									label={ __( 'Discard', 'jetpack-ai-client' ) }
+									onClick={ discardHandler }
+									tooltipPosition="top"
+								>
+									<Icon icon={ trash } />
+								</Button>
+								<Button
+									className="jetpack-components-ai-control__controls-prompt_button"
+									label={ __( 'Regenerate', 'jetpack-ai-client' ) }
+									onClick={ () => onSend?.( value ) }
+									tooltipPosition="top"
+								>
+									<Icon icon={ reusableBlock } />
+								</Button>
+							</ButtonGroup>
 							<Button
 								className="jetpack-components-ai-control__controls-prompt_button"
-								label={ __( 'Back to edit', 'jetpack-ai-client' ) }
-								onClick={ () => setEditRequest( true ) }
-								tooltipPosition="top"
+								onClick={ onAccept }
+								variant="primary"
+								label={ acceptLabel }
 							>
-								<Icon icon={ arrowLeft } />
+								{ showButtonLabels ? acceptLabel : <Icon icon={ check } /> }
 							</Button>
-							<Button
-								className="jetpack-components-ai-control__controls-prompt_button"
-								label={ __( 'Discard', 'jetpack-ai-client' ) }
-								onClick={ discardHandler }
-								tooltipPosition="top"
-							>
-								<Icon icon={ trash } />
-							</Button>
-							<Button
-								className="jetpack-components-ai-control__controls-prompt_button"
-								label={ __( 'Regenerate', 'jetpack-ai-client' ) }
-								onClick={ () => onSend?.( value ) }
-								tooltipPosition="top"
-							>
-								<Icon icon={ reusableBlock } />
-							</Button>
-						</ButtonGroup>
-						<Button
-							className="jetpack-components-ai-control__controls-prompt_button"
-							onClick={ onAccept }
-							variant="primary"
-							label={ acceptLabel }
-						>
-							{ showButtonLabels ? acceptLabel : <Icon icon={ check } /> }
-						</Button>
-					</div>
-				) }
+						</div>
+					) }
+				</div>
+				{ showGuideLine && ! loading && ! editRequest && <GuidelineMessage /> }
 			</div>
-			{ showGuideLine && ! loading && ! editRequest && <GuidelineMessage /> }
 		</div>
 	);
 }

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -5,7 +5,7 @@
 .jetpack-components-ai-control__container-wrapper {
 	position: sticky;
 	bottom: 0;
-	padding-bottom: 8px;
+	padding-bottom: 16px;
 }
 
 .jetpack-components-ai-control__container {

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -2,6 +2,12 @@
 
 // AI CONTROL
 
+.jetpack-components-ai-control__container-wrapper {
+	position: sticky;
+	bottom: 0;
+	padding-bottom: 8px;
+}
+
 .jetpack-components-ai-control__container {
 	color: var( --jp-gray-80 );
 	background-color: var( --jp-white );
@@ -10,8 +16,6 @@
 	width: 100%;
 	border-radius: 6px;
 	border: 1px solid var(--gutenberg-gray-400, #CCC);
-	position: sticky;
-	bottom: 0;
 }
 
 .jetpack-components-ai-control__wrapper {

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -10,6 +10,8 @@
 	width: 100%;
 	border-radius: 6px;
 	border: 1px solid var(--gutenberg-gray-400, #CCC);
+	position: sticky;
+	bottom: 0;
 }
 
 .jetpack-components-ai-control__wrapper {


### PR DESCRIPTION
When generated content goes over the height of the viewport, AI assistant gets dragged down with the content making for a not ideal UX

Fixes #34337 

## Proposed changes:
This PR uses a simple CSS trick to fix the AI assistant the bottom of the viewport.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-pBB-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The behavior is sometimes quirky, but haven't been able to consistently break it.

Use the AI Assistant, ask for some paragraphs so the content exceeds the height. See the assistant's block stick to bottom when the content starts overflowing. Try scrolling to see the block remains at the bottom 