### PR TITLE
Like block: Add Reblog setting

### DIFF
--- a/projects/plugins/jetpack/changelog/add-like-block-reblog-setting
+++ b/projects/plugins/jetpack/changelog/add-like-block-reblog-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Like block (beta): Add Reblog setting

--- a/projects/plugins/jetpack/extensions/blocks/like/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/like/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"name": "jetpack/like",
 	"title": "Like",
-	"description": "Let readers show their appreciation for your content by liking it.",
+	"description": "Give your readers the ability to show appreciation for your posts.",
 	"keywords": [ "like", "thumbs up", "button" ],
 	"version": "1.0.0",
 	"textdomain": "jetpack",

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -1,43 +1,28 @@
 import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
 import { BlockIcon, useBlockProps, InspectorControls } from '@wordpress/block-editor';
-//import { Placeholder, withNotices } from '@wordpress/components';
 import { Placeholder, ToggleControl, PanelBody } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import metadata from './block.json';
 import './editor.scss';
-//import useFetchReblogSetting from './use-fetch-reblog-setting';
+import useFetchReblogSetting from './use-fetch-reblog-setting';
 
 const icon = getBlockIconComponent( metadata );
 
-//function LikeEdit( { attributes, className, noticeOperations, noticeUI, setAttributes } ) {
 function LikeEdit( { noticeUI } ) {
-	/**
-	 * Write the block editor UI.
-	 *
-	 * @returns {object} The UI displayed when user edits this block.
-	 */
-	//const [ notice, setNotice ] = useState();
-
-	/* Call this function when you want to show an error in the placeholder. */
-	/* const setErrorNotice = () => {
-		noticeOperations.removeAllNotices();
-		noticeOperations.createErrorNotice( __( 'Put error message here.', 'jetpack' ) );
-	}; */
-
 	const blockProps = useBlockProps();
-	const [ hasFixedBackground, setHasFixedBackground ] = useState( false );
+	const blogId = window?.Jetpack_LikeBlock_BlogId;
 
-	//console.log( window?.Jetpack_LikeBlock_BlogId );
-	//console.log( 'blogId', blogId );
+	const { fetchReblogSetting, reblogSetting } = useFetchReblogSetting( blogId );
 
-	//const { fetchReblogSetting, reblogSetting } = useFetchReblogSetting( blogId );
+	const setReblogSetting = newValue => {
+		// eslint-disable-next-line no-console
+		console.log( newValue );
+	};
 
-	//useEffect( () => {
-	//	fetchReblogSetting();
-	//}, [ fetchReblogSetting ] );
-
-	//console.log( 'reblogSetting', reblogSetting );
+	useEffect( () => {
+		fetchReblogSetting();
+	}, [ fetchReblogSetting ] );
 
 	return (
 		<div { ...blockProps }>
@@ -45,10 +30,9 @@ function LikeEdit( { noticeUI } ) {
 				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 					<ToggleControl
 						label="Show reblog button"
-						help={ hasFixedBackground ? 'Has fixed background.' : 'No fixed background.' }
-						checked={ hasFixedBackground }
+						checked={ reblogSetting }
 						onChange={ newValue => {
-							setHasFixedBackground( newValue );
+							setReblogSetting( newValue );
 						} }
 					/>
 				</PanelBody>

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -34,7 +34,7 @@ function LikeEdit( { noticeUI } ) {
 					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 						<ToggleControl
 							label="Show reblog button"
-							checked={ reblogSetting }
+							checked={ ! reblogSetting }
 							onChange={ newValue => {
 								setReblogSetting( newValue );
 							} }

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -11,7 +11,7 @@ const icon = getBlockIconComponent( metadata );
 
 function LikeEdit( { noticeUI } ) {
 	const blockProps = useBlockProps();
-	const blogId = window?.Jetpack_LikeBlock_BlogId;
+	const blogId = window?.Jetpack_LikeBlock?.blog_id;
 
 	const { fetchReblogSetting, reblogSetting } = useFetchReblogSetting( blogId );
 

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -1,4 +1,4 @@
-import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
+import { getBlockIconComponent, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { BlockIcon, useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { Placeholder, ToggleControl, PanelBody } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
@@ -21,22 +21,27 @@ function LikeEdit( { noticeUI } ) {
 	};
 
 	useEffect( () => {
+		if ( ! isSimpleSite() ) {
+			return;
+		}
 		fetchReblogSetting();
 	}, [ fetchReblogSetting ] );
 
 	return (
 		<div { ...blockProps }>
-			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
-					<ToggleControl
-						label="Show reblog button"
-						checked={ reblogSetting }
-						onChange={ newValue => {
-							setReblogSetting( newValue );
-						} }
-					/>
-				</PanelBody>
-			</InspectorControls>
+			{ isSimpleSite() && (
+				<InspectorControls>
+					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
+						<ToggleControl
+							label="Show reblog button"
+							checked={ reblogSetting }
+							onChange={ newValue => {
+								setReblogSetting( newValue );
+							} }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			) }
 			<Placeholder
 				label={ __( 'Like', 'jetpack' ) }
 				instructions={ __( 'Instructions go here.', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -34,7 +34,7 @@ function LikeEdit( { noticeUI } ) {
 					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 						<ToggleControl
 							label="Show reblog button"
-							checked={ ! reblogSetting }
+							checked={ reblogSetting }
 							onChange={ newValue => {
 								setReblogSetting( newValue );
 							} }

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -1,11 +1,12 @@
 import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
-import { BlockIcon, useBlockProps } from '@wordpress/block-editor';
+import { BlockIcon, useBlockProps, InspectorControls } from '@wordpress/block-editor';
 //import { Placeholder, withNotices } from '@wordpress/components';
-import { Placeholder } from '@wordpress/components';
-//import { useState } from '@wordpress/element';
+import { Placeholder, ToggleControl, PanelBody } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import metadata from './block.json';
 import './editor.scss';
+//import useFetchReblogSetting from './use-fetch-reblog-setting';
 
 const icon = getBlockIconComponent( metadata );
 
@@ -25,9 +26,33 @@ function LikeEdit( { noticeUI } ) {
 	}; */
 
 	const blockProps = useBlockProps();
+	const [ hasFixedBackground, setHasFixedBackground ] = useState( false );
+
+	//console.log( window?.Jetpack_LikeBlock_BlogId );
+	//console.log( 'blogId', blogId );
+
+	//const { fetchReblogSetting, reblogSetting } = useFetchReblogSetting( blogId );
+
+	//useEffect( () => {
+	//	fetchReblogSetting();
+	//}, [ fetchReblogSetting ] );
+
+	//console.log( 'reblogSetting', reblogSetting );
 
 	return (
 		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
+					<ToggleControl
+						label="Show reblog button"
+						help={ hasFixedBackground ? 'Has fixed background.' : 'No fixed background.' }
+						checked={ hasFixedBackground }
+						onChange={ newValue => {
+							setHasFixedBackground( newValue );
+						} }
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<Placeholder
 				label={ __( 'Like', 'jetpack' ) }
 				instructions={ __( 'Instructions go here.', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -119,7 +119,6 @@ function add_like_block_data() {
 		$blog_id = \Jetpack_Options::get_option( 'id' );
 	}
 
-	// Create an array to store both $blog_id and $type.
 	$like_block_data = array(
 		'blog_id' => $blog_id,
 	);

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -18,11 +18,14 @@ use Jetpack_Gutenberg;
  * registration if we need to.
  */
 function register_block() {
+	$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
+
 	Blocks::jetpack_register_block(
 		__DIR__,
 		array(
 			'api_version'     => 3,
 			'render_callback' => __NAMESPACE__ . '\render_block',
+			'description'     => $is_wpcom ? __( 'Give your readers the ability to show appreciation for your posts and easily share them with others.', 'jetpack' ) : __( 'Give your readers the ability to show appreciation for your posts.', 'jetpack' ),
 		)
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -112,16 +112,13 @@ function add_like_block_data() {
 
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		$blog_id = get_current_blog_id();
-		$type    = 'wpcom'; // WPCOM simple sites.
 	} else {
 		$blog_id = \Jetpack_Options::get_option( 'id' );
-		$type    = 'jetpack'; // Self-hosted (includes Atomic)
 	}
 
 	// Create an array to store both $blog_id and $type.
 	$like_block_data = array(
 		'blog_id' => $blog_id,
-		'type'    => $type,
 	);
 
 	wp_add_inline_script(

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -101,3 +101,25 @@ function render_block( $attr, $content, $block ) {
 		$html
 	);
 }
+
+/**
+ * Add the initial state for the Like block.
+ */
+function add_like_block_data() {
+	if ( ! is_admin() ) {
+		return;
+	}
+
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		$blog_id = get_current_blog_id();
+	} else {
+		$blog_id = \Jetpack_Options::get_option( 'id' );
+	}
+
+	wp_add_inline_script(
+		'jetpack-blocks-editor',
+		'var Jetpack_LikeBlock_BlogId = ' . $blog_id . ';',
+		'before'
+	);
+}
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\add_like_block_data' );

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -112,13 +112,21 @@ function add_like_block_data() {
 
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		$blog_id = get_current_blog_id();
+		$type    = 'wpcom'; // WPCOM simple sites.
 	} else {
 		$blog_id = \Jetpack_Options::get_option( 'id' );
+		$type    = 'jetpack'; // Self-hosted (includes Atomic)
 	}
+
+	// Create an array to store both $blog_id and $type.
+	$like_block_data = array(
+		'blog_id' => $blog_id,
+		'type'    => $type,
+	);
 
 	wp_add_inline_script(
 		'jetpack-blocks-editor',
-		'var Jetpack_LikeBlock_BlogId = ' . $blog_id . ';',
+		'var Jetpack_LikeBlock = ' . wp_json_encode( $like_block_data, JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
 		'before'
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/use-fetch-reblog-setting.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/use-fetch-reblog-setting.js
@@ -11,12 +11,11 @@ export default function useFetchReblogSetting( blogId ) {
 
 	const fetchReblogSetting = useCallback( async () => {
 		const path = `https://public-api.wordpress.com/rest/v1.3/sites/${ blogId }/settings/`;
-		//const path = `/wpcom/v2/related-posts`;
 
 		setIsLoading( true );
 		await apiFetch( { url: path, method: 'GET' } )
 			.then( response => {
-				setReblogSetting( response );
+				setReblogSetting( response?.settings?.disabled_reblogs );
 				setError( null );
 			} )
 			.catch( err => {

--- a/projects/plugins/jetpack/extensions/blocks/like/use-fetch-reblog-setting.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/use-fetch-reblog-setting.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useCallback } from '@wordpress/element';
+
+export default function useFetchReblogSetting( blogId ) {
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ reblogSetting, setReblogSetting ] = useState( null );
+	const [ error, setError ] = useState( null );
+
+	const fetchReblogSetting = useCallback( async () => {
+		const path = `https://public-api.wordpress.com/rest/v1.3/sites/${ blogId }/settings/`;
+		//const path = `/wpcom/v2/related-posts`;
+
+		setIsLoading( true );
+		await apiFetch( { url: path, method: 'GET' } )
+			.then( response => {
+				setReblogSetting( response );
+				setError( null );
+			} )
+			.catch( err => {
+				setError( err );
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
+	}, [ blogId ] );
+
+	return {
+		isLoading,
+		reblogSetting,
+		error,
+		fetchReblogSetting,
+	};
+}

--- a/projects/plugins/jetpack/extensions/blocks/like/use-fetch-reblog-setting.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/use-fetch-reblog-setting.js
@@ -15,7 +15,7 @@ export default function useFetchReblogSetting( blogId ) {
 		setIsLoading( true );
 		await apiFetch( { url: path, method: 'GET' } )
 			.then( response => {
-				setReblogSetting( response?.settings?.disabled_reblogs );
+				setReblogSetting( ! response?.settings?.disabled_reblogs );
 				setError( null );
 			} )
 			.catch( err => {


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/84879.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

- add block settings toggle for the `disabled_reblogs` site setting (Simple sites only)
- fetch the current `disabled_reblogs` setting and populate the block setting toggle with it (Simple sites only)
- adjust the block description based on whether the site is Simple or Jetpack / WoA
- remove unnecessary code

| Jetpack / WoA site | Simple site |
|--------|--------|
| ![Markup on 2023-12-08 at 10:49:25](https://github.com/Automattic/jetpack/assets/25105483/cefa8f71-e992-4ad0-8620-d1bdb64c2711) | ![Markup on 2023-12-08 at 10:57:18](https://github.com/Automattic/jetpack/assets/25105483/936b7402-52eb-4ed9-8fea-f792ed5417bd) |

ℹ️  The PR **does not** address the following:

* setting the Reblog setting (https://github.com/Automattic/wp-calypso/issues/85024)
* adding support documentation link to the block description (https://github.com/Automattic/wp-calypso/issues/85023)

(these changes will be addressed in their separate PRs)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Related project thread: pdDOJh-2JP-p2

## Does this pull request change what data or activity we track or use?
No, it does not.

## Testing instructions:

**Self-hosted site**

1. Check out the PR and build it.
2. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
3. Launch Jurassic Tube to make your local site available publicly.
4. Connect Jetpack to your WordPress.com account and enable Likes feature.
5. Add the new Like block to a post on your test site.
6. There should be no Reblog setting toggle and the block description should match the one in the design (fJZ60vrt8ZNJwL2TPPM106-fi-347_4547) for the site that doesn't have the Reblog feature.

**Simple site**

1. Sync the changes of this PR to your simple site (e.g. by using the script from the comment below).
2. Sandbox the test site.
3. Add `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` to your `0-sandbox.php` file.
4. Add the new Like block to a post on your test site.
5. There should be the Reblog setting toggle and the block description should match the one in the design (fJZ60vrt8ZNJwL2TPPM106-fi-347_4547) for the site that does have the Reblog feature.
6. Try to change the "Show reblog button" setting in Calypso (_Tools → Marketing → Sharing Buttons_) and then reload the block editor with the Like block in it. The block setting toggle should match the setting in Calypso. The toggle on its own is not functional yet.

**Atomic site** (should have the same behavior as a self-hosted site)
1. Check out the PR - you can use the Jetpack Beta plugin for instance.
3. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
4. Add the new Like block to a post on your test site.
5. There should be no Reblog setting toggle and the block description should match the one in the design (fJZ60vrt8ZNJwL2TPPM106-fi-347_4547) for the site that doesn't have the Reblog feature. Basically, the behavior should be the same as for the self-hosted site.