### PR TITLE
tools: Read `.require.php` in parallel-lint

### DIFF
--- a/tools/parallel-lint.sh
+++ b/tools/parallel-lint.sh
@@ -24,16 +24,24 @@ done
 
 if $ALL; then
 	SKIPS=()
-	if php -r 'exit( PHP_VERSION_ID < 70000 ? 0 : 1 );'; then
-		SKIPS+=( -o -name php7 )
-	fi
-	if php -r 'exit( PHP_VERSION_ID < 70400 ? 0 : 1 );'; then
-		# Plugin requires PHP 7.4 or later.
-		SKIPS+=( -o -path ./projects/plugins/inspect )
-		SKIPS+=( -o -path ./projects/plugins/crm )
-	fi
+
+	# Generic directories for later-version compat code.
 	if php -r 'exit( PHP_VERSION_ID < 80000 ? 0 : 1 );'; then
 		SKIPS+=( -o -name php8 )
+	fi
+
+	# Read `.require.php` from composer.json.
+	while IFS=$'\t' read -r FILE OP VER; do
+		if ! php -r 'exit( version_compare( PHP_VERSION, $argv[2], $argv[1] ) ? 0 : 1 );' "$OP" "$VER"; then
+			SKIPS+=( -o -path "${FILE%/composer.json}" )
+		fi
+	done < <( jq -r '.require.php // "" | capture( "^(?<op>>=)(?<ver>[0-9][0-9.]*)$" ) | [ input_filename, .op, .ver ] | @tsv' ./projects/*/*/composer.json )
+
+	# Plugins requirng PHP 7.4 or later.
+	# @todo Add `.require.php` in their composer.json and remove this.
+	if php -r 'exit( PHP_VERSION_ID < 70400 ? 0 : 1 );'; then
+		SKIPS+=( -o -path ./projects/plugins/inspect )
+		SKIPS+=( -o -path ./projects/plugins/crm )
 	fi
 
 	find . \( \
@@ -43,6 +51,7 @@ if $ALL; then
 		-o -name wordpress \
 		-o -name wordpress-develop \
 		-o -name node_modules \
+		-o -path ./tools/docker/data \
 		"${SKIPS[@]}" \
 	\) -prune -o -name '*.php' -print | vendor/bin/parallel-lint --stdin "${ARGS[@]}"
 else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Since we're specifying `.require.php` in all packages now, let's have parallel-lint read it and automatically skip packages that require a newer version of PHP than what's running.

Also, since we're here, some additional incidental cleanups:
- Remove handling for `php7/` dirs since 7.0 is now the minimum.
- Ignore `tools/docker/data/` so local runs don't complain about it being unreadable.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/34462#discussion_r1417906443

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Try making a PR adding use of new syntax in a project that has a `.require.php` for a corresponding version. CI still happy?
