### PR TITLE
Subscriptions: Fix subscriptions new subscriber issue

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-new-subscriber-subscribe-box
+++ b/projects/plugins/jetpack/changelog/fix-new-subscriber-subscribe-box
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Keeps subscribe box visible but not usable when a subscription token is found in the browser's cookie.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -535,8 +535,6 @@ function render_block( $attributes ) {
 		Jetpack_Gutenberg::load_styles_as_required( FEATURE_NAME );
 	}
 
-	apply_filters( 'jetpack_auto_fill_logged_in_user', '_return true' );
-
 	/** This filter is documented in modules/contact-form/grunion-contact-form.php */
 	if ( is_wpcom() || false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
 		$token_subscribe_email = Jetpack_Memberships::get_current_user_email();
@@ -658,11 +656,12 @@ function render_for_website( $data, $classes, $styles ) {
 							class="screen-reader-text"
 						>
 							<?php
-								if ( $is_subscribed ) {
-									echo esc_html( $data['subscribe_email'] );
-								 } else {
-									echo esc_html( $data['subscribe_placeholder'] );
-								 } ?>
+							if ( $is_subscribed ) {
+								echo esc_html( $data['subscribe_email'] );
+							} else {
+								echo esc_html( $data['subscribe_placeholder'] );
+							}
+							?>
 						</label>
 						<?php
 						printf(

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -629,7 +629,7 @@ function render_for_website( $data, $classes, $styles ) {
 
 	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );
 	$tier_id            = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
-	$is_subscribed      = Jetpack_Memberships::is_current_user_subscribed() || is_user_auth();
+	$is_subscribed      = Jetpack_Memberships::is_current_user_subscribed() || Jetpack_Token_Subscription_Service::has_token_from_cookie();
 	$button_text        = get_submit_button_text( $data );
 
 	ob_start();
@@ -641,7 +641,7 @@ function render_for_website( $data, $classes, $styles ) {
 	);
 	?>
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
-		<div class="wp-block-jetpack-subscriptions__container<?php echo ! $is_subscribed ? ' is-not-subscriber' : 'is_subscriber'; ?>">
+		<div class="wp-block-jetpack-subscriptions__container<?php echo ! $is_subscribed ? ' is-not-subscriber' : ' is_subscriber'; ?>">
 			<form
 				action="<?php echo esc_url( $form_url ); ?>"
 				method="post"
@@ -930,7 +930,7 @@ function get_current_url() {
  * @return string
  */
 function get_submit_button_text( $data ) {
-	if ( ! Jetpack_Memberships::is_current_user_subscribed() && ! is_user_auth() ) {
+	if ( ! Jetpack_Memberships::is_current_user_subscribed() && ! Jetpack_Token_Subscription_Service::has_token_from_cookie() ) {
 		return $data['submit_button_text'];
 	}
 	if ( ! Jetpack_Memberships::user_can_view_post() ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -685,7 +685,7 @@ function render_for_website( $data, $classes, $styles ) {
 								: 'width: 95%; padding: 1px 10px'
 							),
 							$is_subscribed ? esc_attr( $data['subscribe_email'] ) : esc_attr( $data['subscribe_placeholder'] ),
-							esc_attr( $data['subscribe_email'] ),
+							$is_subscribed ? '' : esc_attr( $data['subscribe_email'] ),
 							esc_attr( $subscribe_field_id ),
 							$is_subscribed ? 'disabled' : ''
 						);

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -535,11 +535,14 @@ function render_block( $attributes ) {
 		Jetpack_Gutenberg::load_styles_as_required( FEATURE_NAME );
 	}
 
+	$token_subscribe_email = Jetpack_Memberships::get_current_user_email();
+
 	/** This filter is documented in modules/contact-form/grunion-contact-form.php */
 	if ( is_wpcom() || false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
-		$token_subscribe_email = Jetpack_Memberships::get_current_user_email();
-		$current_user          = wp_get_current_user();
-		$subscribe_email       = ! empty( $current_user->user_email ) ? $current_user->user_email : $token_subscribe_email;
+		$current_user    = wp_get_current_user();
+		$subscribe_email = ! empty( $current_user->user_email ) ? $current_user->user_email : $token_subscribe_email;
+	} else {
+		$subscribe_email = $token_subscribe_email ?? '';
 	}
 
 	// The block is using the Jetpack_Subscriptions_Widget backend, hence the need to increase the instance count.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -32,13 +32,11 @@
 		flex-direction: column;
 	}
 
-	&:not(.wp-block-jetpack-subscriptions__use-newline) 
+	&:not(.wp-block-jetpack-subscriptions__use-newline)
 	{
-		.is-not-subscriber {
-			.wp-block-jetpack-subscriptions__form-elements {
-				display: flex;
-				align-items: flex-start;
-			}
+		.wp-block-jetpack-subscriptions__form-elements {
+			display: flex;
+			align-items: flex-start;
 		}
 		p#subscribe-submit {
 			justify-content: center;

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -17,7 +17,7 @@ export function handleIframeResult( eventFromIframe ) {
 		}
 		if ( data && data.action === 'close' && premiumContentJWTTokenForCookie ) {
 			// The token was set during the purchase flow, we want to reload the whole page so the content is displayed
-			window.location.reload();
+			window.location.reload( true );
 		} else if ( data && data.action === 'close' ) {
 			// User just aborted.
 			window.removeEventListener( 'message', handleIframeResult );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/238

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the way the subscriber box responds when a user enters in an email and the page reloads. Previously, the page would simply reload, and it would give no indication that the signup succeeded after the confirmation modal; it would appear as if they could sign up again. On Firefox, it would also put in the email address that was just entered in, further indicating that maybe something went wrong. In reality, the signup succeeded.

With these changes, the user will enter an email and hit Enter or click Subscribe. They will get the plan selection (if plans exist) or the confirmation modal popup. Upon going through those modals, the page reloads, and pulls the email address from the token that will be set during the signup. It changes the email field's placeholder to that email address, and disables the form field. Additionally, the subscribe button text switches to "Manage Subscriptions", and clicking will send the user to `https://wordpress.com/email-subscriptions` so they can manage their subscriptions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This diff should be tested on both WPCOM and Jetpack/Jurassic Ninja sites.

* Create a Subscribe block on a test site.
* Sign up and select the Free plan (if you have plans on the site). Continue through the modal(s) otherwise.
* Upon page reload, note that the email field should be disabled, and show the email you signed up with. The Subscribe button should have also changed to Manage Subscriptions and go to `https://wordpress.com/email-subscriptions` when clicked.
* Additionally, on Firefox, make sure that the email address is light gray and not black after the page reload.

**Result**
![Screenshot 2023-12-06 at 3 19 02 PM](https://github.com/Automattic/jetpack/assets/8002138/fc8adcb7-26c5-43e5-bc21-52ec8fae80b6)