### PR TITLE
 Carousel: fix unresponsive navigation

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-frozen-carousel-buttons
+++ b/projects/plugins/jetpack/changelog/fix-frozen-carousel-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+ Carousel: fix unresponsive navigation

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -116,16 +116,19 @@
 			// Ensure the item is in the render tree, in its initial state.
 			el.style.removeProperty( 'display' );
 			el.style.opacity = start;
-			el.style.transition = 'opacity 0.2s';
 			el.style.pointerEvents = 'none';
 
-			var finished = function ( e ) {
-				if ( e.target === el && e.propertyName === 'opacity' ) {
-					el.style.removeProperty( 'transition' );
-					el.style.removeProperty( 'opacity' );
+			var animate = function ( t0, duration ) {
+				var t = performance.now();
+				var diff = t - t0;
+				var ratio = diff / duration;
+
+				if ( ratio < 1 ) {
+					el.style.opacity = start + ( end - start ) * ratio;
+					requestAnimationFrame( () => animate( t0, duration ) );
+				} else {
+					el.style.opacity = end;
 					el.style.removeProperty( 'pointer-events' );
-					el.removeEventListener( 'transitionend', finished );
-					el.removeEventListener( 'transitioncancel', finished );
 					callback();
 				}
 			};
@@ -133,22 +136,19 @@
 			requestAnimationFrame( function () {
 				// Double rAF for browser compatibility.
 				requestAnimationFrame( function () {
-					el.addEventListener( 'transitionend', finished );
-					el.addEventListener( 'transitioncancel', finished );
-					// Trigger transition.
-					el.style.opacity = end;
+					animate( performance.now(), 200 );
 				} );
 			} );
 		}
 
 		function fadeIn( el, callback ) {
 			callback = callback || util.noop;
-			fade( el, '0', '1', callback );
+			fade( el, 0, 1, callback );
 		}
 
 		function fadeOut( el, callback ) {
 			callback = callback || util.noop;
-			fade( el, '1', '0', function () {
+			fade( el, 1, 0, function () {
 				if ( el ) {
 					el.style.display = 'none';
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34657

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes the carousel being unresponsive when using a mouse, an issue occurring with the latest version of Chrome (120).

The reason the overlay became unresponsive was that the `pointer-events: none` rule added [here](https://github.com/Automattic/jetpack/blob/924b3a3c5faf82be8c683f2646f0fd130fd8b0b1/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js#L120) wasn't cleared. It was supposed to be when the [overlay transition ended](https://github.com/Automattic/jetpack/blob/924b3a3c5faf82be8c683f2646f0fd130fd8b0b1/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js#L126C6-L126C6). For some reason, transition events are not fired anymore in this instance with the latest Chrome version.

My hunch is that there must be a "reasonable" delay between the moment the transitioned property is initialized and updated, a condition that `requestAnimationFrame` doesn't seem to satisfy anymore. I could only make the events trigger after setting a time out of several tens of seconds.

Since it's become hard to rely on the CSS transition events in that case, I've chosen to implement the transition in JS, which is how `requestAnimationFrame` should probably be used anyway.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See issue above.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Use the latest Chrome version (120)
- Spin up a test site with this branch
- Enable the "carousel" option in the Jetpack settings
<img width="1061" alt="Screenshot 2023-12-15 at 3 36 34 PM" src="https://github.com/Automattic/jetpack/assets/1620183/69e0c023-a547-444b-aae3-a3d54df37cb2">

- Create a new post
- Add the _Gallery_ block, with two or more images
- Open the preview
- Click one of the images
- Check that you can navigate the slider by clicking on the previous and next buttons
- Check that the overlay fades out properly when you close it
- Optionally, test with previous versions and different browsers
