### PR TITLE
AI Client: remove back to edit button

### DIFF
--- a/projects/js-packages/ai-client/changelog/remove-back-to-edit-ai-assistant
+++ b/projects/js-packages/ai-client/changelog/remove-back-to-edit-ai-assistant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+AI Client: remove "back to edit" button

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -12,15 +12,7 @@ import {
 	useCallback,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import {
-	Icon,
-	closeSmall,
-	check,
-	arrowUp,
-	arrowLeft,
-	trash,
-	reusableBlock,
-} from '@wordpress/icons';
+import { Icon, closeSmall, check, arrowUp, trash, reusableBlock } from '@wordpress/icons';
 import classNames from 'classnames';
 import React from 'react';
 /**
@@ -248,16 +240,6 @@ export function AIControl(
 						<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
 							{ ( value?.length > 0 || lastValue === null ) && (
 								<ButtonGroup>
-									{ value.length > 0 && (
-										<Button
-											className="jetpack-components-ai-control__controls-prompt_button"
-											label={ __( 'Back to edit', 'jetpack-ai-client' ) }
-											onClick={ () => setEditRequest( true ) }
-											tooltipPosition="top"
-										>
-											<Icon icon={ arrowLeft } />
-										</Button>
-									) }
 									<Button
 										className="jetpack-components-ai-control__controls-prompt_button"
 										label={ __( 'Discard', 'jetpack-ai-client' ) }


### PR DESCRIPTION
Editing the previous prompt already triggers the "editing" state, no need for an extra button to trigger it

Fixes #34670 

## Proposed changes:
This PR removes the "Back to Edit" button, recently introduced for the UI/UX update on the AI Assistant

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1702552144058089-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert an AI Assistant block, ask something from the AI. When done, you should see only Discard, Re-generate and Accept buttons. Typing/editing the prompt should get you immediately in "edit mode" (only Cancel | Generate buttons should be seen)