### PR TITLE
Top Posts & Pages Block: Set Aspect Ratio for Thumbnails

### DIFF
--- a/projects/plugins/jetpack/changelog/update-top-posts-thumbnails
+++ b/projects/plugins/jetpack/changelog/update-top-posts-thumbnails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Top Posts and Pages block: set aspect ratio for thumbnail images.

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/style.scss
@@ -46,9 +46,16 @@
 		.jetpack-top-posts-mock-thumbnail {
 			background-color: $gray-100;
 			height: 0;
-			padding-bottom: 65%;
+			padding-bottom: 75%;
 			position: relative;
 			width: 100%;
+		}
+
+		.jetpack-top-posts-thumbnail {
+			aspect-ratio: 4 / 3;
+			height: auto;
+			object-fit: cover;
+			max-width: 100%;
 		}
 
 		.jetpack-top-posts-item {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #32937

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The grid layout for the Top Posts & Pages block looks a little weird when there are images of different sizes. Related Posts handles this by setting a 4:3 aspect ratio, so it probably makes sense to do the same here. 

It looks like the Related Posts block does it in a rather complicated way that doesn't always quite work though - since Jetpack has now stopped supporting IE11, it's possible to do this with CSS. That seems not only simpler in the code, but also allows users to more easily override it with their own desired aspect ratio. 

## Jetpack product discussion
N/A - drawing off the Related Posts block here. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Create some posts with some funky thumbnail sizes - ideally mix up landscape and portrait ones. You'll need to view these a couple of times, and then add a Top Posts and Pages block. Select "Grid layout" in Block Controls and ensure thumbnails are displayed. 

I've also made sure that the `mock-thumbnail` fits this ratio - that appears for posts which have no images in them, and no featured image. 

| Before | After |
|--------|--------|
| <img width="574" alt="Screenshot 2023-12-10 at 19 32 06" src="https://github.com/Automattic/jetpack/assets/43215253/4a9c8440-8f58-4f1a-aeae-8365a4eeed74"> | <img width="696" alt="Screenshot 2023-12-10 at 19 32 15" src="https://github.com/Automattic/jetpack/assets/43215253/b25ad468-db45-4057-8b37-97958ab264f1"> |

