### PR TITLE
Subscriptions: consolidate pre/post panel copy to a component

### DIFF
--- a/projects/plugins/jetpack/changelog/update-consolidate-newsletter-affirm-text
+++ b/projects/plugins/jetpack/changelog/update-consolidate-newsletter-affirm-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: consolidate pre/post panel copy to a component

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -15,22 +15,17 @@ import {
 	PluginPostPublishPanel,
 } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
-import { useState, createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { external, Icon } from '@wordpress/icons';
 import { accessOptions } from '../../shared/memberships/constants';
 import { useAccessLevel, isNewsletterFeatureEnabled } from '../../shared/memberships/edit';
 import {
-	Link,
-	getReachForAccessLevelKey,
 	NewsletterAccessDocumentSettings,
 	NewsletterAccessPrePublishSettings,
 } from '../../shared/memberships/settings';
-import {
-	getFormattedCategories,
-	getFormattedSubscriptionsCount,
-	getShowMisconfigurationWarning,
-} from '../../shared/memberships/utils';
+import SubscribersAffirmation from '../../shared/memberships/subscribers-affirmation';
+import { getShowMisconfigurationWarning } from '../../shared/memberships/utils';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import metadata from './block.json';
 import EmailPreview from './email-preview';
@@ -172,117 +167,7 @@ function NewsletterPrePublishSettingsPanel( {
 	);
 }
 
-// Determines copy to show in post-publish panel to confirm number and type of subscribers who received the post as email, or will receive in case of scheduled post.
-function getNumberOfSubscribersText( {
-	accessLevel,
-	isScheduledPost,
-	newsletterCategories,
-	newsletterCategoriesEnabled,
-	postCategories,
-	postName,
-	reachCount,
-	subscriptionsCount,
-} ) {
-	// Text when categories are enabled
-	if (
-		newsletterCategoriesEnabled &&
-		newsletterCategories.length &&
-		accessLevel !== accessOptions.paid_subscribers.key
-	) {
-		const formattedCategoryNames = getFormattedCategories( postCategories, newsletterCategories );
-		const formattedSubscriptionsCount = getFormattedSubscriptionsCount( subscriptionsCount );
-		const categoryNamesAndSubscriptionsCount = formattedCategoryNames + formattedSubscriptionsCount;
-
-		if ( isScheduledPost && formattedCategoryNames ) {
-			return sprintf(
-				// translators: %1s is the post name, %2s is the list of categories with subscriptions count
-				__(
-					'<postPublishedLink>%1$s</postPublishedLink> will be sent to everyone subscribed to %2$s.',
-					'jetpack'
-				),
-				postName,
-				categoryNamesAndSubscriptionsCount
-			);
-		} else if ( formattedCategoryNames ) {
-			return sprintf(
-				// translators: %1s is the post name, %2s is the list of categories with subscriptions count
-				__(
-					'<postPublishedLink>%1$s</postPublishedLink> was sent to everyone subscribed to %2$s.',
-					'jetpack'
-				),
-				postName,
-				categoryNamesAndSubscriptionsCount
-			);
-		}
-	}
-
-	// Texts when no categories...
-	const isPaidPost = accessLevel === accessOptions.paid_subscribers.key;
-
-	// Paid subscribers, schedulled post
-	if ( isScheduledPost && isPaidPost ) {
-		return sprintf(
-			/* translators: %1s is the post name, %2s is the number of subscribers in numerical format */
-			__(
-				'<postPublishedLink>%1$s</postPublishedLink> will be sent to <strong>%2$s paid subscribers</strong>.',
-				'jetpack'
-			),
-			postName,
-			reachCount
-		);
-	}
-	// Paid subscribers, post is already published
-	else if ( isPaidPost ) {
-		return sprintf(
-			/* translators: %1s is the post name, %2s is the number of subscribers in numerical format */
-			__(
-				'<postPublishedLink>%1$s</postPublishedLink> was sent to <strong>%2$s paid subscribers</strong>.',
-				'jetpack'
-			),
-			postName,
-			reachCount
-		);
-	}
-	// Free subscribers, schedulled post
-	else if ( isScheduledPost ) {
-		return sprintf(
-			/* translators: %1s is the post name, %2s is the number of subscribers in numerical format */
-			__(
-				'<postPublishedLink>%1$s</postPublishedLink> will be sent to <strong>%2$s subscribers</strong>.',
-				'jetpack'
-			),
-			postName,
-			reachCount
-		);
-	}
-
-	// Free subscribers
-	return sprintf(
-		/* translators: %1s is the post name, %2s is the number of subscribers in numerical format */
-		__(
-			'<postPublishedLink>%1$s</postPublishedLink> was sent to <strong>%2$s subscribers</strong>.',
-			'jetpack'
-		),
-		postName,
-		reachCount
-	);
-}
-
 function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
-	const isScheduledPost = useSelect( select => select( editorStore ).isCurrentPostScheduled(), [] );
-
-	const { emailSubscribers, paidSubscribers } = useSelect( select =>
-		select( membershipProductsStore ).getSubscriberCounts()
-	);
-
-	const { postName, postPublishedLink } = useSelect( select => {
-		const currentPost = select( editorStore ).getCurrentPost();
-		return {
-			postName: currentPost.title,
-			postPublishedLink: currentPost.link,
-		};
-	} );
-
 	const { isStripeConnected } = useSelect( select => {
 		const { getConnectUrl } = select( membershipProductsStore );
 		return {
@@ -292,43 +177,6 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 
 	const postVisibility = useSelect( select => select( editorStore ).getEditedPostVisibility() );
 
-	const { newsletterCategories, newsletterCategoriesEnabled } = useSelect( select => {
-		const { getNewsletterCategories, getNewsletterCategoriesEnabled } = select(
-			'jetpack/membership-products'
-		);
-
-		return {
-			newsletterCategories: getNewsletterCategories(),
-			newsletterCategoriesEnabled: getNewsletterCategoriesEnabled(),
-		};
-	} );
-
-	const postCategories = useSelect( select =>
-		select( editorStore ).getEditedPostAttribute( 'categories' )
-	);
-
-	const subscriptionsCount = useSelect( select => {
-		return select( 'jetpack/membership-products' ).getNewsletterCategoriesSubscriptionsCount(
-			postCategories
-		);
-	} );
-
-	const reachCount = getReachForAccessLevelKey(
-		accessLevel,
-		emailSubscribers,
-		paidSubscribers
-	).toLocaleString();
-
-	const numberOfSubscribersText = getNumberOfSubscribersText( {
-		accessLevel,
-		isScheduledPost,
-		newsletterCategories,
-		newsletterCategoriesEnabled,
-		postCategories,
-		postName,
-		reachCount,
-		subscriptionsCount,
-	} );
 	const showMisconfigurationWarning = getShowMisconfigurationWarning( postVisibility, accessLevel );
 
 	return (
@@ -348,14 +196,7 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 				className="jetpack-subscribe-newsletters-panel jetpack-subscribe-post-publish-panel"
 				icon={ <JetpackEditorPanelLogo /> }
 			>
-				{ ! showMisconfigurationWarning && (
-					<Notice className="jetpack-subscribe-post-publish-panel__notice" isDismissible={ false }>
-						{ createInterpolateElement( numberOfSubscribersText, {
-							strong: <strong />,
-							postPublishedLink: <Link href={ postPublishedLink } />,
-						} ) }
-					</Notice>
-				) }
+				{ ! showMisconfigurationWarning && <SubscribersAffirmation accessLevel={ accessLevel } /> }
 			</PluginPostPublishPanel>
 
 			{ ! isStripeConnected && (

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -195,6 +195,7 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 				}
 				className="jetpack-subscribe-newsletters-panel jetpack-subscribe-post-publish-panel"
 				icon={ <JetpackEditorPanelLogo /> }
+				name="jetpack-subscribe-newsletters-panel"
 			>
 				{ ! showMisconfigurationWarning && <SubscribersAffirmation accessLevel={ accessLevel } /> }
 			</PluginPostPublishPanel>

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -289,13 +289,11 @@ export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
 		<PostVisibilityCheck
 			render={ () => (
 				<PanelRow className="edit-post-post-visibility">
-					<Flex direction="column">
-						{ showMisconfigurationWarning ? (
-							<MisconfigurationWarning />
-						) : (
-							<SubscribersAffirmation prePublish accessLevel={ _accessLevel } />
-						) }
-					</Flex>
+					{ showMisconfigurationWarning ? (
+						<MisconfigurationWarning />
+					) : (
+						<SubscribersAffirmation prePublish accessLevel={ _accessLevel } />
+					) }
 				</PanelRow>
 			) }
 		/>

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -12,8 +12,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PostVisibilityCheck, store as editorStore } from '@wordpress/editor';
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { useState } from 'react';
 import paywallBlockMetadata from '../../blocks/paywall/block.json';
@@ -25,12 +24,8 @@ import {
 	META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
 	META_NAME_FOR_POST_TIER_ID_SETTINGS,
 } from './constants';
-import {
-	getFormattedCategories,
-	getFormattedSubscriptionsCount,
-	getShowMisconfigurationWarning,
-	MisconfigurationWarning,
-} from './utils';
+import SubscribersAffirmation from './subscribers-affirmation';
+import { getShowMisconfigurationWarning, MisconfigurationWarning } from './utils';
 
 const paywallIcon = getBlockIconComponent( paywallBlockMetadata );
 
@@ -285,82 +280,21 @@ export function NewsletterAccessDocumentSettings( { accessLevel } ) {
 }
 
 export function NewsletterAccessPrePublishSettings( { accessLevel } ) {
-	const { isLoading, postHasPaywallBlock, newsletterCategories, newsletterCategoriesEnabled } =
-		useSelect( select => {
-			const {
-				getNewsletterTierProducts,
-				getConnectUrl,
-				isApiStateLoading,
-				getNewsletterCategories,
-				getNewsletterCategoriesEnabled,
-			} = select( 'jetpack/membership-products' );
-			const { getBlocks } = select( 'core/block-editor' );
-
-			return {
-				isLoading: isApiStateLoading(),
-				stripeConnectUrl: getConnectUrl(),
-				hasTierPlans: getNewsletterTierProducts()?.length !== 0,
-				postHasPaywallBlock: getBlocks().some( block => block.name === paywallBlockMetadata.name ),
-				newsletterCategories: getNewsletterCategories(),
-				newsletterCategoriesEnabled: getNewsletterCategoriesEnabled(),
-			};
-		} );
-
 	const postVisibility = useSelect( select => select( editorStore ).getEditedPostVisibility() );
-	const postCategories = useSelect( select =>
-		select( editorStore ).getEditedPostAttribute( 'categories' )
-	);
-
-	const subscriptionsCount = useSelect( select => {
-		return select( 'jetpack/membership-products' ).getNewsletterCategoriesSubscriptionsCount(
-			postCategories
-		);
-	} );
-
-	if ( isLoading ) {
-		return (
-			<Flex direction="column" align="center">
-				<Spinner />
-			</Flex>
-		);
-	}
-
-	const _accessLevel = accessLevel ?? accessOptions.everybody.key;
-	const getText = () => {
-		if ( _accessLevel === accessOptions.paid_subscribers.key ) {
-			if ( ! postHasPaywallBlock ) {
-				return __( 'This post will be sent to paid subscribers only.', 'jetpack' );
-			}
-		}
-		if ( newsletterCategoriesEnabled && newsletterCategories.length ) {
-			const formattedCategoryNames = getFormattedCategories( postCategories, newsletterCategories );
-			const formattedSubscriptionsCount = getFormattedSubscriptionsCount( subscriptionsCount );
-			const categoryNamesAndSubscriptionsCount =
-				formattedCategoryNames + formattedSubscriptionsCount;
-
-			if ( formattedCategoryNames ) {
-				return createInterpolateElement(
-					sprintf(
-						// translators: %1$s is the list of categories with subscriptions count
-						__( 'This post will be sent to everyone subscribed to %1$s.', 'jetpack' ),
-						categoryNamesAndSubscriptionsCount
-					),
-					{ strong: <strong /> }
-				);
-			}
-		}
-		return __( 'This post will be sent to all subscribers.', 'jetpack' );
-	};
 
 	const showMisconfigurationWarning = getShowMisconfigurationWarning( postVisibility, accessLevel );
+	const _accessLevel = accessLevel ?? accessOptions.everybody.key;
 
 	return (
 		<PostVisibilityCheck
 			render={ () => (
 				<PanelRow className="edit-post-post-visibility">
 					<Flex direction="column">
-						{ showMisconfigurationWarning && <MisconfigurationWarning /> }
-						<p>{ getText() }</p>
+						{ showMisconfigurationWarning ? (
+							<MisconfigurationWarning />
+						) : (
+							<SubscribersAffirmation prePublish accessLevel={ _accessLevel } />
+						) }
 					</Flex>
 				</PanelRow>
 			) }

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -1,0 +1,257 @@
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { createInterpolateElement, Spinner, Flex } from '@wordpress/element';
+import { sprintf, __, _n } from '@wordpress/i18n';
+import { name as paywallBlockName } from '../../blocks/paywall/block.json';
+import { accessOptions } from '../../shared/memberships/constants';
+import { getReachForAccessLevelKey } from '../../shared/memberships/settings';
+import { store as membershipProductsStore } from '../../store/membership-products';
+
+/**
+ * Get the formatted list of categories for a post.
+ * @param {Array} postCategories - list of category IDs for the post
+ * @param {Array} newsletterCategories - list of the site's newsletter categories
+ * @returns {string} - formatted list of categories
+ */
+export const getFormattedCategories = ( postCategories, newsletterCategories ) => {
+	// If the post has no categories, then it's going to have the 'Uncategorized' category
+	const updatedPostCategories = postCategories.length ? postCategories : [ 1 ];
+
+	// If the post has a non newsletter category, then it's going to be sent to 'All content' subscribers
+	const hasNonNewsletterCategory = updatedPostCategories.some( postCategory => {
+		return ! newsletterCategories.some( newsletterCategory => {
+			return newsletterCategory.id === postCategory;
+		} );
+	} );
+
+	// Get the newsletter category names for the post
+	const categoryNames = newsletterCategories
+		.filter( category => updatedPostCategories.includes( category.id ) )
+		.map( category => category.name );
+
+	if ( hasNonNewsletterCategory ) {
+		categoryNames.push( __( 'All content', 'jetpack' ) );
+	}
+
+	const formattedCategoriesArray = categoryNames.map(
+		categoryName => `<strong>${ categoryName }</strong>`
+	);
+	let formattedCategories = '';
+
+	if ( formattedCategoriesArray.length === 1 ) {
+		formattedCategories = formattedCategoriesArray[ 0 ];
+	} else if ( formattedCategoriesArray.length === 2 ) {
+		// translators: %1$s: first category name, %2$s: second category name
+		formattedCategories = sprintf( __( '%1$s and %2$s', 'jetpack' ), ...formattedCategoriesArray );
+	} else {
+		const allButLast = formattedCategoriesArray.slice( 0, -1 ).join( `${ __( ',', 'jetpack' ) } ` );
+		const last = formattedCategoriesArray[ formattedCategoriesArray.length - 1 ];
+
+		formattedCategories = sprintf(
+			// translators: %1$s: a comma-separated list of category names except for the last one, %2$s: the name of the last category
+			__( '%1$s, and %2$s', 'jetpack' ),
+			allButLast,
+			last
+		);
+	}
+
+	return formattedCategories;
+};
+
+export const getCopyForCategorySubscribers = ( {
+	futureTense,
+	newsletterCategories,
+	postCategories,
+	reachCount,
+} ) => {
+	const formattedCategoryNames = getFormattedCategories( postCategories, newsletterCategories );
+
+	if ( futureTense ) {
+		return sprintf(
+			// translators: %1s is the list of categories, %2d is subscriptions count
+			_n(
+				'This post will be sent to everyone subscribed to %1$s (%2$d subscriber).',
+				'This post will be sent to everyone subscribed to %1$s (%2$d subscribers).',
+				reachCount,
+				'jetpack'
+			),
+			formattedCategoryNames,
+			reachCount
+		);
+	}
+
+	return sprintf(
+		// translators: %1s is the list of categories, %2d is subscriptions count
+		_n(
+			'This post was sent to everyone subscribed to %1$s (%2$d subscriber).',
+			'This post was sent to everyone subscribed to %1$s (%2$d subscribers).',
+			reachCount,
+			'jetpack'
+		),
+		formattedCategoryNames,
+		reachCount
+	);
+};
+
+// Determines copy to show in post-publish panel to confirm number and type of subscribers who received the post as email, or will receive in case of scheduled post.
+export const getCopyForSubscribers = ( {
+	futureTense,
+	isPaidPost,
+	postHasPaywallBlock,
+	reachCount,
+} ) => {
+	// Paid subscribers, schedulled post
+	if ( futureTense && isPaidPost ) {
+		return sprintf(
+			/* translators: %d is the number of subscribers */
+			_n(
+				'This post will be sent to <strong>%d paid subscriber</strong>.',
+				'This post will be sent to <strong>%d paid subscribers</strong>.',
+				reachCount,
+				'jetpack'
+			),
+			reachCount
+		);
+	}
+	// Paid post sent to paid & free subscribers, with paywall, post is already published
+	else if ( isPaidPost && postHasPaywallBlock ) {
+		return sprintf(
+			/* translators: %d is the number of subscribers */
+			_n(
+				'This post was sent to <strong>%d paid subscriber</strong>.',
+				'This post was sent to <strong>%d paid subscribers</strong>.',
+				reachCount,
+				'jetpack'
+			),
+			reachCount
+		);
+	}
+	// Paid post sent only to paid subscribers, post is already published
+	else if ( isPaidPost && ! postHasPaywallBlock ) {
+		return sprintf(
+			/* translators: %d is the number of subscribers */
+			_n(
+				'This post was sent to <strong>%d paid subscriber</strong> only.',
+				'This post was sent to <strong>%d paid subscribers</strong> only.',
+				reachCount,
+				'jetpack'
+			),
+			reachCount
+		);
+	}
+	// Free subscribers, schedulled post
+	else if ( futureTense ) {
+		return sprintf(
+			/* translators: %d is the number of subscribers */
+			_n(
+				'This post will be sent to <strong>%d subscriber</strong>.',
+				'This post will be sent to <strong>%d subscribers</strong>.',
+				reachCount,
+				'jetpack'
+			),
+			reachCount
+		);
+	}
+
+	// Free subscribers
+	return sprintf(
+		/* translators: %d is the number of subscribers */
+		_n(
+			'This post was sent to <strong>%d subscriber</strong>.',
+			'This post was sent to <strong>%d subscribers</strong>.',
+			reachCount,
+			'jetpack'
+		),
+		reachCount
+	);
+};
+
+/*
+ * Determines copy to show in pre/post-publish panels to confirm number and type of subscribers receiving the post as email.
+ */
+function SubscribersAffirmation( { accessLevel, prePublish } ) {
+	const postHasPaywallBlock = useSelect( select =>
+		select( 'core/block-editor' )
+			.getBlocks()
+			.some( block => block.name === paywallBlockName )
+	);
+
+	const { isScheduledPost, postCategories } = useSelect( select => {
+		const { isCurrentPostScheduled, getEditedPostAttribute } = select( editorStore );
+		return {
+			isScheduledPost: isCurrentPostScheduled(),
+			postCategories: getEditedPostAttribute( 'categories' ),
+		};
+	} );
+
+	const {
+		isLoading,
+		newsletterCategories,
+		newsletterCategoriesEnabled,
+		newsletterCategorySubscriberCount,
+	} = useSelect( select => {
+		const {
+			getNewsletterCategories,
+			getNewsletterCategoriesEnabled,
+			getNewsletterCategoriesSubscriptionsCount,
+			isApiStateLoading,
+		} = select( membershipProductsStore );
+
+		return {
+			isLoading: isApiStateLoading(),
+			newsletterCategories: getNewsletterCategories(),
+			newsletterCategoriesEnabled: getNewsletterCategoriesEnabled(),
+			newsletterCategorySubscriberCount: getNewsletterCategoriesSubscriptionsCount(),
+		};
+	} );
+
+	// Free and paid subscriber counts
+	const { emailSubscribers, paidSubscribers } = useSelect( select =>
+		select( membershipProductsStore ).getSubscriberCounts()
+	);
+
+	if ( isLoading ) {
+		return (
+			<Flex direction="column" align="center">
+				<Spinner />
+			</Flex>
+		);
+	}
+
+	const isPaidPost = accessLevel === accessOptions.paid_subscribers.key;
+
+	// Show all copy in future tense
+	const futureTense = prePublish || isScheduledPost;
+
+	const reachForAccessLevel = getReachForAccessLevelKey(
+		accessLevel,
+		emailSubscribers,
+		paidSubscribers
+	).toLocaleString();
+
+	let text;
+
+	// Get newsletter category copy & count separately, unless post is paid
+	if ( newsletterCategoriesEnabled && newsletterCategories.length > 0 && ! isPaidPost ) {
+		text = getCopyForCategorySubscribers( {
+			futureTense,
+			isPaidPost,
+			newsletterCategories,
+			postCategories,
+			reachCount: newsletterCategorySubscriberCount,
+		} );
+	} else {
+		text = getCopyForSubscribers( {
+			futureTense,
+			isPaidPost,
+			postHasPaywallBlock,
+			reachCount: reachForAccessLevel,
+		} );
+	}
+
+	return createInterpolateElement( text, {
+		strong: <strong />,
+	} );
+}
+
+export default SubscribersAffirmation;

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -100,21 +100,35 @@ export const getCopyForSubscribers = ( {
 	postHasPaywallBlock,
 	reachCount,
 } ) => {
-	// Paid subscribers, schedulled post
-	if ( futureTense && isPaidPost ) {
+	// Schedulled post
+	if ( futureTense ) {
+		// Paid post without paywall: sent only to paid subscribers
+		if ( isPaidPost && ! postHasPaywallBlock ) {
+			return sprintf(
+				/* translators: %d is the number of subscribers */
+				_n(
+					'This post will be sent to <strong>%d paid subscriber</strong>.',
+					'This post will be sent to <strong>%d paid subscribers</strong>.',
+					reachCount,
+					'jetpack'
+				),
+				reachCount
+			);
+		}
+		// Paid post with paywall or Free post, sent to all subscribers
 		return sprintf(
 			/* translators: %d is the number of subscribers */
 			_n(
-				'This post will be sent to <strong>%d paid subscriber</strong>.',
-				'This post will be sent to <strong>%d paid subscribers</strong>.',
+				'This post will be sent to <strong>%d subscriber</strong>.',
+				'This post will be sent to <strong>%d subscribers</strong>.',
 				reachCount,
 				'jetpack'
 			),
 			reachCount
 		);
 	}
-	// Paid post sent to paid & free subscribers, with paywall, post is already published
-	else if ( isPaidPost && postHasPaywallBlock ) {
+	// Paid post without paywall: sent only to paid subscribers
+	if ( isPaidPost && ! postHasPaywallBlock ) {
 		return sprintf(
 			/* translators: %d is the number of subscribers */
 			_n(
@@ -127,7 +141,7 @@ export const getCopyForSubscribers = ( {
 		);
 	}
 	// Paid post sent only to paid subscribers, post is already published
-	else if ( isPaidPost && ! postHasPaywallBlock ) {
+	if ( isPaidPost && ! postHasPaywallBlock ) {
 		return sprintf(
 			/* translators: %d is the number of subscribers */
 			_n(
@@ -139,21 +153,8 @@ export const getCopyForSubscribers = ( {
 			reachCount
 		);
 	}
-	// Free subscribers, schedulled post
-	else if ( futureTense ) {
-		return sprintf(
-			/* translators: %d is the number of subscribers */
-			_n(
-				'This post will be sent to <strong>%d subscriber</strong>.',
-				'This post will be sent to <strong>%d subscribers</strong>.',
-				reachCount,
-				'jetpack'
-			),
-			reachCount
-		);
-	}
 
-	// Free subscribers
+	// Paid post with paywall or Free post, sent to all subscribers, post is already published
 	return sprintf(
 		/* translators: %d is the number of subscribers */
 		_n(

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -2,7 +2,7 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { createInterpolateElement, Spinner, Flex } from '@wordpress/element';
 import { sprintf, __, _n } from '@wordpress/i18n';
-import { name as paywallBlockName } from '../../blocks/paywall/block.json';
+import paywallBlockMetadata from '../../blocks/paywall/block.json';
 import { accessOptions } from '../../shared/memberships/constants';
 import { getReachForAccessLevelKey } from '../../shared/memberships/settings';
 import { store as membershipProductsStore } from '../../store/membership-products';
@@ -173,7 +173,7 @@ function SubscribersAffirmation( { accessLevel, prePublish } ) {
 	const postHasPaywallBlock = useSelect( select =>
 		select( 'core/block-editor' )
 			.getBlocks()
-			.some( block => block.name === paywallBlockName )
+			.some( block => block.name === paywallBlockMetadata.name )
 	);
 
 	const { isScheduledPost, postCategories } = useSelect( select => {

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.js
@@ -1,6 +1,6 @@
 import { Button, ToolbarButton, Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { _x, __, sprintf } from '@wordpress/i18n';
+import { _x, __ } from '@wordpress/i18n';
 import { accessOptions } from './constants';
 
 /**
@@ -69,70 +69,3 @@ export default function GetAddPaidPlanButton( { context = 'other', hasTierPlans 
 		</Button>
 	);
 }
-
-const UNCATEGORIZED_CATEGORY_ID = 1;
-
-/**
- * Get the formatted list of categories for a post.
- * @param {Array} postCategories - list of category IDs for the post
- * @param {Array} newsletterCategories - list of the site's newsletter categories
- * @returns {string} - formatted list of categories
- */
-export const getFormattedCategories = ( postCategories, newsletterCategories ) => {
-	// If the post has no categories, then it's going to have the 'Uncategorized' category
-	const updatedPostCategories = postCategories.length
-		? postCategories
-		: [ UNCATEGORIZED_CATEGORY_ID ];
-
-	// If the post has a non newsletter category, then it's going to be sent to 'All content' subscribers
-	const hasNonNewsletterCategory = updatedPostCategories.some( postCategory => {
-		return ! newsletterCategories.some( newsletterCategory => {
-			return newsletterCategory.id === postCategory;
-		} );
-	} );
-
-	// Get the newsletter category names for the post
-	const categoryNames = newsletterCategories
-		.filter( category => updatedPostCategories.includes( category.id ) )
-		.map( category => category.name );
-
-	if ( hasNonNewsletterCategory ) {
-		categoryNames.push( __( 'All content', 'jetpack' ) );
-	}
-
-	const formattedCategoriesArray = categoryNames.map(
-		categoryName => `<strong>${ categoryName }</strong>`
-	);
-	let formattedCategories = '';
-
-	if ( formattedCategoriesArray.length === 1 ) {
-		formattedCategories = formattedCategoriesArray[ 0 ];
-	} else if ( formattedCategoriesArray.length === 2 ) {
-		// translators: %1$s: first category name, %2$s: second category name
-		formattedCategories = sprintf( __( '%1$s and %2$s', 'jetpack' ), ...formattedCategoriesArray );
-	} else {
-		const allButLast = formattedCategoriesArray.slice( 0, -1 ).join( `${ __( ',', 'jetpack' ) } ` );
-		const last = formattedCategoriesArray[ formattedCategoriesArray.length - 1 ];
-
-		formattedCategories = sprintf(
-			// translators: %1$s: a comma-separated list of category names except for the last one, %2$s: the name of the last category
-			__( '%1$s, and %2$s', 'jetpack' ),
-			allButLast,
-			last
-		);
-	}
-
-	return formattedCategories;
-};
-
-export const getFormattedSubscriptionsCount = subscriptionsCount => {
-	if ( subscriptionsCount === 1 ) {
-		return __( ' (1 subscriber)', 'jetpack' );
-	}
-
-	return sprintf(
-		// translators: %s is the number of subscribers in numerical format
-		__( ' (%s subscribers)', 'jetpack' ),
-		subscriptionsCount
-	);
-};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to https://github.com/Automattic/jetpack/pull/34310 which fixed future-tenses for schedulled posts and problems with combined strings.

Copy for pre/publish panels was still defined all over the place.

Sometimes we had copy starting "This post..." and sometimes "Post name..." (with link). Sometimes we took paywall into account, sometimes not.

Nowhere we took into account singular/plural counts. For newsletter categories we also still had "combined strings", which are hard to translate.

This consolidates everything into a single component, making all variations easier to manage and bugs easier to notice.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Pretty much requires testing lots of scenarios...

* Paid posts
* Free posts
* Paid posts with paywalls
* Categories defined, but not picked
* Categories defined, one picked
* Categories defined, multiple picked
* Categories defined, at least one picked and one non-newsletter category 

All with single subscriber and no-subscribers.