### PR TITLE
Subscriptions: fix typo in post publish panel

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-post-publish-typo
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-post-publish-typo
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: typo fix
+
+

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -207,7 +207,7 @@ function getNumberOfSubscribersText( {
 			return sprintf(
 				// translators: %1s is the post name, %2s is the list of categories with subscriptions count
 				__(
-					'<postPublishedLink>%1$s</postPublishedLink>was sent to everyone subscribed to %2$s.',
+					'<postPublishedLink>%1$s</postPublishedLink> was sent to everyone subscribed to %2$s.',
 					'jetpack'
 				),
 				postName,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes spacing after link:

<img width="320" alt="Screenshot 2023-12-12 at 15 04 51" src="https://github.com/Automattic/jetpack/assets/87168/900663bd-0136-4ac1-bed0-b787b8262e85">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

