### PR TITLE
Like block: Handle the Reblog toggle change

### DIFF
--- a/projects/plugins/jetpack/changelog/add-like-block-handle-reblog-toggle
+++ b/projects/plugins/jetpack/changelog/add-like-block-handle-reblog-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Like block (beta): Handle Reblog toggle change

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -15,38 +15,38 @@ function LikeEdit( { noticeUI } ) {
 	const blogId = window?.Jetpack_LikeBlock?.blog_id;
 
 	const {
-		fetchReblogSetting,
-		reblogSetting,
+		fetchReblog,
+		reblogSetting: currentReblogSetting,
 		isLoading: fetchingReblog,
 	} = useFetchReblogSetting( blogId );
 	const {
-		setReblogSetting,
-		success: reblogSettingSet,
-		resetSuccess: clearReblogSettingStatus,
+		setReblog,
+		success: reblogSet,
+		resetSuccess: clearReblogSetStatus,
 		isLoading: settingReblog,
 	} = useSetReblogSetting( blogId );
 
 	const handleReblogSetting = newValue => {
-		setReblogSetting( newValue );
+		setReblog( newValue );
 	};
 
 	useEffect( () => {
 		if ( ! isSimpleSite() ) {
 			return;
 		}
-		fetchReblogSetting();
-	}, [ fetchReblogSetting ] );
+		fetchReblog();
+	}, [ fetchReblog ] );
 
 	useEffect( () => {
 		if ( ! isSimpleSite() ) {
 			return;
 		}
 
-		if ( reblogSettingSet ) {
-			fetchReblogSetting();
-			clearReblogSettingStatus();
+		if ( reblogSet ) {
+			fetchReblog();
+			clearReblogSetStatus();
 		}
-	}, [ reblogSettingSet, fetchReblogSetting, clearReblogSettingStatus ] );
+	}, [ reblogSet, fetchReblog, clearReblogSetStatus ] );
 
 	return (
 		<div { ...blockProps }>
@@ -55,7 +55,7 @@ function LikeEdit( { noticeUI } ) {
 					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 						<ToggleControl
 							label="Show reblog button"
-							checked={ reblogSetting }
+							checked={ currentReblogSetting }
 							disabled={ settingReblog || fetchingReblog }
 							onChange={ newValue => {
 								handleReblogSetting( newValue );

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import metadata from './block.json';
 import './editor.scss';
 import useFetchReblogSetting from './use-fetch-reblog-setting';
+import useSetReblogSetting from './use-set-reblog-setting';
 
 const icon = getBlockIconComponent( metadata );
 
@@ -14,10 +15,11 @@ function LikeEdit( { noticeUI } ) {
 	const blogId = window?.Jetpack_LikeBlock?.blog_id;
 
 	const { fetchReblogSetting, reblogSetting } = useFetchReblogSetting( blogId );
+	const { setReblogSetting, success } = useSetReblogSetting( blogId );
 
-	const setReblogSetting = newValue => {
-		// eslint-disable-next-line no-console
-		console.log( newValue );
+	const handleReblogSetting = newValue => {
+		setReblogSetting( newValue );
+		// console.log( newValue )
 	};
 
 	useEffect( () => {
@@ -26,6 +28,16 @@ function LikeEdit( { noticeUI } ) {
 		}
 		fetchReblogSetting();
 	}, [ fetchReblogSetting ] );
+
+	useEffect( () => {
+		if ( ! isSimpleSite() ) {
+			return;
+		}
+		// console.log('success is: ', success);
+		if ( success ) {
+			fetchReblogSetting();
+		}
+	}, [ success, fetchReblogSetting ] );
 
 	return (
 		<div { ...blockProps }>
@@ -36,7 +48,7 @@ function LikeEdit( { noticeUI } ) {
 							label="Show reblog button"
 							checked={ reblogSetting }
 							onChange={ newValue => {
-								setReblogSetting( newValue );
+								handleReblogSetting( newValue );
 							} }
 						/>
 					</PanelBody>

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -21,7 +21,7 @@ function LikeEdit( { noticeUI } ) {
 	} = useFetchReblogSetting( blogId );
 	const {
 		setReblog,
-		success: reblogSet,
+		success: reblogSetSuccessfully,
 		resetSuccess: clearReblogSetStatus,
 		isLoading: settingReblog,
 	} = useSetReblogSetting( blogId );
@@ -42,11 +42,11 @@ function LikeEdit( { noticeUI } ) {
 			return;
 		}
 
-		if ( reblogSet ) {
+		if ( reblogSetSuccessfully ) {
 			fetchReblog();
 			clearReblogSetStatus();
 		}
-	}, [ reblogSet, fetchReblog, clearReblogSetStatus ] );
+	}, [ reblogSetSuccessfully, fetchReblog, clearReblogSetStatus ] );
 
 	return (
 		<div { ...blockProps }>

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -54,7 +54,7 @@ function LikeEdit( { noticeUI } ) {
 				<InspectorControls>
 					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 						<ToggleControl
-							label="Show reblog button"
+							label={ __( 'Show reblog button', 'jetpack' ) }
 							checked={ currentReblogSetting }
 							disabled={ settingReblog || fetchingReblog }
 							onChange={ newValue => {

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -14,12 +14,20 @@ function LikeEdit( { noticeUI } ) {
 	const blockProps = useBlockProps();
 	const blogId = window?.Jetpack_LikeBlock?.blog_id;
 
-	const { fetchReblogSetting, reblogSetting } = useFetchReblogSetting( blogId );
-	const { setReblogSetting, success } = useSetReblogSetting( blogId );
+	const {
+		fetchReblogSetting,
+		reblogSetting,
+		isLoading: fetchingReblog,
+	} = useFetchReblogSetting( blogId );
+	const {
+		setReblogSetting,
+		success: reblogSettingSet,
+		resetSuccess: clearReblogSettingStatus,
+		isLoading: settingReblog,
+	} = useSetReblogSetting( blogId );
 
 	const handleReblogSetting = newValue => {
 		setReblogSetting( newValue );
-		// console.log( newValue )
 	};
 
 	useEffect( () => {
@@ -33,11 +41,12 @@ function LikeEdit( { noticeUI } ) {
 		if ( ! isSimpleSite() ) {
 			return;
 		}
-		// console.log('success is: ', success);
-		if ( success ) {
+
+		if ( reblogSettingSet ) {
 			fetchReblogSetting();
+			clearReblogSettingStatus();
 		}
-	}, [ success, fetchReblogSetting ] );
+	}, [ reblogSettingSet, fetchReblogSetting, clearReblogSettingStatus ] );
 
 	return (
 		<div { ...blockProps }>
@@ -47,6 +56,7 @@ function LikeEdit( { noticeUI } ) {
 						<ToggleControl
 							label="Show reblog button"
 							checked={ reblogSetting }
+							disabled={ settingReblog || fetchingReblog }
 							onChange={ newValue => {
 								handleReblogSetting( newValue );
 							} }

--- a/projects/plugins/jetpack/extensions/blocks/like/use-fetch-reblog-setting.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/use-fetch-reblog-setting.js
@@ -9,7 +9,7 @@ export default function useFetchReblogSetting( blogId ) {
 	const [ reblogSetting, setReblogSetting ] = useState( null );
 	const [ error, setError ] = useState( null );
 
-	const fetchReblogSetting = useCallback( async () => {
+	const fetchReblog = useCallback( async () => {
 		const path = `https://public-api.wordpress.com/rest/v1.3/sites/${ blogId }/settings/`;
 
 		setIsLoading( true );
@@ -30,6 +30,6 @@ export default function useFetchReblogSetting( blogId ) {
 		isLoading,
 		reblogSetting,
 		error,
-		fetchReblogSetting,
+		fetchReblog,
 	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/use-fetch-reblog-setting.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/use-fetch-reblog-setting.js
@@ -10,7 +10,7 @@ export default function useFetchReblogSetting( blogId ) {
 	const [ error, setError ] = useState( null );
 
 	const fetchReblog = useCallback( async () => {
-		const path = `https://public-api.wordpress.com/rest/v1.3/sites/${ blogId }/settings/`;
+		const path = `https://public-api.wordpress.com/rest/v1.4/sites/${ blogId }/settings/`;
 
 		setIsLoading( true );
 		await apiFetch( { url: path, method: 'GET' } )

--- a/projects/plugins/jetpack/extensions/blocks/like/use-set-reblog-setting.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/use-set-reblog-setting.js
@@ -9,9 +9,12 @@ export default function useSetReblogSetting( blogId ) {
 	const [ success, setSuccess ] = useState( null );
 	const [ error, setError ] = useState( null );
 
+	const resetSuccess = () => {
+		setSuccess( null );
+	};
+
 	const setReblogSetting = useCallback(
 		async reblogSetting => {
-			// console.log( 'disabled_reblogs is going to be set to: ', ! reblogSetting );
 			const path = `https://public-api.wordpress.com/rest/v1.3/sites/${ blogId }/settings/`;
 			const data = {
 				disabled_reblogs: ! reblogSetting,
@@ -43,5 +46,6 @@ export default function useSetReblogSetting( blogId ) {
 		success,
 		error,
 		setReblogSetting,
+		resetSuccess,
 	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/use-set-reblog-setting.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/use-set-reblog-setting.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useCallback } from '@wordpress/element';
+
+export default function useSetReblogSetting( blogId ) {
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ success, setSuccess ] = useState( null );
+	const [ error, setError ] = useState( null );
+
+	const setReblogSetting = useCallback(
+		async reblogSetting => {
+			// console.log( 'disabled_reblogs is going to be set to: ', ! reblogSetting );
+			const path = `https://public-api.wordpress.com/rest/v1.3/sites/${ blogId }/settings/`;
+			const data = {
+				disabled_reblogs: ! reblogSetting,
+			};
+
+			setIsLoading( true );
+			await apiFetch( {
+				url: path,
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				data: data,
+			} )
+				.then( () => {
+					setSuccess( true );
+					setError( null );
+				} )
+				.catch( err => {
+					setError( err );
+				} )
+				.finally( () => {
+					setIsLoading( false );
+				} );
+		},
+		[ blogId ]
+	);
+
+	return {
+		isLoading,
+		success,
+		error,
+		setReblogSetting,
+	};
+}

--- a/projects/plugins/jetpack/extensions/blocks/like/use-set-reblog-setting.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/use-set-reblog-setting.js
@@ -13,7 +13,7 @@ export default function useSetReblogSetting( blogId ) {
 		setSuccess( null );
 	};
 
-	const setReblogSetting = useCallback(
+	const setReblog = useCallback(
 		async reblogSetting => {
 			const path = `https://public-api.wordpress.com/rest/v1.3/sites/${ blogId }/settings/`;
 			const data = {
@@ -45,7 +45,7 @@ export default function useSetReblogSetting( blogId ) {
 		isLoading,
 		success,
 		error,
-		setReblogSetting,
+		setReblog,
 		resetSuccess,
 	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/use-set-reblog-setting.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/use-set-reblog-setting.js
@@ -15,7 +15,7 @@ export default function useSetReblogSetting( blogId ) {
 
 	const setReblog = useCallback(
 		async reblogSetting => {
-			const path = `https://public-api.wordpress.com/rest/v1.3/sites/${ blogId }/settings/`;
+			const path = `https://public-api.wordpress.com/rest/v1.4/sites/${ blogId }/settings/`;
 			const data = {
 				disabled_reblogs: ! reblogSetting,
 			};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/wp-calypso/issues/85024.

![Screen Capture Dec 12](https://github.com/Automattic/jetpack/assets/25105483/4499fa66-887f-4e07-8a70-59a6c94ba271)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* introduce `useSetReblogSetting` hook that handles setting of the Reblog setting
* translate `Show reblog button` string
* simplify naming of some of the constants to add more clarity

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Related project thread: pdDOJh-2JP-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:

The Reblog feature is available on Simple sites only. Therefore we need to make sure the proposed changes are working there and not introducing any regressions to Jetpack and WoA sites.

**Simple site**

1. Sync the changes of this PR to your simple site (e.g. by using the script from the comment below).
2. Sandbox the test site.
3. Add `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` to your `0-sandbox.php` file.
4. Add the new Like block to a post on your test site.
5. There should be the Reblog setting toggle in the block sidebar.
6. When you click on it, the Reblog setting should change accordingly. The current state of the setting can be checked in Calypso (_Tools → Marketing → Sharing Buttons_). You may also review the endpoint requests in the browser's Network tab.

**Self-hosted site**

1. Check out the PR and build it.
2. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
3. Launch Jurassic Tube to make your local site available publicly.
4. Connect Jetpack to your WordPress.com account and enable Likes feature.
5. Add the new Like block to a post on your test site.
6. There should be no Reblog setting toggle in the block sidebar. There should be no regressions.

**Atomic site** (should have the same behavior as a self-hosted site)
1. Check out the PR - you can use the Jetpack Beta plugin for instance.
3. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
4. Add the new Like block to a post on your test site.
5. There should be no Reblog setting toggle in the block sidebar. There should be no regressions.