### PR TITLE
Contact Form: build JS assets

### DIFF
--- a/projects/packages/forms/changelog/update-contact-form-build
+++ b/projects/packages/forms/changelog/update-contact-form-build
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Contact Form: build JS assets

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -62,7 +62,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.25.x-dev"
+			"dev-trunk": "0.26.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.25.1-alpha",
+	"version": "0.26.0-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.25.1-alpha';
+	const PACKAGE_VERSION = '0.26.0-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -1255,18 +1255,17 @@ class Admin {
 		}
 
 		// Add the scripts that handle the spam check event.
-		wp_register_script(
+		Assets::register_script(
 			'grunion-admin',
-			Assets::get_file_url_for_environment(
-				'_inc/build/contact-form/js/grunion-admin.min.js',
-				'modules/contact-form/js/grunion-admin.js'
-			),
-			array( 'jquery' ),
-			\JETPACK__VERSION,
-			true
+			'../../dist/contact-form/js/grunion-admin.js',
+			__FILE__,
+			array(
+				'enqueue'      => true,
+				'dependencies' => array( 'jquery' ),
+				'version'      => \JETPACK__VERSION,
+				'in_footer'    => true,
+			)
 		);
-
-		wp_enqueue_script( 'grunion-admin' );
 
 		wp_enqueue_style( 'grunion.css' );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -833,16 +833,17 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			);
 		}
 
-		wp_enqueue_script(
+		Assets::register_script(
 			'grunion-frontend',
-			Assets::get_file_url_for_environment(
-				'_inc/build/contact-form/js/grunion-frontend.min.js',
-				'modules/contact-form/js/grunion-frontend.js'
-			),
-			array( 'jquery', 'jquery-ui-datepicker' ),
-			\JETPACK__VERSION,
-			false
+			'../../dist/contact-form/js/grunion-frontend.js',
+			__FILE__,
+			array(
+				'enqueue'      => true,
+				'dependencies' => array( 'jquery', 'jquery-ui-datepicker' ),
+				'version'      => \JETPACK__VERSION,
+			)
 		);
+
 		wp_enqueue_style( 'jp-jquery-ui-datepicker', plugins_url( 'css/jquery-ui-datepicker.css', __FILE__ ), array( 'dashicons' ), '1.0' );
 
 		// Using Core's built-in datepicker localization routine

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -256,11 +256,12 @@ class Contact_Form_Plugin {
 
 		Assets::register_script(
 			'accessible-form',
-			'./js/accessible-form.js',
+			'../../dist/contact-form/js/accessible-form.js',
 			__FILE__,
 			array(
-				'async'   => true,
-				'version' => \JETPACK__VERSION,
+				'async'      => true,
+				'textdomain' => 'jetpack-forms',
+				'version'    => \JETPACK__VERSION,
 			)
 		);
 

--- a/projects/packages/forms/src/contact-form/class-editor-view.php
+++ b/projects/packages/forms/src/contact-form/class-editor-view.php
@@ -94,16 +94,19 @@ class Editor_View {
 
 		wp_enqueue_style( 'grunion-editor-ui', plugins_url( 'css/editor-ui.css', __FILE__ ), array(), \JETPACK__VERSION );
 		wp_style_add_data( 'grunion-editor-ui', 'rtl', 'replace' );
-		wp_enqueue_script(
+
+		Assets::register_script(
 			'grunion-editor-view',
-			Assets::get_file_url_for_environment(
-				'_inc/build/contact-form/js/editor-view.min.js',
-				'modules/contact-form/js/editor-view.js'
-			),
-			array( 'wp-util', 'jquery', 'quicktags' ),
-			\JETPACK__VERSION,
-			true
+			'../../dist/contact-form/js/editor-view.js',
+			__FILE__,
+			array(
+				'enqueue'      => true,
+				'dependencies' => array( 'wp-util', 'jquery', 'quicktags' ),
+				'version'      => \JETPACK__VERSION,
+				'in_footer'    => true,
+			)
 		);
+
 		wp_localize_script(
 			'grunion-editor-view',
 			'grunionEditorView',

--- a/projects/packages/forms/src/contact-form/class-form-view.php
+++ b/projects/packages/forms/src/contact-form/class-form-view.php
@@ -30,15 +30,14 @@ class Form_View {
 		 */
 		$max_new_fields = apply_filters( 'grunion_max_new_fields', 5 );
 
-		wp_register_script(
+		Assets::register_script(
 			'grunion',
-			Assets::get_file_url_for_environment(
-				'_inc/build/contact-form/js/grunion.min.js',
-				'modules/contact-form/js/grunion.js'
-			),
-			array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-draggable' ),
-			\JETPACK__VERSION,
-			false
+			'../../dist/contact-form/js/grunion.js',
+			__FILE__,
+			array(
+				'dependencies' => array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-draggable' ),
+				'version'      => \JETPACK__VERSION,
+			)
 		);
 
 		wp_localize_script(

--- a/projects/plugins/jetpack/changelog/update-contact-form-build
+++ b/projects/plugins/jetpack/changelog/update-contact-form-build
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1167,7 +1167,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "4518ccb0a77e821a6fc9c9a5723cd235aa59ef60"
+                "reference": "f850e2a5de36c7d8bf94e1c40dc5624c473576be"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1193,7 +1193,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.25.x-dev"
+                    "dev-trunk": "0.26.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/jetpack/issues/34280

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR runs the Contact Form scripts through the build, which, among other things, ensures they can be minimized and localized. The PR:
- updates the build configured in `webpack.config.contact-form.js` to handle scripts.
- updates the scripts registered paths so we don't load them from `jetpack/modules` anymore but from `packages/forms`.

_Note: we'll do the same for stylesheets in a subsequent PR._

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-87-p2


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

If you test locally, scripts won't be minified. If you use a JN site running this branch, they will.

### Prerequisites
- Spin up a test site with this branch
- Create a new post
- Add the _Contact Form_ block to the page
- Add a _Date Picker_ field to the form
- Open the Network panel

### Post Editor
- Refresh the editor
- Check that `editor-view.js` is loaded

### Site
- Open the preview
- Check that `grunion-frontend.js` and `accessible-form.js` are loaded

### Form Responses
- Visit the _Form Responses_ page at `/wp-admin/edit.php?post_type=feedback`
- Check that `grunion-admin.js` is loaded

### Classic editor
- Install the Classic Editor plugin and activate it
- Visit `/wp-admin/post-new.php`
- Check that `tinymce-plugin-form-button.js` is loaded

_Note: I don't know what page to visit to test that `grunion.js` is still loaded. Add a comment if you know._