### PR TITLE
CRM: Resolves 3399 - make KB links consistent in settings

### DIFF
--- a/projects/plugins/crm/admin/settings/client-portal.page.php
+++ b/projects/plugins/crm/admin/settings/client-portal.page.php
@@ -187,10 +187,12 @@ if ( isset( $sbupdated ) ) {
 			<tbody>
 
 			<tr>
-				<td class="wfieldname"><label for="wpzbscrm_portalpage"><?php esc_html_e( 'Client Portal page', 'zero-bs-crm' ); ?></label><br /><?php esc_html_e( 'Select the page with your client portal shortcode.', 'zero-bs-crm' ); ?>
+				<td class="wfieldname">
+
 					<?php ##WLREMOVE ?>
-					<a href="<?php echo esc_url( $zbs->urls['kbclientportal'] ); ?>" target="_blank"><?php esc_html_e( 'Learn More', 'zero-bs-crm' ); ?></a>
+					<div class="ui teal label right floated"><i class="circle info icon link"></i>  <a href="<?php echo esc_url( $zbs->urls['kbclientportal'] ); ?>" target="_blank"><?php esc_html_e( 'Read more', 'zero-bs-crm' ); ?></a></div>
 					<?php ##/WLREMOVE ?>
+					<label for="wpzbscrm_portalpage"><?php esc_html_e( 'Client Portal page', 'zero-bs-crm' ); ?></label><br /><?php esc_html_e( 'Select the page with your client portal shortcode.', 'zero-bs-crm' ); ?>
 				</td>
 				<td>
 					<?php
@@ -248,10 +250,11 @@ if ( isset( $sbupdated ) ) {
 			</tr>
 
 			<tr>
-				<td class="wfieldname"><label for="wpzbscrm_easyaccesslinks"><?php esc_html_e( 'Allow Easy-Access links', 'zero-bs-crm' ); ?></label><br /><?php esc_html_e( 'Tick to allow logged-out users to view quotes and invoices via a secure hash URL.', 'zero-bs-crm' ); ?>
+				<td class="wfieldname">
 					<?php ##WLREMOVE ?>
-					<a href="<?php echo esc_url( $zbs->urls['kbeasyaccess'] ); ?>" target="_blank"><?php esc_html_e( 'Learn More', 'zero-bs-crm' ); ?></a>
+					<div class="ui teal label right floated"><i class="circle info icon link"></i>  <a href="<?php echo esc_url( $zbs->urls['kbeasyaccess'] ); ?>" target="_blank"><?php esc_html_e( 'Read more', 'zero-bs-crm' ); ?></a></div>
 					<?php ##/WLREMOVE ?>
+					<label for="wpzbscrm_easyaccesslinks"><?php esc_html_e( 'Allow Easy-Access links', 'zero-bs-crm' ); ?></label><br /><?php esc_html_e( 'Tick to allow logged-out users to view quotes and invoices via a secure hash URL.', 'zero-bs-crm' ); ?>
 				</td>
 				<td style="width:540px"><input type="checkbox" class="winput form-control" name="wpzbscrm_easyaccesslinks" id="wpzbscrm_easyaccesslinks" value="1"
 				<?php
@@ -302,10 +305,11 @@ if ( isset( $sbupdated ) ) {
 
 
 			<tr>
-				<td class="wfieldname"><label for="wpzbscrm_portalusers"><?php esc_html_e( 'Generate WordPress users for new contacts', 'zero-bs-crm' ); ?></label><br /><?php esc_html_e( "By default this will automatically email the new contact a welcome email as soon as they're added. If you prefer to not have this email sent, you can disable this email template.", 'zero-bs-crm' ); ?>
+				<td class="wfieldname">
 					<?php ##WLREMOVE ?>
-					<a href="<?php echo esc_url( $zbs->urls['kbdisablewelcome'] ); ?>" target="_blank"><?php esc_html_e( 'Learn More', 'zero-bs-crm' ); ?></a>
+					<div class="ui teal label right floated"><i class="circle info icon link"></i>  <a href="<?php echo esc_url( $zbs->urls['kbdisablewelcome'] ); ?>" target="_blank"><?php esc_html_e( 'Read more', 'zero-bs-crm' ); ?></a></div>
 					<?php ##/WLREMOVE ?>
+					<label for="wpzbscrm_portalusers"><?php esc_html_e( 'Generate WordPress users for new contacts', 'zero-bs-crm' ); ?></label><br /><?php esc_html_e( "By default this will automatically email the new contact a welcome email as soon as they're added. If you prefer to not have this email sent, you can disable this email template.", 'zero-bs-crm' ); ?>
 				</td>
 				<td style="width:540px"><input type="checkbox" class="winput form-control" name="wpzbscrm_portalusers" id="wpzbscrm_portalusers" value="1"
 				<?php

--- a/projects/plugins/crm/admin/settings/forms.page.php
+++ b/projects/plugins/crm/admin/settings/forms.page.php
@@ -115,7 +115,7 @@ if ( isset( $sbupdated ) ) {
 			<tbody>
 
 			<tr>
-				<td colspan="2" class="wmid"><button type="submit" class="ui button primary"><?php esc_html_e( 'Save Settings', 'zero-bs-crm' ); ?></button></td>
+				<td class="wmid"><button type="submit" class="ui button primary"><?php esc_html_e( 'Save Settings', 'zero-bs-crm' ); ?></button></td>
 			</tr>
 
 			</tbody>

--- a/projects/plugins/crm/admin/settings/general.page.php
+++ b/projects/plugins/crm/admin/settings/general.page.php
@@ -234,7 +234,7 @@ if ( ! $confirmAct ) {
 
 	?>
 
-	<p id="sbDescOLD"><?php echo wp_kses( sprintf( __( 'From this page you can choose global settings for your CRM, and using the tabs above you can set up different <a href="%s" target="_blank">Extensions</a>', 'zero-bs-crm' ), esc_url( $zbs->urls['products'] ) ), $zbs->acceptable_restricted_html ); ?></p>
+	<p id="sbDescOLD"><?php esc_html_e( 'From this page you can choose global settings for your CRM.', 'zero-bs-crm' ); ?></p>
 
 	<?php
 	if ( isset( $sbupdated ) ) {

--- a/projects/plugins/crm/admin/settings/general.page.php
+++ b/projects/plugins/crm/admin/settings/general.page.php
@@ -274,7 +274,12 @@ if ( ! $confirmAct ) {
 			<tbody>
 
 			<tr>
-				<td class="wfieldname"><label for="wpzbscrm_menulayout"><?php esc_html_e( 'Menu Layout', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'How do you want your WordPress Admin Menu to Display?', 'zero-bs-crm' ); ?></td>
+				<td class="wfieldname">
+					<?php ##WLREMOVE ?>
+					<div class="ui teal label right floated"><i class="circle info icon link"></i>  <a href="<?php echo esc_url( $zbs->urls['kbshowwpmenus'] ); ?>" target="_blank"><?php esc_html_e( 'Read more', 'zero-bs-crm' ); ?></a></div>
+					<?php ##/WLREMOVE ?>
+					<label for="wpzbscrm_menulayout"><?php esc_html_e( 'Menu Layout', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'How do you want your WordPress Admin Menu to Display?', 'zero-bs-crm' ); ?>
+				</td>
 				<td style="width:540px">
 					<select class="winput" name="wpzbscrm_menulayout" id="wpzbscrm_menulayout">
 						<!-- common currencies first -->
@@ -300,10 +305,7 @@ if ( ! $confirmAct ) {
 					<br />
 					<div>
 						<?php esc_html_e( 'Are you looking for your other WordPress menu items? (e.g.', 'zero-bs-crm' ); ?> <a href="<?php echo esc_url( admin_url( 'plugins.php' ) ); ?>"><?php esc_html_e( 'Plugins', 'zero-bs-crm' ); ?></a>, <?php esc_html_e( 'or', 'zero-bs-crm' ); ?> <a href="<?php echo esc_url( admin_url( 'users.php' ) ); ?>"><?php esc_html_e( 'Users', 'zero-bs-crm' ); ?></a>)?<br />
-						<?php esc_html_e( "If you can't see these, (and you want to), select 'Slimline' or 'Full' from the above menu, then make sure 'Override WordPress (For All WP Users):' is disabled below", 'zero-bs-crm' ); ?> (<a href="#override-allusers"><?php esc_html_e( 'here', 'zero-bs-crm' ); ?></a>).<br />
-						<?php ##WLREMOVE ?>
-						<a href="<?php echo esc_url( $zbs->urls['kbshowwpmenus'] ); ?>" target="_blank"><?php esc_html_e( 'View Guide', 'zero-bs-crm' ); ?></a>
-						<?php ##/WLREMOVE ?>
+						<?php esc_html_e( "If you can't see these, (and you want to), select 'Slimline' or 'Full' from the above menu, then make sure 'Override WordPress (For All WP Users):' is disabled below", 'zero-bs-crm' ); ?> (<a href="#override-allusers"><?php esc_html_e( 'here', 'zero-bs-crm' ); ?></a>).
 					</div>
 				</td>
 			</tr>
@@ -570,8 +572,11 @@ if ( ! $confirmAct ) {
 
 			<?php ##WLREMOVE ?>
 			<tr>
-				<td class="wfieldname"><label for="wpzbscrm_shareessentials"><?php esc_html_e( 'Usage Tracking', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Share CRM usage with us. No contact or sensitive CRM data is shared.', 'zero-bs-crm' ); ?>
-				<a href="<?php echo esc_url( $zbs->urls['usageinfo'] ); ?>" target="_blank"><?php esc_html_e( 'Learn More', 'zero-bs-crm' ); ?>.</a>
+				<td class="wfieldname">
+					<?php ##WLREMOVE ?>
+					<div class="ui teal label right floated"><i class="circle info icon link"></i>  <a href="<?php echo esc_url( $zbs->urls['usageinfo'] ); ?>" target="_blank"><?php esc_html_e( 'Read more', 'zero-bs-crm' ); ?></a></div>
+					<?php ##/WLREMOVE ?>
+					<label for="wpzbscrm_shareessentials"><?php esc_html_e( 'Usage Tracking', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Share CRM usage with us. No contact or sensitive CRM data is shared.', 'zero-bs-crm' ); ?>
 				</td>
 				<td style="width:540px"><input type="checkbox" class="winput form-control" name="wpzbscrm_shareessentials" id="wpzbscrm_shareessentials" value="1"
 				<?php

--- a/projects/plugins/crm/admin/settings/partials/menu.block.php
+++ b/projects/plugins/crm/admin/settings/partials/menu.block.php
@@ -241,5 +241,5 @@ foreach ( $tabs as $tab => $name ) {
 	<?php ##WLREMOVE ?>
 	<a class="item" href="<?php echo jpcrm_esc_link( $zbs->slugs['extensions'] ); ?>"><i class="ui orange puzzle piece icon"></i> <?php echo esc_html__( 'Extensions', 'zero-bs-crm' ); ?></a>
 	<?php ##/WLREMOVE ?>
-	<a class="item" href="<?php echo jpcrm_esc_link( wp_nonce_url( $zbs->slugs['settings'] . '&resetsettings=1' ) ); ?> "></i> <?php echo esc_html__( 'Restore default settings', 'zero-bs-crm' ); ?></a>
+	<a class="item" href="<?php echo jpcrm_esc_link( wp_nonce_url( $zbs->slugs['settings'] . '&resetsettings=1' ) ); ?> "> <?php echo esc_html__( 'Restore default settings', 'zero-bs-crm' ); ?></a>
 </div>

--- a/projects/plugins/crm/changelog/fix-crm-3399-add_kb_links_to_settings
+++ b/projects/plugins/crm/changelog/fix-crm-3399-add_kb_links_to_settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Settings: Make KB links more consistent.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -971,6 +971,7 @@ final class ZeroBSCRM {
 		$this->urls['kb-pre-v5-migration-todo'] = 'https://kb.jetpackcrm.com/knowledge-base/upgrading-to-jetpack-crm-v5-0/';
 		$this->urls['kb-mailpoet']              = 'https://kb.jetpackcrm.com/knowledge-base/mailpoet-crm-sync/';
 		$this->urls['kb-automations']           = 'https://kb.jetpackcrm.com/knowledge-base/automations/';
+		$this->urls['kb-contact-fields']        = 'https://kb.jetpackcrm.com/knowledge-base/contact-field-list/';
 
 		// coming soon
 		$this->urls['soon'] = 'https://jetpackcrm.com/coming-soon/';

--- a/projects/plugins/crm/modules/mailpoet/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/mailpoet/admin/settings/main.page.php
@@ -143,18 +143,18 @@ function jpcrm_settings_page_html_mailpoet_main(){
             </tbody>
         </table>
 
-        <table class="table table-bordered table-striped wtab">
-            <tbody>
+			<table class="table table-bordered table-striped wtab">
+				<tbody>
 
-            <tr>
-                <td colspan="2" class="wmid"><button type="submit" class="button button-primary button-large"><?php esc_html_e('Save Settings','zero-bs-crm'); ?></button></td>
-            </tr>
+					<tr>
+						<td class="wmid"><button type="submit" class="button button-primary button-large"><?php esc_html_e( 'Save Settings', 'zero-bs-crm' ); ?></button></td>
+					</tr>
 
-            </tbody>
-        </table>
+				</tbody>
+			</table>
 
-    </form>
+		</form>
 
-    </div><?php
-
+	</div>
+	<?php
 }

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
@@ -387,7 +387,7 @@ function jpcrm_settings_page_html_woosync_main() {
 				<tbody>
 
 					<tr>
-						<td colspan="2" class="wmid"><button type="submit" class="button button-primary button-large"><?php esc_html_e( 'Save Settings', 'zero-bs-crm' ); ?></button></td>
+						<td class="wmid"><button type="submit" class="button button-primary button-large"><?php esc_html_e( 'Save Settings', 'zero-bs-crm' ); ?></button></td>
 					</tr>
 
 				</tbody>

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
@@ -289,7 +289,7 @@ function jpcrm_settings_page_html_woosync_main() {
 							<div class="ui teal label right floated"><i class="circle info icon link"></i>  <a href="<?php echo esc_url( $zbs->urls['kb-contact-fields'] ); ?>" target="_blank"><?php esc_html_e( 'Read more', 'zero-bs-crm' ); ?></a></div>
 							<?php ##/WLREMOVE ?>
 							<label for="wpzbscrm_port"><?php esc_html_e( 'WooCommerce My Account', 'zero-bs-crm' ); ?>:</label><br />
-							<?php esc_html_e( 'Enter a comma-separated list of Jetpack CRM fields to let customers edit these via WooCommerce My Account.', 'zero-bs-crm' ); ?>
+							<?php esc_html_e( 'Enter a comma-separated list of Jetpack CRM contact fields to let customers edit these via WooCommerce My Account.', 'zero-bs-crm' ); ?>
 						</td>
 						<td style="width:540px">
 							<input type="text" class="winput form-control" name="wpzbscrm_wcport" id="wpzbscrm_port" value="<?php echo ( ! empty( $settings['wcport'] ) ? esc_attr( $settings['wcport'] ) : '' ); ?>" placeholder="e.g. addr1,custom-field-1" />

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
@@ -285,6 +285,9 @@ function jpcrm_settings_page_html_woosync_main() {
 
 					<tr>
 						<td class="wfieldname">
+							<?php ##WLREMOVE ?>
+							<div class="ui teal label right floated"><i class="circle info icon link"></i>  <a href="<?php echo esc_url( $zbs->urls['kb-contact-fields'] ); ?>" target="_blank"><?php esc_html_e( 'Read more', 'zero-bs-crm' ); ?></a></div>
+							<?php ##/WLREMOVE ?>
 							<label for="wpzbscrm_port"><?php esc_html_e( 'WooCommerce My Account', 'zero-bs-crm' ); ?>:</label><br />
 							<?php esc_html_e( 'Enter a comma-separated list of Jetpack CRM fields to let customers edit these via WooCommerce My Account.', 'zero-bs-crm' ); ?>
 						</td>

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
@@ -286,10 +286,10 @@ function jpcrm_settings_page_html_woosync_main() {
 					<tr>
 						<td class="wfieldname">
 							<label for="wpzbscrm_port"><?php esc_html_e( 'WooCommerce My Account', 'zero-bs-crm' ); ?>:</label><br />
-							<?php esc_html_e( 'Enter a comma-separated list of Jetpack CRM custom fields to let customers edit these via WooCommerce My Account (e.g. custom-field-1,other-custom-field)', 'zero-bs-crm' ); ?>
+							<?php esc_html_e( 'Enter a comma-separated list of Jetpack CRM fields to let customers edit these via WooCommerce My Account.', 'zero-bs-crm' ); ?>
 						</td>
 						<td style="width:540px">
-							<input type="text" class="winput form-control" name="wpzbscrm_wcport" id="wpzbscrm_port" value="<?php echo ( ! empty( $settings['wcport'] ) ? esc_attr( $settings['wcport'] ) : '' ); ?>" />
+							<input type="text" class="winput form-control" name="wpzbscrm_wcport" id="wpzbscrm_port" value="<?php echo ( ! empty( $settings['wcport'] ) ? esc_attr( $settings['wcport'] ) : '' ); ?>" placeholder="e.g. addr1,custom-field-1" />
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: Resolves Automattic/zero-bs-crm#3399 - make KB links consistent in settings

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR does the following:

1. Clarifies that any contact field (rather than just custom fields) can be added to the Woo My Account page and adds a link to the relevant KB.
2. Makes KB links in the settings more consistent in location and appearance.
3. Some basic HTML validation cleanup (stray tags and attributes).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Review the code and make sure the moved/added KB links are correct. Their appearance in the settings should be consistently in the left column, with a few exceptions (e.g. settings from paid extensions, or instances where there isn't a clear two-column layout).

Before examples ("View Guide", "Learn More", "Read more"):
![image](https://github.com/Automattic/jetpack/assets/32492176/a132c4fd-f04d-473d-b6af-4cbb732fee40)
![image](https://github.com/Automattic/jetpack/assets/32492176/c2caf526-3a1c-46db-a7a6-4bd7bdf9d512)
![image](https://github.com/Automattic/jetpack/assets/32492176/9a4fc7b6-3612-4db2-adc0-8fbb32d39c88)

After examples (all use the "Read more" button):
![image](https://github.com/Automattic/jetpack/assets/32492176/615d00c9-5360-4633-95f3-9f46b1d18679)
![image](https://github.com/Automattic/jetpack/assets/32492176/10d51fa1-1e0b-4952-8def-2fbebe897dc6)

