### PR TITLE
AI Assistant: add showRemove attribute to AIControl

### DIFF
--- a/projects/js-packages/ai-client/changelog/remove-cancel-button-on-blank-ai-assistant
+++ b/projects/js-packages/ai-client/changelog/remove-cancel-button-on-blank-ai-assistant
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Client: add showRemove attribute for ai-control

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -49,6 +49,7 @@ type AiControlProps = {
 	onStop?: () => void;
 	onAccept?: () => void;
 	onDiscard?: () => void;
+	showRemove?: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -78,6 +79,7 @@ export function AIControl(
 		onStop = noop,
 		onAccept = noop,
 		onDiscard = null,
+		showRemove = false,
 	}: AiControlProps,
 	ref: React.MutableRefObject< null > // eslint-disable-line @typescript-eslint/ban-types
 ): React.ReactElement {
@@ -196,7 +198,7 @@ export function AIControl(
 										</Button>
 									) }
 
-									{ ! editRequest && ! value?.length && onDiscard && (
+									{ showRemove && ! editRequest && ! value?.length && onDiscard && (
 										<Button
 											className="jetpack-components-ai-control__controls-prompt_button"
 											onClick={ discardHandler }

--- a/projects/plugins/jetpack/changelog/remove-cancel-button-on-blank-ai-assistant
+++ b/projects/plugins/jetpack/changelog/remove-cancel-button-on-blank-ai-assistant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: provide showRemove attribute for AIControl component

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -586,6 +586,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					showAccept={ requestingState !== 'init' && contentIsLoaded && ! isWaitingState }
 					acceptLabel={ acceptLabel }
 					showGuideLine={ contentIsLoaded }
+					showRemove={ attributes?.content?.length > 0 }
 				/>
 
 				{ ! loadingImages && resultImages.length > 0 && (


### PR DESCRIPTION
Newly inserted AI Assistant blocks can rely on Gutenberg's default "remove block" pattern 

Fixes #34669 

## Proposed changes:
This PR adds a new prop for the AI Client's AIControl component: showRemove. The prop indicates if the remove button should be shown. This is turned to false when the control is being applied over already existing content.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1702666088243979/1702552144.058089-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert an AI Assistant block. See that there is no "Cancel" button. Typing and interacting with the block should remain functional as usual.

Now invoke the AI Assistant on some existing content. The input, while empty, should show a "Cancel" button. Clicking it should just get rid of the AI Assistant, not the original content.