### PR TITLE
AI assistant: fix positioning

### DIFF
--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -12,7 +12,6 @@
 	background-color: var( --jp-white );
 	box-shadow: 0px 12px 15px 0px rgba(0, 0, 0, 0.12), 0px 3px 9px 0px rgba(0, 0, 0, 0.12), 0px 1px 3px 0px rgba(0, 0, 0, 0.15);
 	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	width: 100%;
 	border-radius: 6px;
 	border: 1px solid var(--gutenberg-gray-400, #CCC);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/style.scss
@@ -9,7 +9,7 @@
     &.is-fixed {
 		.jetpack-components-ai-control__container-wrapper {
 			position: relative;
-			padding-bottom: 0;
+			bottom: 0;
 		}
 
 		.jetpack-components-ai-control__container {
@@ -32,11 +32,12 @@
 
 	.jetpack-ai-assistant__bar-wrapper {
 		position: relative;
+		bottom: 0;
 	}
 }
 
 .jetpack-ai-assistant__bar-wrapper {
 	position: sticky;
-	bottom: 0;
 	z-index: 30;
+	bottom: 16px;
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/style.scss
@@ -1,5 +1,4 @@
 .jetpack-ai-assistant__bar {
-    width: 100%;
 
     &:not(.is-fixed) {
         position: relative;


### PR DESCRIPTION
The new sticky position needs to work throughout the myriad containers and wrappers dedicated to the task. 

## Proposed changes:
This PR addresses an issue where fixing one of the positioning directives for the control would mess with the (differently styled) assistant bar.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert an AI Assistant block (or invoke on content), make sure the positioning works as expected, floating at the bottom of the content block and sticky to the bottom of the viewport when content exceeds the viewport height. Switch between mobile and desktop view and confirm the positioning is consistent in both.

Now repeat the test, but use the assistant in the Form block extension: insert a form and wait for the assistant to show at the bottom. On desktop view the position should be the same as the regular assistant, sticking to the bottom. Switching to mobile should turn the assistant into a fixed bar right below the toolbar. It should not overlap the toolbar.