### PR TITLE
Form block: hide 'lead capture' variation for WP.com Atomic sites

### DIFF
--- a/projects/packages/forms/changelog/update-forms-lead-capture-atomic
+++ b/projects/packages/forms/changelog/update-forms-lead-capture-atomic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Form block: hide 'lead capture' variation for WP.com Atomic sites

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -62,7 +62,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.26.x-dev"
+			"dev-trunk": "0.27.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.26.0",
+	"version": "0.27.0-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -1,5 +1,9 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
-import { getJetpackData, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import {
+	getJetpackData,
+	isAtomicSite,
+	isSimpleSite,
+} from '@automattic/jetpack-shared-extension-utils';
 import {
 	InnerBlocks,
 	InspectorControls,
@@ -327,7 +331,7 @@ export const JetpackContactFormEdit = forwardRef(
 							instanceId={ instanceId }
 						/>
 					) }
-					{ ! isSimpleSite() && (
+					{ ! ( isSimpleSite() || isAtomicSite() ) && (
 						<Fragment>
 							{ canUserInstallPlugins && (
 								<PanelBody title={ __( 'CRM Connection', 'jetpack-forms' ) } initialOpen={ false }>

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -1,4 +1,4 @@
-import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { Path } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { people } from '@wordpress/icons';
@@ -52,33 +52,6 @@ const variations = compact( [
 				'jetpack/button',
 				{
 					text: __( 'Contact Us', 'jetpack-forms' ),
-					element: 'button',
-					lock: { remove: true },
-				},
-			],
-		],
-		attributes: {
-			...defaultBlockStyling,
-		},
-	},
-	! isSimpleSite() && {
-		name: 'newsletter-form',
-		title: __( 'Lead capture', 'jetpack-forms' ),
-		description: __( 'A simple way to collect leads using forms on your site.', 'jetpack-forms' ),
-		keywords: [
-			_x( 'subscribe', 'block search term', 'jetpack-forms' ),
-			_x( 'email', 'block search term', 'jetpack-forms' ),
-			_x( 'signup', 'block search term', 'jetpack-forms' ),
-		],
-		icon: people,
-		innerBlocks: [
-			[ 'jetpack/field-name', { required: true, label: __( 'Name', 'jetpack-forms' ) } ],
-			[ 'jetpack/field-email', { required: true, label: __( 'Email', 'jetpack-forms' ) } ],
-			[ 'jetpack/field-consent', {} ],
-			[
-				'jetpack/button',
-				{
-					text: __( 'Subscribe', 'jetpack-forms' ),
 					element: 'button',
 					lock: { remove: true },
 				},
@@ -327,6 +300,33 @@ const variations = compact( [
 		attributes: {
 			...defaultBlockStyling,
 			subject: __( 'New feedback received from your website', 'jetpack-forms' ),
+		},
+	},
+	! ( isAtomicSite() || isSimpleSite() ) && {
+		name: 'lead-capture-form',
+		title: __( 'Lead capture', 'jetpack-forms' ),
+		description: __( 'A simple way to collect leads using forms on your site.', 'jetpack-forms' ),
+		keywords: [
+			_x( 'subscribe', 'block search term', 'jetpack-forms' ),
+			_x( 'email', 'block search term', 'jetpack-forms' ),
+			_x( 'signup', 'block search term', 'jetpack-forms' ),
+		],
+		icon: people,
+		innerBlocks: [
+			[ 'jetpack/field-name', { required: true, label: __( 'Name', 'jetpack-forms' ) } ],
+			[ 'jetpack/field-email', { required: true, label: __( 'Email', 'jetpack-forms' ) } ],
+			[ 'jetpack/field-consent', {} ],
+			[
+				'jetpack/button',
+				{
+					text: __( 'Subscribe', 'jetpack-forms' ),
+					element: 'button',
+					lock: { remove: true },
+				},
+			],
+		],
+		attributes: {
+			...defaultBlockStyling,
 		},
 	},
 	salesforceLeadFormVariation,

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.26.0';
+	const PACKAGE_VERSION = '0.27.0-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/plugins/jetpack/changelog/update-forms-lead-capture-atomic
+++ b/projects/plugins/jetpack/changelog/update-forms-lead-capture-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1167,7 +1167,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "f850e2a5de36c7d8bf94e1c40dc5624c473576be"
+                "reference": "91cdedeae6c8fc54fb18196d9465098efca69975"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1193,7 +1193,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.26.x-dev"
+                    "dev-trunk": "0.27.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I noticed that the Creative Mail CRM integration in forms was hidden just for simple sites, but not for WP.com sites.

I believe this was a partnership block developed for Jetpack audience, but WP.com didn't have the partnership?

Also moves the thing next to the other lead-capture form.

<img width="721" alt="Screenshot 2023-12-13 at 13 29 05" src="https://github.com/Automattic/jetpack/assets/87168/d959f089-34c8-4ea6-8a71-11479fe96149">
<img width="1367" alt="Screenshot 2023-12-13 at 13 28 43" src="https://github.com/Automattic/jetpack/assets/87168/f2264a9f-0971-49dc-a2b3-265f676af3a4">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

