### PR TITLE
Calendly Block: Fix Embed Attributes Being Stripped

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-calendly-block-attributes
+++ b/projects/plugins/jetpack/changelog/fix-calendly-block-attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Calendly block: fix custom colours being stripped.

--- a/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
@@ -112,14 +112,17 @@ function load_assets( $attr, $content ) {
 			esc_attr( $block_id )
 		);
 		$script  = <<<JS_END
-jetpackInitCalendly( %s, '%s' );
+jetpackInitCalendly( %s, %s );
 JS_END;
 		wp_add_inline_script(
 			'jetpack-calendly-external-js',
 			sprintf(
 				$script,
-				wp_json_encode( esc_url_raw( $url ), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
-				esc_attr( $block_id )
+				wp_json_encode(
+					esc_url_raw( $url ),
+					JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+				),
+				wp_json_encode( $block_id, JSON_HEX_TAG | JSON_HEX_AMP )
 			)
 		);
 	}

--- a/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
@@ -114,7 +114,7 @@ function load_assets( $attr, $content ) {
 		$script  = <<<JS_END
 jetpackInitCalendly( '%s', '%s' );
 JS_END;
-		wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
+		wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url_raw( $url ), esc_js( $block_id ) ) );
 	}
 
 	return $content;

--- a/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
@@ -122,7 +122,7 @@ JS_END;
 					esc_url_raw( $url ),
 					JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 				),
-				wp_json_encode( $block_id, JSON_HEX_TAG | JSON_HEX_AMP )
+				wp_json_encode( $block_id, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP )
 			)
 		);
 	}

--- a/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
@@ -112,9 +112,16 @@ function load_assets( $attr, $content ) {
 			esc_attr( $block_id )
 		);
 		$script  = <<<JS_END
-jetpackInitCalendly( '%s', '%s' );
+jetpackInitCalendly( %s, '%s' );
 JS_END;
-		wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url_raw( $url ), esc_js( $block_id ) ) );
+		wp_add_inline_script(
+			'jetpack-calendly-external-js',
+			sprintf(
+				$script,
+				wp_json_encode( esc_url_raw( $url ), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+				esc_attr( $block_id )
+			)
+		);
 	}
 
 	return $content;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34445

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`esc_url` turns this: `https://calendly.com/user/30min?hide_event_type_details=0&background_color=ac1e1e&text_color=ff1c1c&primary_color=16345f`

Into this: `https://calendly.com/user/30min?embed_domain=a96d-2a00-23c8-3f07-3e01-c57f-94f3-a43c-a1fa.ngrok-free.app&embed_type=Inline&hide_event_type_details=0&=undefined`

I've tried to research why this might be happening, but I can't figure it out. `esc_url_raw` fixes this problem, and seems to be encouraged [here](https://developer.wordpress.org/reference/functions/esc_url_raw/#more-information) since the URL isn't displayed, but I'm curious if there's any downsides that explain why it wasn't used in the first place. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the instructions listed here to embed a Calendly block with custom colours: https://wordpress.com/support/wordpress-editor/blocks/calendly-block/#change-the-look-and-feel-of-the-calendly-embed

On the front end, those colours should correctly display with this change. 

