### PR TITLE
Launchpad: Complete the plan tasks after upgrade

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-launchpad-complete-task-after-upgrade
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-launchpad-complete-task-after-upgrade
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: Complete the plan tasks when the user purchses a plan

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -94,7 +94,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
 			},
+			'subtitle'             => 'wpcom_launchpad_get_plan_selected_subtitle',
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'badge_text_callback'  => 'wpcom_launchpad_get_plan_selected_badge_text',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$flow = get_option( 'site_intent' );
 				return '/setup/' . $flow . '/plans?siteSlug=' . $data['site_slug_encoded'];
@@ -1904,6 +1906,25 @@ function wpcom_launchpad_mark_domain_tasks_complete( $blog_id, $user_id, $produc
 	wpcom_mark_launchpad_task_complete( 'domain_upsell_deferred' );
 }
 add_action( 'activate_product', 'wpcom_launchpad_mark_domain_tasks_complete', 10, 6 );
+
+/**
+ * Mark `plan_selected`, and `plan_completed` tasks complete when a plan product is purchased.
+ *
+ * @param int $blog_id The blog ID.
+ *
+ * @return void
+ */
+function wpcom_launchpad_mark_plan_tasks_complete( $blog_id ) {
+	require_once WP_CONTENT_DIR . '/admin-plugins/wpcom-billing.php';
+	$current_plan = WPCOM_Store_API::get_current_plan( $blog_id );
+	if ( $current_plan['is_free'] ) {
+		return;
+	}
+
+	wpcom_mark_launchpad_task_complete( 'plan_selected' );
+	wpcom_mark_launchpad_task_complete( 'plan_completed' );
+}
+add_action( 'activate_product', 'wpcom_launchpad_mark_plan_tasks_complete', 10, 6 );
 
 /**
  * Re-trigger email campaigns for blog onboarding after user edit one of the fields in the launchpad.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/83390

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Mark the plan tasks as completed once the user purchases a plan

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync the changes to your sandbox
  ```
  bin/jetpack-downloader test jetpack-mu-wpcom-plugin feat/launchpad-complete-task-after-upgrade
  ```
* Use the Calypso Live URL from https://github.com/Automattic/wp-calypso/pull/84854#issuecomment-1840341518 as that PR adds the plan step to the assembler-first flow
* Go to `/setup/assembler-first` to create a new site
* On the Assembler step
  * Select any patterns
  * Select any styles
  * Upgrade to the Premium plan immediately
 * Finish the Assembler step
* Go to the launchpad, `/setup/assembler-first/launchpad?siteSlug=<your_site>`
* Ensure the “Choose a plan” task is completed