### PR TITLE
Subscriptions: fix missing class fatal related to PR #34635

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fatal-pr-34635
+++ b/projects/plugins/jetpack/changelog/fix-fatal-pr-34635
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix fatal for missing Abstract_Token_Subscription_Service class.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Extensions\Subscriptions;
 
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Jetpack_Token_Subscription_Service;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;


### PR DESCRIPTION
Fixes #34635

## Proposed changes:

Fix fatal by adding missing class reference:

```
PHP Fatal error:  Uncaught Error: Class "Automattic\Jetpack\Extensions\Subscriptions\Abstract_Token_Subscription_Service" not found in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php:814
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1702943798252359-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- On latest trunk in local dev, verify the fatal occurs by opening the post editor (may need subscriptions enabled)
- Patch with this PR and the fatal should no longer occur

CC @millerf In case there was something missed with this quick-fix.