### PR TITLE
Like block: inactivate block when the Likes module or related site options are disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-like-block-disabled-case
+++ b/projects/plugins/jetpack/changelog/fix-like-block-disabled-case
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Like block (beta): Make sure the block is not available when the Likes module or Likes / Reblog site options are disabled

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -18,12 +18,16 @@ use Jetpack_Gutenberg;
  * registration if we need to.
  */
 function register_block() {
-	// The Like block is only available when the Likes module is active and either the Likes or Reblogs option is enabled.
-	if ( ! \Jetpack::is_module_active( 'likes' ) || ( get_option( 'disabled_likes' ) && get_option( 'disabled_reblogs' ) ) ) {
+	$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
+
+	$is_likes_module_inactive = ! \Jetpack::is_module_active( 'likes' );
+	$is_disabled_on_wpcom     = $is_wpcom && get_option( 'disabled_likes' ) && get_option( 'disabled_reblogs' );
+	$is_disabled_on_non_wpcom = ! $is_wpcom && get_option( 'disabled_likes' );
+	$disable_like_block       = $is_likes_module_inactive || $is_disabled_on_wpcom || $is_disabled_on_non_wpcom;
+
+	if ( $disable_like_block ) {
 		return;
 	}
-
-	$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
 
 	Blocks::jetpack_register_block(
 		__DIR__,

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -18,6 +18,11 @@ use Jetpack_Gutenberg;
  * registration if we need to.
  */
 function register_block() {
+	// The Like block is only available when the Likes module is active and either the Likes or Reblogs option is enabled.
+	if ( ! \Jetpack::is_module_active( 'likes' ) || ( get_option( 'disabled_likes' ) && get_option( 'disabled_reblogs' ) ) ) {
+		return;
+	}
+
 	$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
 
 	Blocks::jetpack_register_block(


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/85156.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* check the `likes` module and `disabled_likes` and `disabled_reblogs` options to decide whether the Likes block should be registered or not.

ℹ️ Please note that only for Simple sites:
- the `likes` module is always active and the Like block will be disabled only when both site options above are `true` 
- the Reblog button is available

ℹ️ We have a separate task that will properly communicate to the user how they can enable the Like block: https://github.com/Automattic/jetpack/pull/34639#issuecomment-1855822381.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Related project thread: pdDOJh-2JP-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:

Generally, it shouldn't be possible to reproduce the issues outlined in the description of https://github.com/Automattic/wp-calypso/issues/85156.

**Simple site**

1. Sync the changes of this PR to your simple site (e.g. by using the script from the comment below).
2. Sandbox the test site.
3. Add `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` to your `0-sandbox.php` file.
4. Add the new Like block to a post on your test site.
5. Navigate to _Tools → Marketing → Sharing Buttons_ in Calypso and try to change the _Reblog & Like_ settings:

![Markup on 2023-12-14 at 13:02:21](https://github.com/Automattic/jetpack/assets/25105483/f39a5705-f618-4aca-bf97-2d95affd6eef)

6. The block editor and the post front-end should display the Like block in all cases apart from the one **when both buttons are disabled**. In that case, the **front-end shouldn't include any block markup** and the block editor should display the following message:

![Markup on 2023-12-14 at 11:58:20](https://github.com/Automattic/jetpack/assets/25105483/96711e99-4b31-4313-b671-bb7198f2eb0f) 

**Self-hosted site**

1. Check out the PR and build it.
2. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
3. Launch Jurassic Tube to make your local site available publicly.
4. Connect Jetpack to your WordPress.com account and enable Likes feature.
5. Add the new Like block to a post on your test site.
6. Navigate to _Tools → Marketing → Sharing Buttons_ in Calypso or _Jetpack → Settings → Sharing_ in WP Admin and disable the related Likes toggle (both toggles enable / disable the `likes` Jetpack module).
7. If the toggles are disabled, the Like block shouldn't be available (similar as with the Simple site above).

**Atomic site** (should have the same behavior as a self-hosted site)
1. Check out the PR - you can use the Jetpack Beta plugin for instance.
3. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
4. Add the new Like block to a post on your test site.
5. Navigate to _Tools → Marketing → Sharing Buttons_ in Calypso or _Jetpack → Settings → Sharing_ in WP Admin and disable the related Likes toggle (both toggles enable / disable the `likes` Jetpack module).
6. If **any of the two toggles is disabled**, the Like block shouldn't be available.