### PR TITLE
Launchpad: Add sensei setup task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-sensei-setup-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-sensei-setup-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Sensei Setup Task, to allow us to retire the old checklist card

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -643,6 +643,16 @@ function wpcom_launchpad_get_task_definitions() {
 				return site_url( '/wp-admin/admin.php?page=wc-admin' );
 			},
 		),
+		'sensei_setup'                       => array(
+			'get_title'            => function () {
+				return __( 'Finish Sensei setup', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_sensei_setup_visible',
+			'get_calypso_path'     => function () {
+				return site_url( '/wp-admin/admin.php?page=sensei' );
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );
@@ -975,6 +985,21 @@ function wpcom_launchpad_is_woocommerce_setup_visible() {
 
 	$active_plugins = get_option( 'active_plugins' );
 	return in_array( 'woocommerce/woocommerce.php', $active_plugins, true );
+}
+
+/**
+ * Determines wheter or not the sensei setup task should be visible.
+ *
+ * @return bool True if the sensei setup task should be visible.
+ */
+function wpcom_launchpad_is_sensei_setup_visible() {
+	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
+	if ( ! $is_atomic_site ) {
+		return false;
+	}
+
+	$active_plugins = get_option( 'active_plugins' );
+	return in_array( 'sensei-lms/sensei-lms.php', $active_plugins, true );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -998,8 +998,7 @@ function wpcom_launchpad_is_sensei_setup_visible() {
 		return false;
 	}
 
-	$active_plugins = get_option( 'active_plugins' );
-	return in_array( 'sensei-lms/sensei-lms.php', $active_plugins, true );
+	return is_plugin_active( 'sensei-lms/sensei-lms.php' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -280,6 +280,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'  => array(
 				'woocommerce_setup',
+				'sensei_setup',
 				'blogname_set',
 				'front_page_updated',
 				'verify_domain_email',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to: https://github.com/Automattic/jetpack/pull/34320
More context: paYKcK-3Hy-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* As part of the migration from the Site Setup Checklist to the Launchpad, we need to reproduce the logic of the legacy task so we can enable the Launchpad to be used for new sites only. 
* This PR adds the Sensei Setup task to the Legacy Site Setup checklist and also the visibility logic.
* The completion logic will be tackled in another PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox using the command below.
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-sensei-setup-task
```
* Create a new site through the `/setup/free` flow, and then add the Business plan
* Once you reach the Customer Home, go to the Developer Console and make a `GET` request to `wpcom/v2` -> ` /sites/:siteSlug/launchpad?checklist_slug=legacy-site-setup`
* Make sure the `Finish Sensei setup` task is not shown

<img width="1034" alt="Screen Shot 2023-12-08 at 16 07 03" src="https://github.com/Automattic/jetpack/assets/1234758/70eb7856-96c3-49d4-a5e1-08661734c22b">

* Now, add your site to the WoA Developer list.
* Then, install the Sensei LMS plugin, which should change your site to Atomic.
* Use the Jetpack Beta plugin to apply this PR to your site(You may have to updated the files manually, as the plugin doesn't seem to work on my end)
* Go back to the Developer Console and make the request again. Now you should see the `Finish Sensei setup` task in the response.
<img width="1035" alt="Screen Shot 2023-12-08 at 16 20 26" src="https://github.com/Automattic/jetpack/assets/1234758/368d0ef4-0454-4bdd-a626-c696de052186">
