### PR TITLE
Improve sharing buttons events performance

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-sharing-buttons-events-performance
+++ b/projects/plugins/jetpack/changelog/improve-sharing-buttons-events-performance
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This feature is not awailable for users yet and should not affect visual representation. It's only inner performance improvements.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -44,7 +44,7 @@ function render_block( $attr, $content, $block ) {
 
 	$style_type  = $block->context['styleType'];
 	$style       = 'style-' . $style_type;
-	$data_shared = 'sharing-' . $attr['service'] . '-' . $post_id . $attr['service'];
+	$data_shared = 'sharing-' . $attr['service'] . '-' . $post_id;
 	$query       = 'share=' . $attr['service'] . '&nb=1';
 
 	$services   = get_services();
@@ -65,7 +65,8 @@ function render_block( $attr, $content, $block ) {
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
 	$component  = '<li class="jetpack-sharing-button__list-item">';
-	$component .= '<a rel="nofollow noopener noreferrer" class="' . $sharing_link_class . '" href="' . $link_url . '" target="_blank" data-shared="' . $data_shared . '" aria-label="' . $link_aria_label . '" primary>';
+	$component .= '<a rel="nofollow noopener noreferrer" class="' . $sharing_link_class . '" href="' . $link_url . '" target="_blank" ';
+	$component .= 'data-service="' . $attr['service'] . '" data-shared="' . $data_shared . '" aria-label="' . $link_aria_label . '" primary>';
 	$component .= $icon;
 	$component .= '<span class="jetpack-sharing-button__service-label" aria-hidden="true">' . $title . '</span>';
 	$component .= '</a>';

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -42,19 +42,19 @@ function render_block( $attr, $content, $block ) {
 	$post_id = $block->context['postId'];
 	$title   = $attr['label'] ?? $attr['service'];
 
-	$style_type  = $block->context['styleType'];
-	$style       = 'style-' . $style_type;
+	$style_type = $block->context['styleType'];
+	$style      = 'style-' . $style_type;
+	$query      = 'share=' . $attr['service'] . '&nb=1';
+
 	$data_shared = 'sharing-' . $attr['service'] . '-' . $post_id;
-	$query       = 'share=' . $attr['service'] . '&nb=1';
 
 	$services   = get_services();
 	$service    = new $services[ $attr['service'] ]( $attr['service'], array() );
 	$link_props = $service->get_link( $post, $query, $data_shared );
-	$link_url   = $link_props['url'];
 
-	$icon = get_social_logo( $attr['service'] );
-
-	$sharing_link_class = 'jetpack-sharing-button__button ' . $style . ' share-' . $attr['service'];
+	$link_url           = esc_html( $link_props['url'] );
+	$icon               = get_social_logo( $attr['service'] );
+	$sharing_link_class = esc_html( 'jetpack-sharing-button__button ' . $style . ' share-' . $attr['service'] );
 
 	$link_aria_label = sprintf(
 		/* translators: %s refers to a string representation of sharing service, e.g. Facebook  */
@@ -66,9 +66,9 @@ function render_block( $attr, $content, $block ) {
 
 	$component  = '<li class="jetpack-sharing-button__list-item">';
 	$component .= '<a rel="nofollow noopener noreferrer" class="' . $sharing_link_class . '" href="' . $link_url . '" target="_blank" ';
-	$component .= 'data-service="' . $attr['service'] . '" data-shared="' . $data_shared . '" aria-label="' . $link_aria_label . '" primary>';
+	$component .= 'data-service="' . esc_html( $attr['service'] ) . '" data-shared="' . esc_html( $data_shared ) . '" aria-label="' . $link_aria_label . '" primary>';
 	$component .= $icon;
-	$component .= '<span class="jetpack-sharing-button__service-label" aria-hidden="true">' . $title . '</span>';
+	$component .= '<span class="jetpack-sharing-button__service-label" aria-hidden="true">' . esc_html( $title ) . '</span>';
 	$component .= '</a>';
 	$component .= '</li>';
 

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -65,7 +65,7 @@ function render_block( $attr, $content, $block ) {
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
 	$component  = '<li class="jetpack-sharing-button__list-item">';
-	$component .= '<a rel="nofollow noopener noreferrer" class="' . $sharing_link_class . '" href="' . esc_attr( $link_url ) . '" target="_blank" ';
+	$component .= '<a rel="nofollow noopener noreferrer" class="' . esc_attr( $sharing_link_class ) . '" href="' . esc_attr( $link_url ) . '" target="_blank" ';
 	$component .= 'data-service="' . esc_attr( $attr['service'] ) . '" data-shared="' . esc_attr( $data_shared ) . '" aria-label="' . esc_attr( $link_aria_label ) . '" primary>';
 	$component .= $icon;
 	$component .= '<span class="jetpack-sharing-button__service-label" aria-hidden="true">' . esc_html( $title ) . '</span>';

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -52,9 +52,9 @@ function render_block( $attr, $content, $block ) {
 	$service    = new $services[ $attr['service'] ]( $attr['service'], array() );
 	$link_props = $service->get_link( $post, $query, $data_shared );
 
-	$link_url           = esc_html( $link_props['url'] );
+	$link_url           = $link_props['url'];
 	$icon               = get_social_logo( $attr['service'] );
-	$sharing_link_class = esc_html( 'jetpack-sharing-button__button ' . $style . ' share-' . $attr['service'] );
+	$sharing_link_class = 'jetpack-sharing-button__button ' . $style . ' share-' . $attr['service'];
 
 	$link_aria_label = sprintf(
 		/* translators: %s refers to a string representation of sharing service, e.g. Facebook  */
@@ -65,8 +65,8 @@ function render_block( $attr, $content, $block ) {
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
 	$component  = '<li class="jetpack-sharing-button__list-item">';
-	$component .= '<a rel="nofollow noopener noreferrer" class="' . $sharing_link_class . '" href="' . $link_url . '" target="_blank" ';
-	$component .= 'data-service="' . esc_html( $attr['service'] ) . '" data-shared="' . esc_html( $data_shared ) . '" aria-label="' . $link_aria_label . '" primary>';
+	$component .= '<a rel="nofollow noopener noreferrer" class="' . $sharing_link_class . '" href="' . esc_attr( $link_url ) . '" target="_blank" ';
+	$component .= 'data-service="' . esc_attr( $attr['service'] ) . '" data-shared="' . esc_attr( $data_shared ) . '" aria-label="' . esc_attr( $link_aria_label ) . '" primary>';
 	$component .= $icon;
 	$component .= '<span class="jetpack-sharing-button__service-label" aria-hidden="true">' . esc_html( $title ) . '</span>';
 	$component .= '</a>';

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/save.js
@@ -2,7 +2,7 @@ import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
 export default function save() {
 	const className = 'jetpack-sharing-buttons__services-list';
-	const id = 'serivces-list';
+	const id = 'jetpack-sharing-serivces-list';
 	const blockProps = useBlockProps.save( { className } );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/save.js
@@ -2,8 +2,9 @@ import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
 export default function save() {
 	const className = 'jetpack-sharing-buttons__services-list';
+	const id = 'serivces-list';
 	const blockProps = useBlockProps.save( { className } );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 
-	return <ul { ...innerBlocksProps } />;
+	return <ul { ...innerBlocksProps } id={ id } />;
 }

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/view.js
@@ -3,7 +3,7 @@ import './style.scss';
 let sharingWindowOpen;
 
 ( function () {
-	const servicesContainer = document.getElementById( 'serivces-list' );
+	const servicesContainer = document.getElementById( 'jetpack-sharing-serivces-list' );
 	if ( ! servicesContainer ) {
 		return;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/view.js
@@ -1,38 +1,43 @@
 import './style.scss';
 
-const services = window?.jetpack_sharing_buttons_services || [];
-let windowOpen;
+let sharingWindowOpen;
 
 ( function () {
-	services.forEach( service => {
-		document.querySelectorAll( `a.share-${ service }` ).forEach( link => {
-			link.addEventListener( 'click', event => {
-				if ( service === 'mail' ) {
-					return;
-				}
-				event.preventDefault();
-				event.stopPropagation();
+	const servicesContainer = document.getElementById( 'serivces-list' );
+	if ( ! servicesContainer ) {
+		return;
+	}
+	servicesContainer.addEventListener( 'click', event => {
+		const link = event.target.closest( 'a' );
+		const service = link?.dataset?.service;
 
-				if ( service === 'print' ) {
-					window.print();
-					return;
-				}
+		if ( ! link || ! link.classList.contains( `share-${ service }` ) ) {
+			return;
+		}
 
-				const el = event.target.closest( `a.share-${ service }` );
-				if ( ! el ) {
-					return;
-				}
+		if ( service === 'mail' ) {
+			return;
+		}
 
-				if ( windowOpen !== undefined ) {
-					windowOpen.close();
-				}
+		event.preventDefault();
+		event.stopPropagation();
 
-				const options = 'menubar=1,resizable=1,width=600,height=400';
-				windowOpen = window.open( el.getAttribute( 'href' ), `wpcom${ service }`, options );
-				if ( windowOpen ) {
-					windowOpen.focus();
-				}
-			} );
-		} );
+		if ( service === 'print' ) {
+			window.print();
+			return;
+		}
+		if ( sharingWindowOpen ) {
+			sharingWindowOpen.close();
+		}
+
+		sharingWindowOpen = window.open(
+			link.getAttribute( 'href' ),
+			`wpcom${ service }`,
+			'menubar=1,resizable=1,width=600,height=400'
+		);
+
+		if ( sharingWindowOpen ) {
+			sharingWindowOpen.focus();
+		}
 	} );
 } )();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34581

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Instead of having listener for each button, we are now have only one on parent element. Additionally:
- Adding `id` to parent element
- Adding `service` dataset link item for easier retrieval

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up your site with local changes
- Make sure you have beta block enabled. In your environment (example Docker) wp-config.php you should have define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
- Add Sharing Buttons block to a post and check it's behaviour.
- View the post and check Sharing Buttons functionality.