### PR TITLE
Fixed typo in class-creator.php

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-typo-in-class-creator-string
+++ b/projects/packages/my-jetpack/changelog/fix-typo-in-class-creator-string
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Class-creator.php: fixes a small typo in "Newsletter" where the "E" was forgotten.

--- a/projects/packages/my-jetpack/changelog/fix-typo-in-class-creator-string
+++ b/projects/packages/my-jetpack/changelog/fix-typo-in-class-creator-string
@@ -1,4 +1,4 @@
-Significance: minor
-Type: enhancement
+Significance: patch
+Type: fixed
 
-Class-creator.php: fixes a small typo in "Newsletter" where the "E" was forgotten.
+Creator Card: fix typo.

--- a/projects/packages/my-jetpack/src/products/class-creator.php
+++ b/projects/packages/my-jetpack/src/products/class-creator.php
@@ -210,7 +210,7 @@ class Creator extends Product {
 				),
 			),
 			array(
-				'name'  => __( 'Newsltter', 'jetpack-my-jetpack' ),
+				'name'  => __( 'Newsletter', 'jetpack-my-jetpack' ),
 				'info'  => array(
 					'content' => __(
 						'Start a Newsletter by sending your content as an email newsletter direct to your fans email inboxes.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34477

## Proposed changes:
* Fixing the typo

## Testing instructions:

* Go to the view of class-creator.php and now see Newsletter instead of Nwsletter

## Does this pull request change what data or activity we track or use?

None. Since it just fixes a typo.