### PR TITLE
Social: Fix auto-conversion cleanup logic

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-auto-conversion-cleanup-logic
+++ b/projects/packages/publicize/changelog/fix-social-auto-conversion-cleanup-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed issue with auto-conversion option logic

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.38.1",
+	"version": "0.38.2-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -54,7 +54,9 @@ class Settings {
 		}
 		// Checking if the new option is valid.
 		$auto_conversion_settings = get_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES );
-		if ( ! is_array( $auto_conversion_settings ) || ! isset( $auto_conversion_settings['enabled'] ) ) {
+		// If the option is not set, we don't need to delete it.
+		// If it is set, but it is not an array or it does not have the enabled key, we delete it.
+		if ( false !== $auto_conversion_settings && ( ! is_array( $auto_conversion_settings ) || ! isset( $auto_conversion_settings['enabled'] ) ) ) {
 			delete_option( self::OPTION_PREFIX . self::AUTOCONVERT_IMAGES );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue where a delete_option call is getting called on every API call with Social.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixed the logic so we are mindful of the option being absent and do not try to delete it if it's not there.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*  Without this PR sandbox Jetpack SUN. Looking at the logs while hitting `https://public-api.wordpress.com/` should call https://github.com/Automattic/jetpack/pull/34636/files#diff-fcaff5fe90306f15c873c21bc21a7f091da0b003f9982ac57e16bf52aa90752cR58 delete_option on every call. You can put a log in there to see it in the logs
* Apply this PR with the jetpack-downloader to your sandbox. Logging in the same place should not result in any logs on calling the api.