### PR TITLE
AI Assistant: fix bottom padding issue

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-ai-bottom-padding-issue
+++ b/projects/js-packages/ai-client/changelog/fix-ai-bottom-padding-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Client: fix bottom padding

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -4,7 +4,6 @@
 
 .jetpack-components-ai-control__container-wrapper {
 	position: sticky;
-	bottom: 0;
 	bottom: 16px;
 }
 

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -5,7 +5,7 @@
 .jetpack-components-ai-control__container-wrapper {
 	position: sticky;
 	bottom: 0;
-	padding-bottom: 16px;
+	bottom: 16px;
 }
 
 .jetpack-components-ai-control__container {


### PR DESCRIPTION
Latest changes introduced a padding which doesn't look good in combination with shadow

## Proposed changes:
This PR changes the bottom padding with the use of `bottom` directive. The issue is noticeable when the AI is suggesting or by merely selecting the content block while the AI assistant is visible. The border assigned to the selected block extends to the shadow, giving it a quirky look.

Before:
<img width="583" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/d6341b0b-977b-4cb2-b999-4b432fb3b050">

After:
<img width="582" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/576f7c03-c7f9-4eef-963b-f9c9fe4ed13b">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the editor and insert an AI assistant block, see that it looks like the screenshots. Try and make some request to watch it while the assistant is suggesting.

Test on an extension (Form).