### PR TITLE
Super Cache: Add "days" time to the "next preload scheduled" notice

### DIFF
--- a/projects/plugins/super-cache/changelog/update-supercache_next_preload_time
+++ b/projects/plugins/super-cache/changelog/update-supercache_next_preload_time
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Supercache: add "days" to "Next preload scheduled" message.

--- a/projects/plugins/super-cache/js/preload-notification.js
+++ b/projects/plugins/super-cache/js/preload-notification.js
@@ -79,6 +79,7 @@ jQuery( document ).ready( function () {
 				const seconds = diff % 60;
 				const minutes = Math.floor( diff / 60 ) % 60;
 				const hours = Math.floor( diff / 3600 ) % 24;
+				const days = Math.floor( diff / 86400 );
 
 				// If we're preloading within the next minute, start loading faster.
 				if ( minutes + hours === 0 ) {
@@ -89,11 +90,12 @@ jQuery( document ).ready( function () {
 				p.append(
 					jQuery( '<b>' ).html(
 						sprintf(
-							/* Translators: 1: Number of hours, 2: Number of minutes, 3: Number of seconds */
+							/* Translators: 1: Number of days, 2: Number of hours, 3: Number of minutes, 4: Number of seconds */
 							__(
-								'<b>Next preload scheduled</b> in %1$s hours, %2$s minutes and %3$s seconds.',
+								'<b>Next preload scheduled</b> in %1$s days, %2$s hours, %3$s minutes and %4$s seconds.',
 								'wp-super-cache'
 							),
+							days,
 							hours,
 							minutes,
 							seconds


### PR DESCRIPTION
The notice displayed to users when the preload was set to more than a day away did not include the number of days.
This PR adds that number to the notice.

ref: https://wordpress.org/support/topic/refresh-preload-issues/

## Proposed changes:
* Add "days" time to js/preload-notification.js

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1701848747611459-slack-C016BBAFHHS


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Go to the Preload page and set the preload interval to 10080 minutes and save settings.
* Start a preload and when it completes, the "next preload" notice will be missing the number of days
* Apply the PR.
* Reload the "Preload" settings page, and the notice will now include the number of days.