### PR TITLE
Like block: Add Learn More link to the Like block inspector

### DIFF
--- a/projects/plugins/jetpack/changelog/add-like-block-learn-more
+++ b/projects/plugins/jetpack/changelog/add-like-block-learn-more
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Like block: Add Learn more link to the Like block inspector

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -1,6 +1,10 @@
-import { getBlockIconComponent, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import {
+	getBlockIconComponent,
+	isSimpleSite,
+	isAtomicSite,
+} from '@automattic/jetpack-shared-extension-utils';
 import { BlockIcon, useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { Placeholder, ToggleControl, PanelBody } from '@wordpress/components';
+import { ExternalLink, Placeholder, ToggleControl, PanelBody } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import metadata from './block.json';
@@ -48,10 +52,18 @@ function LikeEdit( { noticeUI } ) {
 		}
 	}, [ reblogSetSuccessfully, fetchReblog, clearReblogSetStatus ] );
 
+	const learnMoreUrl =
+		isAtomicSite() || isSimpleSite()
+			? 'https://wordpress.com/support/likes/'
+			: 'https://jetpack.com/support/likes/';
+
 	return (
 		<div { ...blockProps }>
-			{ isSimpleSite() && (
-				<InspectorControls>
+			<InspectorControls key="like-inspector">
+				<div className="wp-block-jetpack-like__learn-more">
+					<ExternalLink href={ learnMoreUrl }>{ __( 'Learn more', 'jetpack' ) }</ExternalLink>
+				</div>
+				{ isSimpleSite() && (
 					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 						<ToggleControl
 							label={ __( 'Show reblog button', 'jetpack' ) }
@@ -62,8 +74,8 @@ function LikeEdit( { noticeUI } ) {
 							} }
 						/>
 					</PanelBody>
-				</InspectorControls>
-			) }
+				) }
+			</InspectorControls>
 			<Placeholder
 				label={ __( 'Like', 'jetpack' ) }
 				instructions={ __( 'Instructions go here.', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -2,4 +2,9 @@
  * Editor styles for Like
  */
 
-.wp-block-jetpack-like { }
+.wp-block-jetpack-like {
+	&__learn-more {
+		padding: 0 16px 16px 52px;
+		margin-top: -12px;
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/85023

## Proposed changes:

* Add Learn More link to the Like block inspector

<img width="313" alt="image" src="https://github.com/Automattic/jetpack/assets/3113712/438d3891-23cf-48bf-a6c0-2ceda9644a51">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the same setup instructions from this PR: https://github.com/Automattic/jetpack/pull/34514
* Create a new post and add the Like block
* You should see the `Learn more` link on the inspector
  * Link for Atomic/Simple sites: https://wordpress.com/support/likes/
  * Link for self-hosted sites: https://jetpack.com/support/likes/



