### PR TITLE
Admin Menu: check for both plan feature variants

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -281,7 +281,7 @@ class Jetpack_Recommendations {
 		$site_products         = array_column( Jetpack_Plan::get_products(), 'product_slug' );
 		$has_anti_spam_product = count( array_intersect( array( 'jetpack_anti_spam', 'jetpack_anti_spam_monthly' ), $site_products ) ) > 0;
 
-		if ( Jetpack_Plan::supports( 'antispam' ) || $has_anti_spam_product ) {
+		if ( Jetpack_Plan::supports( 'akismet' ) || Jetpack_Plan::supports( 'antispam' ) || $has_anti_spam_product ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/changelog/update-supports-checks
+++ b/projects/plugins/jetpack/changelog/update-supports-checks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Inside baseball item for VIP, not needing in an user-facing changelog.
+
+

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -82,7 +82,7 @@ class Jetpack_Admin {
 			$site_products         = array_column( Jetpack_Plan::get_products(), 'product_slug' );
 			$has_anti_spam_product = count( array_intersect( array( 'jetpack_anti_spam', 'jetpack_anti_spam_monthly' ), $site_products ) ) > 0;
 
-			if ( Jetpack_Plan::supports( 'antispam' ) || $has_anti_spam_product ) {
+			if ( Jetpack_Plan::supports( 'akismet' ) || Jetpack_Plan::supports( 'antispam' ) || $has_anti_spam_product ) {
 				// Prevent Akismet from adding a menu item.
 				add_action(
 					'admin_menu',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks for both variants used historically for antispam products.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this on VIP, confirm no double menu for Akismet.
* Run on a regular self-hosted with and without a plan that includes Akismet (e.g. Complete), confirm only one Akismet menu (at most) appears at any given time.

