### PR TITLE
Jetpack Debug Helper: Use error_log if l() is not defined in XML-RPC logger

### DIFF
--- a/projects/plugins/debug-helper/changelog/update-use-error_log_not_l_xmlrpc_logger
+++ b/projects/plugins/debug-helper/changelog/update-use-error_log_not_l_xmlrpc_logger
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Resort to error_log if l() is not available

--- a/projects/plugins/debug-helper/composer.json
+++ b/projects/plugins/debug-helper/composer.json
@@ -23,6 +23,8 @@
 		"version-constants": {
 			"JETPACK_DEBUG_HELPER_VERSION": "plugin.php"
 		},
+		"release-branch-prefix": "debug-helper",
+		"beta-plugin-slug": "jetpack-debug-helper",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-debug-helper/compare/v${old}...v${new}"
 		}

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b93c13c400642c5a702ebc5ab0805c7",
+    "content-hash": "90508ab73efdc01ec5346540c36554d7",
     "packages": [],
     "packages-dev": [
         {

--- a/projects/plugins/debug-helper/modules/class-xmlrpc-logger.php
+++ b/projects/plugins/debug-helper/modules/class-xmlrpc-logger.php
@@ -154,6 +154,27 @@ class XMLRPC_Logger {
 	}
 
 	/**
+	 * Logs a message.
+	 *
+	 * Checks if WP_DEBUG_LOG is enabled and logs the message.
+	 * If the l() function exists, it is used to log the message.
+	 * Otherwise, the message is logged using error_log().
+	 *
+	 * @param string $message The message to log.
+	 */
+	public function log( $message ) {
+		if ( ! ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) ) {
+			return;
+		}
+		if ( function_exists( 'l' ) ) {
+			l( $message );
+		} else {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( $message );
+		}
+	}
+
+	/**
 	 * Logs the XML-RPC request.
 	 * Captures the request data, formats it, and logs it if WP_DEBUG_LOG is enabled.
 	 */
@@ -161,7 +182,7 @@ class XMLRPC_Logger {
 		// Load the XML from the raw POST data
 		$xml_string = file_get_contents( 'php://input' );
 		if ( ! $xml_string ) {
-			l( 'XML-RPC Request: Empty payload' );
+			$this->log( 'XML-RPC Request: Empty payload' );
 			return;
 		}
 		libxml_use_internal_errors( true );
@@ -177,10 +198,10 @@ class XMLRPC_Logger {
 			if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
 				$log_message  = "XML-RPC Request - Method: $method_name\n";
 				$log_message .= "Payload:\n" . $formatted . "\n";
-				l( $log_message );
+				$this->log( $log_message );
 			}
 		} else {
-			l( 'XML-RPC Request: Invalid XML - ' . libxml_get_errors()[0]->message );
+			$this->log( 'XML-RPC Request: Invalid XML - ' . libxml_get_errors()[0]->message );
 			libxml_clear_errors();
 			return;
 		}


### PR DESCRIPTION
This PR introduces a new method log to the XML-RPC Logger module in the Jetpack Debug Helper plugin.
Follow-up to https://github.com/Automattic/jetpack/pull/34487

This method checks if WP_DEBUG_LOG is enabled and logs the provided message. It uses the l function if available, otherwise, it falls back to error_log.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Makes it compatible with environments where `l()` is not defined.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-DN-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

### In local docker environment

* Check out this branch in your local environment
* Activate the **Jetpack Debug Tools** plugin
* Visit the menu item Jetpack Debug
  * Enable the **XMLRPC Logger** checkbox
  <img width="505" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/15b21cd0-45f8-474a-ac1e-1fb6fd25cd1d">
* In a terminal run `jetpack docker tail`
* Assuming your site is connected and reachable from the web, visit Calypso (any page)
* Expect to see an XML-RPC request logged

### In Jurassic Ninja site

* Launch a [Jurassic Ninja site with the Jetpack Debug Helper running this branch](https://jurassic.ninja/create?jetpack-beta&branches.jetpack-debug-helper=update/use-error_log_not_l_xmlrpc_logger&wp-debug-log)
* Visit the menu item Jetpack Debug
  * Enable the **XMLRPC Logger** checkbox
  <img width="505" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/15b21cd0-45f8-474a-ac1e-1fb6fd25cd1d">
* `tail -f` the `debug.log` file.
* Visit Calypso for the Jetpack site (any page like stats)
* Expect to see an XML-RPC request logged in the `debug.log` file
