### PR TITLE
Repo Gardening: fix event trigger name

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-update-board-trigger-reference
+++ b/projects/github-actions/repo-gardening/changelog/fix-update-board-trigger-reference
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Automated Board triage: fix event reference to trigger the action.

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -89,7 +89,7 @@ const automations = [
 	},
 	{
 		event: 'issues',
-		action: [ 'labeled', 'created' ],
+		action: [ 'labeled', 'opened' ],
 		task: updateBoard,
 	},
 ];


### PR DESCRIPTION
## Proposed changes:

Follow-up to #34313. Issues are "opened", not "created".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test on this one, you can check other `issues` triggers on that same file, just above.
