### PR TITLE
wp-admin Site Default: Fix admin bar when notifications are disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-admin-bar-when-notifications-are-disabled
+++ b/projects/plugins/jetpack/changelog/fix-admin-bar-when-notifications-are-disabled
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: It's a fix for WoA sites.
+Comment: wp-admin Site Default: Fix WP classic style admin bar when Jetpack Notifications module is off
 
 

--- a/projects/plugins/jetpack/changelog/fix-admin-bar-when-notifications-are-disabled
+++ b/projects/plugins/jetpack/changelog/fix-admin-bar-when-notifications-are-disabled
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: It's a fix for WoA sites.
+
+

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -276,8 +276,9 @@ class Masterbar {
 		/*
 		 * Notifications need the admin bar styles,
 		 * so let's not remove them when the module is active.
+		 * Also, don't remove the styles if the user has opted to use wp-admin.
 		 */
-		if ( ! Jetpack::is_module_active( 'notes' ) ) {
+		if ( ! Jetpack::is_module_active( 'notes' ) && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
 			wp_dequeue_style( 'admin-bar' );
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34685

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

In this PR, I propose to fix an issue with broken admin-bar styling when the Notifications module is disabled and the Admin interface style is set to “Classic style”.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a WoA site
2. Go to Settings -> Hosting Configuration: https://wordpress.com/hosting-config/
3. Scroll to the bottom and change the Admin interface style to “Classic style”.
4. Open the Jetpack modules page: [site]/wp-admin/admin.php?page=jetpack_modules.
5. Turn off the “Notifications” module.
6. Confirm that top bar has broken styling
7. Open Jetpack Debug and switch to the feature branch
8. Confirm that top bar styling is fixed
