### PR TITLE
Backport mu-wpcom-plugin 2.0.6, jetpack 13.0-a.3 Changes

### DIFF
--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.0] - 2023-12-14
+### Changed
+- Moved `usePostMeta` hook to `/hooks/` directory. [#34611]
+- Split PublicizeForm component into smaller ones. [#34612]
+- Updated the share limit bar design. [#34182]
+
+### Fixed
+- Fixed Jetpack Social scheduled post messaging. [#34182]
+- Fixed the scheduled post double count for share limits. [#34182]
+
 ## [0.42.0] - 2023-12-11
 ### Changed
 - Refactored storing of feature options to use core functions. [#34113]
@@ -534,6 +544,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.43.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.9...v0.42.0
 [0.41.9]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.8...v0.41.9
 [0.41.8]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.7...v0.41.8

--- a/projects/js-packages/publicize-components/changelog/add-tests-for-sharing-data
+++ b/projects/js-packages/publicize-components/changelog/add-tests-for-sharing-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-

--- a/projects/js-packages/publicize-components/changelog/fix-jetpack-social-sheduled-posts-messaging
+++ b/projects/js-packages/publicize-components/changelog/fix-jetpack-social-sheduled-posts-messaging
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed Jetpack Social scheduled post messaging

--- a/projects/js-packages/publicize-components/changelog/fix-scheduled-post-double-count
+++ b/projects/js-packages/publicize-components/changelog/fix-scheduled-post-double-count
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed the scheduled post double count for share limits

--- a/projects/js-packages/publicize-components/changelog/update-jp-social-move-use-post-meta-to-hooks
+++ b/projects/js-packages/publicize-components/changelog/update-jp-social-move-use-post-meta-to-hooks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Moved `usePostMeta` hook to `/hooks/` directory

--- a/projects/js-packages/publicize-components/changelog/update-share-limits-bar-design
+++ b/projects/js-packages/publicize-components/changelog/update-share-limits-bar-design
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated the share limit bar design

--- a/projects/js-packages/publicize-components/changelog/update-split-publicize-form-component
+++ b/projects/js-packages/publicize-components/changelog/update-split-publicize-form-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Splitted PublicizeForm component into smaller ones

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.43.0-alpha",
+	"version": "0.43.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/boost-speed-score/CHANGELOG.md
+++ b/projects/packages/boost-speed-score/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-12-14
+### Changed
+- Internal updates.
+
 ## [0.3.0] - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]
@@ -31,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new package for Boost Speed Score [#30914]
 - Add a new argument to `Speed_Score` to identify where the request was made from (e.g. 'boost-plugin', 'jetpack-dashboard', etc). [#31012]
 
+[0.3.1]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.2.0...v0.2.1

--- a/projects/packages/boost-speed-score/changelog/boost-migrate-score-popout
+++ b/projects/packages/boost-speed-score/changelog/boost-migrate-score-popout
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Part of the React migration, not visible to users
-
-

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -23,7 +23,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.3.1-alpha';
+	const PACKAGE_VERSION = '0.3.1';
 
 	/**
 	 * An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup passed to the constructor

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.0] - 2023-12-14
+### Added
+- Contact Form: build JS assets [#34622]
+
+### Fixed
+- Avoid PHP warnings when methods are called too early. [#34576]
+
 ## [0.25.0] - 2023-12-11
 ### Added
 - Contact Form: Added submitting state. [#34367]
@@ -416,6 +423,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.26.0]: https://github.com/automattic/jetpack-forms/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/automattic/jetpack-forms/compare/v0.24.2...v0.25.0
 [0.24.2]: https://github.com/automattic/jetpack-forms/compare/v0.24.1...v0.24.2
 [0.24.1]: https://github.com/automattic/jetpack-forms/compare/v0.24.0...v0.24.1

--- a/projects/packages/forms/changelog/fix-contact-form-screen-warnings
+++ b/projects/packages/forms/changelog/fix-contact-form-screen-warnings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Avoid PHP warnings when methods are called too early.

--- a/projects/packages/forms/changelog/update-contact-form-build
+++ b/projects/packages/forms/changelog/update-contact-form-build
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Contact Form: build JS assets

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.26.0-alpha",
+	"version": "0.26.0",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.26.0-alpha';
+	const PACKAGE_VERSION = '0.26.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.0] - 2023-12-14
+### Added
+- Add the Sensei and WooCommerce Setup Task, to allow us to retire the old checklist card. [#34551] [#34564]
+- Launchpad: Add context param to endpoint. [#34498]
+
+### Changed
+- Mark the setup_general task as complete based on whether blogname or blog description options changed. [#34579]
+
 ## [5.3.0] - 2023-12-11
 ### Added
 - Added editor error handling from ETK. [#34158]
@@ -475,6 +483,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.4.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.3.0...v5.4.0
 [5.3.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.2.0...v5.3.0
 [5.2.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.1.1...v5.2.0
 [5.1.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.1.0...v5.1.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-context-for-api-requests
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-context-for-api-requests
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Launchpad: Added context param to endpoint.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-sensei-setup-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-sensei-setup-task
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the Sensei Setup Task, to allow us to retire the old checklist card

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-woocommerce-setup-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-woocommerce-setup-task
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the WooCommerce Setup task to the Site Setup Launchpad, to allow us to retire the old checklist card.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-setup-general-completion-callback
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-setup-general-completion-callback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Will mark the setup_general task as complete based on wether blogname or bogdescription options changed

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.4.0-alpha",
+	"version": "5.4.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.4.0-alpha';
+	const PACKAGE_VERSION = '5.4.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.38.1] - 2023-12-14
+### Fixed
+- Fixed Jetpack Social scheduled post messaging. [#34182]
+- Social: Fixed bug with PHP conversion error. [#34636]
+- Updated version. [#34182]
+
 ## [0.38.0] - 2023-12-11
 ### Changed
 - Social: Refactored storing of feature options to use core functions. [#34113]
@@ -433,6 +439,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.38.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.0...v0.38.1
 [0.38.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.37.2...v0.38.0
 [0.37.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.37.1...v0.37.2
 [0.37.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.37.0...v0.37.1

--- a/projects/packages/publicize/changelog/fix-jetpack-social-sheduled-posts-messaging
+++ b/projects/packages/publicize/changelog/fix-jetpack-social-sheduled-posts-messaging
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed Jetpack Social scheduled post messaging

--- a/projects/packages/publicize/changelog/fix-scheduled-post-double-count
+++ b/projects/packages/publicize/changelog/fix-scheduled-post-double-count
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Updated version

--- a/projects/packages/publicize/changelog/fix-social-auto-conversion-php-error
+++ b/projects/packages/publicize/changelog/fix-social-auto-conversion-php-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social: Fixed bug with PHP conversion error

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.38.1-alpha",
+	"version": "0.38.1",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.0-a.3 - 2023-12-14
+### Improved compatibility
+- Contact Form: avoid PHP warnings in the WordPress dashboard when used alongside other plugins making changes to admin pages. [#34576]
+
+### Bug fixes
+- Widgets: Fix console JS error in EU Cookie Widget. [#34591]
+- Paywall: Fix stuck pending subscription state when email isn't verified. [#34543]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add page view tracking for WooCommerce Checkout Flow. [#34065]
+- AI Assistant: Register ai-logo-generator beta flag. [#34641]
+- Backup: Bug fixes in helper script installation class. [#34297]
+- Ensure block use, shortcode use, and additional blocks in use are tracked correctly on classic themes. [#34065]
+- Fix fatal in Simple. [#34602]
+- Like block (beta): Handle Reblog toggle change. [#34572]
+- Like block (beta): Temporarily hide the Reblog setting toggle. [#34646]
+- Like block: Add Learn more link to the Like block inspector. [#34625]
+- OpenTable: Keep input form at a constant width so button doesn't jump out from under the cursor. [#34654]
+- Subscriptions: consolidate pre/post panel copy to a component [#34631]
+- Updated package dependencies. [#34559]
+
 ## 13.0-a.1 - 2023-12-11
 ### Enhancements
 - AI Usage panel: Added yellow color to indicate going over the soft limit. [#34555]

--- a/projects/plugins/jetpack/changelog/add-ai-logo-generator-beta-flag
+++ b/projects/plugins/jetpack/changelog/add-ai-logo-generator-beta-flag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Register ai-logo-generator beta flag

--- a/projects/plugins/jetpack/changelog/add-like-block-edit-view
+++ b/projects/plugins/jetpack/changelog/add-like-block-edit-view
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: This is still a internal beta block so no changelog needed.
-
-

--- a/projects/plugins/jetpack/changelog/add-like-block-handle-reblog-toggle
+++ b/projects/plugins/jetpack/changelog/add-like-block-handle-reblog-toggle
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Like block (beta): Handle Reblog toggle change

--- a/projects/plugins/jetpack/changelog/add-like-block-learn-more
+++ b/projects/plugins/jetpack/changelog/add-like-block-learn-more
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Like block: Add Learn more link to the Like block inspector

--- a/projects/plugins/jetpack/changelog/add-page-view-events-for-wc-checkout-flow
+++ b/projects/plugins/jetpack/changelog/add-page-view-events-for-wc-checkout-flow
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add page view tracking for WooCommerce Checkout Flow

--- a/projects/plugins/jetpack/changelog/disable-jetpack-sharing-buttons-official-buttons-option
+++ b/projects/plugins/jetpack/changelog/disable-jetpack-sharing-buttons-official-buttons-option
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: This block is still in development and not visible to users. No change will be noticed.
-
-

--- a/projects/plugins/jetpack/changelog/fix-blocks-for-gutenberg-17.2.1
+++ b/projects/plugins/jetpack/changelog/fix-blocks-for-gutenberg-17.2.1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-OpenTable: Keep input form at a constant width so button doesn't jump out from under the cursor.

--- a/projects/plugins/jetpack/changelog/fix-contact-form-screen-warnings
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-screen-warnings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Contact Form: avoid PHP warnings in the WordPress dashboard when used alongside other plugins making changes to admin pages.

--- a/projects/plugins/jetpack/changelog/fix-eu-cookie-widget-console-error
+++ b/projects/plugins/jetpack/changelog/fix-eu-cookie-widget-console-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix console JS error in EU Cookie Widget 

--- a/projects/plugins/jetpack/changelog/fix-fatal-subscription-service
+++ b/projects/plugins/jetpack/changelog/fix-fatal-subscription-service
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix fatal in Simple

--- a/projects/plugins/jetpack/changelog/fix-paywall-pending-subscription
+++ b/projects/plugins/jetpack/changelog/fix-paywall-pending-subscription
@@ -1,4 +1,0 @@
-Significance: minor
-Type: bugfix
-
-Paywall: Fix pending subscription state

--- a/projects/plugins/jetpack/changelog/fix-subscribe-post-publish-typo
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-post-publish-typo
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: typo fix
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.0-a.4
+
+

--- a/projects/plugins/jetpack/changelog/modify-backup-helper-script-manager-tests-verbosity
+++ b/projects/plugins/jetpack/changelog/modify-backup-helper-script-manager-tests-verbosity
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Backup: Bug fixes in helper script installation class.

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/update-classic-theme-tracking
+++ b/projects/plugins/jetpack/changelog/update-classic-theme-tracking
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Ensure block use, shortcode use, and additional blocks in use are tracked correctly on classic themes

--- a/projects/plugins/jetpack/changelog/update-consolidate-newsletter-affirm-text
+++ b/projects/plugins/jetpack/changelog/update-consolidate-newsletter-affirm-text
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: consolidate pre/post panel copy to a component

--- a/projects/plugins/jetpack/changelog/update-contact-form-build
+++ b/projects/plugins/jetpack/changelog/update-contact-form-build
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-like-block-reblog-toggle-display
+++ b/projects/plugins/jetpack/changelog/update-like-block-reblog-toggle-display
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Like block (beta): Temporarily hide the Reblog setting toggle

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_4",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_2",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_3",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.2
+ * Version: 13.0-a.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.2' );
+define( 'JETPACK__VERSION', '13.0-a.3' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.3
+ * Version: 13.0-a.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.3' );
+define( 'JETPACK__VERSION', '13.0-a.4' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.3",
+	"version": "13.0.0-a.4",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.2",
+	"version": "13.0.0-a.3",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.6 - 2023-12-14
+### Changed
+- Updated package dependencies. [#34559]
+
 ## 2.0.5 - 2023-12-11
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-context-for-api-requests
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-context-for-api-requests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_6_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_6"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.6-alpha
+ * Version: 2.0.6
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.6-alpha",
+	"version": "2.0.6",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.6, jetpack 13.0-a.3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.