### PR TITLE
Woo Express Trial: Add `was_upgraded_from_trial` flag

### DIFF
--- a/projects/plugins/jetpack/changelog/add-flag-for-expired-plans
+++ b/projects/plugins/jetpack/changelog/add-flag-for-expired-plans
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add a flag for sites that have upgraded from the ecommerce trial

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -79,6 +79,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_staging_site'       => '(bool) If the site is a WP.com staging site.',
 		'user_interactions'           => '(array) An array of user interactions with a site.',
 		'was_ecommerce_trial'         => '(bool) If the site ever used an eCommerce trial.',
+		'was_upgraded_from_trial'     => '(bool) If the site ever upgraded to a paid plan from a trial.',
 		'was_migration_trial'         => '(bool) If the site ever used a migration trial.',
 		'was_hosting_trial'           => '(bool) If the site ever used a hosting trial.',
 		'wpcom_site_setup'            => '(string) The WP.com site setup identifier.',
@@ -605,6 +606,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'was_hosting_trial':
 				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials['was_hosting_trial'] );
+				break;
+			case 'was_upgraded_from_trial':
+				$response[ $key ] = $this->site->was_upgraded_from_trial();
 				break;
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -234,6 +234,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'was_ecommerce_trial',
 		'was_migration_trial',
 		'was_hosting_trial',
+		'was_upgraded_from_trial',
 	);
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -74,6 +74,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'is_wpcom_atomic'             => '(bool) If the site is a WP.com Atomic one.',
 		'is_wpcom_staging_site'       => '(bool) If the site is a WP.com staging site.',
 		'was_ecommerce_trial'         => '(bool) If the site ever used an eCommerce trial.',
+		'was_upgraded_from_trial'     => '(bool) If the site ever upgraded to a paid plan from a trial.',
 		'was_migration_trial'         => '(bool) If the site ever used a migration trial.',
 		'was_hosting_trial'           => '(bool) If the site ever used a hosting trial.',
 	);

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -503,6 +503,18 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Indicate whether this site was upgraded from a trial plan at some point.
+	 *
+	 * @return bool
+	 */
+	public function was_upgraded_from_trial() {
+		if ( function_exists( 'has_blog_sticker' ) ) {
+			return has_blog_sticker( 'has-upgraded-from-ecommerce-trial' );
+		}
+		return false;
+	}
+
+	/**
 	 * Detect whether a site has the WooCommerce plugin active.
 	 *
 	 * @see /wpcom/public.api/rest/sal/class.json-api-site-jetpack-shadow.php.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/83120

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new flag `was_upgraded_from_trial` that checks for any of the `has-upgraded-from-${trial}-trial` blog stickers to aid us in determining when a site has upgraded from a trial plan to a paid plan.
* This flag will be used in Calypso to change the behavior of the trial expiration screen; related PR with testing instructions: https://github.com/Automattic/wp-calypso/pull/85104
`
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox
* Create a new Woo Express site from `/setup/wooexpress`
* Upgrade your Woo Express site to any paid plan
* Navigate to the dev console and GET from WP REST API v1.2 `/sites/{your woo express site}`
* Confirm you see the `was_upgraded_from_trial` key with the correct value in the response:

<img width="482" alt="Screenshot 2023-12-12 at 12 33 16 PM" src="https://github.com/Automattic/jetpack/assets/2124984/80206f42-d628-40fe-a196-f4ff94be9fdc">

* See full testing instructions here: https://github.com/Automattic/wp-calypso/pull/85104