### PR TITLE
Contact Form: add extra field settings to base field

### DIFF
--- a/projects/packages/forms/changelog/update-contact-form-extra-field-settings
+++ b/projects/packages/forms/changelog/update-contact-form-extra-field-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Contact Form: add extra field settings to base field

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -62,7 +62,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.27.x-dev"
+			"dev-trunk": "0.28.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.27.0",
+	"version": "0.28.0-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -13,6 +13,7 @@ import {
 	ToggleControl,
 	RangeControl,
 } from '@wordpress/components';
+import { isValidElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useFormStyle, FORM_STYLE, getBlockStyle } from '../util/form';
 import ToolbarRequiredGroup from './block-controls/toolbar-required-group';
@@ -31,6 +32,7 @@ const JetpackFieldControls = ( {
 	setAttributes,
 	type,
 	width,
+	extraFieldSettings = [],
 } ) => {
 	const formStyle = useFormStyle( clientId );
 	const blockStyle = getBlockStyle( blockClassNames );
@@ -103,6 +105,50 @@ const JetpackFieldControls = ( {
 		setAttributes( { id: newValue } );
 	};
 
+	let fieldSettings = [
+		<ToggleControl
+			label={ __( 'Field is required', 'jetpack-forms' ) }
+			className="jetpack-field-label__required"
+			checked={ required }
+			onChange={ value => setAttributes( { required: value } ) }
+			help={ __( 'You can edit the "required" label in the editor', 'jetpack-forms' ) }
+		/>,
+		! hidePlaceholder && (
+			<TextControl
+				label={ __( 'Placeholder text', 'jetpack-forms' ) }
+				value={ placeholder || '' }
+				onChange={ value => setAttributes( { [ placeholderField ]: value } ) }
+				help={ __(
+					'Show visitors an example of the type of content expected. Otherwise, leave blank.',
+					'jetpack-forms'
+				) }
+			/>
+		),
+		<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />,
+		<ToggleControl
+			label={ __( 'Sync fields style', 'jetpack-forms' ) }
+			checked={ attributes.shareFieldAttributes }
+			onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
+			help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
+		/>,
+	];
+
+	extraFieldSettings.forEach( ( { element, index } ) => {
+		if ( ! isValidElement( element ) ) {
+			return;
+		}
+
+		if ( index >= 0 && index < fieldSettings.length ) {
+			fieldSettings = [
+				...fieldSettings.slice( 0, index ),
+				element,
+				...fieldSettings.slice( index ),
+			];
+		} else {
+			fieldSettings.push( element );
+		}
+	} );
+
 	return (
 		<>
 			<BlockControls>
@@ -117,31 +163,9 @@ const JetpackFieldControls = ( {
 					<JetpackManageResponsesSettings isChildBlock />
 				</PanelBody>
 				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
-					<ToggleControl
-						label={ __( 'Field is required', 'jetpack-forms' ) }
-						className="jetpack-field-label__required"
-						checked={ required }
-						onChange={ value => setAttributes( { required: value } ) }
-						help={ __( 'You can edit the "required" label in the editor', 'jetpack-forms' ) }
-					/>
-					{ ! hidePlaceholder && (
-						<TextControl
-							label={ __( 'Placeholder text', 'jetpack-forms' ) }
-							value={ placeholder || '' }
-							onChange={ value => setAttributes( { [ placeholderField ]: value } ) }
-							help={ __(
-								'Show visitors an example of the type of content expected. Otherwise, leave blank.',
-								'jetpack-forms'
-							) }
-						/>
-					) }
-					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
-					<ToggleControl
-						label={ __( 'Sync fields style', 'jetpack-forms' ) }
-						checked={ attributes.shareFieldAttributes }
-						onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
-						help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
-					/>
+					{ fieldSettings.filter( Boolean ).map( ( elt, index ) => (
+						<div key={ index }>{ elt }</div>
+					) ) }
 				</PanelBody>
 				<PanelColorSettings
 					title={ __( 'Color', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.27.0';
+	const PACKAGE_VERSION = '0.28.0-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/plugins/jetpack/changelog/update-contact-form-extra-field-settings
+++ b/projects/plugins/jetpack/changelog/update-contact-form-extra-field-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1167,7 +1167,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "91cdedeae6c8fc54fb18196d9465098efca69975"
+                "reference": "c72fbe74edbc293518b22c39de5c8f609e2f235b"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1193,7 +1193,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.27.x-dev"
+                    "dev-trunk": "0.28.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Prep work for https://github.com/Automattic/jetpack/issues/34501

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fields of the _Contact Form_ block have a _Field Settings_ section in the Jetpack sidebar. To add settings, one must duplicate existing settings in a new component. This PR makes the process easier by enabling the passing of extra fields to the `JetpackFieldControls` component.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-87-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Download this branch locally
- Open `/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js` in your code editor
- Add the following prop to the instance of `JetpackFieldControls`
```
extraFieldSettings={ [
	{
		index: 1,
		element: (
			<TextControl label={ __( 'EXTRA', 'jetpack-forms' ) } onChange={ () => null } />
		),
	},
] }
```

- Build the package: `cd projects/packages/forms && npm run build:blocks`
- Spin up a test site
- Create a new post
- Add the _Contact Form_ block
- Add a _Dropdown_ field
- Notice it has an extra settings field in the sidebar
<img width="279" alt="Screenshot 2023-12-18 at 5 33 01 PM" src="https://github.com/Automattic/jetpack/assets/1620183/2355f311-5bdb-43b1-be6e-b735ee6af0a3">

- Check that other fields work as usual