### PR TITLE
AI Assistant: remove try again toolbar button

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-ai-assistant-try-again
+++ b/projects/plugins/jetpack/changelog/remove-ai-assistant-try-again
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Assistant: remove "Try Again" toolbar button

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
@@ -101,9 +101,9 @@ const ToolbarControls = ( {
 					</>
 				) }
 
-				{ ( showRetry || contentIsLoaded ) && (
+				{ ( showRetry || handleTryAgain ) && (
 					<ToolbarGroup>
-						{ ! showRetry && contentIsLoaded && (
+						{ ! showRetry && contentIsLoaded && handleTryAgain && (
 							<ToolbarButton onClick={ handleTryAgain }>
 								{ __( 'Try Again', 'jetpack' ) }
 							</ToolbarButton>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -525,7 +525,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 						handleAcceptTitle={ handleAcceptTitle }
 						handleGetSuggestion={ handleGetSuggestion }
 						handleImageRequest={ handleImageRequest }
-						handleTryAgain={ handleTryAgain }
+						handleTryAgain={ null }
 						showRetry={ showRetry }
 						contentBefore={ contentBefore }
 						hasPostTitle={ !! postTitle?.length }


### PR DESCRIPTION
Remove the "Try again" toolbar button

Fixes #34463 

## Proposed changes:
This PR removes the toolbar button as it's now implemented on the block itself

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1701789076275979-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the editor, insert an AI assistant block. See that there's now no "Try again" toolbar button. Check this is also true when creating forms with AI