### PR TITLE
Launchpad: Add WooCommerce Setup task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-woocommerce-setup-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-woocommerce-setup-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the WooCommerce Setup task to the Site Setup Launchpad, to allow us to retire the old checklist card.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -633,6 +633,16 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/site-editor/' . $data['site_slug_encoded'] . '?canvas=edit';
 			},
 		),
+		'woocommerce_setup'                  => array(
+			'get_title'            => function () {
+				return __( 'Finish store setup', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
+			'get_calypso_path'     => function () {
+				return site_url( '/wp-admin/admin.php?page=wc-admin' );
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );
@@ -950,6 +960,21 @@ function wpcom_launchpad_is_domain_upsell_task_visible() {
 	);
 
 	return empty( $bundle_purchases );
+}
+
+/**
+ * Determines whether or not the WooCommerce setup task should be visible.
+ *
+ * @return bool True if the site is a WOA site and WooCommerce is active.
+ */
+function wpcom_launchpad_is_woocommerce_setup_visible() {
+	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
+	if ( ! $is_atomic_site ) {
+		return false;
+	}
+
+	$active_plugins = get_option( 'active_plugins' );
+	return in_array( 'woocommerce/woocommerce.php', $active_plugins, true );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -279,6 +279,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Site setup', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'  => array(
+				'woocommerce_setup',
 				'blogname_set',
 				'front_page_updated',
 				'verify_domain_email',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to: https://github.com/Automattic/jetpack/pull/34320
More context: paYKcK-3Hy-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* As part of the Site Setup checklist migration, we must add the WooCommerce setup task to the Launchpad when installed.
* This PR ensures that the WooCommerce setup task is available only when the WC plugin is installed and the site is atomic.
* The completion logic will be tackled in another PR.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox using the command below.
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-woocommerce-setup-task
```
* Create a new site through the `/setup/free` flow, and then add the Business plan
* Once you reach the Customer Home, go to the Developer Console and make a `GET` request to `wpcom/v2` -> ` /sites/:siteSlug/launchpad?checklist_slug=legacy-site-setup`
* Make sure the `Finish store setup` task is not shown

![Screen Shot 2023-12-11 at 09 29 42](https://github.com/Automattic/jetpack/assets/1234758/cd0ef58a-5cb1-491c-b80f-75b175e53a4c)

* Now, add your site to the WoA Developer list.
* Then, install the WooCommerce plugin, which should change your site to Atomic.
* Use the Jetpack Beta plugin to apply this PR to your site(You may have to updated the files manually, as the plugin doesn't seem to work on my end)
* Go back to the Developer Console and make the request again. Now you should see the `Finish store setup` task in the response.

![Screen Shot 2023-12-11 at 09 39 34](https://github.com/Automattic/jetpack/assets/1234758/5fddd624-4361-46e1-aed1-56b01ca8cf51)


