### PR TITLE
Contact Form: revalidate missing value as user types

### DIFF
--- a/projects/packages/forms/changelog/update-contact-form-validation-strategy
+++ b/projects/packages/forms/changelog/update-contact-form-validation-strategy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Contact Form: revalidate missing value as user types


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In https://github.com/Automattic/jetpack/pull/34401, we revalidated the input of a Contact Form as it lost focus in order to provide quicker feedback to a user correcting an invalid form.

This PR is a further improvement. When a field is invalid because of a missing value, we revalidate the field as the user types (in the case of simple inputs) or checks a radio button or checkbox to provide even quicker feedback.

We've limited this to the "missing value" kind of error because it's a black-or-white situation that's easy to handle. With an invalid email input, the native error message (at least on Chrome) changes as a user types an email address, which is more distracting than helpful. In these instances, we keep the revalidation on the field blur.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-87-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Create a new post
- Add the _Contact Form_ block
- Add at least a text, Single Choice, and Multiple Choice fields, and mark them as required
- Open the preview
- Submit the form
- Fix the issues
- Notice the "required field" message disappears as you type or check an input