### PR TITLE
Publicize Components | Move `usePostMeta` from `utils/` to `hooks/`

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-jp-social-move-use-post-meta-to-hooks
+++ b/projects/js-packages/publicize-components/changelog/update-jp-social-move-use-post-meta-to-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Moved `usePostMeta` hook to `/hooks/` directory

--- a/projects/js-packages/publicize-components/index.ts
+++ b/projects/js-packages/publicize-components/index.ts
@@ -32,4 +32,5 @@ export * from './src/hooks/use-sync-post-data-to-store';
 export * from './src/components/share-limits-bar';
 export * from './src/hooks/use-saving-post';
 export * from './src/hooks/use-share-limits';
+export * from './src/hooks/use-post-meta';
 export * from './src/components/share-buttons';

--- a/projects/js-packages/publicize-components/src/components/share-buttons/useShareButtonText.ts
+++ b/projects/js-packages/publicize-components/src/components/share-buttons/useShareButtonText.ts
@@ -1,6 +1,6 @@
 import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { usePostMeta } from '../../utils';
+import { usePostMeta } from '../../hooks/use-post-meta';
 
 /**
  * Prepares the text to share.

--- a/projects/js-packages/publicize-components/src/components/social-previews/mastodon.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/mastodon.js
@@ -1,9 +1,9 @@
 import { MastodonPreviews } from '@automattic/social-previews';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
+import { usePostMeta } from '../../hooks/use-post-meta';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import { SOCIAL_STORE_ID, CONNECTION_SERVICE_MASTODON } from '../../social-store';
-import { usePostMeta } from '../../utils';
 
 const MastodonPreview = props => {
 	const { message } = useSocialMediaMessage();

--- a/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
@@ -1,8 +1,8 @@
 import { TwitterPreviews } from '@automattic/social-previews';
 import { useSelect } from '@wordpress/data';
 import React from 'react';
+import { usePostMeta } from '../../hooks/use-post-meta';
 import { SOCIAL_STORE_ID, CONNECTION_SERVICE_TWITTER } from '../../social-store';
-import { usePostMeta } from '../../utils';
 
 /**
  * The twitter tab component.

--- a/projects/js-packages/publicize-components/src/components/social-previews/use-post-data.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/use-post-data.js
@@ -1,6 +1,6 @@
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { usePostMeta } from '../../utils';
+import { usePostMeta } from '../../hooks/use-post-meta';
 import { getSigImageUrl } from '../generated-image-preview/utils';
 import { getMediaSourceUrl } from './utils';
 

--- a/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
@@ -1,4 +1,4 @@
-import { usePostMeta } from '../../utils';
+import { usePostMeta } from '../use-post-meta';
 
 /**
  * @typedef {object} AttachedMediaHook

--- a/projects/js-packages/publicize-components/src/hooks/use-image-generator-config/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-image-generator-config/index.js
@@ -1,7 +1,7 @@
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
-import { usePostMeta } from '../../utils';
+import { usePostMeta } from '../use-post-meta';
 
 const getCurrentSettings = ( sigSettings, isPostPublished ) => ( {
 	isEnabled: sigSettings?.enabled ?? ! isPostPublished,

--- a/projects/js-packages/publicize-components/src/hooks/use-post-meta/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-post-meta/index.js
@@ -1,7 +1,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo } from '@wordpress/element';
-import { getShareMessageMaxLength } from './get-share-message-max-length';
+import { getShareMessageMaxLength } from '../../utils';
 
 /**
  * Returns the post meta values.

--- a/projects/js-packages/publicize-components/src/hooks/use-post-meta/test/index.test.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-post-meta/test/index.test.js
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { RegistryProvider } from '@wordpress/data';
-import { createRegistryWithStores } from '../test-utils';
-import { usePostMeta } from '../use-post-meta';
+import { usePostMeta } from '../';
+import { createRegistryWithStores } from '../../../utils/test-utils';
 
 const post = {
 	meta: {

--- a/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
@@ -6,7 +6,7 @@ import {
 } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { usePostMeta } from '../../utils/use-post-meta';
+import { usePostMeta } from '../use-post-meta';
 
 const republicizeFeatureName = 'republicize';
 

--- a/projects/js-packages/publicize-components/src/hooks/use-social-media-message/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-media-message/index.js
@@ -1,4 +1,5 @@
-import { getShareMessageMaxLength, usePostMeta } from '../../utils';
+import { getShareMessageMaxLength } from '../../utils';
+import { usePostMeta } from '../use-post-meta';
 
 /**
  * @typedef {object} MessageHook

--- a/projects/js-packages/publicize-components/src/utils/index.js
+++ b/projects/js-packages/publicize-components/src/utils/index.js
@@ -1,4 +1,3 @@
 export * from './get-share-message-max-length';
 export * from './get-supported-additional-connections';
 export * from './types';
-export * from './use-post-meta';


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR simply moves the `usePostMeta` hook from `utils/` to `hooks/` directory for obvious reasons

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack build --all`
* Do a sanity check in the post editor
* Confirm that everything works as before

