### PR TITLE
Paywall: fix pending subscription check

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-paywall-pending-subscription
+++ b/projects/plugins/jetpack/changelog/fix-paywall-pending-subscription
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Paywall: Fix pending subscription state

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-jetpack-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-jetpack-token-subscription-service.php
@@ -52,4 +52,14 @@ class Jetpack_Token_Subscription_Service extends Token_Subscription_Service {
 		}
 		return $token->secret;
 	}
+
+	/**
+	 * Returns true if the current authenticated user has a pending subscription to the current site.
+	 *
+	 * @return boolean
+	 */
+	public function is_current_user_pending_subscriber() {
+
+		return $this->get_token_property( 'blog_sub' ) === 'pending';
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-subscription-service.php
@@ -49,6 +49,13 @@ interface Subscription_Service {
 	public function visitor_can_view_content( $valid_plan_ids, $access_level );
 
 	/**
+	 * is the current user a pending subscriber for the current site?
+	 *
+	 * @return boolean
+	 */
+	public function is_current_user_pending_subscriber();
+
+	/**
 	 * The current visitor would like to obtain access. Where do they go?
 	 *
 	 * @param string $mode .

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-subscription-service.php
@@ -49,7 +49,7 @@ interface Subscription_Service {
 	public function visitor_can_view_content( $valid_plan_ids, $access_level );
 
 	/**
-	 * is the current user a pending subscriber for the current site?
+	 * Is the current user a pending subscriber for the current site?
 	 *
 	 * @return boolean
 	 */

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -165,6 +165,15 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	}
 
 	/**
+	 * Returns true if the current authenticated user has a pending subscription to the current site.
+	 *
+	 * @return boolean
+	 */
+	public function is_current_user_pending_subscriber() {
+		return $this->get_token_property( 'blog_sub' ) === 'pending';
+	}
+
+	/**
 	 * Return if the user has access to the content depending on the access level and the user rights
 	 *
 	 * @param string $access_level Post or blog access level.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -170,7 +170,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	 * @return boolean
 	 */
 	public function is_current_user_pending_subscriber() {
-		return $this->get_token_property( 'blog_sub' ) === 'pending';
+		return false;
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-unconfigured-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-unconfigured-subscription-service.php
@@ -47,6 +47,15 @@ class Unconfigured_Subscription_Service implements Subscription_Service {
 	}
 
 	/**
+	 * is the current user a pending subscriber for the current site?
+	 * 
+	 * @return boolean
+	 */
+	public function is_current_user_pending_subscriber() {
+		return false;
+	}
+
+	/**
 	 * The current visitor would like to obtain access. Where do they go?
 	 *
 	 * @param string $mode .

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
@@ -83,6 +83,26 @@ class WPCOM_Online_Subscription_Service extends Jetpack_Token_Subscription_Servi
 	}
 
 	/**
+	 * Returns true if the current authenticated user has a pending subscription to the current site.
+	 *
+	 * @return boolean
+	 */
+	public function is_current_user_pending_subscriber() {
+		include_once WP_CONTENT_DIR . '/mu-plugins/email-subscriptions/subscriptions.php';
+		$email             = wp_get_current_user()->user_email;
+		$subscriber_object = \Blog_Subscriber::get( $email );
+		if ( empty( $subscriber_object ) ) {
+			return false;
+		}
+		$blog_id             = $this->get_site_id();
+		$subscription_status = \Blog_Subscription::get_subscription_status_for_blog( $subscriber_object, $blog_id );
+		if ( 'pending' !== $subscription_status ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Lookup users subscriptions for a site and determine if the user has a valid subscription to match the plan ID
 	 *
 	 * @param array  $valid_plan_ids .

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -861,7 +861,6 @@ function maybe_gate_existing_comments( $comment ) {
  * Returns paywall content blocks
  *
  * @param string $post_access_level The newsletter access level.
- * @param string $email_confirmation_pending True if the current user needs to validate their email.
  * @return string
  */
 function get_paywall_content( $post_access_level ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -17,7 +17,6 @@ use Jetpack;
 use Jetpack_Gutenberg;
 use Jetpack_Memberships;
 use Jetpack_Subscriptions_Widget;
-use function Automattic\Jetpack\Extensions\Premium_Content\subscription_service;
 
 require_once __DIR__ . '/constants.php';
 
@@ -806,14 +805,7 @@ function add_paywall( $the_content ) {
 		return $the_content;
 	}
 
-	require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
-	$token_service              = subscription_service();
-	$token                      = $token_service->get_and_set_token_from_request();
-	$payload                    = $token_service->decode_token( $token );
-	$is_valid_token             = ! empty( $payload );
-	$email_confirmation_pending = $is_valid_token && isset( $payload['blog_sub'] ) && $payload['blog_sub'] === 'pending';
-
-	$paywalled_content = get_paywall_content( $post_access_level, $email_confirmation_pending ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$paywalled_content = get_paywall_content( $post_access_level ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 	if ( has_block( \Automattic\Jetpack\Extensions\Paywall\BLOCK_NAME ) ) {
 		if ( strpos( $the_content, \Automattic\Jetpack\Extensions\Paywall\BLOCK_HTML ) ) {
@@ -872,7 +864,7 @@ function maybe_gate_existing_comments( $comment ) {
  * @param string $email_confirmation_pending True if the current user needs to validate their email.
  * @return string
  */
-function get_paywall_content( $post_access_level, $email_confirmation_pending = false ) {
+function get_paywall_content( $post_access_level ) {
 	if ( $email_confirmation_pending ) {
 		return get_paywall_blocks_subscribe_pending();
 	}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -865,7 +865,7 @@ function maybe_gate_existing_comments( $comment ) {
  * @return string
  */
 function get_paywall_content( $post_access_level ) {
-	if ( $email_confirmation_pending ) {
+	if ( Jetpack_Memberships::user_is_pending_subscriber() ) {
 		return get_paywall_blocks_subscribe_pending();
 	}
 	if ( doing_filter( 'get_the_excerpt' ) ) {

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -567,6 +567,17 @@ class Jetpack_Memberships {
 	}
 
 	/**
+	 * Determines whether the current user has a pending subscription.
+	 *
+	 * @return bool Whether the user has a pending subscription
+	 */
+	public static function user_is_pending_subscriber() {
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
+		return $subscription_service->is_current_user_pending_subscriber();
+	}
+
+	/**
 	 * Determines whether the current user can view the post based on the newsletter access level
 	 * and caches the result.
 	 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34540

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fix paywall status when user hasn’t confirmed their email but used “already subscriber?” flow to log in.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a new session go to a subscribers only post in a WPCOM site.
* Subscribe with a new user email but don't confirm the email
* Restart the session and log in via the “already subscriber?” in the post
* Make sure you get:

<img width="699" alt="Screenshot 2023-12-11 at 14 54 09" src="https://github.com/Automattic/jetpack/assets/104869/874c6934-45a2-4feb-a67c-7852c35e9142">

* Check the subscription flow in Jetpack sites hasn't been affected.