### PR TITLE
AI Assistant: change prompt placeholder

### DIFF
--- a/projects/plugins/jetpack/changelog/change-ai-assistant-dont-rotate-placeholder
+++ b/projects/plugins/jetpack/changelog/change-ai-assistant-dont-rotate-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: remove typing effect on prompt placeholder

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -408,10 +408,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 	const innerBlocks = useInnerBlocksProps( blockProps );
 
 	const promptPlaceholder = __( 'Ask Jetpack AI…', 'jetpack' );
-	const promptPlaceholderWithSamples = __(
-		'Ask Jetpack AI… Post about… Make a table for…',
-		'jetpack'
-	);
+	const promptPlaceholderWithSamples = __( 'Write about… Make a table for…', 'jetpack' );
 	return (
 		<KeyboardShortcuts
 			bindGlobal

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -407,10 +407,11 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 
 	const innerBlocks = useInnerBlocksProps( blockProps );
 
-	const promptPlaceholder = attributes?.content
-		? __( 'Ask Jetpack AI…', 'jetpack' )
-		: __( 'Ask Jetpack AI… Post about… Make a table for…', 'jetpack' );
-
+	const promptPlaceholder = __( 'Ask Jetpack AI…', 'jetpack' );
+	const promptPlaceholderWithSamples = __(
+		'Ask Jetpack AI… Post about… Make a table for…',
+		'jetpack'
+	);
 	return (
 		<KeyboardShortcuts
 			bindGlobal
@@ -554,7 +555,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					ref={ aiControlRef }
 					disabled={ requireUpgrade || ! connected }
 					value={ attributes.userPrompt }
-					placeholder={ promptPlaceholder }
+					placeholder={ attributes?.content ? promptPlaceholder : promptPlaceholderWithSamples }
 					onChange={ handleChange }
 					onSend={ handleSend }
 					onStop={ handleStopSuggestion }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -407,6 +407,10 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 
 	const innerBlocks = useInnerBlocksProps( blockProps );
 
+	const promptPlaceholder = attributes?.content
+		? __( 'Ask Jetpack AI…', 'jetpack' )
+		: __( 'Ask Jetpack AI… Post about… Make a table for…', 'jetpack' );
+
 	return (
 		<KeyboardShortcuts
 			bindGlobal
@@ -550,11 +554,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					ref={ aiControlRef }
 					disabled={ requireUpgrade || ! connected }
 					value={ attributes.userPrompt }
-					placeholder={
-						attributes?.content
-							? __( 'Ask Jetpack AI…', 'jetpack' )
-							: __( 'Ask Jetpack AI… Post about… Make a table for…', 'jetpack' )
-					}
+					placeholder={ promptPlaceholder }
 					onChange={ handleChange }
 					onSend={ handleSend }
 					onStop={ handleStopSuggestion }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -550,7 +550,11 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					ref={ aiControlRef }
 					disabled={ requireUpgrade || ! connected }
 					value={ attributes.userPrompt }
-					placeholder={ __( 'Ask Jetpack AI… Post about… Make a table for…', 'jetpack' ) }
+					placeholder={
+						attributes?.content
+							? __( 'Ask Jetpack AI…', 'jetpack' )
+							: __( 'Ask Jetpack AI… Post about… Make a table for…', 'jetpack' )
+					}
 					onChange={ handleChange }
 					onSend={ handleSend }
 					onStop={ handleStopSuggestion }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -559,12 +559,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 							// Focus the text area
 							userPromptInput.focus();
 
-							// Add a typing effect in the text area
-							for ( let i = 0; i < prompt.length; i++ ) {
-								setTimeout( () => {
-									setAttributes( { userPrompt: prompt.slice( 0, i + 1 ) } );
-								}, 25 * i );
-							}
+							setAttributes( { userPrompt: prompt } );
 						} }
 						recordEvent={ tracks.recordEvent }
 						isGeneratingTitle={ isGeneratingTitle }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -32,7 +32,6 @@ import { USAGE_PANEL_PLACEMENT_BLOCK_SETTINGS_SIDEBAR } from '../../plugins/ai-a
 import ConnectPrompt from './components/connect-prompt';
 import FeedbackControl from './components/feedback-control';
 import ImageWithSelect from './components/image-with-select';
-import { promptTemplates } from './components/prompt-templates-control';
 import ToolbarControls from './components/toolbar-controls';
 import UpgradePrompt from './components/upgrade-prompt';
 import { getStoreBlockId } from './extensions/ai-assistant/with-ai-assistant';
@@ -200,24 +199,6 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		// Populate block inner blocks
 		replaceBlocks( clientId, storedInnerBlocks );
 	}, [ initialContent, clientId, replaceBlocks, getBlock, attributes?.useGutenbergSyntax ] );
-
-	const [ promptPlaceholder, setPromptPlaceholder ] = useState( '' );
-	const [ currentIndex, setCurrentIndex ] = useState( 0 );
-
-	// Loop through placeholder prompts for a nice UX effect.
-	useEffect( () => {
-		const interval = setInterval( () => {
-			if ( currentIndex < promptTemplates.length ) {
-				setPromptPlaceholder( promptTemplates[ currentIndex ].label );
-				setCurrentIndex( prevIndex => prevIndex + 1 );
-			} else {
-				clearInterval( interval );
-				setPromptPlaceholder( __( 'Ask Jetpack AI', 'jetpack' ) );
-			}
-		}, 1600 );
-
-		return () => clearInterval( interval );
-	}, [ promptPlaceholder, currentIndex ] );
 
 	useEffect( () => {
 		// we don't want to store "half way" states
@@ -569,7 +550,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					ref={ aiControlRef }
 					disabled={ requireUpgrade || ! connected }
 					value={ attributes.userPrompt }
-					placeholder={ promptPlaceholder || __( 'Ask Jetpack AI', 'jetpack' ) }
+					placeholder={ __( 'Ask Jetpack AI… Post about… Make a table for…', 'jetpack' ) }
 					onChange={ handleChange }
 					onSend={ handleSend }
 					onStop={ handleStopSuggestion }


### PR DESCRIPTION
Rotating placeholders are a bit confusing

Fixes #34668 

## Proposed changes:
This PR removes both the typing effect and the rotating placeholders for a fixed one with prompt crafting suggestions: 
`Ask Jetpack AI… Post about… Make a table for…`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1702552144058089-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert an AI Assistant block, confirm that the placeholder is the one on the description, it doesn't rotate nor does it have a typing effect. Make sure other AI Assistant block functions work correctly.