### PR TITLE
AI Client: fix empty prompts handling

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-ai-action-prompts
+++ b/projects/js-packages/ai-client/changelog/fix-ai-action-prompts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Ai Client: use default last value (not empty), allows for handling 'one click' prompts (empty prompts)

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -54,6 +54,8 @@ type AiControlProps = {
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
+const DEFAULT_LAST_VALUE = '--LAST-VALUE--';
+
 /**
  * AI Control component.
  *
@@ -84,14 +86,14 @@ export function AIControl(
 	const promptUserInputRef = useRef( null );
 	const loading = state === 'requesting' || state === 'suggesting';
 	const [ editRequest, setEditRequest ] = React.useState( false );
-	const [ lastValue, setLastValue ] = React.useState( value || '' );
+	const [ lastValue, setLastValue ] = React.useState( value || DEFAULT_LAST_VALUE );
 
 	useEffect( () => {
 		if ( editRequest ) {
 			promptUserInputRef?.current?.focus();
 		}
 
-		if ( ! editRequest && lastValue && value !== lastValue ) {
+		if ( ! editRequest && lastValue !== DEFAULT_LAST_VALUE && value !== lastValue ) {
 			onChange?.( lastValue );
 		}
 	}, [ editRequest, lastValue ] );
@@ -229,34 +231,39 @@ export function AIControl(
 						</div>
 					) }
 
-					{ showAccept && ! editRequest && value?.length > 0 && (
+					{ showAccept && ! editRequest && (
 						<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
-							<ButtonGroup>
-								<Button
-									className="jetpack-components-ai-control__controls-prompt_button"
-									label={ __( 'Back to edit', 'jetpack-ai-client' ) }
-									onClick={ () => setEditRequest( true ) }
-									tooltipPosition="top"
-								>
-									<Icon icon={ arrowLeft } />
-								</Button>
-								<Button
-									className="jetpack-components-ai-control__controls-prompt_button"
-									label={ __( 'Discard', 'jetpack-ai-client' ) }
-									onClick={ discardHandler }
-									tooltipPosition="top"
-								>
-									<Icon icon={ trash } />
-								</Button>
-								<Button
-									className="jetpack-components-ai-control__controls-prompt_button"
-									label={ __( 'Regenerate', 'jetpack-ai-client' ) }
-									onClick={ () => onSend?.( value ) }
-									tooltipPosition="top"
-								>
-									<Icon icon={ reusableBlock } />
-								</Button>
-							</ButtonGroup>
+							{ ( value?.length > 0 || lastValue === DEFAULT_LAST_VALUE ) && (
+								<ButtonGroup>
+									{ value.length > 0 && (
+										<Button
+											className="jetpack-components-ai-control__controls-prompt_button"
+											label={ __( 'Back to edit', 'jetpack-ai-client' ) }
+											onClick={ () => setEditRequest( true ) }
+											tooltipPosition="top"
+										>
+											<Icon icon={ arrowLeft } />
+										</Button>
+									) }
+									<Button
+										className="jetpack-components-ai-control__controls-prompt_button"
+										label={ __( 'Discard', 'jetpack-ai-client' ) }
+										onClick={ discardHandler }
+										tooltipPosition="top"
+									>
+										<Icon icon={ trash } />
+									</Button>
+									<Button
+										className="jetpack-components-ai-control__controls-prompt_button"
+										label={ __( 'Regenerate', 'jetpack-ai-client' ) }
+										onClick={ () => onSend?.( value ) }
+										tooltipPosition="top"
+										disabled={ ! value?.length || disabled }
+									>
+										<Icon icon={ reusableBlock } />
+									</Button>
+								</ButtonGroup>
+							) }
 							<Button
 								className="jetpack-components-ai-control__controls-prompt_button"
 								onClick={ onAccept }

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -54,8 +54,6 @@ type AiControlProps = {
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
-const DEFAULT_LAST_VALUE = '--LAST-VALUE--';
-
 /**
  * AI Control component.
  *
@@ -86,14 +84,14 @@ export function AIControl(
 	const promptUserInputRef = useRef( null );
 	const loading = state === 'requesting' || state === 'suggesting';
 	const [ editRequest, setEditRequest ] = React.useState( false );
-	const [ lastValue, setLastValue ] = React.useState( value || DEFAULT_LAST_VALUE );
+	const [ lastValue, setLastValue ] = React.useState( value || null );
 
 	useEffect( () => {
 		if ( editRequest ) {
 			promptUserInputRef?.current?.focus();
 		}
 
-		if ( ! editRequest && lastValue !== DEFAULT_LAST_VALUE && value !== lastValue ) {
+		if ( ! editRequest && lastValue !== null && value !== lastValue ) {
 			onChange?.( lastValue );
 		}
 	}, [ editRequest, lastValue ] );
@@ -233,7 +231,7 @@ export function AIControl(
 
 					{ showAccept && ! editRequest && (
 						<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
-							{ ( value?.length > 0 || lastValue === DEFAULT_LAST_VALUE ) && (
+							{ ( value?.length > 0 || lastValue === null ) && (
 								<ButtonGroup>
 									{ value.length > 0 && (
 										<Button
@@ -258,7 +256,7 @@ export function AIControl(
 										label={ __( 'Regenerate', 'jetpack-ai-client' ) }
 										onClick={ () => onSend?.( value ) }
 										tooltipPosition="top"
-										disabled={ ! value?.length || disabled }
+										disabled={ ! value?.length || value === null || disabled }
 									>
 										<Icon icon={ reusableBlock } />
 									</Button>


### PR DESCRIPTION
When using toolbar's one-click AI prompts (tone, language, summarize/expand, etc) the prompt input remains empty, causing inconsistency with the suggestion action buttons

## Proposed changes:
This PR adds a default value for the internal state in charge of tracking the changes in the input. This way, we can compare inputs against a defined value to more precisely decide how and when to show the suggestion action buttons

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1701974862002309-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The change is subtle, try to just make sense of what you're requesting and the options presented as buttons/actions.

### Insert an AI assistant block from scratch
- [ ] empty input should show you a Cancel button (test if you like, will remove the entire block)

Request something quick/small (haiku on something)

- [ ] watch button go from Generate to Stop, then to suggestion actions (Back to edit, Discard, Regenerate, Accept)
  - [ ] Accept will just remove the AI assistant and let you with the suggested content
  - [ ] Regenerate will trigger the same prompt again (?!)
  - [ ] Discard will remove the entire AI Assistant and any content (since you started with nothing), unless you've reloaded the editor since the suggestion was made. In that case, AI Assistant is removed but the last suggestion remains
  - [ ] Back to edit will get you to editing the prompt (same as start typing in the input)
- [ ] editing the prompt gets you to edit the prompt: Cancel | Generate
  - [ ] Cancel will get you back at the original (sent) prompt and the suggestion actions
  - [ ] Generate will get you back to the beginning of this checklist

### Ask AI Assistant on content
Get some content/phrase on a paragraph ("life is short", AI loves mumbling about philosophical things), then ask for AI assistant one-clicks: tone change, translation, expand, spelling/grammar check
- [ ] once done, you should see the AI assistant input with suggestion actions shown: Discard, Regenerate (disabled), Accept
- [ ] input should be empty, any change there should get you into "Back to edit" mode (see previous test)
  - [ ] making the input empty again CAN'T get you to the original state, as the suggestion was a single click action
  - [ ] once the input is changed it will REMAIN in edit mode, even if it's emptied
  - [ ] Cancel will show the suggestion actions again, Generate/Regenerate will send the newly entered prompt and act upon the already suggested content
- [ ] Discard will always get you back to your original content 