### PR TITLE
Jetpack Dashboard: disable VideoPress card in offline mode

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -39,6 +39,10 @@
 			padding: 0;
 		}
 	}
+
+	.jp-dash-item__content .jp-support-info {
+		top: auto;
+	}
 }
 
 .jp-dash-section-header.jp-dash-section-header-stats {
@@ -672,7 +676,7 @@ a.jp-dash-item__manage-in-wpcom,
 			display: flex;
 			flex-direction: row;
 		}
-		
+
 		.dash-backup-undo__activity-log-user-meta-avatar {
 			display: flex;
 			margin-right: 8px;

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -75,7 +75,7 @@ class DashVideoPress extends Component {
 						/* dummy arg to avoid bad minification */ 0
 				  );
 
-		if ( this.props.getOptionValue( 'videopress' ) && hasConnectedOwner ) {
+		if ( this.props.getOptionValue( 'videopress' ) && hasConnectedOwner && ! isOffline ) {
 			return (
 				<DashItem
 					className="jp-dash-item__videopress"

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
@@ -69,7 +69,17 @@ export class DashItem extends Component {
 		if ( '' !== this.props.module ) {
 			toggle =
 				( includes(
-					[ 'monitor', 'protect', 'photon', 'vaultpress', 'scan', 'backups', 'akismet', 'search' ],
+					[
+						'monitor',
+						'protect',
+						'photon',
+						'vaultpress',
+						'scan',
+						'backups',
+						'akismet',
+						'search',
+						'videopress',
+					],
 					this.props.module
 				) &&
 					this.props.isOfflineMode ) ||

--- a/projects/plugins/jetpack/changelog/fix-videopress-card-offline-mode
+++ b/projects/plugins/jetpack/changelog/fix-videopress-card-offline-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: disable VideoPress card in offline mode.


### PR DESCRIPTION
Fixes #33944

## Proposed changes:
* Fully disable VideoPress card on Jetpack Dashboard in Offline Mode.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Install Jetpack, connect it to WPCOM.
2. Go to Jetpack Dashboard and activate the VideoPress card.
3. Activate "Offline Mode".
4. Go to Jetpack Dashboard and find the "VideoPress" card.
5. Confirm the toggle isn't there, and the card says "Unavailable in Offline Mode".
6. Confirm the "Info" icon is aligned with the text.
7. Deactivate "Offline Mode", deactivate the VideoPress card, and activate "Offline Mode" again.
8. Confirm the toggle isn't there, and the card says "Unavailable in Offline Mode".
9. Deactivate "Offline Mode", try to enable/disable the VideoPress card and confirm it works fine.
10. Confirm the "Info" icon is aligned with the text.
