### PR TITLE
[Boost] Exclude charset from Critcial CSS

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2641,8 +2641,8 @@ importers:
         specifier: 5.3.0
         version: 5.3.0
       jetpack-boost-critical-css-gen:
-        specifier: github:automattic/jetpack-boost-critical-css-gen#release-0.0.10
-        version: github.com/automattic/jetpack-boost-critical-css-gen/450c06a55c1982c67c3200045e9be13ea6b13629
+        specifier: github:automattic/jetpack-boost-critical-css-gen#release-0.0.11
+        version: github.com/automattic/jetpack-boost-critical-css-gen/56adf5a550475fd30962cd4e8f8bfcaf71f84177
       prettier:
         specifier: npm:wp-prettier@3.0.3
         version: /wp-prettier@3.0.3
@@ -25033,10 +25033,11 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
 
-  github.com/automattic/jetpack-boost-critical-css-gen/450c06a55c1982c67c3200045e9be13ea6b13629:
-    resolution: {tarball: https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/450c06a55c1982c67c3200045e9be13ea6b13629}
+  github.com/automattic/jetpack-boost-critical-css-gen/56adf5a550475fd30962cd4e8f8bfcaf71f84177:
+    resolution: {tarball: https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/56adf5a550475fd30962cd4e8f8bfcaf71f84177}
     name: jetpack-boost-critical-css-gen
-    version: 0.0.10
+    version: 0.0.11
+    prepare: true
     requiresBuild: true
     dependencies:
       clean-css: 5.3.2

--- a/projects/plugins/boost/changelog/boost-exclude-charsets
+++ b/projects/plugins/boost/changelog/boost-exclude-charsets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Exclude @charset and @import statements from Critical CSS

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -17,7 +17,7 @@
 		"@wordpress/element": "5.24.0",
 		"classnames": "2.3.2",
 		"history": "5.3.0",
-		"jetpack-boost-critical-css-gen": "github:automattic/jetpack-boost-critical-css-gen#release-0.0.10",
+		"jetpack-boost-critical-css-gen": "github:automattic/jetpack-boost-critical-css-gen#release-0.0.11",
 		"prettier": "npm:wp-prettier@3.0.3",
 		"svelte-navigator": "3.2.2",
 		"zod": "3.22.3"


### PR DESCRIPTION
Fixes #33447

Exclude `@charset` and `@import` statements from Critical CSS blocks by bumping to the latest version to include https://github.com/Automattic/jetpack-boost-critical-css-gen/pull/43.

## Proposed changes:
* Bump to latest version of critical css gen lib
* Exclude `@charset` and `@import` statements from Critical CSS.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
* Apply this patch
* Make sure you have some `@charset` rules in your CSS files
* Generate Critical CSS
* Ensure there are no `@charset` statements in your generated Critical CSS block