### PR TITLE
Fully implement` jetpack_is_potential_blogging_site` function

### DIFF
--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -334,6 +334,7 @@ function _jetpack_show_posts_on_front() {
 	if ( 'posts' === get_option( 'show_on_front' ) ) {
 		return true;
 	}
+	return false;
 }
 
 /**

--- a/projects/plugins/jetpack/changelog/judge-blogging-site
+++ b/projects/plugins/jetpack/changelog/judge-blogging-site
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Better implementation of jetpack_is_potential_blogging_site


### PR DESCRIPTION
Currently, in wpcom, we have some features which we think only make sense for "bloggers" but not for people building business promotion websites or eCommerce sites. The best example of this is the "blogging prompts" feature.

Currently we only rely on the site_intent, which is a wpcom `site_option` set in onboarding. But this is quite insufficient as I investigated in this post pe7F0s-1ql-p2.

This change adds to the existing `jetpack_is_potential_blogging_site` function to make it as robust as possible to determine whether a site is likely to be a blog or not.

Currently, this function is unused, but I intend on first applying it to the blogging prompts feature in wpcom.

I chose to add this to jetpack rather than wpcom, because I believe it will be a useful function for jetpack features, I can see that `launchpad` in particular may be able to use this function as it is currently checking for `site_intent === 'write'` which was the original method for testing for a blogging site.

### Testing instructions.

I tested this by pushing to my wpcom sandbox and testing via wpsh:
```
pnpm install
jetpack install plugins/jetpack
jetpack build plugins/jetpack
# after setting up `wpcom-sandbox` in my ~/.ssh/config
jetpack rsync jetpack wpdev@wpcom-sandbox:~/public_html/wp-content/mu-plugins/jetpack-plugin/production
```

in wpsh:

```
switch_to_blog(227131231);
return jetpack_is_potential_blogging_site();
restore_current_blog();
```

I tested this with sites I created myself and recently created wpcom sites.


## Does this pull request change what data or activity we track or use?

N/A



