### PR TITLE
Fix/eu cookie widget console error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-eu-cookie-widget-console-error
+++ b/projects/plugins/jetpack/changelog/fix-eu-cookie-widget-console-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix console JS error in EU Cookie Widget 

--- a/projects/plugins/jetpack/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/projects/plugins/jetpack/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -90,8 +90,7 @@
 		overlay.classList.add( 'hide' );
 		setTimeout( function () {
 			overlay.parentNode.removeChild( overlay );
-			var widgetSection = document.querySelector( '.widget.widget_eu_cookie_law_widget' );
-			widgetSection.parentNode.removeChild( widgetSection );
+			widget.parentNode.removeChild( widget );
 		}, 400 );
 	}
 } )();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34389 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The proposed change gets the widget using an existing variable, since  below code  was not a proper selector for old themes where the widget did not have the `widget` class but `widget-container`
```js
var widgetSection = document.querySelector( '.widget.widget_eu_cookie_law_widget' )
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Same as the ones from the issue.

In **wp-admin**
- Go to Jetpack > Settings, and enable the _Make Extra Widgets available_ toggle .
- Go to Appearance > Themes and add and activate a new classic theme like Twenty Ten.
- Go to Plugins > Add New, install and activate the Classic Widgets plugin
- Go to Appearance > Customize > Widgets and add the Cookie Consent widget to your site

**Navigate to the site**, you should see the Cookie Consent Banner on the bottom of the screen. 

- Open Developer Tools on your browser. 
- Click the Close and Accept button on the banner. 

Banner should disappear and no error should be shown in the Console of Dev Tools.


