### PR TITLE
Issue references triage: update matching for p2 comments

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-support-reference-matches
+++ b/projects/github-actions/repo-gardening/changelog/update-support-reference-matches
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Issue references triage: update matching for p2 comments
+
+

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -88,7 +88,7 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 			correctedSupportIds.add( correctedId );
 		} else {
 			// Switch to lowercase when it's not a p2 comment reference.
-			const standardizedsupportId = supportId.includes( '#comment' )
+			const standardizedsupportId = supportId.match( /[a-zA-Z0-9-]+-p2#comment-[0-9]*/ )
 				? supportId
 				: supportId.toLowerCase();
 			correctedSupportIds.add( standardizedsupportId );


### PR DESCRIPTION
See https://github.com/Automattic/jetpack/pull/34426#discussion_r1416019636

## Proposed changes:

Follow-up to #34426. A small update to be more precise in matching p2 comments.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Same as #34426
