### PR TITLE
Like block: temporarily hide the Reblog setting toggle

### DIFF
--- a/projects/plugins/jetpack/changelog/update-like-block-reblog-toggle-display
+++ b/projects/plugins/jetpack/changelog/update-like-block-reblog-toggle-display
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Like block (beta): Temporarily hide the Reblog setting toggle

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -65,7 +65,7 @@ function LikeEdit() {
 				<div className="wp-block-jetpack-like__learn-more">
 					<ExternalLink href={ learnMoreUrl }>{ __( 'Learn more', 'jetpack' ) }</ExternalLink>
 				</div>
-				{ isSimpleSite() && (
+				{ false && isSimpleSite() && (
 					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 						<ToggleControl
 							label={ __( 'Show reblog button', 'jetpack' ) }


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* hide the Reblog setting toggle from the Like block sidebar

ℹ️  This is a temporary measure until we come up with a way to enable / disable Reblog button on per-block basis: https://github.com/Automattic/wp-calypso/issues/85273.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

- Related Slack discussion: p1702549633269559/1702545690.384679-slack-C02TCEHP3HA
- Related project thread: pdDOJh-2JP-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:

**Simple site**

1. Sync the changes of this PR to your simple site (e.g. by using the script from the comment below).
2. Sandbox the test site.
3. Add `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` to your `0-sandbox.php` file.
4. Add the new Like block to a post on your test site.
5. When you take a look into the block sidebar, there should be no Reblog setting toggle.
6. There should be no regressions.

ℹ️ The Reblog feature is available for Simple sites only.