### PR TITLE
Like block: remove condition that decided whether to display Like block or Like widget (Jetpack & WoA sites)

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-like-block-special-treatment
+++ b/projects/plugins/jetpack/changelog/remove-like-block-special-treatment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Like block (beta): remove the condition that decided whether to display Like block or Like widget

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -464,15 +464,7 @@ class Jetpack_Likes {
 		// Let's make sure that the script is enqueued.
 		wp_enqueue_script( 'jetpack_likes_queuehandler' );
 
-		$beta_blocks_active = defined( 'JETPACK_BLOCKS_VARIATION' ) && JETPACK_BLOCKS_VARIATION === 'beta';
-
-		// If we're using a block-based theme and the Like block (beta) is available, return content without the Like button widget.
-		// Otherwise return content with the Like button widget.
-		if ( wp_is_block_theme() && $beta_blocks_active ) {
-			return $content;
-		} else {
-			return $content . $html;
-		}
+		return $content . $html;
 	}
 
 	/** Checks if admin bar is visible.*/


### PR DESCRIPTION
Partially addresses https://github.com/Automattic/wp-calypso/issues/85153
Related WPCOM patch: D132068-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* we are basically removing the following change: https://github.com/Automattic/jetpack/blob/ca18c7d2d7e7fef74e25f9a13a14a138b69d7270/projects/plugins/jetpack/modules/likes.php#L470 (introduced in https://github.com/Automattic/jetpack/pull/34450)

The reason for the shift in direction is that we currently cannot replace the Like widget with Like block as originally planned. More context: pdDOJh-2JP-p2#comment-2175.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

- more context: pdDOJh-2JP-p2#comment-2175
- related project thread: pdDOJh-2JP-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:

Please test with self-hosted Jetpack and WoA sites. Simple sites have their own patch: D132068-code.

**Self-hosted site**

1. Check out the PR and build it.
2. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
3. Launch Jurassic Tube to make your local site available publicly.
4. Connect Jetpack to your WordPress.com account and enable Likes feature.
5. Add the new Like block to a post on your test site.
6. Review the post in the front-end.
7. Both: Like block and Like widget should load (if https://github.com/Automattic/wp-calypso/issues/84852 was already fixed); or at least one should load and the other should be in the loading state - as can be seen in the following screenshot:

![Markup on 2023-12-14 at 18:01:51](https://github.com/Automattic/jetpack/assets/25105483/5c3fee50-6b12-4d12-b0ba-f99e1811b2cb)
(this screenshot is from a Simple site, but it illustrates the point)

**Atomic site**
1. Check out the PR - you can use the Jetpack Beta plugin for instance.
3. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
4. Add the new Like block to a post on your test site.
6. Review the post in the front-end.
5. Both: Like block and Like widget should load (if https://github.com/Automattic/wp-calypso/issues/84852 was already fixed); or at least one should load and the other should be in the loading state (same behavior as with the self-hosted Jetpack site).


