### PR TITLE
Contact Form: ensure warning icons are visible

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-warning-icon
+++ b/projects/packages/forms/changelog/fix-contact-form-warning-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: ensure warning icons are visible

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -767,7 +767,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form__input-error {
 	display: flex;
 	align-items: center;
-	gap: 0.25em;
+	gap: 0.33em;
 
 	font-size: 1rem;
 }
@@ -799,6 +799,27 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .wp-block-jetpack-contact-form:not(.is-style-outlined) fieldset[aria-invalid="true"] {
 	outline: solid 1px var(--jetpack--contact-form--error-color);
 	outline-offset: 0.5em;
+}
+
+.contact-form__warning-icon {
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
+
+	width: 1.25em;
+	height: 1.25em;
+
+	background-color: var(--jetpack--contact-form--error-color);
+	border-radius: 50%;
+	border: solid 1px var(--jetpack--contact-form--inverted-text-color);
+	color: var(--jetpack--contact-form--inverted-text-color);
+}
+
+.contact-form__warning-icon::after {
+	content: "\0021";
+
+	font-size: 0.8em;
+	font-weight: bold;
 }
 
 .contact-form__checkbox-wrap {

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -151,7 +151,7 @@ const createSpinner = () => {
 const createWarningIcon = () => {
 	const elt = document.createElement( 'span' );
 
-	elt.classList.add( 'dashicons', 'dashicons-warning' );
+	elt.classList.add( 'contact-form__warning-icon' );
 	elt.setAttribute( 'aria-label', L10N.warning || 'Warning' );
 
 	return elt;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The warning icons displayed after submitting an invalid _Contact Form_ relied on Dashicons, which were not available for non-authenticated users. This PR replaces dashicons by a Unicode + CSS implementation.

|Before|After|
|-|-|
|<img width="500" alt="Screenshot 2023-12-05 at 10 29 53 AM" src="https://github.com/Automattic/jetpack/assets/1620183/566b3222-9320-4b5f-871b-5887cd4e5f16">|<img width="500" alt="Screenshot 2023-12-05 at 10 47 47 AM" src="https://github.com/Automattic/jetpack/assets/1620183/ae59f91b-163e-4f6a-813b-735fa7993baa">|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See this PR comment: https://github.com/Automattic/jetpack/pull/34367#pullrequestreview-1759344241

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Create a new post
- Add the _Contact Form_ block
- Make sure at least one field is required
- Publish the post
- Open the post in a private window
- Submit an invalid form
- Notice the warning icons

