### PR TITLE
Disable official buttons option in Sharing Buttons block

### DIFF
--- a/projects/plugins/jetpack/changelog/disable-jetpack-sharing-buttons-official-buttons-option
+++ b/projects/plugins/jetpack/changelog/disable-jetpack-sharing-buttons-official-buttons-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This block is still in development and not visible to users. No change will be noticed.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/edit.js
@@ -38,8 +38,6 @@ export function SharingButtonsEdit( props ) {
 							{ value: 'icon', label: __( 'Icon Only', 'jetpack' ) },
 							/* translators: Sharing: Sharing button option label. */
 							{ value: 'text', label: __( 'Text Only', 'jetpack' ) },
-							/* translators: Sharing: Sharing button option label. */
-							{ value: 'official', label: __( 'Official Buttons', 'jetpack' ), disabled: true },
 						] }
 						value={ styleType }
 						onSelect={ value => setAttributes( { styleType: value } ) }

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/edit.js
@@ -32,10 +32,14 @@ export function SharingButtonsEdit( props ) {
 				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 					<MenuItemsChoice
 						choices={ [
-							{ value: 'icon-text', label: 'Icon & Text' },
-							{ value: 'icon', label: 'Icon Only' },
-							{ value: 'text', label: 'Text Only' },
-							{ value: 'official', label: 'Official Buttons' },
+							/* translators: Sharing: Sharing button option label. */
+							{ value: 'icon-text', label: __( 'Icon & Text', 'jetpack' ) },
+							/* translators: Sharing: Sharing button option label. */
+							{ value: 'icon', label: __( 'Icon Only', 'jetpack' ) },
+							/* translators: Sharing: Sharing button option label. */
+							{ value: 'text', label: __( 'Text Only', 'jetpack' ) },
+							/* translators: Sharing: Sharing button option label. */
+							{ value: 'official', label: __( 'Official Buttons', 'jetpack' ), disabled: true },
 						] }
 						value={ styleType }
 						onSelect={ value => setAttributes( { styleType: value } ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34580

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
As this feature is not available yet, we want to mark this option disabled.
I've also added localization to the options.

Also, open to change it so we just remove the button entirely as mentioned https://github.com/Automattic/jetpack/issues/34580#issuecomment-1852331255, as don't have a strong opinion on this

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up your site with local changes
- Make sure you have beta block enabled. In your environment (example Docker) wp-config.php you should have define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
- Add Sharing Buttons block.
- In settings (right block sidebar), `Official buttons` should not be present
