### PR TITLE
AI Assistant: add cancel button

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-ai-cancel-button
+++ b/projects/js-packages/ai-client/changelog/add-ai-cancel-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Client: add cancel button to get rid of the assistant block

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -77,7 +77,7 @@ export function AIControl(
 		onSend = noop,
 		onStop = noop,
 		onAccept = noop,
-		onDiscard = noop,
+		onDiscard = null,
 	}: AiControlProps,
 	ref: React.MutableRefObject< null > // eslint-disable-line @typescript-eslint/ban-types
 ): React.ReactElement {
@@ -162,7 +162,7 @@ export function AIControl(
 						/>
 					</div>
 
-					{ ( ! showAccept || editRequest ) && value?.length > 0 && (
+					{ ( ! showAccept || editRequest ) && (
 						<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
 							{ ! loading ? (
 								<>
@@ -181,19 +181,36 @@ export function AIControl(
 										</Button>
 									) }
 
-									<Button
-										className="jetpack-components-ai-control__controls-prompt_button"
-										onClick={ sendRequest }
-										variant="primary"
-										disabled={ ! value?.length || disabled }
-										label={ __( 'Send request', 'jetpack-ai-client' ) }
-									>
-										{ showButtonLabels ? (
-											__( 'Generate', 'jetpack-ai-client' )
-										) : (
-											<Icon icon={ arrowUp } />
-										) }
-									</Button>
+									{ ! editRequest && ! value?.length && onDiscard && (
+										<Button
+											className="jetpack-components-ai-control__controls-prompt_button"
+											onClick={ discardHandler }
+											variant="secondary"
+											label={ __( 'Cancel', 'jetpack-ai-client' ) }
+										>
+											{ showButtonLabels ? (
+												__( 'Cancel', 'jetpack-ai-client' )
+											) : (
+												<Icon icon={ closeSmall } />
+											) }
+										</Button>
+									) }
+
+									{ value?.length > 0 && (
+										<Button
+											className="jetpack-components-ai-control__controls-prompt_button"
+											onClick={ sendRequest }
+											variant="primary"
+											disabled={ ! value?.length || disabled }
+											label={ __( 'Send request', 'jetpack-ai-client' ) }
+										>
+											{ showButtonLabels ? (
+												__( 'Generate', 'jetpack-ai-client' )
+											) : (
+												<Icon icon={ arrowUp } />
+											) }
+										</Button>
+									) }
 								</>
 							) : (
 								<Button


### PR DESCRIPTION
Currently there is no way to get rid of the AI assistant once the block is invoked

## Proposed changes:
This PR introduces a "Cancel" button to be shown when the input is empty, not loading and not showing suggestion actions

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1701816887734759-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert an AI Assistant block, see the cancel button. Click it to remove the block. Try typing/requesting and test the different scenarios.