### PR TITLE
Subscriptions: fix reach count above 1000 in editor pre- & post-publish panel

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-reach-count
+++ b/projects/plugins/jetpack/changelog/fix-subscription-reach-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribers: fix the reach count above 1000

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -66,31 +66,32 @@ const getCopyForCategorySubscribers = ( {
 	reachCount,
 } ) => {
 	const formattedCategoryNames = getFormattedCategories( postCategories, newsletterCategories );
+	const reachCountString = reachCount.toLocaleString();
 
 	if ( futureTense ) {
 		return sprintf(
 			// translators: %1s is the list of categories, %2d is subscriptions count
 			_n(
-				'This post will be sent to everyone subscribed to %1$s (%2$d subscriber).',
-				'This post will be sent to everyone subscribed to %1$s (%2$d subscribers).',
+				'This post will be sent to everyone subscribed to %1$s (%2$s subscriber).',
+				'This post will be sent to everyone subscribed to %1$s (%2$s subscribers).',
 				reachCount,
 				'jetpack'
 			),
 			formattedCategoryNames,
-			reachCount
+			reachCountString
 		);
 	}
 
 	return sprintf(
 		// translators: %1s is the list of categories, %2d is subscriptions count
 		_n(
-			'This post was sent to everyone subscribed to %1$s (%2$d subscriber).',
-			'This post was sent to everyone subscribed to %1$s (%2$d subscribers).',
+			'This post was sent to everyone subscribed to %1$s (%2$s subscriber).',
+			'This post was sent to everyone subscribed to %1$s (%2$s subscribers).',
 			reachCount,
 			'jetpack'
 		),
 		formattedCategoryNames,
-		reachCount
+		reachCountString
 	);
 };
 
@@ -101,70 +102,72 @@ export const getCopyForSubscribers = ( {
 	postHasPaywallBlock,
 	reachCount,
 } ) => {
+	const reachCountString = reachCount.toLocaleString();
+
 	// Schedulled post
 	if ( futureTense ) {
 		// Paid post without paywall: sent only to paid subscribers
 		if ( isPaidPost && ! postHasPaywallBlock ) {
 			return sprintf(
-				/* translators: %d is the number of subscribers */
+				/* translators: %s is the number of subscribers */
 				_n(
-					'This post will be sent to <strong>%d paid subscriber</strong>.',
-					'This post will be sent to <strong>%d paid subscribers</strong>.',
+					'This post will be sent to <strong>%s paid subscriber</strong>.',
+					'This post will be sent to <strong>%s paid subscribers</strong>.',
 					reachCount,
 					'jetpack'
 				),
-				reachCount
+				reachCountString
 			);
 		}
 		// Paid post with paywall or Free post, sent to all subscribers
 		return sprintf(
-			/* translators: %d is the number of subscribers */
+			/* translators: %s is the number of subscribers */
 			_n(
-				'This post will be sent to <strong>%d subscriber</strong>.',
-				'This post will be sent to <strong>%d subscribers</strong>.',
+				'This post will be sent to <strong>%s subscriber</strong>.',
+				'This post will be sent to <strong>%s subscribers</strong>.',
 				reachCount,
 				'jetpack'
 			),
-			reachCount
+			reachCountString
 		);
 	}
 	// Paid post without paywall: sent only to paid subscribers
 	if ( isPaidPost && ! postHasPaywallBlock ) {
 		return sprintf(
-			/* translators: %d is the number of subscribers */
+			/* translators: %s is the number of subscribers */
 			_n(
-				'This post was sent to <strong>%d paid subscriber</strong>.',
-				'This post was sent to <strong>%d paid subscribers</strong>.',
+				'This post was sent to <strong>%s paid subscriber</strong>.',
+				'This post was sent to <strong>%s paid subscribers</strong>.',
 				reachCount,
 				'jetpack'
 			),
-			reachCount
+			reachCountString
 		);
 	}
 	// Paid post sent only to paid subscribers, post is already published
 	if ( isPaidPost && ! postHasPaywallBlock ) {
 		return sprintf(
-			/* translators: %d is the number of subscribers */
+			/* translators: %s is the number of subscribers */
 			_n(
-				'This post was sent to <strong>%d paid subscriber</strong> only.',
-				'This post was sent to <strong>%d paid subscribers</strong> only.',
+				'This post was sent to <strong>%s paid subscriber</strong> only.',
+				'This post was sent to <strong>%s paid subscribers</strong> only.',
 				reachCount,
 				'jetpack'
 			),
-			reachCount
+			reachCountString
 		);
 	}
 
 	// Paid post with paywall or Free post, sent to all subscribers, post is already published
 	return sprintf(
-		/* translators: %d is the number of subscribers */
+		/* translators: %s is the number of subscribers */
 		_n(
-			'This post was sent to <strong>%d subscriber</strong>.',
-			'This post was sent to <strong>%d subscribers</strong>.',
+			'This post was sent to <strong>%s subscriber</strong>.',
+			'This post was sent to <strong>%s subscribers</strong>.',
 			reachCount,
 			'jetpack'
 		),
-		reachCount
+		reachCountString
 	);
 };
 
@@ -242,7 +245,7 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 		emailSubscribers: emailSubscribersCount,
 		paidSubscribers: paidSubscribersCount,
 		postHasPaywallBlock,
-	} ).toLocaleString();
+	} );
 
 	let text;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes issues where subscription reach counts above 1000 in some locales (e.g. en-US) would cause translations return as "%d subscribers", as they add thousand-delimiters like comma or empty space, turning the number into a string.

Before
<img width="300" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/5d29380d-3ef8-451e-86b8-270aab1886b3">

After
<img width="289" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/2d702da1-11a5-4cfe-9b26-15b268608935">

<img width="278" alt="Screenshot 2023-12-18 at 12 27 57" src="https://github.com/Automattic/jetpack/assets/87168/70ac0900-d89c-4517-9513-3eda4b3f23c1">


### Context & examples
Issue is caused by `.toLocaleString()` in one of lines handling the numbers. Issue does not show up if you have less than 1000 subscribers, or use a locale that doesn't add commas or spacing as thousands-separator, like Spanish.

EN-US locale, `1000` and `10` — 1000 breaks, but 10 works with `%d` placholder:

```js
wp.i18n.sprintf('test %d', (10).toLocaleString());
"test 10"
```

```js
wp.i18n.sprintf('test %d', (1000).toLocaleString('en-US'));
sprintf error: 

TypeError: [sprintf] expecting number but found string
"test %d"
```

Spanish locale `1000` works with `%d` as placeholder:

```js
wp.i18n.sprintf('test %d', (1000).toLocaleString('es'));
"test 1000"
```

EN-US locale, `1000` works with `%s` placeholder:
```js
wp.i18n.sprintf('test %s', (1000).toLocaleString());
"test 1,000" 
```


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allows strings in translation strings. Ensures reachCount is consistently a Number, and convert it to string for localization.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Either have a site with 1000+ subscribers, or mock the number at `getReachForAccessLevelKey()`:
https://github.com/Automattic/jetpack/blob/93aa805dac3d38dc6b310f7de35cb4462ae87450/projects/plugins/jetpack/extensions/shared/memberships/settings.js#L41-L48
* Create a post, and publish. See string work correctly in pre- and post-publish panels.
