### PR TITLE
Sharing buttons block alternate settings screen

### DIFF
--- a/projects/plugins/jetpack/changelog/sharing-buttons-block-alternate-settings-screen
+++ b/projects/plugins/jetpack/changelog/sharing-buttons-block-alternate-settings-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+When using Sharing Buttons block we will show different settings screen

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
@@ -438,3 +438,17 @@ body.settings_page_sharing .advanced input[type=submit] {
 	width: 0;
 	text-indent: 100%;
 }
+
+.sharing-block-message__items-wrapper {
+	display: flex;
+	flex-wrap: wrap;
+	column-gap: 6rem;
+}
+
+.sharing-block-message__buttons-wrapper {
+	display: inline-flex;
+}
+
+.sharing-block-message__buttons-wrapper a {
+	margin-right:1rem;
+}

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
@@ -445,10 +445,7 @@ body.settings_page_sharing .advanced input[type=submit] {
 	column-gap: 6rem;
 }
 
-.sharing-block-message__buttons-wrapper {
-	display: inline-flex;
-}
 
-.sharing-block-message__buttons-wrapper a {
+.sharing-block-message__buttons-wrapper .button {
 	margin-right:1rem;
 }

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -8,6 +8,7 @@
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
 if ( ! defined( 'WP_SHARING_PLUGIN_URL' ) ) {
@@ -686,14 +687,12 @@ class Sharing_Admin {
 
 	<!-- Showing Sharing Buttons Block message -->
 	<?php elseif ( current_user_can( 'manage_options' ) ) : ?>
-		
 		<?php
-			$sharer            = new Sharing_Service();
 			$showcase_services = array(
-				$sharer->get_service( 'twitter' ),
-				$sharer->get_service( 'facebook' ),
-				$sharer->get_service( 'email' ),
-				$sharer->get_service( 'reddit' ),
+				new Share_Tumblr( 'tumblr', array() ),
+				new Share_Facebook( 'facebook', array() ),
+				new Share_Email( 'email', array() ),
+				new Share_Reddit( 'reddit', array() ),
 			);
 			?>
 		
@@ -705,8 +704,12 @@ class Sharing_Admin {
 					<p><?php esc_html_e( 'Add sharing buttons to your blog and allow your visitors to share posts with their friends.', 'jetpack' ); ?></p>
 					
 					<div class="sharing-block-message__buttons-wrapper">
-						<a href="<?php echo esc_url( 'https://wordpress.com' ); ?>" class="button button-primary"><?php esc_html_e( 'Go to the site editor', 'jetpack' ); ?></a>
-						<a href="<?php echo esc_url( 'https://wordpress.com' ); ?>" class="button"><?php esc_html_e( 'Learn how to add Sharing Buttons', 'jetpack' ); ?></a>
+						<a href="<?php echo esc_url( admin_url( 'site-editor.php?path=%2Fwp_template' ) ); ?>" class="button button-primary">
+							<?php esc_html_e( 'Go to the site editor', 'jetpack' ); ?>
+						</a>
+						<a href="<?php echo esc_url( Redirect::get_url( 'jetpack-support-sharing-block' ) ); ?>" class="button" target="_blank" rel="noopener noreferrer">
+							<?php esc_html_e( 'Learn how to add Sharing Buttons', 'jetpack' ); ?>
+						</a>
 					</div>
 				</div>
 				<div>

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -376,7 +376,15 @@ class Sharing_Admin {
 		do_action( 'pre_admin_screen_sharing' );
 		?>
 
-		<?php if ( current_user_can( 'manage_options' ) ) : ?>
+		<?php
+			$block_availability = Jetpack_Gutenberg::get_cached_availability();
+			$is_block_available = (bool) isset( $block_availability['sharing-buttons'] ) && $block_availability['sharing-buttons']['available'];
+			$current_theme      = wp_get_theme();
+			$is_block_theme     = $current_theme->is_block_theme();
+			$show_block_message = $is_block_available && $is_block_theme;
+		?>
+
+		<?php if ( current_user_can( 'manage_options' ) && ! $show_block_message ) : ?>
 
 		<div class="share_manage_options">
 		<h2><?php esc_html_e( 'Sharing Buttons', 'jetpack' ); ?></h2>
@@ -675,6 +683,48 @@ class Sharing_Admin {
 		</form>
 	</div>
 	</div>
+
+	<!-- Showing Sharing Buttons Block message -->
+	<?php elseif ( current_user_can( 'manage_options' ) ) : ?>
+		
+		<?php
+			$sharer            = new Sharing_Service();
+			$showcase_services = array(
+				$sharer->get_service( 'twitter' ),
+				$sharer->get_service( 'facebook' ),
+				$sharer->get_service( 'email' ),
+				$sharer->get_service( 'reddit' ),
+			);
+			?>
+		
+		<div class="share_manage_options">
+			<br class="clearing" />
+			<h2><?php esc_html_e( 'Sharing Buttons', 'jetpack' ); ?></h2>
+			<div class="sharing-block-message__items-wrapper">
+				<div>
+					<p><?php esc_html_e( 'Add sharing buttons to your blog and allow your visitors to share posts with their friends.', 'jetpack' ); ?></p>
+					
+					<div class="sharing-block-message__buttons-wrapper">
+						<a href="<?php echo esc_url( 'https://wordpress.com' ); ?>" class="button button-primary"><?php esc_html_e( 'Go to the site editor', 'jetpack' ); ?></a>
+						<a href="<?php echo esc_url( 'https://wordpress.com' ); ?>" class="button"><?php esc_html_e( 'Learn how to add Sharing Buttons', 'jetpack' ); ?></a>
+					</div>
+				</div>
+				<div>
+					<p><?php esc_html_e( 'Sharing Buttons example: ', 'jetpack' ); ?></p>
+					<div class="sharedaddy sd-sharing-enabled">
+						<div class="sd-content">
+							<ul class="preview">
+								<?php foreach ( $showcase_services as $id => $service ) : ?>
+									<?php $this->output_preview( $service ); ?>
+								<?php endforeach; ?>
+							</ul>
+						</div>
+					</div>
+				</div>
+			</div>
+			<br class="clearing" />
+		</div>
+		
 
 	<?php endif; ?>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34326

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR changes the view of Sharing Settings menu (/wp-admin/options-general.php?page=sharing) when the block is available and block-based theme is used. Following the approach in https://github.com/Automattic/jetpack/pull/34619.

New view should appear like this:
<img width="1103" alt="Screenshot 2023-12-15 at 11 00 01" src="https://github.com/Automattic/jetpack/assets/60262784/f84d2032-0001-4e32-aa5f-ca69c67a4266">

Note: `Learn how to add Sharing Buttons` points to page still not ready.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Checkout changes locally, build `jetpack build plugins/jetpack` and spin up your site locally
- Check `/wp-admin/options-general.php?page=sharing`.
- You should see new view only when beta blocks enabled: `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`
- For block-based theme (eg Twenty Twenty-Four) you should see new view.
- For older themes (eg Twenty Ten) old view should appear