### PR TITLE
Launchpad: Complete the task, Personalize your site, when the user updates the site title, site tagline or site logo

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-launchpad-complete-setup-free-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-launchpad-complete-setup-free-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: Complete the task, Personalize your site, when the user updates the site title, site tagline or site logo

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -305,7 +305,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Personalize your site', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => '__return_true',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},
@@ -1352,6 +1352,32 @@ function wpcom_launchpad_mark_site_title_complete( $old_value, $value ) {
 	}
 }
 add_action( 'update_option_blogname', 'wpcom_launchpad_mark_site_title_complete', 10, 3 );
+
+/**
+ * Mark the setup site task as complete if the value is changed.
+ *
+ * @param string $old_value The old value of the site title.
+ * @param string $value The new value of the site title.
+ *
+ * @return void
+ */
+function wpcom_launchpad_mark_setup_site_tasks_complete( $old_value, $value ) {
+	if ( defined( 'HEADSTART' ) && HEADSTART ) {
+		return;
+	}
+
+	if ( wp_installing() ) {
+		return;
+	}
+
+	if ( $value !== $old_value ) {
+		wpcom_mark_launchpad_task_complete( 'setup_free' );
+	}
+}
+add_action( 'update_option_blogname', 'wpcom_launchpad_mark_setup_site_tasks_complete', 10, 3 );
+add_action( 'update_option_blogdescription', 'wpcom_launchpad_mark_setup_site_tasks_complete', 10, 3 );
+add_action( 'update_option_site_icon', 'wpcom_launchpad_mark_setup_site_tasks_complete', 10, 3 );
+add_action( 'update_option_site_logo', 'wpcom_launchpad_mark_setup_site_tasks_complete', 10, 3 );
 
 /**
  * Mark the enable_subscribers_modal task complete


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/83390

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Complete the task, Personalize your site, when the user updates the site title, site tagline or site logo

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Sync the changes to your sandbox
  ```
  bin/jetpack-downloader test jetpack-mu-wpcom-plugin feat/launchpad-complete-setup-free-task
  ```
* Go to `/setup/assembler-first` to create a new site
* Finish the Assembler step
* When you land on the launchpad, ensure the task, Personalize your site, is not completed
* Select that task and submit the changes
* When you come back to the launchpad, ensure the task, Personalize your site, is completed