### PR TITLE
AI Assistant: restrict stored state value

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-state-stored-issue
+++ b/projects/plugins/jetpack/changelog/fix-ai-state-stored-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: restrict stored states to init and done to prevent half way states of the block

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -219,7 +219,9 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 	}, [ promptPlaceholder, currentIndex ] );
 
 	useEffect( () => {
-		setAttributes( { requestingState } );
+		// we don't want to store "half way" states
+		const stateToSet = requestingState === 'init' ? 'init' : 'done';
+		setAttributes( { stateToSet } );
 	}, [ requestingState, setAttributes ] );
 
 	const saveImage = async image => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -220,8 +220,11 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 
 	useEffect( () => {
 		// we don't want to store "half way" states
-		const stateToSet = requestingState === 'init' ? 'init' : 'done';
-		setAttributes( { stateToSet } );
+		if ( ! [ 'init', 'done' ].includes( requestingState ) ) {
+			return;
+		}
+
+		setAttributes( { requestingState } );
 	}, [ requestingState, setAttributes ] );
 
 	const saveImage = async image => {


### PR DESCRIPTION
AI Assistant block should only store deterministic state values

## Proposed changes:
This PR fixes an issue with the latest change to store the state as a block attribute. Half way states are not easy to recover from without context, so we now restrict to `init` and `done` states in case of a reload in the middle of an assistant session.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the editor and use the AI Assistant block. Ask a suggestion (eg: haiku on testing), once it's done, check the Code Editor to see the `requestingState` is now `done`. Save draft and reload, you should get back at where you left. 

Now open the developer tools, Network tab, and disable the connection. Hit "Regenerate" button to get the error. Check again the Code Editor, it should still read 'done'. Re-enable the connection and reload the page, you should be once more where you left and continue to work with the block.