### PR TITLE
CRM: Fixing quote date placeholders in the editor, portal, pdf, and mail templates

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-quote-date-placeholders
+++ b/projects/plugins/crm/changelog/fix-crm-quote-date-placeholders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Quotes: Consistent rendering of dates in placeholders.

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -757,8 +757,8 @@ function ZeroBSCRM_get_quote_template() {
 				$quote_val = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_value'] ) );
 			}
 			if ( isset( $_POST['quote_fields']['zbscq_date'] ) && ! empty( $_POST['quote_fields']['zbscq_date'] ) ) {
-				$sanitized_date = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_date'] ) );
-				$quote_date     = jpcrm_uts_to_date_str( strtotime( $sanitized_date ), get_option( 'date_format' ) );
+				$sanitized_date = jpcrm_date_str_to_uts( sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_date'] ) ) );
+				$quote_date     = jpcrm_uts_to_date_str( $sanitized_date );
 			}
 		}
 
@@ -841,7 +841,7 @@ function ZeroBSCRM_get_quote_template() {
 								// Here is where we search and replace placeholders for dates with a date string and date time strings), initially checking the value is similar to that of 'yyyy-mm-dd'.
 								if ( preg_match( '/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/', $v ) ) {
 
-									// Additional date validation to confirm the date is valid
+									// Additional date validation to confirm the date is valid, before processing (creating placeholder strings for searching and replacing).
 									$date_time = DateTime::createFromFormat( 'Y-m-d', $v );
 									if ( $date_time && $date_time->format( 'Y-m-d' ) === $v ) {
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -758,7 +758,7 @@ function ZeroBSCRM_get_quote_template() {
 			}
 			if ( isset( $_POST['quote_fields']['zbscq_date'] ) && ! empty( $_POST['quote_fields']['zbscq_date'] ) ) {
 				$sanitized_date = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_date'] ) );
-				$quote_date     = wp_date( get_option( 'date_format' ), strtotime( $sanitized_date ) );
+				$quote_date     = jpcrm_uts_to_date_str( strtotime( $sanitized_date ), get_option( 'date_format' ) );
 			}
 		}
 
@@ -795,7 +795,7 @@ function ZeroBSCRM_get_quote_template() {
 				$quote_val = '[QUOTEVALUE]';
 			}
 			if ( empty( $quote_date ) ) {
-				$quote_date = wp_date( get_option( 'date_format' ) );
+				$quote_date = jpcrm_uts_to_date_str( time(), get_option( 'date_format' ) );
 			}
 			if ( empty( $quote_notes ) ) {
 				if ( isset( $_POST['quote_fields']['zbscq_notes'] ) ) {
@@ -845,7 +845,7 @@ function ZeroBSCRM_get_quote_template() {
 									$date_time = DateTime::createFromFormat( 'Y-m-d', $v );
 									if ( $date_time && $date_time->format( 'Y-m-d' ) === $v ) {
 
-										$working_html = jpcrm_process_date_variables( $v, $key, $working_html, $custom_field = true );
+										$working_html = jpcrm_process_date_variables( $v, $key, $working_html, $placeholder_str_start = '##QUOTE-' );
 
 									}
 								}

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -838,7 +838,7 @@ function ZeroBSCRM_get_quote_template() {
 							if ( isset( $_POST['quote_fields'][ 'zbscq_' . $key ] ) ) {
 								$v = sanitize_text_field( $_POST['quote_fields'][ 'zbscq_' . $key ] );
 
-								// Here is where we search and replace placeholders for dates with a date string and date time strings), initially checking the value is similar to that of a Unix timestamp
+								// Here is where we search and replace placeholders for dates with a date string and date time strings), initially checking the value is similar to that of 'yyyy-mm-dd'.
 								if ( preg_match( '/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/', $v ) ) {
 
 									// Additional date validation to confirm the date is valid

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -757,7 +757,8 @@ function ZeroBSCRM_get_quote_template() {
 				$quote_val = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_value'] ) );
 			}
 			if ( isset( $_POST['quote_fields']['zbscq_date'] ) && ! empty( $_POST['quote_fields']['zbscq_date'] ) ) {
-				$quote_date = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_date'] ) );
+				$sanitized_date = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_date'] ) );
+				$quote_date     = wp_date( get_option( 'date_time' ), strtotime( $sanitized_date ) );
 			}
 		}
 
@@ -794,7 +795,7 @@ function ZeroBSCRM_get_quote_template() {
 				$quote_val = '[QUOTEVALUE]';
 			}
 			if ( empty( $quote_date ) ) {
-				$quote_date = gmdate( 'Y-m-d' );
+				$quote_date = wp_date( get_option( 'date_format' ) );
 			}
 			if ( empty( $quote_notes ) ) {
 				if ( isset( $_POST['quote_fields']['zbscq_notes'] ) ) {
@@ -844,17 +845,7 @@ function ZeroBSCRM_get_quote_template() {
 									$date_time = DateTime::createFromFormat( 'Y-m-d', $v );
 									if ( $date_time && $date_time->format( 'Y-m-d' ) === $v ) {
 
-										$datetime_key       = $key . '_datetime_str';
-										$string_to_datetime = gmdate( 'd F Y H:i:s', strtotime( $v ) );
-										$date_key           = $key . '_date_str';
-										$string_to_date     = gmdate( 'd F Y', strtotime( $v ) );
-
-										$working_html = str_replace( '##QUOTE-' . strtoupper( $datetime_key ) . '##', $string_to_datetime, $working_html );
-										$working_html = str_replace( '##QUOTE-' . strtolower( $datetime_key ) . '##', $string_to_datetime, $working_html );
-										$working_html = str_replace( '##quote-' . strtolower( $datetime_key ) . '##', $string_to_datetime, $working_html );
-										$working_html = str_replace( '##QUOTE-' . strtoupper( $date_key ) . '##', $string_to_date, $working_html );
-										$working_html = str_replace( '##QUOTE-' . strtolower( $date_key ) . '##', $string_to_date, $working_html );
-										$working_html = str_replace( '##quote-' . strtolower( $date_key ) . '##', $string_to_date, $working_html );
+										$working_html = jpcrm_process_date_variables( $v, $key, $working_html, $custom_field = true );
 
 									}
 								}

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -859,7 +859,7 @@ function ZeroBSCRM_get_quote_template() {
 					}
 				}
 			}
-			$keys_staying_unrendered = array( 'quote-ID', 'quote-url' );
+			$keys_staying_unrendered = array( 'quote-ID', 'quote-url', 'quote-created', 'quote-created_datetime_str', 'quote-created_date_str', 'quote-accepted', 'quote-accepted_datetime_str', 'quote-accepted_date_str', 'quote-lastupdated', 'quote-lastupdated_datetime_str', 'quote-lastupdated_date_str' );
 			$working_html            = $placeholder_templating->replace_placeholders( array( 'global', 'contact', 'quote' ), $working_html, $replacements, array( ZBS_TYPE_CONTACT => $contact_object ), false, $keys_staying_unrendered ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 			// } replace the rest (#fname, etc)

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -836,6 +836,28 @@ function ZeroBSCRM_get_quote_template() {
 							$v = '';
 							if ( isset( $_POST['quote_fields'][ 'zbscq_' . $key ] ) ) {
 								$v = sanitize_text_field( $_POST['quote_fields'][ 'zbscq_' . $key ] );
+
+								// Here is where we search and replace placeholders for dates with a date string and date time strings), initially checking the value is similar to that of a Unix timestamp
+								if ( preg_match( '/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/', $v ) ) {
+
+									// Additional date validation to confirm the date is valid
+									$date_time = DateTime::createFromFormat( 'Y-m-d', $v );
+									if ( $date_time && $date_time->format( 'Y-m-d' ) === $v ) {
+
+										$datetime_key       = $key . '_datetime_str';
+										$string_to_datetime = gmdate( 'd F Y H:i:s', strtotime( $v ) );
+										$date_key           = $key . '_date_str';
+										$string_to_date     = gmdate( 'd F Y', strtotime( $v ) );
+
+										$working_html = str_replace( '##QUOTE-' . strtoupper( $datetime_key ) . '##', $string_to_datetime, $working_html );
+										$working_html = str_replace( '##QUOTE-' . strtolower( $datetime_key ) . '##', $string_to_datetime, $working_html );
+										$working_html = str_replace( '##quote-' . strtolower( $datetime_key ) . '##', $string_to_datetime, $working_html );
+										$working_html = str_replace( '##QUOTE-' . strtoupper( $date_key ) . '##', $string_to_date, $working_html );
+										$working_html = str_replace( '##QUOTE-' . strtolower( $date_key ) . '##', $string_to_date, $working_html );
+										$working_html = str_replace( '##quote-' . strtolower( $date_key ) . '##', $string_to_date, $working_html );
+
+									}
+								}
 							}
 
 							// allow upper or lower to catch various uses

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -758,7 +758,7 @@ function ZeroBSCRM_get_quote_template() {
 			}
 			if ( isset( $_POST['quote_fields']['zbscq_date'] ) && ! empty( $_POST['quote_fields']['zbscq_date'] ) ) {
 				$sanitized_date = sanitize_text_field( wp_unslash( $_POST['quote_fields']['zbscq_date'] ) );
-				$quote_date     = wp_date( get_option( 'date_time' ), strtotime( $sanitized_date ) );
+				$quote_date     = wp_date( get_option( 'date_format' ), strtotime( $sanitized_date ) );
 			}
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -851,30 +851,27 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
 	}
 
 /**
- * Return an updated HTML string, replacing quote date placeholders with correct date strings based on site settings.
- * @param  string  $value         The value of the date variable to be replaced.
- * @param  string  $key           The key of the date variable to be replaced.
- * @param  string  $working_html  The HTML string to be updated.
- * @param  boolean $custom_field Whether the key in question is a custom quote field.
+ * Return an updated HTML string, replacing date placeholders with correct date strings based on site settings.
+ * @param  string $value                 The value of the date variable to be replaced.
+ * @param  string $key                   The key of the date variable to be replaced.
+ * @param  string $working_html          The HTML string to be updated.
+ * @param  string $placeholder_str_start The string to add to the beginning of the placeholder string (eg. ##QUOTE-).
  *
  * @return string                The updated HTML string.
  */
-function jpcrm_process_date_variables( $value, $key, $working_html, $custom_field = false ) {
-	$placeholder_str_start = '##';
-	if ( $custom_field ) {
-		$placeholder_str_start = '##QUOTE-';
-	}
-	$numeric_date_key       = $key;
-	$string_to_numeric_date = wp_date( get_option( 'date_format' ), strtotime( $value ) );
-	$datetime_key           = $key . '_datetime_str';
-	$string_to_datetime     = wp_date( 'd F Y ' . get_option( 'time_format' ), strtotime( $value ) );
-	$date_key               = $key . '_date_str';
-	$string_to_date         = wp_date( 'd F Y', strtotime( $value ) );
+function jpcrm_process_date_variables( $value, $key, $working_html, $placeholder_str_start = '##' ) {
+
+	$base_date_key       = $key;
+	$string_to_base_date = jpcrm_uts_to_date_str( strtotime( $value ), get_option( 'date_format' ) );
+	$datetime_key        = $key . '_datetime_str';
+	$string_to_datetime  = jpcrm_uts_to_date_str( strtotime( $value ), 'd F Y ' . get_option( 'time_format' ) );
+	$date_key            = $key . '_date_str';
+	$string_to_date      = jpcrm_uts_to_date_str( strtotime( $value ), 'd F Y' );
 
 	$search_replace_pairs = array(
-		$placeholder_str_start . strtoupper( $numeric_date_key ) . '##' => $string_to_numeric_date,
-		$placeholder_str_start . strtolower( $numeric_date_key ) . '##' => $string_to_numeric_date,
-		$placeholder_str_start . strtolower( $numeric_date_key ) . '##' => $string_to_numeric_date,
+		$placeholder_str_start . strtoupper( $base_date_key ) . '##' => $string_to_base_date,
+		$placeholder_str_start . strtolower( $base_date_key ) . '##' => $string_to_base_date,
+		$placeholder_str_start . strtolower( $base_date_key ) . '##' => $string_to_base_date,
 		$placeholder_str_start . strtoupper( $datetime_key ) . '##' => $string_to_datetime,
 		$placeholder_str_start . strtolower( $datetime_key ) . '##' => $string_to_datetime,
 		$placeholder_str_start . strtolower( $datetime_key ) . '##' => $string_to_datetime,

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -861,23 +861,18 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
  */
 function jpcrm_process_date_variables( $value, $key, $working_html, $placeholder_str_start = '##' ) {
 
-	$base_date_key       = $key;
-	$string_to_base_date = jpcrm_uts_to_date_str( strtotime( $value ), get_option( 'date_format' ) );
-	$datetime_key        = $key . '_datetime_str';
-	$string_to_datetime  = jpcrm_uts_to_date_str( strtotime( $value ), 'd F Y ' . get_option( 'time_format' ) );
-	$date_key            = $key . '_date_str';
-	$string_to_date      = jpcrm_uts_to_date_str( strtotime( $value ), 'd F Y' );
+	$base_date_key        = $key;
+	$date_to_uts          = jpcrm_date_str_to_uts( $value );
+	$datetime_key         = $key . '_datetime_str';
+	$date_uts_to_datetime = jpcrm_uts_to_datetime_str( $date_to_uts );
+	$date_key             = $key . '_date_str';
+	$date_uts__to_date    = jpcrm_uts_to_date_str( $date_to_uts );
 
 	$search_replace_pairs = array(
-		$placeholder_str_start . strtoupper( $base_date_key ) . '##' => $string_to_base_date,
-		$placeholder_str_start . strtolower( $base_date_key ) . '##' => $string_to_base_date,
-		$placeholder_str_start . strtolower( $base_date_key ) . '##' => $string_to_base_date,
-		$placeholder_str_start . strtoupper( $datetime_key ) . '##' => $string_to_datetime,
-		$placeholder_str_start . strtolower( $datetime_key ) . '##' => $string_to_datetime,
-		$placeholder_str_start . strtolower( $datetime_key ) . '##' => $string_to_datetime,
-		$placeholder_str_start . strtoupper( $date_key ) . '##' => $string_to_date,
-		$placeholder_str_start . strtolower( $date_key ) . '##' => $string_to_date,
-		$placeholder_str_start . strtolower( $date_key ) . '##' => $string_to_date,
+		$placeholder_str_start . strtoupper( $base_date_key ) . '##' => $date_to_uts,
+		$placeholder_str_start . strtoupper( $datetime_key ) . '##' => $date_uts_to_datetime,
+		$placeholder_str_start . strtoupper( $date_key ) . '##' => $date_uts__to_date,
+
 	);
 
 	$working_html = str_replace( array_keys( $search_replace_pairs ), $search_replace_pairs, $working_html );

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -850,6 +850,44 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
 
 	}
 
+/**
+ * Return an updated HTML string, replacing quote date placeholders with correct date strings based on site settings.
+ * @param  string  $value         The value of the date variable to be replaced.
+ * @param  string  $key           The key of the date variable to be replaced.
+ * @param  string  $working_html  The HTML string to be updated.
+ * @param  boolean $custom_field Whether the key in question is a custom quote field.
+ *
+ * @return string                The updated HTML string.
+ */
+function jpcrm_process_date_variables( $value, $key, $working_html, $custom_field = false ) {
+	$placeholder_str_start = '##';
+	if ( $custom_field ) {
+		$placeholder_str_start = '##QUOTE-';
+	}
+	$numeric_date_key       = $key;
+	$string_to_numeric_date = wp_date( get_option( 'date_format' ), strtotime( $value ) );
+	$datetime_key           = $key . '_datetime_str';
+	$string_to_datetime     = wp_date( 'd F Y ' . get_option( 'time_format' ), strtotime( $value ) );
+	$date_key               = $key . '_date_str';
+	$string_to_date         = wp_date( 'd F Y', strtotime( $value ) );
+
+	$search_replace_pairs = array(
+		$placeholder_str_start . strtoupper( $numeric_date_key ) . '##' => $string_to_numeric_date,
+		$placeholder_str_start . strtolower( $numeric_date_key ) . '##' => $string_to_numeric_date,
+		$placeholder_str_start . strtolower( $numeric_date_key ) . '##' => $string_to_numeric_date,
+		$placeholder_str_start . strtoupper( $datetime_key ) . '##' => $string_to_datetime,
+		$placeholder_str_start . strtolower( $datetime_key ) . '##' => $string_to_datetime,
+		$placeholder_str_start . strtolower( $datetime_key ) . '##' => $string_to_datetime,
+		$placeholder_str_start . strtoupper( $date_key ) . '##' => $string_to_date,
+		$placeholder_str_start . strtolower( $date_key ) . '##' => $string_to_date,
+		$placeholder_str_start . strtolower( $date_key ) . '##' => $string_to_date,
+	);
+
+	$working_html = str_replace( array_keys( $search_replace_pairs ), $search_replace_pairs, $working_html );
+
+	return $working_html;
+}
+
 /* ======================================================
   /	Quotes
    ====================================================== */

--- a/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
+++ b/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
@@ -1755,22 +1755,24 @@ class jpcrm_templating_placeholders {
 					
 					}
 
-					// If this is a Quote Accepted key and it is not set, let's print out a message saying the quote isn't accepted.
-					if ( $key === 'quote-accepted' || $key === 'quote-accepted_date_str' || $key === 'quote-accepted_datetime_str' ) {
-
-						if ( empty( $replace_with ) || str_starts_with( $replace_with, '1 January 1970' ) ) {
-							$replace_with = __( 'Quote not yet accepted', 'zero-bs-crm' );
+					// If this is a Quote date key and is not set (Quote accepted or last viewed), let's print out a message saying the quote isn't accepted or viewed.
+					$possible_empty_quote_keys = array( 'quote-accepted', 'quote-accepted_date_str', 'quote-accepted_datetime_str', 'quote-lastviewed', 'quote-lastviewed_datetime_str', 'quote-lastviewed_date_str' );
+					if ( in_array( $key, $possible_empty_quote_keys, true ) ) {
+						// 82799 is 23hrs, 59mins, 59secs on Jan 1, 1970 (so a blank timestamp, allowing for systems to update the time within that day for any reason)
+						if ( empty( $replace_with ) || strtotime( $replace_with ) <= 82799 ) {
+							$replace_with = str_starts_with( $key, 'quote-accepted' ) ? __( 'Quote not yet accepted', 'zero-bs-crm' ) : __( 'Quote not yet viewed', 'zero-bs-crm' );
 						}
 					}
 
 					// We want to check if a quote field is a unix timestamp, so this light approach will check if the value is numeric initially to lower the searches,
 					// then check if its _datetime_str equivalent exists (unless it's the 'quote-date' key), confirming our current key is a timestamp.
-					// Then we can convert the replace_with value to a human readable 'Y-m-d' format.
+					// Then we can convert the replace_with value to a human readable format based on site date settings.
 					if ( str_starts_with( $key, 'quote-' ) && is_numeric( $replace_with ) ) {
 
 						$new_key = '##' . strtoupper( $key ) . '_DATETIME_STR##';
 						if ( array_key_exists( $new_key, $to_replace ) || $key === 'quote-date' ) {
-							$replace_with = gmdate( 'Y-m-d', $replace_with );
+							$replace_with = wp_date( get_option( 'date_format' ), $replace_with );
+							$string       = jpcrm_process_date_variables( $replace_with, $key, $string );
 						}
 					}
 

--- a/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
+++ b/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
@@ -1755,6 +1755,14 @@ class jpcrm_templating_placeholders {
 					
 					}
 
+					// If this is a Quote Accepted key and it is not set, let's print out a message saying the quote isn't accepted.
+					if ( $key === 'quote-accepted' || $key === 'quote-accepted_date_str' || $key === 'quote-accepted_datetime_str' ) {
+
+						if ( empty( $replace_with ) || str_starts_with( $replace_with, '1 January 1970' ) ) {
+							$replace_with = __( 'Quote not yet accepted', 'zero-bs-crm' );
+						}
+					}
+
 					// We want to check if a quote field is a unix timestamp, so this light approach will check if the value is numeric initially to lower the searches,
 					// then check if its _datetime_str equivalent exists (unless it's the 'quote-date' key), confirming our current key is a timestamp.
 					// Then we can convert the replace_with value to a human readable 'Y-m-d' format.
@@ -1767,9 +1775,9 @@ class jpcrm_templating_placeholders {
 					}
 
 					// Replace main key.
-					// In the Quote editor itself we don't want to render the Quote ID or URL placeholders,
+					// In the Quote editor itself we don't want to render the Quote ID, URL, Created, Accepted or Last Updated placeholders,
 					// So, $include_non_rendered_quote_keys will be set to false in that case. See ZeroBSCRM_get_quote_template().
-					$non_rendered_quote_keys = array( 'quote-ID', 'quote-url' );
+					$non_rendered_quote_keys = array( 'quote-ID', 'quote-url', 'quote-created', 'quote-created_datetime_str', 'quote-created_date_str', 'quote-accepted', 'quote-accepted_datetime_str', 'quote-accepted_date_str', 'quote-lastupdated', 'quote-lastupdated_datetime_str', 'quote-lastupdated_date_str' );
 					if ( $include_non_rendered_quote_keys || ( ! $include_non_rendered_quote_keys && ! in_array( $replacement_info['key'], $non_rendered_quote_keys, true ) ) ) {
 
 						$string = str_replace( $replace_string, $replace_with, $string );

--- a/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
+++ b/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
@@ -1758,21 +1758,9 @@ class jpcrm_templating_placeholders {
 					// If this is a Quote date key and is not set (Quote accepted or last viewed), let's print out a message saying the quote isn't accepted or viewed.
 					$possible_empty_quote_keys = array( 'quote-accepted', 'quote-accepted_date_str', 'quote-accepted_datetime_str', 'quote-lastviewed', 'quote-lastviewed_datetime_str', 'quote-lastviewed_date_str' );
 					if ( in_array( $key, $possible_empty_quote_keys, true ) ) {
-						// 82799 is 23hrs, 59mins, 59secs on Jan 1, 1970 (so a blank timestamp, allowing for systems to update the time within that day for any reason)
-						if ( empty( $replace_with ) || strtotime( $replace_with ) <= 82799 ) {
+
+						if ( empty( $replace_with ) || jpcrm_date_str_to_uts( $replace_with ) === 0 || jpcrm_datetime_str_to_uts( $replace_with ) === 0 ) {
 							$replace_with = str_starts_with( $key, 'quote-accepted' ) ? __( 'Quote not yet accepted', 'zero-bs-crm' ) : __( 'Quote not yet viewed', 'zero-bs-crm' );
-						}
-					}
-
-					// We want to check if a quote field is a unix timestamp, so this light approach will check if the value is numeric initially to lower the searches,
-					// then check if its _datetime_str equivalent exists (unless it's the 'quote-date' key), confirming our current key is a timestamp.
-					// Then we can convert the replace_with value to a human readable format based on site date settings.
-					if ( str_starts_with( $key, 'quote-' ) && is_numeric( $replace_with ) ) {
-
-						$new_key = '##' . strtoupper( $key ) . '_DATETIME_STR##';
-						if ( array_key_exists( $new_key, $to_replace ) || $key === 'quote-date' ) {
-							$replace_with = gmdate( 'Y-m-d', $replace_with );
-							$string       = jpcrm_process_date_variables( $replace_with, $key, $string );
 						}
 					}
 

--- a/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
+++ b/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
@@ -1771,7 +1771,7 @@ class jpcrm_templating_placeholders {
 
 						$new_key = '##' . strtoupper( $key ) . '_DATETIME_STR##';
 						if ( array_key_exists( $new_key, $to_replace ) || $key === 'quote-date' ) {
-							$replace_with = wp_date( get_option( 'date_format' ), $replace_with );
+							$replace_with = gmdate( 'Y-m-d', $replace_with );
 							$string       = jpcrm_process_date_variables( $replace_with, $key, $string );
 						}
 					}

--- a/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
+++ b/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
@@ -1755,6 +1755,17 @@ class jpcrm_templating_placeholders {
 					
 					}
 
+					// We want to check if a quote field is a unix timestamp, so this light approach will check if the value is numeric initially to lower the searches,
+					// then check if its _datetime_str equivalent exists (unless it's the 'quote-date' key), confirming our current key is a timestamp.
+					// Then we can convert the replace_with value to a human readable 'Y-m-d' format.
+					if ( str_starts_with( $key, 'quote-' ) && is_numeric( $replace_with ) ) {
+
+						$new_key = '##' . strtoupper( $key ) . '_DATETIME_STR##';
+						if ( array_key_exists( $new_key, $to_replace ) || $key === 'quote-date' ) {
+							$replace_with = gmdate( 'Y-m-d', $replace_with );
+						}
+					}
+
 					// Replace main key.
 					// In the Quote editor itself we don't want to render the Quote ID or URL placeholders,
 					// So, $include_non_rendered_quote_keys will be set to false in that case. See ZeroBSCRM_get_quote_template().


### PR DESCRIPTION
## Proposed changes:

This PR is a child PR of it's parent - https://github.com/Automattic/jetpack/pull/34490 - which is needed as well in order for the changes in this PR to take full effect. The changes in this PR include:

* The Quote Date placeholder now shows the same date format (in the quote editor, client portal, and pdf) when initially set, or left to be set by default. This matches custom date fields as well.
* Custom Quote Date placeholders now render as expected in all areas (editor, portal, pdf, and the two quote email templates).
* Quote Accepted, Last Updated and Created placeholders now render 'as expected' (see additional notes below) in all areas except the quote editor (so portal, pdf, and the two quote email templates). For that, no information is available on initial quote creation so the placeholders are left unrendered there.
* The main date versions of date placeholders (see notes below) render the date based on site settings.

## Additional notes:

- For the 'Last Viewed' placeholder - how do we track a quote has been viewed? Do we need to? I don't see that we are currently doing this so it looks like it may have been added as something that may get implemented in the future, from what I can tell. I would vote for removing this completely.
- In terms of picking the correct date time:
  - The complication is that we have three different placeholders for several main placeholders. These include Quote Accepted, Quote Last Viewed, Quote Last Updated and Quote Created, as well as custom date fields.
  - What I've done to both respect the available placeholder options but also consider the date format itself and let there be some flexibility to site admins can make sure dates are displayed in the format of their choice, is to use the site date settings at `/wp-admin/options-general.php` for the datetime_str and date_str placeholder verisons of dates where three exist, and UTS for the main placeholder. All except for Quote Date which would use site settings.~main date (eg. quote-date, quote-accepted, etc - not considering the 'datetime_str' and 'date_str' versions). That does mean that two placeholders may be duplicated if one option is chosen in particular (`j F Y`), but I don't think that matters so much. It allows more flexibility in options for most.~
  - Also related, the reason the date functions are taking place at the placeholder rendering / Ajax file level is because once the date has rendered, we then save it in that format (affecting the quote editor, preview and portal). The date value sent via $_POST will always be yyyy-mm-dd ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date)), so the first place to change this is when building the quote data.
  - For emails, we could fetch the data from the database directly, so we can actually update the date functionality further up so it is saved correctly (eg `tidyquote`). There is a pending date related issue and existing functions that need updating here and further testing needed as this affects more than just palceholders, so I'm leaving that as a separate issue: https://github.com/Automattic/zero-bs-crm/issues/313


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Parent issue: https://github.com/Automattic/zero-bs-crm/issues/3004
Parent PR: https://github.com/Automattic/jetpack/pull/34490

Addresses:
- https://github.com/Automattic/zero-bs-crm/issues/3288

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test, check out this PR locally or via Jurassic Ninja and the Jetpack Beta plugin.
* Test the ##QUOTE-DATE## placeholder in a quote template, setting the quote date when creating a new quote and also not setting it. In both cases, the formatted date shown in the editor should be the same, and also in the client portal and pdf. This should be the same as the custom date field (bearing in mind each custom date field creates three placeholders, you need the correct one! That would be the first date custom field in the placeholder list (on the system status page) for that custom field).
* Test the custom Quote Date placeholders by creating a new custom quote field - `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=customfields` - and checking the placeholder map for the new values (there should be three - regular date, date string, date time string). Add these to a quote template and check the rendering in the editor, portal and pdf. Similarly add these to the two quote email templates -  (`/wp-admin/admin.php?page=zbs-email-templates&zbs_template_id=4` and `/wp-admin/admin.php?page=zbs-email-templates&zbs_template_id=2`) - and check the results. What you should see is the main date rendered as a UTS string, then the datetime and date strings as per the site settings.
* Test the Quote Accepted, Last Updated and Created placeholders (there are three of each, available via the placeholder map). Add these to a quote template and check the rendering in the portal and pdf (will remain unrendered in the quote editor). Similarly, the placeholders will now work in the two quote email templates. 
* To test the date formatting, keep all of the date placeholders you've been testing with in place in a template. Then on the site settings page at `/wp-admin/options-general.php` change the site's date format. Create a new quote with the relevant template, and what you should see is all custom date fields, plus the quote-date placeholder, rendering. The date should be in the format you selected in site settings. All other date fields (Quote Accepted, Quote Created, Quote Last Updated) will not render in the editor (and the Quote Last viewed placeholders will just show 'Quote not yet viewed' text for now.
* Save the quote, and view the quote in the portal and pdf. All fields should now be rendered, in the correct format. The previously rendered date format should match those in the editor, and any date_str and datetime_str placeholders should now render what is in the site settings, and the main placeholder rendering a UTS string. Quote date should render the date as per the site settings.
* For all of the above, where the placeholders are rendering the date in a specific language, you can test changing the site language on the same admin settings page as the date settings. Try creating a new quote and viewing emails / portal / pdf and where relevant the quote editor, and the correct language should be used.

