### PR TITLE
CRM: Fixing assorted placeholders: currency symbol and currency, notes from templates

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-quote-placeholders-notes-currency
+++ b/projects/plugins/crm/changelog/fix-crm-quote-placeholders-notes-currency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Quotes: Consistent rendering of values and currency in placeholders.

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -816,6 +816,11 @@ function ZeroBSCRM_get_quote_template() {
 			$replacements['biz-state']        = $bizState;
 			$replacements['contact-fullname'] = $customerName;
 
+			$settings = $zbs->settings->getAll();
+			if ( $settings['currency'] && $settings['currency']['strval'] ) {
+				$replacements['quote-currency'] = $settings['currency']['strval'];
+			}
+
 			// if DAL3, also replace any custom fields
 			if ( isset( $_POST['quote_fields'] ) && is_array( $_POST['quote_fields'] ) ) {
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -802,9 +802,6 @@ function ZeroBSCRM_get_quote_template() {
 			if ( empty( $quote_date ) ) {
 				$quote_date = gmdate( 'Y-m-d' );
 			}
-			if ( empty( $quote_notes ) ) {
-				$quote_notes = '[QUOTENOTES]';
-			}
 
 			// HTML is escaped just prior to the complete HTML in this function being returned
 			$working_html = wpautop( $quote_template['content'] );

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -759,6 +759,9 @@ function ZeroBSCRM_get_quote_template() {
 			if ( isset( $_POST['quote_fields']['zbscq_date'] ) && ! empty( $_POST['quote_fields']['zbscq_date'] ) ) {
 				$quote_date = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_date'] ) );
 			}
+			if ( isset( $_POST['quote_fields']['zbscq_notes'] ) && ! empty( $_POST['quote_fields']['zbscq_notes'] ) ) {
+				$quote_notes = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_notes'] ) );
+			}
 		}
 
 		// } Fill out rest

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -788,6 +788,9 @@ function ZeroBSCRM_get_quote_template() {
 			if ( empty( $quote_val ) && ! empty( $quote_template['value'] ) ) {
 				$quote_val = $quote_template['value'];
 			}
+			if ( empty( $quote_notes ) && ! empty( $quote_template['notes'] ) ) {
+				$quote_notes = $quote_template['notes'];
+			}
 
 			// catch empty pass...
 			if ( empty( $quote_title ) ) {
@@ -800,9 +803,7 @@ function ZeroBSCRM_get_quote_template() {
 				$quote_date = gmdate( 'Y-m-d' );
 			}
 			if ( empty( $quote_notes ) ) {
-				if ( isset( $_POST['quote_fields']['zbscq_notes'] ) ) {
-					$quote_notes = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_notes'] ) );
-				}
+				$quote_notes = '[QUOTENOTES]';
 			}
 
 			// HTML is escaped just prior to the complete HTML in this function being returned

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.QuoteTemplates.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.QuoteTemplates.php
@@ -1070,7 +1070,7 @@ class zbsDAL_quotetemplates extends zbsDAL_ObjectLayer {
             $res['owner'] = $obj->zbs_owner;
 
 
-			$res['title']            = $this->stripSlashes( $obj->zbsqt_title );
+			$res['title']            = wp_kses( html_entity_decode( $obj->zbsqt_title, ENT_QUOTES, 'UTF-8' ), $zbs->acceptable_restricted_html );
             $res['value'] = $this->stripSlashes($obj->zbsqt_value);
             $res['date_str'] = $this->stripSlashes($obj->zbsqt_date_str);
             $res['date'] = (int)$obj->zbsqt_date;

--- a/projects/plugins/crm/includes/jpcrm-mail-templating.php
+++ b/projects/plugins/crm/includes/jpcrm-mail-templating.php
@@ -463,6 +463,11 @@ function zeroBSCRM_quote_generateNotificationHTML( $quoteID = -1, $return = true
 				$replacements['msg-content'] = $bodyHTML;
 				$replacements['unsub-line'] = $unsub_line;
 				$replacements['biz-info'] = $bizInfoTable;
+
+				$settings = $zbs->settings->getAll();
+				if ( $settings['currency'] && $settings['currency']['strval'] ) {
+					$replacements['quote-currency'] = $settings['currency']['strval'];
+				}
 				$html = $placeholder_templating->replace_placeholders( array( 'global', 'quote' ), $templatedHTML, $replacements );
 
 			}
@@ -561,7 +566,12 @@ function zeroBSCRM_quote_generateAcceptNotifHTML( $quoteID = -1, $quoteSignedBy 
 				$replacements['biz-info'] = $bizInfoTable;
 				$replacements['quote-url']      = zeroBSCRM_portal_linkObj( $quoteID, ZBS_TYPE_QUOTE ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				$replacements['quote-edit-url'] = jpcrm_esc_link( 'edit', $quoteID, 'zerobs_quote' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-        $replacements['quote-value']    = $quote['value'] ? zeroBSCRM_formatCurrency( $quote['value'] ) : '';
+				$replacements['quote-value']    = $quote['value'] ? zeroBSCRM_formatCurrency( $quote['value'] ) : '';
+
+				$settings = $zbs->settings->getAll();
+				if ( $settings['currency'] && $settings['currency']['strval'] ) {
+					$replacements['quote-currency'] = $settings['currency']['strval'];
+				}
 				$html = $placeholder_templating->replace_placeholders( array( 'global', 'quote' ), $templatedHTML, $replacements );
 
 			}

--- a/projects/plugins/crm/includes/jpcrm-mail-templating.php
+++ b/projects/plugins/crm/includes/jpcrm-mail-templating.php
@@ -423,6 +423,7 @@ function zeroBSCRM_quote_generateNotificationHTML( $quoteID = -1, $return = true
 				// replacements $bodyHTML
 				$replacements['quote-url'] = $quote_url;
 				$replacements['quote-title'] = $proposalTitle;
+				$replacements['quote-value'] = $quote['value'] ? zeroBSCRM_formatCurrency( $quote['value'] ) : '';
 
 				$viewInPortal = '';
 				$quoteID = '';
@@ -534,6 +535,7 @@ function zeroBSCRM_quote_generateAcceptNotifHTML( $quoteID = -1, $quoteSignedBy 
 				$quote_edit_url                 = jpcrm_esc_link( 'edit', $quoteID, 'zerobs_quote' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				$replacements['quote-url']      = $quote_url;
 				$replacements['quote-edit-url'] = $quote_edit_url;
+				$replacements['quote-value']    = $quote['value'] ? zeroBSCRM_formatCurrency( $quote['value'] ) : '';
 
 				// build msg-content html
 				$bodyHTML = $placeholder_templating->replace_placeholders( array( 'global', 'quote', 'contact' ), $bodyHTML, $replacements, array( ZBS_TYPE_QUOTE => $quote, ZBS_TYPE_CONTACT => $quote_contact ) );

--- a/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
+++ b/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
@@ -1755,6 +1755,16 @@ class jpcrm_templating_placeholders {
 					
 					}
 
+					// If the key is quote-currency and the value is empty, let's use the currency set in the site settings.
+					if ( $key === 'quote-currency' && $replace_with === '' ) {
+
+						$settings = $zbs->settings->getAll();
+						if ( $settings['currency'] && $settings['currency']['strval'] ) {
+
+							$replace_with = $settings['currency']['strval'];
+						}
+					}
+
 					// Replace main key.
 					// In the Quote editor itself we don't want to render the Quote ID or URL placeholders,
 					// So, $include_non_rendered_quote_keys will be set to false in that case. See ZeroBSCRM_get_quote_template().

--- a/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
+++ b/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
@@ -1659,8 +1659,6 @@ class jpcrm_templating_placeholders {
 
 	) {
 
-		global $zbs;
-
 		// retrieve replacements for this tooling
 		$to_replace = $this->get_placeholders_for_tooling( $tooling );
 
@@ -1753,16 +1751,6 @@ class jpcrm_templating_placeholders {
 					
 						$string = str_replace( $replacement_info['aliases'], $replace_with, $string );
 					
-					}
-
-					// If the key is quote-currency and the value is empty, let's use the currency set in the site settings.
-					if ( $key === 'quote-currency' && $replace_with === '' ) {
-
-						$settings = $zbs->settings->getAll();
-						if ( $settings['currency'] && $settings['currency']['strval'] ) {
-
-							$replace_with = $settings['currency']['strval'];
-						}
 					}
 
 					// Replace main key.


### PR DESCRIPTION

## Proposed changes:

This PR is a child PR of it's parent - https://github.com/Automattic/jetpack/pull/34490 - which is needed as well in order for the changes in this PR to take full effect. The changes in this PR include:

* The Quote Value placeholder will now show a currency symbol in mail templates (in the quote notification and quote accepted email notification).
* The Quote Currency placeholder now shows the currency set in CRM settings. It isn't clear to me what else that should be set to, or if the idea was to be able to set the currency for individual Quotes - if so that's beyond the scope of this PR for now.
* The Quote Notes placeholder will correctly render the Quote Template notes field if the notes field in the quote itself is blank.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Parent issue: https://github.com/Automattic/zero-bs-crm/issues/3004
Parent PR: https://github.com/Automattic/jetpack/pull/34490

This PR fixes:
- https://github.com/Automattic/zero-bs-crm/issues/1588

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test, check out this PR locally or via Jurassic Ninja and the Jetpack Beta plugin.
* Test the ##QUOTE-VALUE## placeholder in the quote accepted and quote notification email templates (`/wp-admin/admin.php?page=zbs-email-templates&zbs_template_id=4` and `/wp-admin/admin.php?page=zbs-email-templates&zbs_template_id=2`). These should now display the currency symbol in those emails, whereas before they did not.
* Test the ##QUOTE-CURRENCY## placeholder in the two email templates, as well as adding it to a quote template. You should see the currency set in CRM site settings - `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=locale` - displaying as a string (eg 'USD'). This should display in the quote editor, portal, pdf, and the emails.
* To test the ##QUOTE-NOTES## field rendering the quote template notes field if the quote is blank (and test escaping issues), follow the excellent testing steps in the comment of this issue: https://github.com/Automattic/zero-bs-crm/issues/1588