### PR TITLE
Top Posts & Pages Block: Refactor Endpoint 

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Top Posts & Pages block helper.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Stats\WPCOM_Stats;
+
+/**
+ * Class Jetpack_Top_Posts_Helper
+ */
+class Jetpack_Top_Posts_Helper {
+	/**
+	 * Returns user's top posts. 
+	 *
+	 * @param int $period       Period of days to draw stats from.
+	 * @param int $items_count  Number of items to display.
+	 * @param string $types     Content types to include.
+	 * @return array
+	 */
+	public static function get_top_posts( $period, $items_count, $types ) {
+		$all_time_days = floor( ( time() - strtotime( get_option( 'site_created_date' ) ) ) / ( 60 * 60 * 24 * 365 ) );
+
+		// While we only display ten posts, users can filter out content types.
+		// As such, we should obtain a few spare posts from the Stats endpoint.
+		$posts_to_obtain_count = 30;
+
+		// We should not override cache when displaying the block on the frontend.
+		// But we should allow instant preview of changes when editing the block.
+		$is_rendering_block = isset( $types );
+		$override_cache     = ! $is_rendering_block;
+
+		$query_args = array(
+			'max'       => $posts_to_obtain_count,
+			'summarize' => true,
+			'num'       => $period !== 'all-time' ? $period : $all_time_days,
+			'period'    => 'day',
+		);
+
+		$data = ( new WPCOM_Stats() )->get_top_posts( $query_args, $override_cache );
+
+		if ( is_wp_error( $data ) ) {
+			$data = array( 'summary' => array( 'postviews' => array() ) );
+		}
+
+		$posts_retrieved = count( $data['summary']['postviews'] );
+
+		// Fallback to random posts if user does not have enough top content.
+		if ( $posts_retrieved < $posts_to_obtain_count ) {
+			$args = array(
+				'numberposts' => $posts_to_obtain_count - $posts_retrieved,
+				'exclude'     => array_column( $data['summary']['postviews'], 'id' ),
+				'orderby'     => 'rand',
+				'post_status' => 'publish',
+			);
+
+			$random_posts = get_posts( $args );
+
+			foreach ( $random_posts as $post ) {
+				$random_posts_data = array(
+					'id'     => $post->ID,
+					'href'   => get_permalink( $post->ID ),
+					'date'   => $post->post_date,
+					'title'  => $post->post_title,
+					'type'   => 'post',
+					'public' => true,
+				);
+
+				$data['summary']['postviews'][] = $random_posts_data;
+			}
+
+			$data['summary']['postviews'] = array_slice( $data['summary']['postviews'], 0, 10 );
+		}
+
+		$top_posts = array();
+
+		foreach ( $data['summary']['postviews'] as $post ) {
+			$post_id   = $post['id'];
+			$thumbnail = get_the_post_thumbnail_url( $post_id );
+
+			if ( ! $thumbnail ) {
+				$post_images = get_attached_media( 'image', $post_id );
+				$post_image  = reset( $post_images );
+				if ( $post_image ) {
+					$thumbnail = wp_get_attachment_url( $post_image->ID );
+				}
+			}
+
+			if ( $post['public'] ) {
+				$top_posts[] = array(
+					'id'        => $post_id,
+					'author'    => get_the_author_meta( 'display_name', get_post_field( 'post_author', $post_id ) ),
+					'context'   => get_the_category( $post_id ) ? get_the_category( $post_id ) : get_the_tags( $post_id ),
+					'href'      => $post['href'],
+					'date'      => get_the_date( '', $post_id ),
+					'title'     => $post['title'],
+					'type'      => $post['type'],
+					'public'    => $post['public'],
+					'views'     => isset( $post['views'] ) ? $post['views'] : 0,
+					'thumbnail' => $thumbnail,
+				);
+			}
+		}
+
+		// This applies for rendering the block front-end, but not for editing it.
+		if ( $is_rendering_block ) {
+			$acceptable_types = explode( ',', $types );
+
+			$top_posts = array_filter(
+				$top_posts,
+				function ( $item ) use ( $acceptable_types ) {
+					return in_array( $item['type'], $acceptable_types, true );
+				}
+			);
+
+			$top_posts = array_slice( $top_posts, 0, $items_count );
+		}
+
+		return $top_posts;
+	}
+}

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
@@ -12,11 +12,11 @@ use Automattic\Jetpack\Stats\WPCOM_Stats;
  */
 class Jetpack_Top_Posts_Helper {
 	/**
-	 * Returns user's top posts. 
+	 * Returns user's top posts.
 	 *
-	 * @param int $period       Period of days to draw stats from.
-	 * @param int $items_count  Number of items to display.
-	 * @param string $types     Content types to include.
+	 * @param int    $period       Period of days to draw stats from.
+	 * @param int    $items_count  Number of items to display.
+	 * @param string $types        Content types to include.
 	 * @return array
 	 */
 	public static function get_top_posts( $period, $items_count, $types ) {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-top-posts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-top-posts.php
@@ -5,8 +5,6 @@
  * @package automattic/jetpack
  */
 
-use Automattic\Jetpack\Stats\WPCOM_Stats;
-
 /**
  * Top Posts & Pages block endpoint.
  */
@@ -16,6 +14,10 @@ class WPCOM_REST_API_V2_Endpoint_Top_Posts extends WP_REST_Controller {
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+
+		if ( ! class_exists( 'Jetpack_Top_Posts_Helper' ) ) {
+			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-top-posts-helper.php';
+		}
 	}
 
 	/**
@@ -104,105 +106,10 @@ class WPCOM_REST_API_V2_Endpoint_Top_Posts extends WP_REST_Controller {
 	 * @return array Data on top posts.
 	 */
 	public function get_top_posts( $request ) {
-		$period        = $request->get_param( 'period' );
-		$all_time_days = floor( ( time() - strtotime( get_option( 'site_created_date' ) ) ) / ( 60 * 60 * 24 * 365 ) );
-
-		// While we only display ten posts, users can filter out content types.
-		// As such, we should obtain a few spare posts from the Stats endpoint.
-		$posts_to_obtain_count = 30;
-
-		// We should not override cache when displaying the block on the frontend.
-		// But we should allow instant preview of changes when editing the block.
-		$is_rendering_block = isset( $request['types'] );
-		$override_cache     = ! $is_rendering_block;
-
-		$query_args = array(
-			'max'       => $posts_to_obtain_count,
-			'summarize' => true,
-			'num'       => $period !== 'all-time' ? $period : $all_time_days,
-			'period'    => 'day',
-		);
-
-		$data = ( new WPCOM_Stats() )->get_top_posts( $query_args, $override_cache );
-
-		if ( is_wp_error( $data ) ) {
-			$data = array( 'summary' => array( 'postviews' => array() ) );
-		}
-
-		$posts_retrieved = count( $data['summary']['postviews'] );
-
-		// Fallback to random posts if user does not have enough top content.
-		if ( $posts_retrieved < $posts_to_obtain_count ) {
-			$args = array(
-				'numberposts' => $posts_to_obtain_count - $posts_retrieved,
-				'exclude'     => array_column( $data['summary']['postviews'], 'id' ),
-				'orderby'     => 'rand',
-				'post_status' => 'publish',
-			);
-
-			$random_posts = get_posts( $args );
-
-			foreach ( $random_posts as $post ) {
-				$random_posts_data = array(
-					'id'     => $post->ID,
-					'href'   => get_permalink( $post->ID ),
-					'date'   => $post->post_date,
-					'title'  => $post->post_title,
-					'type'   => 'post',
-					'public' => true,
-				);
-
-				$data['summary']['postviews'][] = $random_posts_data;
-			}
-
-			$data['summary']['postviews'] = array_slice( $data['summary']['postviews'], 0, 10 );
-		}
-
-		$top_posts = array();
-
-		foreach ( $data['summary']['postviews'] as $post ) {
-			$post_id   = $post['id'];
-			$thumbnail = get_the_post_thumbnail_url( $post_id );
-
-			if ( ! $thumbnail ) {
-				$post_images = get_attached_media( 'image', $post_id );
-				$post_image  = reset( $post_images );
-				if ( $post_image ) {
-					$thumbnail = wp_get_attachment_url( $post_image->ID );
-				}
-			}
-
-			if ( $post['public'] ) {
-				$top_posts[] = array(
-					'id'        => $post_id,
-					'author'    => get_the_author_meta( 'display_name', get_post_field( 'post_author', $post_id ) ),
-					'context'   => get_the_category( $post_id ) ? get_the_category( $post_id ) : get_the_tags( $post_id ),
-					'href'      => $post['href'],
-					'date'      => get_the_date( '', $post_id ),
-					'title'     => $post['title'],
-					'type'      => $post['type'],
-					'public'    => $post['public'],
-					'views'     => isset( $post['views'] ) ? $post['views'] : 0,
-					'thumbnail' => $thumbnail,
-				);
-			}
-		}
-
-		// This applies for rendering the block front-end, but not for editing it.
-		if ( $is_rendering_block ) {
-			$acceptable_types = explode( ',', $request->get_param( 'types' ) );
-
-			$top_posts = array_filter(
-				$top_posts,
-				function ( $item ) use ( $acceptable_types ) {
-					return in_array( $item['type'], $acceptable_types, true );
-				}
-			);
-
-			$top_posts = array_slice( $top_posts, 0, $request->get_param( 'number' ) );
-		}
-
-		return $top_posts;
+		$period = $request->get_param( 'period' );
+		$number = $request->get_param( 'number' );
+		$types  = $request->get_param( 'types' );
+		return Jetpack_Top_Posts_Helper::get_top_posts( $period, $number, $types );
 	}
 }
 

--- a/projects/plugins/jetpack/changelog/update-top-posts-endpoint
+++ b/projects/plugins/jetpack/changelog/update-top-posts-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Top Posts and Pages block: refactor endpoint to use helper.

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
@@ -13,6 +13,11 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
 use Jetpack_Gutenberg;
+use Jetpack_Top_Posts_Helper;
+
+if ( ! class_exists( 'Jetpack_Top_Posts_Helper' ) ) {
+	require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-top-posts-helper.php';
+}
 
 /**
  * Registers the block for use in Gutenberg
@@ -46,19 +51,15 @@ function load_assets( $attributes ) {
 	/*
 	 * We cannot rely on obtaining posts from the block because
 	 * top posts might have changed since then. As such, we must
-	 * make another request to check for updated stats.
+	 * check for updated stats.
 	 */
-	$request_url = sprintf(
-		'/wp-json/wpcom/v2/top-posts?period=%1$s&number=%2$s&types=%3$s',
-		$attributes['period'],
-		$attributes['postsToShow'],
-		implode( ',', array_keys( array_filter( $attributes['postTypes'] ) ) )
-	);
+	$period = $attributes['period'];
+	$number = $attributes['postsToShow'];
+	$types  = implode( ',', array_keys( array_filter( $attributes['postTypes'] ) ) );
 
-	$request = wp_remote_get( home_url( $request_url ) );
-	$data    = json_decode( wp_remote_retrieve_body( $request ), true );
+	$data = Jetpack_Top_Posts_Helper::get_top_posts( $period, $number, $types );
 
-	if ( is_wp_error( $request ) || ! is_array( $data ) ) {
+	if ( ! is_array( $data ) ) {
 		return;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
@@ -101,7 +101,7 @@ function load_assets( $attributes ) {
 
 		if ( $attributes['displayContext'] && ! empty( $item['context'] ) && is_array( $item['context'] ) ) {
 			$context = reset( $item['context'] );
-			$output .= '<a class="jetpack-top-posts-context has-small-font-size" href="' . esc_url( get_category_link( $context['term_id'] ) ) . '">' . esc_html( $context['name'] ) . '</a>';
+			$output .= '<a class="jetpack-top-posts-context has-small-font-size" href="' . esc_url( get_category_link( $context->term_id ) ) . '">' . esc_html( $context->name ) . '</a>';
 		}
 
 		$output .= '</div>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addresses https://github.com/Automattic/jetpack/pull/34153#discussion_r1416408893

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refactors the endpoint used by the Top Posts and Pages block to use a helper function, which also avoids making an extra API request when rendering the block. cc @kangzj 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See https://github.com/Automattic/jetpack/pull/34153#discussion_r1416408893

> I'm wondering whether the remote request could be saved by calling a function that returns top posts, which could save us the HTTP request overhead, and hence improve the performance of the block. More importantly, it would work with WP.COM with no issues. To accomplish this, we could refactor the following code to a helper or something be shared by the API and the block.


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

You'll need to enable Beta blocks to use the Top Posts & Pages block. Confirm that after inserting it, there's still content displaying. You can also make a request here and there should be no difference to what currently happens: `/wp-json/wpcom/v2/top-posts?period=1&number=3&types=post,page`

Changing `number` should ensure the endpoint returns that number of items; `types` can be used to set the content types which are included. 
