### PR TITLE
Like block: Escape attributes in the block output

### DIFF
--- a/projects/plugins/jetpack/changelog/add-like-block-attributes-escape
+++ b/projects/plugins/jetpack/changelog/add-like-block-attributes-escape
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Like block (beta): Escape block output attributes

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -89,11 +89,11 @@ function render_block( $attr, $content, $block ) {
 	$name    = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 	$wrapper = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 
-	$html  = "<div class='sharedaddy sd-block sd-like jetpack-likes-widget-wrapper jetpack-likes-widget-unloaded' id='$wrapper' data-src='$src' data-name='$name' data-title='$title'>";
-	$html .= $headline;
-	$html .= "<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='button'><span>" . esc_html__( 'Like', 'jetpack' ) . '</span></span> <span class="loading">' . esc_html__( 'Loading...', 'jetpack' ) . '</span></div>';
-	$html .= "<span class='sd-text-color'></span><a class='sd-link-color'></a>";
-	$html .= '</div>';
+	$html = "<div class='sharedaddy sd-block sd-like jetpack-likes-widget-wrapper jetpack-likes-widget-unloaded' id='" . esc_attr( $wrapper ) . "' data-src='" . esc_attr( $src ) . "' data-name='" . esc_attr( $name ) . "' data-title='" . esc_attr( $title ) . "'>"
+		. $headline
+		. "<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='button'><span>" . esc_html__( 'Like', 'jetpack' ) . "</span></span> <span class='loading'>" . esc_html__( 'Loading...', 'jetpack' ) . '</span></div>'
+		. "<span class='sd-text-color'></span><a class='sd-link-color'></a>"
+		. '</div>';
 
 	return sprintf(
 		'<div class="%1$s">%2$s</div>',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addresses https://github.com/Automattic/jetpack/pull/34450/files#r1419678652.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* escape all attributes in the Like block output

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Discussion: https://github.com/Automattic/jetpack/pull/34450/files#r1419678652

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Check out the PR and build it.
2. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
3. Launch Jurassic Tube to make your local site available publicly.
4. Connect Jetpack to your WordPress.com account and enable Likes feature.
5. Add the new Like block to a post on your test site.
6. Check out the post in the front-end: the Like block should render and work correctly.

