### PR TITLE
Newsletter post publish: show initially closed instead of open

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-post-publish-initially-closed
+++ b/projects/plugins/jetpack/changelog/update-newsletter-post-publish-initially-closed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Newsletter post-publish panel: closed initially

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -175,7 +175,6 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 	return (
 		<>
 			<PluginPostPublishPanel
-				initialOpen
 				title={
 					<>
 						{ __( 'Newsletter:', 'jetpack' ) }
@@ -195,7 +194,6 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 
 			{ ! isStripeConnected && (
 				<PluginPostPublishPanel
-					initialOpen
 					className="jetpack-subscribe-newsletters-panel paid-newsletters-post-publish-panel"
 					title={ __( 'Set up a paid newsletter', 'jetpack' ) }
 					icon={ <JetpackEditorPanelLogo /> }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The panel was open by default, but we can show it closed. It's more informative while other panels are more like "next steps", and also are open.

The information we also already have in post-settings panel, and pre-publish panel.

<img src="https://github.com/Automattic/jetpack/assets/87168/94a0f0f4-22d5-4a34-b120-1e0a4ddd1397" width="250"/>

Came up in slack p1702584651727199-slack-C052XEUUBL4

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove `initiallyOpen` props from post-publish panels.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Publish blog post, see the post-publish panel
* When stripe is disconnected, there's additional upsell panel.
