### PR TITLE
Launchpad: Add context param to endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-context-for-api-requests
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-context-for-api-requests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: Added context param to endpoint.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -49,7 +49,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.3.x-dev"
+			"dev-trunk": "5.4.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.3.0",
+	"version": "5.4.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.3.0';
+	const PACKAGE_VERSION = '5.4.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -295,7 +295,7 @@ class Launchpad_Task_Lists {
 	 *
 	 * @return Task[] Collection of tasks associated with a task list.
 	 */
-	public function build( $id, $launchpad_context ) {
+	public function build( $id, $launchpad_context = null ) {
 		$task_list           = $this->get_task_list( $id );
 		$tasks_for_task_list = array();
 
@@ -342,7 +342,7 @@ class Launchpad_Task_Lists {
 	 * @param string $launchpad_context Screen where Laucnhpad is loading.
 	 * @return Task Task with current state.
 	 */
-	private function build_task( $task, $launchpad_context ) {
+	private function build_task( $task, $launchpad_context = null ) {
 		$built_task = array(
 			'id' => $task['id'],
 		);
@@ -464,7 +464,7 @@ class Launchpad_Task_Lists {
 	 * @param string $launchpad_context Screen where Launchpad is loading.
 	 * @return string|null
 	 */
-	private function load_calypso_path( $task, $launchpad_context ) {
+	private function load_calypso_path( $task, $launchpad_context = null ) {
 		if ( null === $this->site_slug ) {
 			$this->site_slug = wpcom_get_site_slug();
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -291,10 +291,11 @@ class Launchpad_Task_Lists {
 	 * Builds a collection of tasks for a given task list
 	 *
 	 * @param string $id Task list id.
+	 * @param string $launchpad_context Context/screen in which launchpad is loading.
 	 *
 	 * @return Task[] Collection of tasks associated with a task list.
 	 */
-	public function build( $id ) {
+	public function build( $id, $launchpad_context ) {
 		$task_list           = $this->get_task_list( $id );
 		$tasks_for_task_list = array();
 
@@ -312,7 +313,7 @@ class Launchpad_Task_Lists {
 
 			// if task can't be found don't add anything
 			if ( $this->is_visible( $task_definition ) ) {
-				$tasks_for_task_list[] = $this->build_task( $task_definition );
+				$tasks_for_task_list[] = $this->build_task( $task_definition, $launchpad_context );
 			}
 		}
 
@@ -337,10 +338,11 @@ class Launchpad_Task_Lists {
 	/**
 	 * Builds a single task with current state
 	 *
-	 * @param Task $task Task definition.
+	 * @param Task   $task Task definition.
+	 * @param string $launchpad_context Screen where Laucnhpad is loading.
 	 * @return Task Task with current state.
 	 */
-	private function build_task( $task ) {
+	private function build_task( $task, $launchpad_context ) {
 		$built_task = array(
 			'id' => $task['id'],
 		);
@@ -363,7 +365,7 @@ class Launchpad_Task_Lists {
 		}
 
 		if ( isset( $task['get_calypso_path'] ) ) {
-			$calypso_path = $this->load_calypso_path( $task );
+			$calypso_path = $this->load_calypso_path( $task, $launchpad_context );
 
 			if ( ! empty( $calypso_path ) ) {
 				$built_task['calypso_path'] = $calypso_path;
@@ -458,10 +460,11 @@ class Launchpad_Task_Lists {
 	/**
 	 * Helper function to load the Calypso path for a task.
 	 *
-	 * @param array $task A task definition.
+	 * @param array  $task A task definition.
+	 * @param string $launchpad_context Screen where Launchpad is loading.
 	 * @return string|null
 	 */
-	private function load_calypso_path( $task ) {
+	private function load_calypso_path( $task, $launchpad_context ) {
 		if ( null === $this->site_slug ) {
 			$this->site_slug = wpcom_get_site_slug();
 		}
@@ -469,6 +472,7 @@ class Launchpad_Task_Lists {
 		$data = array(
 			'site_slug'         => $this->site_slug,
 			'site_slug_encoded' => rawurlencode( $this->site_slug ),
+			'launchpad_context' => $launchpad_context,
 		);
 
 		$calypso_path = $this->load_value_from_callback( $task, 'get_calypso_path', null, $data );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -339,7 +339,7 @@ class Launchpad_Task_Lists {
 	 * Builds a single task with current state
 	 *
 	 * @param Task   $task Task definition.
-	 * @param string $launchpad_context Screen where Laucnhpad is loading.
+	 * @param string $launchpad_context Screen where Launchpad is loading.
 	 * @return Task Task with current state.
 	 */
 	private function build_task( $task, $launchpad_context = null ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -189,11 +189,12 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_visible_callback' => 'wpcom_launchpad_has_goal_paid_subscribers',
 			'get_calypso_path'    => function ( $task, $default, $data ) {
 				if ( function_exists( 'get_memberships_connected_account_redirect' ) ) {
-					return get_memberships_connected_account_redirect(
-						get_current_user_id(),
-						get_current_blog_id(),
-						$data['launchpad_context']
-					);
+					$user_id = get_current_user_id();
+					$blog_id = get_current_blog_id();
+					$source = $data['launchpad_context'];
+					return $source
+						? get_memberships_connected_account_redirect( $user_id, $blog_id, $source )
+						: get_memberships_connected_account_redirect( $user_id, $blog_id );
 				}
 				return '/earn/payments/' . $data['site_slug_encoded'];
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -191,7 +191,8 @@ function wpcom_launchpad_get_task_definitions() {
 				if ( function_exists( 'get_memberships_connected_account_redirect' ) ) {
 					return get_memberships_connected_account_redirect(
 						get_current_user_id(),
-						get_current_blog_id()
+						get_current_blog_id(),
+						$data['launchpad_context']
 					);
 				}
 				return '/earn/payments/' . $data['site_slug_encoded'];

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -407,15 +407,16 @@ function wpcom_is_checklist_task_complete( $task_id ) {
  * Returns launchpad checklist by checklist slug.
  *
  * @param string $checklist_slug Checklist slug.
+ * @param string $launchpad_context Screen where Launchpad is loading.
  *
  * @return Task[] Collection of tasks for a given checklist
  */
-function wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug ) {
+function wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context ) {
 	if ( ! $checklist_slug ) {
 		return array();
 	}
 
-	return wpcom_launchpad_checklists()->build( $checklist_slug );
+	return wpcom_launchpad_checklists()->build( $checklist_slug, $launchpad_context );
 }
 
 // TODO: Write code p2 post or dotcom post

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -411,7 +411,7 @@ function wpcom_is_checklist_task_complete( $task_id ) {
  *
  * @return Task[] Collection of tasks for a given checklist
  */
-function wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context ) {
+function wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context = null ) {
 	if ( ! $checklist_slug ) {
 		return array();
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -143,11 +143,15 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	public function get_data( $request ) {
 		$checklist_slug = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );
 
+		$launchpad_context = isset( $request['launchpad_context'] )
+			? sanitize_text_string( $request['checklist_slug'] )
+			: null;
+
 		return array(
 			'site_intent'        => get_option( 'site_intent' ),
 			'launchpad_screen'   => get_option( 'launchpad_screen' ),
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
-			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
+			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context ),
 			'is_enabled'         => wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ),
 			'is_dismissed'       => wpcom_launchpad_is_task_list_dismissed( $checklist_slug ),
 			'title'              => wpcom_get_launchpad_checklist_title_by_checklist_slug( $checklist_slug ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -144,7 +144,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 		$checklist_slug = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );
 
 		$launchpad_context = isset( $request['launchpad_context'] )
-			? sanitize_text_string( $request['checklist_slug'] )
+			? $request['launchpad_context']
 			: null;
 
 		return array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -36,10 +36,14 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_data' ),
 					'permission_callback' => array( $this, 'can_access' ),
 					'args'                => array(
-						'checklist_slug' => array(
+						'checklist_slug'    => array(
 							'description' => 'Checklist slug',
 							'type'        => 'string',
 							'enum'        => $this->get_checklist_slug_enums(),
+						),
+						'launchpad_context' => array(
+							'description' => 'Screen where Launchpand instance is loaded.',
+							'type'        => 'string',
 						),
 					),
 				),

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-context-for-api-requests
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-context-for-api-requests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "ed1e289e5546d515831427073252671aabfec269"
+                "reference": "208bc96ac854f49e4793bc0d3665ee5d1ed970f7"
             },
             "require": {
                 "php": ">=7.0"
@@ -33,7 +33,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.3.x-dev"
+                    "dev-trunk": "5.4.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
**Companion to:**
D131162-code
https://github.com/Automattic/wp-calypso/pull/84929

## Proposed changes:

* Updates the Launchpad endpoint to take in a 'launchpad_context' parameter. 
* Passes this parameter down to get_memberships_connected_account_redirect() method. Doing so will allow us to redirect users back to the Launchpad screen/context where they initiated the stripe connection.
* Must be tested alongside these: 
   - Backend diff (updates redirect logic based on new context/source): D131162-code
   - Frontend PR (passes the new laucnchpad_context param to the endpoint): https://github.com/Automattic/wp-calypso/pull/84929
 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Test that new param works. This is difficult to test in isolation. You can test it together with the associated diff/frontend pr by following the testing instructions here: https://github.com/Automattic/wp-calypso/pull/84929

2) Confirm no regressions/breakages. Because we're updating common Launchpad endpoint/logic, we want to be sure that existing Launchpad instances (that do not pass the context) all continue to work as before. 
   - Load this branch in your sandbox by running `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-context-for-api-requests`
   - Sandbox public-api
   - Start a newsletter site at https://wordpress.com/setup/newsletter/intro, select the paid option, go through to Launchpad, and confirm you can complete all tasks as needed. 
   - Start any other kind of site, go to Launchpad or My Home Launchpad, and confirm Launchpad loads and behaves as before. 