### PR TITLE
Subscriptions: localize number format in access panel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-apply-locale-string-to-numbers
+++ b/projects/plugins/jetpack/changelog/update-apply-locale-string-to-numbers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriptions: localize number format in access panel

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -168,7 +168,7 @@ export function NewsletterAccessRadioButtons( {
 							accessLevel: accessOptions.subscribers.key,
 							emailSubscribers,
 							paidSubscribers,
-						} ) })`,
+						} ).toLocaleString() })`,
 						value: accessOptions.subscribers.key,
 					},
 					{
@@ -176,7 +176,7 @@ export function NewsletterAccessRadioButtons( {
 							accessLevel: accessOptions.paid_subscribers.key,
 							emailSubscribers,
 							paidSubscribers,
-						} ) })`,
+						} ).toLocaleString() })`,
 						value: accessOptions.paid_subscribers.key,
 					},
 				] }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to https://github.com/Automattic/jetpack/pull/34689

Makes numbers across the panels more uniform in locales that add thousand-delimiters like US-English.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `.toLocaleString()` when we output numbers in the access panel

Before
<img width="289" alt="Screenshot 2023-12-18 at 12 41 51" src="https://github.com/Automattic/jetpack/assets/87168/b3d234ac-4c1e-49f6-8c4d-36bfe3554745">

After
<img width="285" alt="Screenshot 2023-12-18 at 12 42 18" src="https://github.com/Automattic/jetpack/assets/87168/e6d1ca0e-7e93-4e48-857a-4113fa9866e3">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Either have a site with 1000+ subscribers, or mock the number at `getReachForAccessLevelKey()`:
https://github.com/Automattic/jetpack/blob/93aa805dac3d38dc6b310f7de35cb4462ae87450/projects/plugins/jetpack/extensions/shared/memberships/settings.js#L41-L48
* Create a post, and publish. See string work correctly in access panels.

