### PR TITLE
Like block: remove like module dependency

### DIFF
--- a/projects/plugins/jetpack/changelog/add-like-block-no-deps
+++ b/projects/plugins/jetpack/changelog/add-like-block-no-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove like block dependency on Like module and insert iframe once.

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -52,6 +52,10 @@ function render_block( $attr, $content, $block ) {
 	$post_id = $block->context['postId'];
 	$title   = esc_html__( 'Like or Reblog', 'jetpack' );
 
+	if ( ! $post_id ) {
+		return;
+	}
+
 	/**
 	 * Enable an alternate Likes layout.
 	 *

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -71,7 +71,6 @@ function render_block( $attr, $content, $block ) {
 	static $main_iframe_added = false;
 
 	if ( ! $main_iframe_added && is_legacy_likes_disabled() ) {
-		require_once JETPACK__PLUGIN_DIR . 'modules/likes.php';
 		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
 		wp_enqueue_script( 'jetpack_likes_queuehandler' );
 		wp_enqueue_style( 'jetpack_likes' );

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -74,6 +74,7 @@ function render_block( $attr, $content, $block ) {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			add_action( 'wp_footer', array( 'Jetpack_Likes', 'likes_master' ), 21 );
 		} else {
+			require_once JETPACK__PLUGIN_DIR . 'modules/likes.php';
 			add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
 		}
 		wp_enqueue_script( 'jetpack_likes_queuehandler' );

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -67,7 +67,7 @@ function render_block( $attr, $content, $block ) {
 	 */
 	$new_layout = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
 
-	static $master_iframe_added = false;
+	static $main_iframe_added = false;
 
 	$is_wpcom                 = defined( 'IS_WPCOM' ) && IS_WPCOM;
 	$is_likes_module_inactive = ! \Jetpack::is_module_active( 'likes' );
@@ -75,9 +75,9 @@ function render_block( $attr, $content, $block ) {
 	$is_disabled_on_non_wpcom = ! $is_wpcom && get_option( 'disabled_likes' );
 	$like_widget_inactive     = $is_likes_module_inactive || $is_disabled_on_wpcom || $is_disabled_on_non_wpcom;
 
-	if ( ! $master_iframe_added && $like_widget_inactive ) {
+	if ( ! $main_iframe_added && $like_widget_inactive ) {
 		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
-		$master_iframe_added = true;
+		$main_iframe_added = true;
 	}
 
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -71,7 +71,11 @@ function render_block( $attr, $content, $block ) {
 	static $main_iframe_added = false;
 
 	if ( ! $main_iframe_added && is_legacy_likes_disabled() ) {
-		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			add_action( 'wp_footer', array( 'Jetpack_Likes', 'likes_master' ), 21 );
+		} else {
+			add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
+		}
 		wp_enqueue_script( 'jetpack_likes_queuehandler' );
 		wp_enqueue_style( 'jetpack_likes' );
 		$main_iframe_added = true;

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -69,7 +69,13 @@ function render_block( $attr, $content, $block ) {
 
 	static $master_iframe_added = false;
 
-	if ( ! $master_iframe_added && ! \Jetpack::is_module_active( 'likes' ) ) {
+	$is_wpcom                 = defined( 'IS_WPCOM' ) && IS_WPCOM;
+	$is_likes_module_inactive = ! \Jetpack::is_module_active( 'likes' );
+	$is_disabled_on_wpcom     = $is_wpcom && get_option( 'disabled_likes' ) && get_option( 'disabled_reblogs' );
+	$is_disabled_on_non_wpcom = ! $is_wpcom && get_option( 'disabled_likes' );
+	$like_widget_inactive     = $is_likes_module_inactive || $is_disabled_on_wpcom || $is_disabled_on_non_wpcom;
+
+	if ( ! $master_iframe_added && $like_widget_inactive ) {
 		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
 		$master_iframe_added = true;
 	}


### PR DESCRIPTION
## Proposed changes:
- This removes the like block's dependency on the like module being enabled
- It ensures the master iframe gets inserted once
- It doesn't render anything when there's no post_id present 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

Depends on this PR for WPCOM: D132336-code 

- Check out the PR and build it.
- Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
- Launch Jurassic Tube to make your local site available publicly.
- Connect Jetpack to your WordPress.com account and enable Likes feature.
- Add the new Like block to a post on your test site.

Now try different scenarios:
- Go to Jetpack → Settings → Sharing & toggle on/off the Likes
- The master iframe should be inserted once if there's a Like widget/block present

Also test on Simple site, the only difference is the location of the toggle: Tools > Marketing > Sharing Buttons


⚠️ The actual rendering of the widget depends on an API call, which checks among other things ... if the module is enabled. We'll tackle this in a follow up PR. For now  return `true` here: fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qyvfg%2Qcbfg%2Qyvxrf%2Qraqcbvag.cuc%2367%2Q68-og  ⚠️