### PR TITLE
Contact Form: add accessible name to form

### DIFF
--- a/projects/packages/forms/changelog/add-contact-form-accessible-name
+++ b/projects/packages/forms/changelog/add-contact-form-accessible-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Contact Form: add accessible name to form

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -62,7 +62,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.27.x-dev"
+			"dev-trunk": "0.28.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.27.0",
+	"version": "0.28.0-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
@@ -1,5 +1,5 @@
 import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
-import { Button, TextControl } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { get } from 'lodash';
 import React from 'react';
@@ -7,11 +7,7 @@ import InspectorHint from '../components/inspector-hint';
 
 const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
 
-const JetpackManageResponsesSettings = ( {
-	formTitle = '',
-	isChildBlock = false,
-	setAttributes,
-} ) => {
+const JetpackManageResponsesSettings = () => {
 	return (
 		<>
 			<InspectorHint>
@@ -23,15 +19,6 @@ const JetpackManageResponsesSettings = ( {
 					{ __( '(opens in a new tab)', 'jetpack-forms' ) }
 				</span>
 			</Button>
-			{ /* Temporarily hiding the Form Title */ }
-			{ false && ! isChildBlock && (
-				<TextControl
-					label={ __( 'Title of the Form', 'jetpack-forms' ) }
-					value={ formTitle }
-					onChange={ value => setAttributes( { formTitle: value } ) }
-					help={ __( 'Optional - not visible to viewers', 'jetpack-forms' ) }
-				/>
-			) }
 		</>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -20,6 +20,7 @@ import {
 	SelectControl,
 	TextareaControl,
 	TextControl,
+	Notice,
 } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -160,7 +161,7 @@ export const JetpackContactFormEdit = forwardRef(
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [] );
 
-		useFormAccessibleName( postTitle, formTitle, clientId, setAttributes );
+		useFormAccessibleName( formTitle, clientId, setAttributes );
 
 		useEffect( () => {
 			if ( to === undefined && postAuthorEmail ) {
@@ -308,6 +309,16 @@ export const JetpackContactFormEdit = forwardRef(
 		return (
 			<>
 				<InspectorControls>
+					{ ! attributes.formTitle && (
+						<PanelBody>
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									'Add a heading inside the form or before it to help everybody identify it.',
+									'jetpack-forms'
+								) }
+							</Notice>{ ' ' }
+						</PanelBody>
+					) }
 					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 						<JetpackManageResponsesSettings setAttributes={ setAttributes } />
 					</PanelBody>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -160,7 +160,7 @@ export const JetpackContactFormEdit = forwardRef(
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [] );
 
-		useFormAccessibleName( postTitle, attributes.formTitle, clientId, setAttributes );
+		useFormAccessibleName( postTitle, formTitle, clientId, setAttributes );
 
 		useEffect( () => {
 			if ( to === undefined && postAuthorEmail ) {
@@ -309,10 +309,7 @@ export const JetpackContactFormEdit = forwardRef(
 			<>
 				<InspectorControls>
 					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
-						<JetpackManageResponsesSettings
-							formTitle={ formTitle }
-							setAttributes={ setAttributes }
-						/>
+						<JetpackManageResponsesSettings setAttributes={ setAttributes } />
 					</PanelBody>
 					<PanelBody title={ __( 'Submission Settings', 'jetpack-forms' ) } initialOpen={ false }>
 						{ renderSubmissionSettings() }

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -36,6 +36,7 @@ import JetpackEmailConnectionSettings from './components/jetpack-email-connectio
 import JetpackManageResponsesSettings from './components/jetpack-manage-responses-settings';
 import NewsletterIntegrationSettings from './components/jetpack-newsletter-integration-settings';
 import SalesforceLeadFormSettings from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
+import useFormAccessibleName from './hooks/use-form-accessible-name';
 import { withStyleVariables } from './util/with-style-variables';
 import defaultVariations from './variations';
 
@@ -158,6 +159,8 @@ export const JetpackContactFormEdit = forwardRef(
 			}
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [] );
+
+		useFormAccessibleName( postTitle, attributes.formTitle, clientId, setAttributes );
 
 		useEffect( () => {
 			if ( to === undefined && postAuthorEmail ) {

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-form-accessible-name.js
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-form-accessible-name.js
@@ -1,0 +1,57 @@
+import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+const getNameFromBlockHeading = block => {
+	const innerHeading = block.innerBlocks?.find( b => b.name === 'core/heading' );
+
+	return innerHeading?.attributes?.content;
+};
+
+const getNameFromBlockPreviousHeadings = ( block, pageBlocks ) => {
+	const blockIndex = pageBlocks.findIndex( b => b.clientId === block.clientId );
+	const previousBlocks = pageBlocks.slice( 0, blockIndex );
+	const closestHeading = previousBlocks.findLast( b => b.name === 'core/heading' );
+
+	return closestHeading?.attributes?.content;
+};
+
+/**
+ * Update the form accessible stored in the `formTitle` attribute as the block or page
+ * content changes. The heuristic is as follows:
+ * 1. Look for a heading inside the form
+ * 2. Look for a heading in the previous siblings
+ * 3. Use the post title
+ *
+ * @param {string} postTitle - The post title
+ * @param {string} formTitle - The form title
+ * @param {string} clientId - The block unique identifier
+ * @param {Function} setAttributes - Function to call to update one or more attributes
+ */
+export default function useFormAccessibleName( postTitle, formTitle, clientId, setAttributes ) {
+	const { pageBlocks } = useSelect( select => ( {
+		pageBlocks: select( 'core/block-editor' ).getBlocks(),
+	} ) );
+
+	useEffect( () => {
+		const currentBlock = pageBlocks.find( block => block.clientId === clientId );
+
+		let name;
+
+		if ( currentBlock ) {
+			// #1
+			name = getNameFromBlockHeading( currentBlock );
+
+			if ( ! name ) {
+				// #2
+				name = getNameFromBlockPreviousHeadings( currentBlock, pageBlocks );
+			}
+		}
+
+		// #3
+		name = name || postTitle;
+
+		if ( formTitle !== name ) {
+			setAttributes( { formTitle: name } );
+		}
+	}, [ postTitle, clientId, formTitle, setAttributes, pageBlocks ] );
+}

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-form-accessible-name.js
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-form-accessible-name.js
@@ -20,14 +20,13 @@ const getNameFromBlockPreviousHeadings = ( block, pageBlocks ) => {
  * content changes. The heuristic is as follows:
  * 1. Look for a heading inside the form
  * 2. Look for a heading in the previous siblings
- * 3. Use the post title
+ * 3. Use the post title (in Contact_Form::parse, server side)
  *
- * @param {string} postTitle - The post title
  * @param {string} formTitle - The form title
  * @param {string} clientId - The block unique identifier
  * @param {Function} setAttributes - Function to call to update one or more attributes
  */
-export default function useFormAccessibleName( postTitle, formTitle, clientId, setAttributes ) {
+export default function useFormAccessibleName( formTitle, clientId, setAttributes ) {
 	const { pageBlocks } = useSelect( select => ( {
 		pageBlocks: select( 'core/block-editor' ).getBlocks(),
 	} ) );
@@ -35,7 +34,7 @@ export default function useFormAccessibleName( postTitle, formTitle, clientId, s
 	useEffect( () => {
 		const currentBlock = pageBlocks.find( block => block.clientId === clientId );
 
-		let name;
+		let name = '';
 
 		if ( currentBlock ) {
 			// #1
@@ -47,11 +46,8 @@ export default function useFormAccessibleName( postTitle, formTitle, clientId, s
 			}
 		}
 
-		// #3
-		name = name || postTitle;
-
 		if ( formTitle !== name ) {
 			setAttributes( { formTitle: name } );
 		}
-	}, [ postTitle, clientId, formTitle, setAttributes, pageBlocks ] );
+	}, [ clientId, formTitle, setAttributes, pageBlocks ] );
 }

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.27.0';
+	const PACKAGE_VERSION = '0.28.0-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -240,6 +240,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string HTML for the concat form.
 	 */
 	public static function parse( $attributes, $content ) {
+		global $post;
+
 		if ( Settings::is_syncing() ) {
 			return '';
 		}
@@ -352,7 +354,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$url                     = apply_filters( 'grunion_contact_form_form_action', "{$url}#contact-form-{$id}", $GLOBALS['post'], $id );
 			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' );
 			$form_classes            = 'contact-form commentsblock';
-			$form_accessible_name    = $attributes['formTitle'];
+			$form_accessible_name    = $attributes['formTitle'] ? $attributes['formTitle'] : $post->post_title;
 			$form_aria_label         = isset( $form_accessible_name ) && ! empty( $form_accessible_name ) ? 'aria-label="' . esc_attr( $form_accessible_name ) . '"' : '';
 
 			if ( $has_submit_button_block ) {

--- a/projects/plugins/jetpack/changelog/add-contact-form-accessible-name
+++ b/projects/plugins/jetpack/changelog/add-contact-form-accessible-name
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1167,7 +1167,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "91cdedeae6c8fc54fb18196d9465098efca69975"
+                "reference": "c72fbe74edbc293518b22c39de5c8f609e2f235b"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1193,7 +1193,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.27.x-dev"
+                    "dev-trunk": "0.28.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34504

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Forms with an accessible name are easier to discover and access with a screen reader. One way to define an accessible name is adding an `aria-label` attribute to the `form`, the value being the name.

Adding a title to a form, visible to all users, is considered a best practice (see [this MDN article](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/form_role#description)). We'll therefore look for headings to determine a form accessible name. The heuristic is:
1. Look for the first heading inside the form
2. Look for a heading preceding the form
3. Use the post title

The strategy here is to save the accessible name in a block attribute (recycling the existing `formTitle` attribute, which was declared but wasn't used) as the content of the page changes in the editor. When the page is rendered, we simply get the attribute.

In the editor, we've added a warning notice to nudge users to add a heading to the form.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-87-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
- Spin up a test site with this branch
- Create a new post
- Add the _Contact Form_ block
- Open the preview in a separate tab

### Notice
- Select the _Contact Form_ in the editor
- Notice the warning notice in the sidebar
<img width="500" alt="Screenshot 2023-12-19 at 4 15 58 PM" src="https://github.com/Automattic/jetpack/assets/1620183/c12d19da-5d84-40e6-9418-624db908a4f5">

### Heading Inside Form
- Add a heading inside the form
- Notice the warning has disappeared
- Save the post and refresh the preview
- Notice the `form`  has an `aria-label` attribute of which the value is the heading content
- Remove the heading

### Heading Before Form
- Add a heading just before the form
- Save the post and refresh the preview
- Notice the `form`  has an `aria-label` attribute of which the value is the heading content
- Remove the heading

### No Heading
- Notice the `form`  has an `aria-label` attribute of which the value is the post title, followed by `Form`

## Captures
_Form in the editor_
<img width="500" alt="Screenshot 2023-12-19 at 12 35 22 PM" src="https://github.com/Automattic/jetpack/assets/1620183/d09ff3c1-4065-4b1e-b678-4fd68fc96c48">

_Form in the site_
<img width="500" alt="Screenshot 2023-12-19 at 12 35 32 PM" src="https://github.com/Automattic/jetpack/assets/1620183/ed6657e9-456d-4f96-b8c9-9c23a32a02cc">

_The VoiceOver screen reader shows the form in the landmarks shortcut_
<img width="500" alt="Screenshot 2023-12-19 at 12 36 47 PM" src="https://github.com/Automattic/jetpack/assets/1620183/16802096-d7df-4855-9b64-c6538292f740">


