### PR TITLE
Add export and import capabilities to the sites endpoint response

### DIFF
--- a/projects/plugins/jetpack/changelog/add-sal-capabilities-export-import
+++ b/projects/plugins/jetpack/changelog/add-sal-capabilities-export-import
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+WordPress.com API: add the export and import capabilities to the sites endpoint response

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -953,6 +953,8 @@ abstract class SAL_Site {
 			'view_stats'          => stats_is_blog_user( $this->blog_id ),
 			'activate_plugins'    => $this->current_user_can( 'activate_plugins' ),
 			'update_plugins'      => $this->current_user_can( 'update_plugins' ),
+			'export'              => $this->current_user_can( 'export' ),
+			'import'              => $this->current_user_can( 'import' ),
 		);
 	}
 


### PR DESCRIPTION
Adds the `export` and `import` capabilities to the `/sites` REST API response. Calypso importer UI needs them to correctly verify that the user has the capability to export from a source site and import to a target site. See also https://github.com/Automattic/wp-calypso/issues/85031.

## Testing instructions:

Apply this patch on your WP.com sandbox, and try to read from the `/sites/:siteid` REST endpoint. The response's `capabilities` field should newly contain also the `export` and `import` capabilities.

## Does this pull request change what data or activity we track or use?

No.