### PR TITLE
Protect: App-Level Admin Notifications

### DIFF
--- a/projects/plugins/protect/changelog/unify-protect-notifications
+++ b/projects/plugins/protect/changelog/unify-protect-notifications
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Unify display of notifications across Scan and Firewall screens"
+Unify display of notifications across Scan and Firewall screens

--- a/projects/plugins/protect/changelog/unify-protect-notifications
+++ b/projects/plugins/protect/changelog/unify-protect-notifications
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Unify display of notifications across Scan and Firewall screens"

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -1,4 +1,4 @@
-import { AdminPage as JetpackAdminPage, Container, Notice } from '@automattic/jetpack-components';
+import { AdminPage as JetpackAdminPage, Container } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -10,6 +10,7 @@ import useWafData from '../../hooks/use-waf-data';
 import { STORE_ID } from '../../state/store';
 import InterstitialPage from '../interstitial-page';
 import Logo from '../logo';
+import Notice from '../notice';
 import Tabs, { Tab } from '../tabs';
 import styles from './styles.module.scss';
 import useRegistrationWatcher from './use-registration-watcher';

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -1,7 +1,7 @@
-import { AdminPage as JetpackAdminPage, Container } from '@automattic/jetpack-components';
+import { AdminPage as JetpackAdminPage, Container, Notice } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import apiFetch from '@wordpress/api-fetch';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import React, { useEffect } from 'react';
@@ -18,6 +18,7 @@ const AdminPage = ( { children } ) => {
 	useRegistrationWatcher();
 
 	const { isSeen: wafSeen } = useWafData();
+	const notice = useSelect( select => select( STORE_ID ).getNotice() );
 	const { refreshPlan, startScanOptimistically, refreshStatus } = useDispatch( STORE_ID );
 	const { adminUrl } = window.jetpackProtectInitialState || {};
 	const { run, isRegistered, hasCheckoutStarted } = useProductCheckoutWorkflow( {
@@ -51,6 +52,7 @@ const AdminPage = ( { children } ) => {
 
 	return (
 		<JetpackAdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) } header={ <Logo /> }>
+			{ notice.message && <Notice floating={ true } dismissable={ true } { ...notice } /> }
 			<Container horizontalSpacing={ 0 }>
 				<Tabs className={ styles.navigation }>
 					<Tab link="/" label={ __( 'Scan', 'jetpack-protect' ) } />

--- a/projects/plugins/protect/src/js/components/firewall-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-page/index.jsx
@@ -9,7 +9,7 @@ import {
 } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { ExternalLink, Popover } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { Icon, arrowLeft, closeSmall } from '@wordpress/icons';
@@ -25,7 +25,6 @@ import AdminPage from '../admin-page';
 import FirewallFooter from '../firewall-footer';
 import ConnectedFirewallHeader from '../firewall-header';
 import FormToggle from '../form-toggle';
-import Notice from '../notice';
 import ScanFooter from '../scan-footer';
 import Textarea from '../textarea';
 import styles from './styles.module.scss';
@@ -35,7 +34,6 @@ const SUCCESS_NOTICE_DURATION = 5000;
 
 const FirewallPage = () => {
 	const [ isSmall ] = useBreakpointMatch( [ 'sm', 'lg' ], [ null, '<' ] );
-	const notice = useSelect( select => select( STORE_ID ).getNotice() );
 	const { setWafIsSeen, setWafUpgradeIsSeen, setNotice } = useDispatch( STORE_ID );
 	const {
 		config: {
@@ -829,8 +827,7 @@ const FirewallPage = () => {
 	 */
 	return (
 		<AdminPage>
-			{ notice.message && <Notice floating={ true } dismissable={ true } { ...notice } /> }
-			{ <ConnectedFirewallHeader /> }
+			<ConnectedFirewallHeader />
 			<Container className={ styles.container } horizontalSpacing={ 8 } horizontalGap={ 4 }>
 				{ wafSupported && ! isEnabled && <Col>{ moduleDisabledNotice } </Col> }
 				<Col>{ ! showManualRules ? mainSettings : manualRulesSettings }</Col>

--- a/projects/plugins/protect/src/js/components/summary/index.jsx
+++ b/projects/plugins/protect/src/js/components/summary/index.jsx
@@ -5,12 +5,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import React from 'react';
 import useProtectData from '../../hooks/use-protect-data';
 import { STORE_ID } from '../../state/store';
-import Notice from '../notice';
 import styles from './styles.module.scss';
 
 const Summary = () => {
 	const { numThreats, lastChecked, hasRequiredPlan } = useProtectData();
-	const notice = useSelect( select => select( STORE_ID ).getNotice() );
 	const scanIsEnqueuing = useSelect( select => select( STORE_ID ).getScanIsEnqueuing() );
 	const { scan } = useDispatch( STORE_ID );
 	const Icon = getIconBySlug( 'protect' );
@@ -45,9 +43,6 @@ const Summary = () => {
 								) }
 							</Text>
 						) }
-					</div>
-					<div className={ styles.summary__notice }>
-						{ notice && notice.message && <Notice { ...notice } /> }
 					</div>
 					{ hasRequiredPlan && numThreats === 0 && (
 						<Button

--- a/projects/plugins/protect/src/js/components/summary/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/summary/styles.module.scss
@@ -20,14 +20,6 @@
 	margin-right: var( --spacing-base ); // 8px
 }
 
-.summary__notice {
-	margin-top: calc( var( --spacing-base ) * 3 ); // 24px
-
-	@media ( min-width: 960px ) {
-		margin-top: 0;
-	}
-}
-
 .summary__scan-button {
 	margin-top: calc( var( --spacing-base ) * 2 ); // 16px
 	width: 100%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-scan-team/issues/433

Currently, the global `notice` value is implemented separately in the Scan and Firewall screens. The objective of this PR is to unify how notices are displayed across screens in Protect, by displaying them in the higher-level admin template used by the Scan and Firewall screens.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves rendering of notices to the higher level `AdminPage` component.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack-scan-team/issues/433

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Trigger a notice from both the Scan and Firewall tabs inside the Protect admin screen. Validate that the notice persists between tabs, and is dismissed automatically.
  * Scan tab: trigger an auto-fixer for a threat.
  * Firewall tab: click any of the setting toggles.

<img width="1186" alt="Screenshot 2024-01-03 at 7 27 17 PM" src="https://github.com/Automattic/jetpack/assets/10933065/b1e26cdf-0abb-4e10-b525-f85c7a177842">
