### PR TITLE
Social: Fix register_settings namespace php error

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-auto-conversion-php-error
+++ b/projects/packages/publicize/changelog/fix-social-auto-conversion-php-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed bug with PHP conversion error

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -88,6 +88,7 @@ class Settings {
 				'default'      => array(
 					'enabled' => true,
 				),
+				'type'         => 'object',
 				'show_in_rest' => array(
 					'schema' => array(
 						'type'       => 'object',
@@ -98,7 +99,6 @@ class Settings {
 						),
 					),
 				),
-				'type'         => 'boolean',
 			)
 		);
 
@@ -140,9 +140,12 @@ class Settings {
 	public function get_settings( $with_available = false ) {
 		$this->migrate_old_option();
 
+		$auto_conversion_settings = get_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES, self::DEFAULT_AUTOCONVERT_IMAGES_SETTINGS );
+		$sig_settings             = get_option( self::OPTION_PREFIX . self::IMAGE_GENERATOR_SETTINGS, self::DEFAULT_IMAGE_GENERATOR_SETTINGS );
+
 		$settings = array(
-			'autoConversionSettings'       => get_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES, self::DEFAULT_AUTOCONVERT_IMAGES_SETTINGS ),
-			'socialImageGeneratorSettings' => get_option( self::OPTION_PREFIX . self::IMAGE_GENERATOR_SETTINGS, self::DEFAULT_IMAGE_GENERATOR_SETTINGS ),
+			'autoConversionSettings'       => is_array( $auto_conversion_settings ) ? $auto_conversion_settings : self::DEFAULT_AUTOCONVERT_IMAGES_SETTINGS,
+			'socialImageGeneratorSettings' => is_array( $sig_settings ) ? $sig_settings : self::DEFAULT_IMAGE_GENERATOR_SETTINGS,
 		);
 
 		// The feature cannot be enabled without Publicize.

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -55,7 +55,7 @@ class Settings {
 		// Checking if the new option is valid.
 		$auto_conversion_settings = get_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES );
 		if ( ! is_array( $auto_conversion_settings ) || ! isset( $auto_conversion_settings['enabled'] ) ) {
-			update_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES, self::DEFAULT_AUTOCONVERT_IMAGES_SETTINGS );
+			delete_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES );
 		}
 
 		$sig_settings = get_option( 'jetpack_social_image_generator_settings' );

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -46,10 +46,16 @@ class Settings {
 	 * @return void
 	 */
 	private function migrate_old_option() {
-		$auto_conversion_settings = get_option( 'jetpack_social_settings' );
-		if ( ! empty( $auto_conversion_settings ) ) {
-			update_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES, array( 'enabled' => ! empty( $auto_conversion_settings['image'] ) ) );
+		// Migrating from the old option.
+		$old_auto_conversion_settings = get_option( 'jetpack_social_settings' );
+		if ( ! empty( $old_auto_conversion_settings ) ) {
+			update_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES, array( 'enabled' => ! empty( $old_auto_conversion_settings['image'] ) ) );
 			delete_option( 'jetpack_social_settings' );
+		}
+		// Checking if the new option is valid.
+		$auto_conversion_settings = get_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES );
+		if ( ! is_array( $auto_conversion_settings ) || ! isset( $auto_conversion_settings['enabled'] ) ) {
+			update_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES, self::DEFAULT_AUTOCONVERT_IMAGES_SETTINGS );
 		}
 
 		$sig_settings = get_option( 'jetpack_social_image_generator_settings' );
@@ -140,12 +146,9 @@ class Settings {
 	public function get_settings( $with_available = false ) {
 		$this->migrate_old_option();
 
-		$auto_conversion_settings = get_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES, self::DEFAULT_AUTOCONVERT_IMAGES_SETTINGS );
-		$sig_settings             = get_option( self::OPTION_PREFIX . self::IMAGE_GENERATOR_SETTINGS, self::DEFAULT_IMAGE_GENERATOR_SETTINGS );
-
 		$settings = array(
-			'autoConversionSettings'       => is_array( $auto_conversion_settings ) ? $auto_conversion_settings : self::DEFAULT_AUTOCONVERT_IMAGES_SETTINGS,
-			'socialImageGeneratorSettings' => is_array( $sig_settings ) ? $sig_settings : self::DEFAULT_IMAGE_GENERATOR_SETTINGS,
+			'autoConversionSettings'       => get_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES, self::DEFAULT_AUTOCONVERT_IMAGES_SETTINGS ),
+			'socialImageGeneratorSettings' => get_option( self::OPTION_PREFIX . self::IMAGE_GENERATOR_SETTINGS, self::DEFAULT_IMAGE_GENERATOR_SETTINGS ),
 		);
 
 		// The feature cannot be enabled without Publicize.

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -59,8 +59,13 @@ class Settings {
 		}
 
 		$sig_settings = get_option( 'jetpack_social_image_generator_settings' );
-		$enabled      = false;
-		$template     = Templates::DEFAULT_TEMPLATE;
+		// If the option is not set, we don't need to migrate.
+		if ( $sig_settings === false ) {
+			return;
+		}
+
+		$enabled  = false;
+		$template = Templates::DEFAULT_TEMPLATE;
 
 		if ( isset( $sig_settings['defaults']['template'] ) ) {
 			$template = $sig_settings['defaults']['template'];

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -88,7 +88,7 @@ class Settings {
 	 */
 	public function register_settings() {
 		register_setting(
-			'general',
+			'jetpack_social',
 			self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES,
 			array(
 				'default'      => array(
@@ -109,7 +109,7 @@ class Settings {
 		);
 
 		register_setting(
-			'general',
+			'jetpack_social',
 			self::OPTION_PREFIX . self::IMAGE_GENERATOR_SETTINGS,
 			array(
 				'type'         => 'object',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

With the Social store refactor we introduced new registered settings, where to be able to use core API endpoints. That change caused some issues on Atomic sites, this change fixes that.

With a lot of debugging @pablinos found out that the namespace of the settings was set to `general` which is a problem in this case, as any change on `wp-admin/options-general.php` will set our `jetpack_social_autoconvert_images` option to an empty string.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updated the namespace of the options
* Fixed a possible bug where the type was set incorrectly
* Added a guard clause so the currently messed up options get restored to the defaults

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #34627
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On trunk Go to your local site on `wp-admin/options-general.php` and click on Save. It should set the option to empty string. Loading the editor will cause the issue.
* Apply this patch. Loading the editor should be fine, as the option should get reset to the defaults.
* Do the first step again on this branch, and confirm that it still works
