### PR TITLE
Subscriptions: add "Send as email" toggle

### DIFF
--- a/projects/plugins/jetpack/changelog/add-dont-email-to-subs-toggle
+++ b/projects/plugins/jetpack/changelog/add-dont-email-to-subs-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscriptions: adds toggle to disable email sending

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/constants.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/constants.php
@@ -11,4 +11,5 @@ const FEATURE_NAME                             = 'subscriptions';
 const BLOCK_NAME                               = 'jetpack/' . FEATURE_NAME;
 const NEWSLETTER_COLUMN_ID                     = 'newsletter_access';
 const META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS = '_jetpack_newsletter_access';
+const META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS    = '_jetpack_dont_email_post_to_subs';
 const META_NAME_FOR_POST_TIER_ID_SETTINGS      = '_jetpack_newsletter_tier_id';

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -215,6 +215,12 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 
 	const showMisconfigurationWarning = getShowMisconfigurationWarning( postVisibility, accessLevel );
 
+	const isSendEmailEnabled = useSelect( select => {
+		const meta = select( editorStore ).getEditedPostAttribute( 'meta' );
+		// Meta value is negated, "don't send", but toggle is truthy when enabled "send"
+		return ! meta?.[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ];
+	} );
+
 	return (
 		<>
 			<PluginPostPublishPanel
@@ -233,7 +239,11 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 				icon={ <JetpackEditorPanelLogo /> }
 				name="jetpack-subscribe-newsletters-postpublish-panel"
 			>
-				{ ! showMisconfigurationWarning && <SubscribersAffirmation accessLevel={ accessLevel } /> }
+				{ ! isSendEmailEnabled || showMisconfigurationWarning ? (
+					<p>{ __( 'Only published, did not send this post.', 'jetpack' ) }</p>
+				) : (
+					<SubscribersAffirmation accessLevel={ accessLevel } />
+				) }
 			</PluginPostPublishPanel>
 
 			{ ! isStripeConnected && (

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -18,14 +18,20 @@ import { store as editorStore } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { external, Icon } from '@wordpress/icons';
-import { accessOptions } from '../../shared/memberships/constants';
+import {
+	accessOptions,
+	META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS,
+} from '../../shared/memberships/constants';
 import { useAccessLevel, isNewsletterFeatureEnabled } from '../../shared/memberships/edit';
 import {
 	NewsletterAccessDocumentSettings,
-	NewsletterAccessPrePublishSettings,
+	NewsletterEmailDocumentSettings,
 } from '../../shared/memberships/settings';
 import SubscribersAffirmation from '../../shared/memberships/subscribers-affirmation';
-import { getShowMisconfigurationWarning } from '../../shared/memberships/utils';
+import {
+	getShowMisconfigurationWarning,
+	MisconfigurationWarning,
+} from '../../shared/memberships/utils';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import metadata from './block.json';
 import EmailPreview from './email-preview';
@@ -56,7 +62,7 @@ const SubscriptionsPanelPlaceholder = ( { children } ) => {
 function NewsletterEditorSettingsPanel( { accessLevel } ) {
 	return (
 		<PluginDocumentSettingPanel
-			className="jetpack-subscribe-newsletters-panel"
+			className="jetpack-subscribe-newsletter-panel"
 			title={ __( 'Access', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 			name="jetpack-subscribe-newsletters-editor-panel"
@@ -76,21 +82,21 @@ const NewsletterDisabledPanels = () => (
 	<>
 		<PluginDocumentSettingPanel
 			className="jetpack-subscribe-newsletters-panel"
-			title={ __( 'Newsletter visibility', 'jetpack' ) }
+			title={ __( 'Access', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
 			<NewsletterDisabledNotice />
 		</PluginDocumentSettingPanel>
 		<PluginPrePublishPanel
 			className="jetpack-subscribe-newsletters-panel"
-			title={ __( 'Newsletter visibility', 'jetpack' ) }
+			title={ __( 'Newsletter', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
 			<NewsletterDisabledNotice />
 		</PluginPrePublishPanel>
 		<PluginPostPublishPanel
 			className="jetpack-subscribe-newsletters-panel"
-			title={ __( 'Newsletter visibility', 'jetpack' ) }
+			title={ __( 'Newsletter', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
 			<NewsletterDisabledNotice />
@@ -113,32 +119,24 @@ function NewsletterPrePublishSettingsPanel( { accessLevel, isModuleActive, showP
 		return ! isModuleActive && ! isLoadingModules && ! meta?.jetpack_post_was_ever_published;
 	} );
 
-	return (
-		<PluginPrePublishPanel
-			initialOpen
-			className="jetpack-subscribe-newsletters-panel"
-			title={
-				<>
-					{ __( 'Newsletter:', 'jetpack' ) }
-					{ accessLevel && (
-						<span className={ 'jetpack-subscribe-post-publish-panel__heading' }>
-							{ accessOptions[ accessLevel ].panelHeading }
-						</span>
-					) }
-				</>
-			}
-			icon={ <JetpackEditorPanelLogo /> }
-		>
-			{ isModuleActive && (
-				<>
-					<NewsletterAccessPrePublishSettings accessLevel={ accessLevel } />
-					<Button variant="secondary" onClick={ showPreviewModal }>
-						{ __( 'Send test email', 'jetpack' ) }
-					</Button>
-				</>
-			) }
+	const postVisibility = useSelect( select => select( editorStore ).getEditedPostVisibility() );
+	const showMisconfigurationWarning = getShowMisconfigurationWarning( postVisibility, accessLevel );
 
-			{ shouldLoadSubscriptionPlaceholder && (
+	const isSendEmailEnabled = useSelect( select => {
+		const meta = select( editorStore ).getEditedPostAttribute( 'meta' );
+		// Meta value is negated, "don't send", but toggle is truthy when enabled "send"
+		return ! meta?.[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ];
+	} );
+
+	// Nudge to enable module
+	if ( ! isModuleActive && shouldLoadSubscriptionPlaceholder ) {
+		return (
+			<PluginPrePublishPanel
+				initialOpen
+				name="jetpack-subscribe-newsletters-panel"
+				title={ __( 'Newsletter', 'jetpack' ) }
+				icon={ <JetpackEditorPanelLogo /> }
+			>
 				<SubscriptionsPanelPlaceholder>
 					<Button
 						variant="secondary"
@@ -155,8 +153,53 @@ function NewsletterPrePublishSettingsPanel( { accessLevel, isModuleActive, showP
 							  ) }
 					</Button>
 				</SubscriptionsPanelPlaceholder>
-			) }
-		</PluginPrePublishPanel>
+			</PluginPrePublishPanel>
+		);
+	}
+
+	return (
+		<>
+			<PluginPrePublishPanel
+				initialOpen
+				name="jetpack-subscribe-access-panel"
+				className="jetpack-subscribe-newsletters-panel"
+				title={
+					<>
+						{ __( 'Access:', 'jetpack' ) }
+						{ accessLevel && (
+							<span className={ 'jetpack-subscribe-post-publish-panel__heading' }>
+								{ accessOptions[ accessLevel ].panelHeading }
+							</span>
+						) }
+					</>
+				}
+				icon={ <JetpackEditorPanelLogo /> }
+			>
+				<NewsletterAccessDocumentSettings accessLevel={ accessLevel } />
+			</PluginPrePublishPanel>
+			<PluginPrePublishPanel
+				initialOpen
+				name="jetpack-subscribe-newsletters-panel"
+				title={ __( 'Newsletter', 'jetpack' ) }
+				icon={ <JetpackEditorPanelLogo /> }
+			>
+				{ isModuleActive && (
+					<>
+						<NewsletterEmailDocumentSettings />
+						{ showMisconfigurationWarning && <MisconfigurationWarning /> }
+
+						{ ! isSendEmailEnabled || showMisconfigurationWarning ? (
+							<p>{ __( 'Only publishing, not sending this post.', 'jetpack' ) }</p>
+						) : (
+							<SubscribersAffirmation prePublish={ true } accessLevel={ accessLevel } />
+						) }
+						<Button variant="link" onClick={ showPreviewModal }>
+							{ __( 'Send test email', 'jetpack' ) }
+						</Button>
+					</>
+				) }
+			</PluginPrePublishPanel>
+		</>
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.scss
@@ -11,6 +11,7 @@
 
 	&__heading {
 		margin-inline-start: 3px;
+		font-weight: normal;
 	}
 
 	.components-notice__content {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -19,6 +19,7 @@ use Jetpack_Memberships;
 use Jetpack_Subscriptions_Widget;
 
 require_once __DIR__ . '/constants.php';
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 
 /**
  * These block defaults should match ./constants.js
@@ -93,6 +94,20 @@ function register_block() {
 
 	register_post_meta(
 		'post',
+		META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS,
+		array(
+			'default'       => false,
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'boolean',
+			'auth_callback' => function () {
+				return wp_get_current_user()->has_cap( 'edit_posts' );
+			},
+		)
+	);
+
+	register_post_meta(
+		'post',
 		META_NAME_FOR_POST_TIER_ID_SETTINGS,
 		array(
 			'show_in_rest'  => true,
@@ -108,7 +123,13 @@ function register_block() {
 	add_filter(
 		'jetpack_sync_post_meta_whitelist',
 		function ( $allowed_meta ) {
-			return array_merge( $allowed_meta, array( META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ) );
+			return array_merge(
+				$allowed_meta,
+				array(
+					META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
+					META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS,
+				)
+			);
 		}
 	);
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/constants.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/constants.js
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 
 export const META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS = '_jetpack_newsletter_access';
+export const META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS = '_jetpack_dont_email_post_to_subs';
 export const META_NAME_FOR_POST_TIER_ID_SETTINGS = '_jetpack_newsletter_tier_id';
 export const accessOptions = {
 	everybody: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/wp-calypso/issues/44263
Resolves https://github.com/Automattic/jetpack/issues/10876

Adds "Send as email" toggle:

(FYI Below screenshots are outdated)

<img width="300" alt="Screenshot 2023-12-12 at 15 08 01" src="https://github.com/Automattic/jetpack/assets/87168/0dc3dabe-9beb-4f84-bd8a-345512dd5d37">

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a toggle to disable email sending post-by-post basis.
* Register the meta, and sync the setting to WP.com

The feature pre-existed before Gutenberg, so the backend was already handled in Jetpack.

Previously the toggle was "negated", i.e. checking it to "not send email". Clearer UX is to do something when toggle is enabled, hence the meta and toggle handling seem a bit backwards.

**TODO:** PR needs some minor work in pre/post-publish panel copies and to check if post was published previously.
<img width="287" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/50c69e7c-1365-4eea-ae39-3f4a4c3e99fa">
<img width="287" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/d9000b93-10f1-44ed-8ebf-4636cb54147d">
<img width="292" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/a9b60aac-2336-40a0-9ef5-96814031d338">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post
* In post settings, leave toggle enabled and publish the post.
* Note pre-publish panel toggle — you can try change it, go back to post panel, etc.
* Note copy at pre-publish panel.
* Post gets sent as an email
* The toggle should be disabled now and in truthy setting (the email was already sent)
   <img width="306" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/f891183b-d1d0-439d-a0e8-f1416b47ab20">


* Create another post, leave toggle disabled and publish the post
* Note copy at pre-publish panel.
* No email was sent
* The toggle should be disabled now and in falsy setting (no way to send email now that post was published)
