### PR TITLE
Launchpad: setup_general task completion callback

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-setup-general-completion-callback
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-setup-general-completion-callback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Will mark the setup_general task as complete based on wether blogname or bogdescription options changed

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1474,7 +1474,6 @@ function wpcom_launchpad_mark_setup_general_task_complete( $old_value, $value ) 
 		return;
 	}
 
-	l( 'CALLING wpcom_launchpad_mark_setup_site_tasks_complete', $old_value, $value );
 	if ( $old_value !== $value ) {
 		wpcom_mark_launchpad_task_complete( 'setup_general' );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -117,7 +117,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Set up your site', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => '__return_true',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_disabled_callback' => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/settings/general/' . $data['site_slug_encoded'];
@@ -1456,6 +1456,31 @@ add_action( 'update_option_blogname', 'wpcom_launchpad_mark_setup_site_tasks_com
 add_action( 'update_option_blogdescription', 'wpcom_launchpad_mark_setup_site_tasks_complete', 10, 3 );
 add_action( 'update_option_site_icon', 'wpcom_launchpad_mark_setup_site_tasks_complete', 10, 3 );
 add_action( 'update_option_site_logo', 'wpcom_launchpad_mark_setup_site_tasks_complete', 10, 3 );
+
+/**
+ * Mark the setup_general task as complete if the site title or the site description is changed.
+ *
+ * @param string $old_value The old value of the site title.
+ * @param string $value The new value of the site title.
+ *
+ * @return void
+ */
+function wpcom_launchpad_mark_setup_general_task_complete( $old_value, $value ) {
+	if ( defined( 'HEADSTART' ) && HEADSTART ) {
+		return;
+	}
+
+	if ( wp_installing() ) {
+		return;
+	}
+
+	l( 'CALLING wpcom_launchpad_mark_setup_site_tasks_complete', $old_value, $value );
+	if ( $old_value !== $value ) {
+		wpcom_mark_launchpad_task_complete( 'setup_general' );
+	}
+}
+add_action( 'update_option_blogname', 'wpcom_launchpad_mark_setup_general_task_complete', 10, 3 );
+add_action( 'update_option_blogdescription', 'wpcom_launchpad_mark_setup_general_task_complete', 10, 3 );
 
 /**
  * Mark the enable_subscribers_modal task complete


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/84058

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This diff will change the completion event of the `setup_general` task to be based on wether the blog title or description changed.

**This should be merged AFTER https://github.com/Automattic/wp-calypso/pull/85101** so the incomplete task shows in the right position.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
* Sandbox public-api
* Go to wordpress.com/start and create a new site (can be free) with the `other` intent
* Go through the design flow and get to the Fullscreen Launchpad
* Verify that the `Set up your site` task appears as not completed
* Click on the task
* Change title/description and save
* Verify that  the task is marked as complete in the launchpad
Before
<img width="391" alt="image" src="https://github.com/Automattic/jetpack/assets/375980/f16aa7c5-9e83-487f-a9da-9784699f16cc">

After
<img width="402" alt="image" src="https://github.com/Automattic/jetpack/assets/375980/cffe5fea-472d-4f54-9272-816d5e080906">

*NOTE*: there was also an ordering issue, making the `setup_general` task appear at the top of the list, even if it was incomplete. This is addressed here: 


