### PR TITLE
Fix: Add Missing Sync Posts Sanity Check

### DIFF
--- a/projects/packages/sync/changelog/fix-jetpack-sync-class-posts-sanity-check
+++ b/projects/packages/sync/changelog/fix-jetpack-sync-class-posts-sanity-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a missing sanity check in Sync Posts handler logic that created failed builds.

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -232,7 +232,7 @@ class Posts extends Module {
 		add_filter( 'jetpack_sync_before_send_deleted_post_meta', array( $this, 'trim_post_meta' ) );
 		// Full sync.
 		$sync_module = Modules::get_module( 'full-sync' );
-		if ( str_contains( get_class( $sync_module ), 'Full_Sync_Immediately' ) ) {
+		if ( $sync_module && str_contains( get_class( $sync_module ), 'Full_Sync_Immediately' ) ) {
 			add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'add_term_relationships' ) );
 		} else {
 			add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_posts_with_metadata_and_terms' ) );


### PR DESCRIPTION
A conditional in `projects/packages/sync/src/modules/class-posts.php` didn't have a variable sanity check. This resulted in failed builds. This PR adds the missing check.

Relevant discussion about the issue here: p1702050275703559-slack-C05PV073SG3

## Testing instructions:

* None required.

## Does this pull request change what data or activity we track or use?

No
