### PR TITLE
CRM: Making sure Quote Accepted and Last Viewed placeholders remain unrendered in Quote Editor

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-quote-accepted-placeholder-rendering
+++ b/projects/plugins/crm/changelog/fix-crm-quote-accepted-placeholder-rendering
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: The previously submitted PR covers changes relevant to the next release, this PR just fixes something modified in that PR.
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -865,7 +865,7 @@ function ZeroBSCRM_get_quote_template() {
 					}
 				}
 			}
-			$keys_staying_unrendered = array( 'quote-ID', 'quote-url', 'quote-created', 'quote-created_datetime_str', 'quote-created_date_str', 'quote-accepted', 'quote-accepted_datetime_str', 'quote-accepted_date_str', 'quote-lastupdated', 'quote-lastupdated_datetime_str', 'quote-lastupdated_date_str' );
+			$keys_staying_unrendered = array( 'quote-ID', 'quote-url', 'quote-created', 'quote-created_datetime_str', 'quote-created_date_str', 'quote-accepted', 'quote-accepted_datetime_str', 'quote-accepted_date_str', 'quote-lastupdated', 'quote-lastupdated_datetime_str', 'quote-lastupdated_date_str', 'quote-lastviewed', 'quote-lastviewed_datetime_str', 'quote-lastviewed_date_str' );
 			$working_html            = $placeholder_templating->replace_placeholders( array( 'global', 'contact', 'quote' ), $working_html, $replacements, array( ZBS_TYPE_CONTACT => $contact_object ), false, $keys_staying_unrendered ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 			// } replace the rest (#fname, etc)

--- a/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
+++ b/projects/plugins/crm/includes/jpcrm-templating-placeholders.php
@@ -1754,7 +1754,11 @@ class jpcrm_templating_placeholders {
 					}
 
 					// If this is a Quote date key and is not set (Quote accepted or last viewed), let's print out a message saying the quote isn't accepted or viewed.
-					if ( in_array( $key, array( 'quote-accepted', 'quote-lastviewed' ), true ) && ( empty( $replace_with ) || jpcrm_date_str_to_uts( $replace_with ) === 0 ) ) {
+					if (
+						in_array( $key, array( 'quote-accepted', 'quote-lastviewed' ), true ) &&
+						! in_array( $replacement_info['key'], $keys_staying_unrendered, true ) &&
+						( empty( $replace_with ) || jpcrm_date_str_to_uts( $replace_with ) === 0 )
+						) {
 
 						if ( $key === 'quote-accepted' ) {
 							$replace_with = __( 'Quote not yet accepted', 'zero-bs-crm' );


### PR DESCRIPTION
## Proposed changes:

* This PR fixes an issue introduced by the final commit added to this much larger PR, which modified and fixed various quote placeholders: https://github.com/Automattic/jetpack/pull/34490
* With a change in that final commit, Quote Accepted and Quote Last Viewed placeholders were now rendering with text saying the quote was not accepted or not viewed in the editor, making future rendering the portal and pdf not possible. This PR adds an extra check to the changed case to make sure they remain unrendered in the editor.
* It also adds the Last Viewed keys to the list of keys that should remain unrendered just for completion, even though after discussion the last viewed keys will later be removed: pbhBOz-4fT-p2#comment-5293

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Parent PR: https://github.com/Automattic/jetpack/pull/34490

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test, check out this PR locally or via Jurassic Ninja and the Jetpack Beta plugin.
* Test the Quote Accepted, and Last Viewed placeholders (there are three of each, available via the placeholder map - `/wp-admin/admin.php?page=zerobscrm-systemstatus&tab=placeholder-map`). Add these to a quote template and check the rendering in the quote editor when creating a new quote. All should remain unrendered.
* After saving the quote, check the client portal and pdf for the quote. The Last Viewed placeholders should show 'Quote not yet viewed', and the Quote Accepted placeholders should show 'Quote Not Accepted'. Similarly, the placeholders will now show the same in the two quote email templates (`/wp-admin/admin.php?page=zbs-email-templates&zbs_template_id=4` and `/wp-admin/admin.php?page=zbs-email-templates&zbs_template_id=2`) - you can also add an error_log in the `zeroBSCRM_quote_generateNotificationHTML` function in `jpcrm-mail-templating.php` to log the `$html`, after attempting to send the quote via email from the quote editor page.
* You can test accepting the quote as well, then refresh the client portal page, generate a new PDF, and send new email - the Quote Accepted placeholders should now render the date in the format mentioned in this format - any date_str and datetime_str placeholders should now render what is in the site settings, and the main placeholder rendering a UTS string (this has been previously tested).