### PR TITLE
CRM: Resolves 3393 - add WordPress Playground blueprint

### DIFF
--- a/projects/plugins/crm/.wordpress-org/blueprints/blueprint.json
+++ b/projects/plugins/crm/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,15 @@
+{
+	"landingPage": "/wp-admin/admin.php?page=zerobscrm-dash",
+	"preferredVersions": {
+		"php": "8.0",
+		"wp": "latest"
+	},
+	"phpExtensionBundles": [ "kitchen-sink" ],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		}
+	]
+}

--- a/projects/plugins/crm/changelog/add-crm-3393-WordPress-Playground_blueprint
+++ b/projects/plugins/crm/changelog/add-crm-3393-WordPress-Playground_blueprint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add blueprint for WordPress Playground
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: Resolves Automattic/zero-bs-crm#3393 - add WordPress Playground blueprint

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This is a backport of the blueprint already pushed to the SVN; files in `.wordpress.org` are put in the SVN `assets` folder.

See pbhBOz-4eF-p2 for more details.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The added file should match (spacing differences aside) what is currently in the SVN:
https://plugins.trac.wordpress.org/browser/zero-bs-crm/assets/blueprints/blueprint.json