### PR TITLE
Launchpad: Improve the WC task visibility check

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-improve-wc-visibility-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-improve-wc-visibility-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updates the WC visibility check to use the `is_plugin_active` function.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -49,7 +49,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.4.x-dev"
+			"dev-trunk": "5.5.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.4.0",
+	"version": "5.5.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.4.0';
+	const PACKAGE_VERSION = '5.5.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -983,8 +983,7 @@ function wpcom_launchpad_is_woocommerce_setup_visible() {
 		return false;
 	}
 
-	$active_plugins = get_option( 'active_plugins' );
-	return in_array( 'woocommerce/woocommerce.php', $active_plugins, true );
+	return is_plugin_active( 'woocommerce/woocommerce.php' );
 }
 
 /**

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-improve-wc-task-check
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-improve-wc-task-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Version bump

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_6"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_7_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "208bc96ac854f49e4793bc0d3665ee5d1ed970f7"
+                "reference": "67196edaad741f50bdaa56fbe52cb9c61a583c04"
             },
             "require": {
                 "php": ">=7.0"
@@ -33,7 +33,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "5.5.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.6
+ * Version: 2.0.7-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.6",
+	"version": "2.0.7-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/pull/34551#discussion_r1426702356

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates the WooCommerce setup task visibility check to use the `is_plugin_active` instead of manually checking the plugin list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox using the command below.
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/improve-wc-task-check
```
* Create a new site through the `/setup/free` flow, and then add the Business plan
* Once you reach the Customer Home, go to the Developer Console and make a `GET` request to `wpcom/v2` -> ` /sites/:siteSlug/launchpad?checklist_slug=legacy-site-setup`
* Make sure the `Finish store setup` task is not shown

![Screen Shot 2023-12-11 at 09 29 42](https://github.com/Automattic/jetpack/assets/1234758/cd0ef58a-5cb1-491c-b80f-75b175e53a4c)

* Now, add your site to the WoA Developer list.
* Then, install the WooCommerce plugin, which should change your site to Atomic.
* Use the Jetpack Beta plugin to apply this PR to your site(You may have to updated the files manually, as the plugin doesn't seem to work on my end)
* Go back to the Developer Console and make the request again. Now you should see the `Finish store setup` task in the response.

![Screen Shot 2023-12-11 at 09 39 34](https://github.com/Automattic/jetpack/assets/1234758/5fddd624-4361-46e1-aed1-56b01ca8cf51)

