### PR TITLE
Super Cache: Fixed delete cache button trigger hook from admin panel

### DIFF
--- a/projects/plugins/super-cache/inc/delete-cache-button.php
+++ b/projects/plugins/super-cache/inc/delete-cache-button.php
@@ -86,8 +86,8 @@ function wpsc_admin_bar_delete_cache_ajax() {
 		if ( defined( 'WPSCDELETEERROR' ) ) {
 			return json_decode( constant( 'WPSCDELETEERROR' ) );
 		} else {
-			$req_path = !empty($_POST['path']) ? $_POST['path'] : '/';
-			$referer = !empty($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : admin_url();
+			$req_path = isset( $_POST['path'] ) ? sanitize_text_field( stripslashes( $_POST['path'] ) ) : '';
+			$referer = wp_get_referer();
 			/**
 			 * Hook into the cache deletion process after a successful cache deletion from the admin bar button.
 			 *

--- a/projects/plugins/super-cache/inc/delete-cache-button.php
+++ b/projects/plugins/super-cache/inc/delete-cache-button.php
@@ -86,6 +86,17 @@ function wpsc_admin_bar_delete_cache_ajax() {
 		if ( defined( 'WPSCDELETEERROR' ) ) {
 			return json_decode( constant( 'WPSCDELETEERROR' ) );
 		} else {
+			$req_path = !empty($_POST['path']) ? $_POST['path'] : '/';
+			$referer = !empty($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : admin_url();
+			/**
+			 * Hook into the cache deletion process after a successful cache deletion from the admin bar button.
+			 *
+			 * @since 1.12
+			 *
+			 * @param string $req_path Path of the page where the cache flush was requested.
+			 * @param string $referer  Referer URL.
+			 */
+			do_action( 'wpsc_after_delete_cache_admin_bar', $req_path, $referer );
 			return json_decode( false );
 		}
 	}


### PR DESCRIPTION
After that change hook wpsc_after_delete_cache_admin_bar will be fired also when pressing button from admin panel

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-super-cache#999

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it doesn't.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add any action to hook `wpsc_after_delete_cache_admin_bar`
* Delete cache via button from front page
* Delete cache via buttom from admin panel
* Hook should be triggered in both scenarios

