### PR TITLE
AI Client: Fix one click actions behavior

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-ai-one-click-actions-behavior
+++ b/projects/js-packages/ai-client/changelog/fix-ai-one-click-actions-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Client: fix one click actions behavior on input change

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -94,7 +94,7 @@ export function AIControl(
 		if ( ! editRequest && lastValue !== null && value !== lastValue ) {
 			onChange?.( lastValue );
 		}
-	}, [ editRequest, lastValue ] );
+	}, [ editRequest, lastValue, value ] );
 
 	const sendRequest = useCallback( () => {
 		setLastValue( value );
@@ -105,7 +105,17 @@ export function AIControl(
 	const changeHandler = useCallback(
 		( newValue: string ) => {
 			onChange?.( newValue );
-			setEditRequest( state !== 'init' && lastValue && lastValue !== newValue );
+			if ( state === 'init' ) {
+				return;
+			}
+
+			if ( ! lastValue ) {
+				// here we're coming from a one-click action
+				setEditRequest( newValue.length > 0 );
+			} else {
+				// here we're coming from an edit action
+				setEditRequest( newValue !== lastValue );
+			}
 		},
 		[ lastValue, state ]
 	);
@@ -114,6 +124,11 @@ export function AIControl(
 		onDiscard?.();
 		onAccept?.();
 	}, [] );
+
+	const cancelEdit = useCallback( () => {
+		onChange( lastValue || '' );
+		setEditRequest( false );
+	}, [ lastValue ] );
 
 	// Pass the ref to forwardRef.
 	useImperativeHandle( ref, () => promptUserInputRef.current );
@@ -169,7 +184,7 @@ export function AIControl(
 									{ editRequest && (
 										<Button
 											className="jetpack-components-ai-control__controls-prompt_button"
-											onClick={ () => setEditRequest( false ) }
+											onClick={ cancelEdit }
 											variant="secondary"
 											label={ __( 'Cancel', 'jetpack-ai-client' ) }
 										>


### PR DESCRIPTION
Editing the input after using one of the one-click actions from the AI Assistant ends up in inconsistent state of the action buttons

## Proposed changes:
This PR improves the logic behind which we toggle suggestion and prompt actions upon any change on the input

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1702318281645179-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Before this change, using one of the one-click actions and then editing the input would get you in a weird combination of buttons, allowing you to go "Back to edit" with no visible change and seemingly inconsistent.

With this change, any input on the AI Assistant will get the block on "edit mode", showing the prompt action buttons (Cancel | Generate)