### PR TITLE
Backport mu-wpcom-plugin 2.0.7, jetpack 13.0-a.5 Changes

### DIFF
--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.0] - 2023-12-15
+### Added
+- Contact Form: improve form error message [#34629]
+
+### Changed
+- Form block: hide 'lead capture' variation for WP.com Atomic sites [#34615]
+
+### Fixed
+- Contact Form: add missing Required toolbar button to Checkbox field [#34630]
+- Contact Form: align half-width fields on same row [#34632]
+
 ## [0.26.0] - 2023-12-14
 ### Added
 - Contact Form: build JS assets [#34622]
@@ -423,6 +434,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.27.0]: https://github.com/automattic/jetpack-forms/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/automattic/jetpack-forms/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/automattic/jetpack-forms/compare/v0.24.2...v0.25.0
 [0.24.2]: https://github.com/automattic/jetpack-forms/compare/v0.24.1...v0.24.2

--- a/projects/packages/forms/changelog/fix-contact-form-input-stacking
+++ b/projects/packages/forms/changelog/fix-contact-form-input-stacking
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Contact Form: align half-width fields on same row

--- a/projects/packages/forms/changelog/fix-contact-form-required-checkbox
+++ b/projects/packages/forms/changelog/fix-contact-form-required-checkbox
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Contact Form: add missing Required toolbar button to Checkbox field

--- a/projects/packages/forms/changelog/update-contact-form-error-message
+++ b/projects/packages/forms/changelog/update-contact-form-error-message
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Contact Form: improve form error message

--- a/projects/packages/forms/changelog/update-forms-lead-capture-atomic
+++ b/projects/packages/forms/changelog/update-forms-lead-capture-atomic
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Form block: hide 'lead capture' variation for WP.com Atomic sites

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.27.0-alpha",
+	"version": "0.27.0",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.27.0-alpha';
+	const PACKAGE_VERSION = '0.27.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.0] - 2023-12-15
+### Changed
+- Updates the WC visibility check to use the `is_plugin_active` function. [#34648]
+
 ## [5.4.0] - 2023-12-14
 ### Added
 - Add the Sensei and WooCommerce Setup Task, to allow us to retire the old checklist card. [#34551] [#34564]
@@ -483,6 +487,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.5.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.4.0...v5.5.0
 [5.4.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.3.0...v5.4.0
 [5.3.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.2.0...v5.3.0
 [5.2.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.1.1...v5.2.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-improve-wc-visibility-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-improve-wc-visibility-check
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updates the WC visibility check to use the `is_plugin_active` function.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.5.0-alpha",
+	"version": "5.5.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.5.0-alpha';
+	const PACKAGE_VERSION = '5.5.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.38.2] - 2023-12-15
+### Fixed
+- Social: Fixed issue with auto-conversion option logic. [#34666]
+
 ## [0.38.1] - 2023-12-14
 ### Fixed
 - Fixed Jetpack Social scheduled post messaging. [#34182]
@@ -439,6 +443,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.38.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.1...v0.38.2
 [0.38.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.0...v0.38.1
 [0.38.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.37.2...v0.38.0
 [0.37.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.37.1...v0.37.2

--- a/projects/packages/publicize/changelog/fix-social-auto-conversion-cleanup-logic
+++ b/projects/packages/publicize/changelog/fix-social-auto-conversion-cleanup-logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social: Fixed issue with auto-conversion option logic

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.38.2-alpha",
+	"version": "0.38.2",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.0-a.5 - 2023-12-15
+### Enhancements
+- Subscriptions: adds toggle to disable email sending. [#34592]
+
+### Bug fixes
+- Subscribers: pre/post-publish panel, show correct subscription count when using paywall. [#34643]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add a flag for sites that have upgraded from the ecommerce trial. [#34597]
+- Like block (beta): Make sure the block is not available when the Likes module or Likes / Reblog site options are disabled. [#34639]
+- Like block (beta): remove the condition that decided whether to display Like block or Like widget. [#34650]
+- Newsletter post-publish panel: closed initially [#34663]
+- Refactor checkout modal to be more performant. [#34412]
+
 ## 13.0-a.3 - 2023-12-14
 ### Improved compatibility
 - Contact Form: avoid PHP warnings in the WordPress dashboard when used alongside other plugins making changes to admin pages. [#34576]

--- a/projects/plugins/jetpack/changelog/add-dont-email-to-subs-toggle
+++ b/projects/plugins/jetpack/changelog/add-dont-email-to-subs-toggle
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscriptions: adds toggle to disable email sending

--- a/projects/plugins/jetpack/changelog/add-flag-for-expired-plans
+++ b/projects/plugins/jetpack/changelog/add-flag-for-expired-plans
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add a flag for sites that have upgraded from the ecommerce trial

--- a/projects/plugins/jetpack/changelog/fix-correct-subs-count-with-paywall
+++ b/projects/plugins/jetpack/changelog/fix-correct-subs-count-with-paywall
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscribers: pre/post-publish panel, correct subs count with paywall

--- a/projects/plugins/jetpack/changelog/fix-like-block-disabled-case
+++ b/projects/plugins/jetpack/changelog/fix-like-block-disabled-case
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Like block (beta): Make sure the block is not available when the Likes module or Likes / Reblog site options are disabled

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.0-a.4
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.0-a.6
+
+

--- a/projects/plugins/jetpack/changelog/refactor-memberships-checkout-modal
+++ b/projects/plugins/jetpack/changelog/refactor-memberships-checkout-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Refactor checkout modal to be more performant.

--- a/projects/plugins/jetpack/changelog/remove-like-block-special-treatment
+++ b/projects/plugins/jetpack/changelog/remove-like-block-special-treatment
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Like block (beta): remove the condition that decided whether to display Like block or Like widget

--- a/projects/plugins/jetpack/changelog/update-forms-lead-capture-atomic
+++ b/projects/plugins/jetpack/changelog/update-forms-lead-capture-atomic
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-newsletter-post-publish-initially-closed
+++ b/projects/plugins/jetpack/changelog/update-newsletter-post-publish-initially-closed
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Newsletter post-publish panel: closed initially

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_5",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_6",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_4",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_5",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.4
+ * Version: 13.0-a.5
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.4' );
+define( 'JETPACK__VERSION', '13.0-a.5' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.5
+ * Version: 13.0-a.6
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.5' );
+define( 'JETPACK__VERSION', '13.0-a.6' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.5",
+	"version": "13.0.0-a.6",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.4",
+	"version": "13.0.0-a.5",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.7 - 2023-12-15
+### Changed
+- Version bump [#34648]
+
 ## 2.0.6 - 2023-12-14
 ### Changed
 - Updated package dependencies. [#34559]

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-improve-wc-task-check
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-improve-wc-task-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Version bump

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_7_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_7"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.7-alpha
+ * Version: 2.0.7
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.7-alpha",
+	"version": "2.0.7",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.7, jetpack 13.0-a.5

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.