### PR TITLE
Google Fonts Module: Fix the error when parsing a font family that has a reference to a path

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-google-fonts-font-family-ref
+++ b/projects/plugins/jetpack/changelog/fix-google-fonts-font-family-ref
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Google Fonts Module: Fix the error when parsing a font family that has a reference to a path

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -176,6 +176,13 @@ class Jetpack_Google_Font_Face {
 
 		$font_family = $setting['typography']['fontFamily'];
 
+		// The font family may be a reference to a path to the value stored at that location,
+		// e.g.: { "ref": "styles.elements.heading.typography.fontFamily" }.
+		// Ignore it as we also get the value stored at that location from the setting.
+		if ( ! is_string( $font_family ) ) {
+			return null;
+		}
+
 		// Full string: var(--wp--preset--font-family--slug).
 		// We do not care about the origin of the font, only its slug.
 		preg_match( '/font-family--(?P<slug>.+)\)$/', $font_family, $matches );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to pbxlJb-5a2-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* If the font family is a reference to a path, the Google Fonts module will throw an error as follows in PHP 8.1 when parsing the font families as we assume the value is a string.
  ```
  [08-Dec-2023 15:54:01 UTC] PHP Fatal error:  Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given in /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/sun/modules/google-fonts/current/class-jetpack-google-font-face.php:182
  ```
* As a result, this PR proposes a change to ignore those font families because we also get the value from the path they refer to.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the changes to your sandbox
  ```
  bin/jetpack-downloader test jetpack fix/google-fonts-font-family-ref
  ```
* Go to your WP.com site
* Activate the Assembler theme
* Go to your homepage or the Site Editor
* Ensure the error is gone