### PR TITLE
Jetpack AI: Fix upgrade nudge button style

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-upgrade-nudge-button-style
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-upgrade-nudge-button-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Force button from upgrade nudge to use black and white styles.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/style.scss
@@ -1,3 +1,14 @@
+@import '@automattic/jetpack-base-styles/style';
+
 .jetpack-upgrade-plan-banner__wrapper {
     column-gap: 32px;
+}
+
+.jetpack-upgrade-plan-banner.jetpack-ai-upgrade-banner {
+    .jetpack-upgrade-plan-banner__wrapper {
+        .components-button.is-primary.is-busy {
+            background: var( --jp-white );
+            color: var( --jp-black );
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34472.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the `.is-busy` style of the upgrade nudge button to use black&white style instead of the default pink animation

| Before | After |
| --- | --- |
| <img width="500" alt="Screenshot 2023-12-08 at 16 16 45" src="https://github.com/Automattic/jetpack/assets/6760046/272a36cc-67fd-4c39-96e3-cb716dc93229"> | <img width="500" alt="Screenshot 2023-12-08 at 16 15 58" src="https://github.com/Automattic/jetpack/assets/6760046/c2a8e8ae-6a24-4cc6-80b0-18a61b038224"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor of your test site and add an AI Assistant block
* Dispatch the following action to set the site as having a free plan on the limit

```
wp.data.dispatch( 'wordpress-com/plans' ).storeAiAssistantFeature( {
    "hasFeature": false,
    "isOverLimit": true,
    "requestsCount": 20,
    "requestsLimit": 20,
    "requireUpgrade": true,
    "upgradeType": "default",
    "usagePeriod": {
        "currentStart": null,
        "nextStart": null,
        "requestsCount": 20
    },
    "currentTier": {
        "value": 0,
	"limit": 20,
    },
    "nextTier": {
        "slug": "jetpack_ai_yearly",
        "limit": 999999999,
        "value": 1,
        "readable-limit": "Unlimited"
    },
   "tierPlansEnabled": false,
} );
```

* Change the network throttling settings on the console to make your connection very slow, so you have time to see the effect on the button before the redirect
* Click the "Upgrade" button on the upgrade prompt that should be present
* Confirm the new "Redirecting..." style of the button

| Before | After |
| --- | --- |
| <img width="500" alt="Screenshot 2023-12-08 at 16 16 45" src="https://github.com/Automattic/jetpack/assets/6760046/272a36cc-67fd-4c39-96e3-cb716dc93229"> | <img width="500" alt="Screenshot 2023-12-08 at 16 15 58" src="https://github.com/Automattic/jetpack/assets/6760046/c2a8e8ae-6a24-4cc6-80b0-18a61b038224"> |

