### PR TITLE
Subscribers: pre/post-publish panel, show correct subs count with paywall

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-correct-subs-count-with-paywall
+++ b/projects/plugins/jetpack/changelog/fix-correct-subs-count-with-paywall
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribers: pre/post-publish panel, correct subs count with paywall

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -37,14 +37,22 @@ export function Link( { href, children } ) {
 	);
 }
 
-export function getReachForAccessLevelKey( accessLevelKey, emailSubscribers, paidSubscribers ) {
-	switch ( accessOptions[ accessLevelKey ].key ) {
+export function getReachForAccessLevelKey( {
+	accessLevel,
+	emailSubscribers,
+	paidSubscribers,
+	postHasPaywallBlock = false,
+} ) {
+	emailSubscribers = emailSubscribers ?? 0;
+	paidSubscribers = paidSubscribers ?? 0;
+
+	switch ( accessOptions[ accessLevel ]?.key ) {
 		case accessOptions.everybody.key:
-			return emailSubscribers || 0;
+			return emailSubscribers;
 		case accessOptions.subscribers.key:
-			return emailSubscribers || 0;
+			return emailSubscribers;
 		case accessOptions.paid_subscribers.key:
-			return paidSubscribers || 0;
+			return postHasPaywallBlock ? emailSubscribers : paidSubscribers;
 		default:
 			return 0;
 	}
@@ -155,19 +163,19 @@ export function NewsletterAccessRadioButtons( {
 						  ]
 						: [] ),
 					{
-						label: `${ accessOptions.subscribers.label } (${ getReachForAccessLevelKey(
-							accessOptions.subscribers.key,
+						label: `${ accessOptions.subscribers.label } (${ getReachForAccessLevelKey( {
+							accessLevel: accessOptions.subscribers.key,
 							emailSubscribers,
-							paidSubscribers
-						) })`,
+							paidSubscribers,
+						} ) })`,
 						value: accessOptions.subscribers.key,
 					},
 					{
-						label: `${ accessOptions.paid_subscribers.label } (${ getReachForAccessLevelKey(
-							accessOptions.paid_subscribers.key,
+						label: `${ accessOptions.paid_subscribers.label } (${ getReachForAccessLevelKey( {
+							accessLevel: accessOptions.paid_subscribers.key,
 							emailSubscribers,
-							paidSubscribers
-						) })`,
+							paidSubscribers,
+						} ) })`,
 						value: accessOptions.paid_subscribers.key,
 					},
 				] }

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -237,11 +237,12 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 	// Show all copy in future tense
 	const futureTense = prePublish || isScheduledPost;
 
-	const reachForAccessLevel = getReachForAccessLevelKey(
+	const reachForAccessLevel = getReachForAccessLevelKey( {
 		accessLevel,
-		emailSubscribersCount,
-		paidSubscribersCount
-	).toLocaleString();
+		emailSubscribers: emailSubscribersCount,
+		paidSubscribers: paidSubscribersCount,
+		postHasPaywallBlock,
+	} ).toLocaleString();
 
 	let text;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Show correct subs count with paywall block in the pre/post-publish panel

Previously we would show the paid post reach count, while we actually should show all subscribers -count.

<img width="308" alt="Screenshot 2023-12-14 at 17 30 53" src="https://github.com/Automattic/jetpack/assets/87168/a92c32c8-b10e-468c-ac23-12c4bbcac4b5">

<img width="283" alt="Screenshot 2023-12-14 at 17 30 58" src="https://github.com/Automattic/jetpack/assets/87168/a1aeca12-95a9-41c1-8294-4cfaada99ea0">

Note "paid subscribers" as access, but email will be sent to 11 subscribers, which are free.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post
* See correct numbers for free and paid subscribers in the posts sidebar, and pre/post publish panels
* Create 2nd post with paywall, this time in pre/post publish panel you see "free" subscriber count regardless if the post is gated to "subscribers only" or "paid subscribers only".
