### PR TITLE
Protect: Remove use of "rulesVersion" in the Firewall settings screen

### DIFF
--- a/projects/packages/waf/changelog/deprecate-waf-rules-version
+++ b/projects/packages/waf/changelog/deprecate-waf-rules-version
@@ -1,0 +1,5 @@
+Significance: patch
+Type: deprecated
+Comment: Deprecated a function in the WAF package.
+
+

--- a/projects/packages/waf/src/class-waf-stats.php
+++ b/projects/packages/waf/src/class-waf-stats.php
@@ -52,8 +52,12 @@ class Waf_Stats {
 	 * Get Rules version
 	 *
 	 * @return bool|string False if value is not found. The current stored rules version if cache is found.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Waf\Waf_Stats::get_automatic_rules_last_updated() to version the rules instead.
 	 */
 	public static function get_rules_version() {
+		_deprecated_function( __METHOD__, 'waf-$$next-version$$', 'Automattic\Jetpack\Waf\Waf_Stats::get_automatic_rules_last_updated' );
+
 		return get_option( Waf_Rules_Manager::VERSION_OPTION_NAME );
 	}
 

--- a/projects/plugins/protect/changelog/use-datetime-versioning-for-firewall-rules
+++ b/projects/plugins/protect/changelog/use-datetime-versioning-for-firewall-rules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Firewall: Use datetime versioning for rules file updates.

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -449,7 +449,6 @@ class Jetpack_Protect {
 		return array(
 			'ipAllowListCount'          => Waf_Stats::get_ip_allow_list_count(),
 			'ipBlockListCount'          => Waf_Stats::get_ip_block_list_count(),
-			'rulesVersion'              => Waf_Stats::get_rules_version(),
 			'automaticRulesLastUpdated' => Waf_Stats::get_automatic_rules_last_updated(),
 		);
 	}

--- a/projects/plugins/protect/src/js/components/firewall-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-page/index.jsx
@@ -53,7 +53,7 @@ const FirewallPage = () => {
 		displayUpgradeBadge,
 		wafSupported,
 		isUpdating,
-		stats: { ipAllowListCount, ipBlockListCount, rulesVersion, automaticRulesLastUpdated },
+		stats: { ipAllowListCount, ipBlockListCount, automaticRulesLastUpdated },
 		toggleAutomaticRules,
 		toggleManualRules,
 		toggleBruteForceProtection,
@@ -506,21 +506,16 @@ const FirewallPage = () => {
 						) }
 					</Text>
 					<div className={ styles[ 'toggle-section__details' ] }>
-						{ jetpackWafAutomaticRules && ! automaticRulesInstallationError && (
-							<div className={ styles[ 'automatic-rules-stats' ] }>
-								{ rulesVersion && (
+						{ jetpackWafAutomaticRules &&
+							automaticRulesLastUpdated &&
+							! automaticRulesInstallationError && (
+								<div className={ styles[ 'automatic-rules-stats' ] }>
 									<Text
 										className={ styles[ 'automatic-rules-stats__version' ] }
 										variant={ 'body-small' }
 									>
-										{ sprintf(
-											// translators: placeholder is the latest rules version i.e. "v2.0".
-											__( 'Automatic security rules v%s installed.', 'jetpack-protect' ),
-											rulesVersion
-										) }
+										{ __( 'Automatic security rules installed.', 'jetpack-protect' ) }
 									</Text>
-								) }
-								{ automaticRulesLastUpdated && (
 									<Text
 										className={ styles[ 'automatic-rules-stats__last-updated' ] }
 										variant={ 'body-small' }
@@ -531,9 +526,8 @@ const FirewallPage = () => {
 											moment.unix( automaticRulesLastUpdated ).format( 'MMMM D, YYYY' )
 										) }
 									</Text>
-								) }
-							</div>
-						) }
+								</div>
+							) }
 						{ automaticRulesInstallationError && (
 							<>
 								<Text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes `rulesVersion` in favor of just displaying the "last updated" date. The rules version string is not maintained.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visit the Firewall tab in Jetpack Protect.
* Upgrade to access automatic rules.
* Validate rules are not labelled as "v1.0.0" once installed.

## Screenshots

Before:

<img width="766" alt="Screenshot 2023-12-03 at 3 09 12 PM" src="https://github.com/Automattic/jetpack/assets/10933065/9e2811c6-6659-4d33-bc73-42047f4c1fa2">

After:

<img width="782" alt="Screenshot 2023-12-18 at 11 48 25 AM" src="https://github.com/Automattic/jetpack/assets/10933065/72439627-58d0-47ee-94e5-fec372e60e04">

