### PR TITLE
CRM: Ensure segments can be deleted

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-advanced-segments-bulk-delete
+++ b/projects/plugins/crm/changelog/fix-crm-advanced-segments-bulk-delete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Segments: Fixing a bug to ensure segments can be deleted with Advanced Segments active

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -3741,7 +3741,11 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 	// Check perms for given object
 	$has_perms = zeroBSCRM_permsObjType( $zbs->DAL->objTypeID( $objtype ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	if ( ! $has_perms ) {
-		jpcrm_api_forbidden_request();
+		$reply = array(
+			'status'  => __( 'Forbidden', 'zero-bs-crm' ),
+			'message' => __( 'You do not have permission to access this resource.', 'zero-bs-crm' ),
+		);
+		wp_send_json_error( $reply, 403 );
 	}
 
 	// ret

--- a/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
@@ -718,19 +718,6 @@ function zeroBSCRM_permsCustomers() {
 	    return false;
 	}
 
-/**
- * Determine if the current user is allowed to manage segments.
- *
- * @return bool
- */
-function jpcrm_perms_segments() {
-	$current_user = wp_get_current_user();
-	if ( $current_user->has_cap( 'admin_zerobs_customers' ) ) {
-		return true;
-	}
-	return false;
-}
-
 	// LOGS
 
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
@@ -577,6 +577,9 @@ function zeroBSCRM_permsObjType( $obj_type_id = -1 ) { // phpcs:ignore WordPress
 
 		case ZBS_TYPE_TASK:
 			return zeroBSCRM_perms_tasks();
+
+		case ZBS_TYPE_SEGMENT:
+			return jpcrm_perms_segments();
 	}
 
 	return false;
@@ -716,6 +719,18 @@ function zeroBSCRM_permsCustomers() {
 	    return false;
 	}
 
+/**
+ * Determine if the current user is allowed to manage segments.
+ *
+ * @return bool
+ */
+function jpcrm_perms_segments() {
+	$current_user = wp_get_current_user();
+	if ( $current_user->has_cap( 'admin_zerobs_customers' ) ) {
+		return true;
+	}
+	return false;
+}
 
 	// LOGS
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
@@ -560,6 +560,7 @@ function zeroBSCRM_permsObjType( $obj_type_id = -1 ) { // phpcs:ignore WordPress
 	switch ( $obj_type_id ) {
 		case ZBS_TYPE_CONTACT:
 		case ZBS_TYPE_COMPANY:
+		case ZBS_TYPE_SEGMENT:
 			return zeroBSCRM_permsCustomers();
 
 		case ZBS_TYPE_QUOTE:
@@ -578,8 +579,6 @@ function zeroBSCRM_permsObjType( $obj_type_id = -1 ) { // phpcs:ignore WordPress
 		case ZBS_TYPE_TASK:
 			return zeroBSCRM_perms_tasks();
 
-		case ZBS_TYPE_SEGMENT:
-			return jpcrm_perms_segments();
 	}
 
 	return false;


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/34687

## Proposed changes:

* This PR adds a case and new function to check that a user has permissions to modify segments, which is used to determine whether the bulk actions can be applied on the segments page.
* This fixes an issue with the bulk actions delete option on that page: `/wp-admin/admin.php?page=manage-segments`.
* This is an issue both with and without Advanced Segments installed and active, and also affects segments created both with that extension and without it.
* Note this issue doesn't just affect WoA sites, but also any site with the current version of Jetpack CRM installed an active.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/issues/34687


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To replicate the issue, test in trunk or with a Jurassic Ninja site running the most recent release.
* With the Advanced Segments extension installed an active, add several new segments (and add segments without it active): `/wp-admin/admin.php?page=manage-segments`
* With the Advanced Segments extension active or deactivated, try to delete any segment (created with or without the Advanced Segments extension). You will see an 'Invalid permissions' notice.
* To test the fix, apply this PR locally or using the Beta Tester plugin on a test site. Follow the same steps, and you should be able to delete created segments

