### PR TITLE
Launchpad: Add Site Setup task list for hosted sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-site-setup-hosted-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-site-setup-hosted-launchpad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Site Setup Launchpad, for hosted sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -25,7 +25,7 @@ require_once __DIR__ . '/launchpad-task-definitions.php';
  */
 function wpcom_launchpad_get_task_list_definitions() {
 	$core_task_list_definitions = array(
-		'build'                  => array(
+		'build'                    => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -40,7 +40,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'free'                   => array(
+		'free'                     => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -56,7 +56,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'link-in-bio'            => array(
+		'link-in-bio'              => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -70,7 +70,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'link-in-bio-tld'        => array(
+		'link-in-bio-tld'          => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -84,7 +84,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'newsletter'             => array(
+		'newsletter'               => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -100,7 +100,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'videopress'             => array(
+		'videopress'               => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -113,7 +113,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'write'                  => array(
+		'write'                    => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -127,7 +127,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'start-writing'          => array(
+		'start-writing'            => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -141,7 +141,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'design-first'           => array(
+		'design-first'             => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -156,7 +156,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'intent-build'           => array(
+		'intent-build'             => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -173,7 +173,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),
-		'intent-write'           => array(
+		'intent-write'             => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -187,7 +187,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_intent_write_enabled',
 		),
-		'intent-free-newsletter' => array(
+		'intent-free-newsletter'   => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -201,7 +201,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_free_newsletter_enabled',
 		),
-		'intent-paid-newsletter' => array(
+		'intent-paid-newsletter'   => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -217,14 +217,14 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_paid_newsletter_enabled',
 		),
-		'earn'                   => array(
+		'earn'                     => array(
 			'task_ids'            => array(
 				'stripe_connected',
 				'paid_offer_created',
 			),
 			'is_enabled_callback' => '__return_true',
 		),
-		'host-site'              => array(
+		'host-site'                => array(
 			'task_ids'            => array(
 				'site_theme_selected',
 				'install_custom_plugin',
@@ -235,14 +235,14 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_hosting_flow_enabled',
 		),
-		'subscribers'            => array(
+		'subscribers'              => array(
 			'task_ids' => array(
 				'import_subscribers',
 				'add_subscribe_block',
 				'share_site',
 			),
 		),
-		'assembler-first'        => array(
+		'assembler-first'          => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -258,7 +258,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'legacy-site-setup'      => array(
+		'legacy-site-setup'        => array(
 			'get_title' => function () {
 				return __( 'Site setup', 'jetpack-mu-wpcom' );
 			},
@@ -271,6 +271,19 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'setup_professional_email',
 				'post_sharing_enabled',
 				'site_launched',
+			),
+		),
+		'legacy-site-setup-hosted' => array(
+			'get_title' => function () {
+				return __( 'Site setup', 'jetpack-mu-wpcom' );
+			},
+			'task_ids'  => array(
+				'site_theme_selected',
+				'install_custom_plugin',
+				'setup_ssh',
+				'verify_email',
+				'site_launched',
+				'setup_professional_email',
 			),
 		),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to: https://github.com/Automattic/wp-calypso/issues/84409

More context: paYKcK-3Hy-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* We need to migrate the site setup logic that still displays the old checklist. This PR adds the initial structure for the new checklist called `legacy-site-setup-hosted`, which we will use to show the Launchpad in the Customer Home in case it's a hosted site.

Note: This PR depends on https://github.com/Automattic/jetpack/pull/34320, and should be deployed after.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox using the command below:
```bash
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/site-setup-hosted-launchpad
```
* Navigate to the Developer Console: https://developer.wordpress.com/docs/api/console/
* Make a GET request to `wpcom/v2` -> `/sites/:siteSlug/launchpad?checklist_slug=legacy-site-setup-hosted`
* Ensure you get a response similar to:

![Screen Shot 2023-12-05 at 14 48 47](https://github.com/Automattic/jetpack/assets/1234758/bbabc293-5e08-4ec7-9396-e79984bc27d2)
