### PR TITLE
Contact Form: add missing textdomain

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-a11y-script-textdomain
+++ b/projects/packages/forms/changelog/fix-contact-form-a11y-script-textdomain
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Aavoid warnings by specifying the textdomain with new script.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -262,6 +262,7 @@ class Contact_Form_Plugin {
 				'async'        => true,
 				'version'      => \JETPACK__VERSION,
 				'dependencies' => array( 'wp-i18n' ),
+				'textdomain'   => 'jetpack-forms',
 			)
 		);
 


### PR DESCRIPTION
## Proposed changes:

Follow-up to #34173

The textdomain is mandatory when declaring a new script; let's add it here to avoid warnings in our logs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Epic: #33853

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Open your error logs
* Go to the feedback menu in wp-admin
* Note the errors filling in your logs.
* Apply this branch.
* Refresh the page; no new errors should appear.
