### PR TITLE
Jetpack: Fix OpenTable block input jumping around

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blocks-for-gutenberg-17.2.1
+++ b/projects/plugins/jetpack/changelog/fix-blocks-for-gutenberg-17.2.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+OpenTable: Keep input form at a constant width so button doesn't jump out from under the cursor.

--- a/projects/plugins/jetpack/extensions/blocks/opentable/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/editor.scss
@@ -26,8 +26,13 @@
 
 		form {
 			flex-direction: row;
+			flex-wrap: nowrap;
 			@media screen and ( max-width: 479px ) {
 				display: block;
+			}
+
+			.components-form-token-field {
+				flex-grow: 1;
 			}
 
 			.components-form-token-field__label {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The restaurant input in the OpenTable block would change its width as the search results changed, causing the adjacent Embed button to also move around. Something in Gutenberg 17.2.1 changed which results show up by default in the E2E test, causing this jumping to start making the test fail.

The fix we're applying here is to set the input field with flex-grow and the container with nowrap, so the field remains at the full width with the button beside it in all cases (above the `@media` cutoff that switches away from flexbox completely).

### Before
![before](https://github.com/Automattic/jetpack/assets/1030580/71631871-21ee-4b0e-ae40-3e0137930558)
### After
![after](https://github.com/Automattic/jetpack/assets/1030580/b6a20906-081e-40f0-a307-9cb57784e607)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Embed the block
* Try adding different restaurants, then blurring the input. The Embed button should not move.