### PR TITLE
Fix My plan dashboard js errors due to nested anchor tags 

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -106,13 +106,12 @@ class MyPlanBody extends React.Component {
 					<div className="jp-landing__plan-features-text">
 						<h3 className="jp-landing__plan-features-title">{ title }</h3>
 						<p>{ description }</p>
-						<Button
-							onClick={ this.handleButtonClickForTracking( 'view_backup_dash' ) }
-							href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
-							compact
-							rna
-						>
-							<ExternalLink>{ __( 'View your backups', 'jetpack' ) }</ExternalLink>
+						<Button onClick={ this.handleButtonClickForTracking( 'view_backup_dash' ) } compact rna>
+							<ExternalLink
+								href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
+							>
+								{ __( 'View your backups', 'jetpack' ) }
+							</ExternalLink>
 						</Button>
 					</div>
 				</div>
@@ -146,11 +145,14 @@ class MyPlanBody extends React.Component {
 							</p>
 							<Button
 								onClick={ this.handleButtonClickForTracking( 'view_security_dash_rewind' ) }
-								href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
 								compact
 								rna
 							>
-								<ExternalLink>{ __( 'View your security activity', 'jetpack' ) }</ExternalLink>
+								<ExternalLink
+									href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
+								>
+									{ __( 'View your security activity', 'jetpack' ) }
+								</ExternalLink>
 							</Button>
 						</div>
 					</div>
@@ -200,23 +202,27 @@ class MyPlanBody extends React.Component {
 						this.props.isPluginActive( 'vaultpress/vaultpress.php' ) ? (
 							<Button
 								onClick={ this.handleButtonClickForTracking( 'view_security_dash' ) }
-								href={ getRedirectUrl( 'vaultpress-dashboard' ) }
 								compact
 								rna
 							>
-								<ExternalLink> { __( 'View your security dashboard', 'jetpack' ) }</ExternalLink>
+								<ExternalLink href={ getRedirectUrl( 'vaultpress-dashboard' ) }>
+									{ __( 'View your security dashboard', 'jetpack' ) }
+								</ExternalLink>
 							</Button>
 						) : (
 							<Button
 								onClick={ this.handleButtonClickForTracking( 'configure_vault' ) }
-								href={ getRedirectUrl( 'calypso-plugins-setup', {
-									site: this.props.siteRawUrl,
-									query: 'only=vaultpress',
-								} ) }
 								compact
 								rna
 							>
-								<ExternalLink>{ __( 'View settings', 'jetpack' ) }</ExternalLink>
+								<ExternalLink
+									href={ getRedirectUrl( 'calypso-plugins-setup', {
+										site: this.props.siteRawUrl,
+										query: 'only=vaultpress',
+									} ) }
+								>
+									{ __( 'View settings', 'jetpack' ) }
+								</ExternalLink>
 							</Button>
 						) }
 					</div>
@@ -365,14 +371,17 @@ class MyPlanBody extends React.Component {
 								) : (
 									<Button
 										onClick={ this.handleButtonClickForTracking( 'configure_akismet' ) }
-										href={ getRedirectUrl( 'calypso-plugins-setup', {
-											site: this.props.siteRawUrl,
-											query: 'only=akismet',
-										} ) }
 										compact
 										rna
 									>
-										<ExternalLink>{ __( 'View settings', 'jetpack' ) }</ExternalLink>
+										<ExternalLink
+											href={ getRedirectUrl( 'calypso-plugins-setup', {
+												site: this.props.siteRawUrl,
+												query: 'only=akismet',
+											} ) }
+										>
+											{ __( 'View settings', 'jetpack' ) }
+										</ExternalLink>
 									</Button>
 								) }
 							</div>
@@ -447,11 +456,16 @@ class MyPlanBody extends React.Component {
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'view_site_activity' ) }
-									href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
 									compact
 									rna
 								>
-									<ExternalLink>{ __( 'View your site activity', 'jetpack' ) }</ExternalLink>
+									<ExternalLink
+										href={ getRedirectUrl( 'calypso-activity-log', {
+											site: this.props.siteRawUrl,
+										} ) }
+									>
+										{ __( 'View your site activity', 'jetpack' ) }
+									</ExternalLink>
 								</Button>
 							</div>
 						</div>
@@ -478,13 +492,16 @@ class MyPlanBody extends React.Component {
 									{ this.props.isModuleActivated( 'wordads' ) ? (
 										<Button
 											onClick={ this.handleButtonClickForTracking( 'view_earnings' ) }
-											href={ getRedirectUrl( 'wpcom-ads-earnings', {
-												site: this.props.siteRawUrl,
-											} ) }
 											compact
 											rna
 										>
-											<ExternalLink>{ __( 'View your earnings', 'jetpack' ) }</ExternalLink>
+											<ExternalLink
+												href={ getRedirectUrl( 'wpcom-ads-earnings', {
+													site: this.props.siteRawUrl,
+												} ) }
+											>
+												{ __( 'View your earnings', 'jetpack' ) }
+											</ExternalLink>
 										</Button>
 									) : (
 										<Button
@@ -526,13 +543,14 @@ class MyPlanBody extends React.Component {
 										{ this.props.isModuleActivated( 'google-analytics' ) ? (
 											<Button
 												onClick={ this.handleButtonClickForTracking( 'configure_ga' ) }
-												href={ getRedirectUrl( 'calypso-marketing-traffic', {
-													site: this.props.siteRawUrl,
-												} ) }
 												compact
 												rna
 											>
-												<ExternalLink>
+												<ExternalLink
+													href={ getRedirectUrl( 'calypso-marketing-traffic', {
+														site: this.props.siteRawUrl,
+													} ) }
+												>
 													{ __( 'Configure Google Analytics', 'jetpack' ) }
 												</ExternalLink>
 											</Button>
@@ -573,13 +591,16 @@ class MyPlanBody extends React.Component {
 										{ this.props.isModuleActivated( 'publicize' ) ? (
 											<Button
 												onClick={ this.handleButtonClickForTracking( 'schedule_posts' ) }
-												href={ getRedirectUrl( 'calypso-edit-posts', {
-													site: this.props.siteRawUrl,
-												} ) }
 												compact
 												rna
 											>
-												<ExternalLink>{ __( 'Schedule posts', 'jetpack' ) }</ExternalLink>
+												<ExternalLink
+													href={ getRedirectUrl( 'calypso-edit-posts', {
+														site: this.props.siteRawUrl,
+													} ) }
+												>
+													{ __( 'Schedule posts', 'jetpack' ) }
+												</ExternalLink>
 											</Button>
 										) : (
 											<Button
@@ -635,13 +656,16 @@ class MyPlanBody extends React.Component {
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'free_security' ) }
-									href={ getRedirectUrl( 'calypso-settings-security', {
-										site: this.props.siteRawUrl,
-									} ) }
 									compact
 									rna
 								>
-									<ExternalLink>{ __( 'Set up your site security', 'jetpack' ) }</ExternalLink>
+									<ExternalLink
+										href={ getRedirectUrl( 'calypso-settings-security', {
+											site: this.props.siteRawUrl,
+										} ) }
+									>
+										{ __( 'Set up your site security', 'jetpack' ) }
+									</ExternalLink>
 								</Button>
 							</div>
 						</div>
@@ -693,13 +717,12 @@ class MyPlanBody extends React.Component {
 										'jetpack'
 									) }
 								</p>
-								<Button
-									onClick={ this.handleButtonClickForTracking( 'free_themes' ) }
-									href={ getRedirectUrl( 'calypso-themes', { site: this.props.siteRawUrl } ) }
-									compact
-									rna
-								>
-									<ExternalLink>{ __( 'Explore themes', 'jetpack' ) }</ExternalLink>
+								<Button onClick={ this.handleButtonClickForTracking( 'free_themes' ) } compact rna>
+									<ExternalLink
+										href={ getRedirectUrl( 'calypso-themes', { site: this.props.siteRawUrl } ) }
+									>
+										{ __( 'Explore themes', 'jetpack' ) }
+									</ExternalLink>
 								</Button>
 							</div>
 						</div>
@@ -729,13 +752,16 @@ class MyPlanBody extends React.Component {
 									{ this.props.isModuleActivated( 'publicize' ) ? (
 										<Button
 											onClick={ this.handleButtonClickForTracking( 'free_sharing' ) }
-											href={ getRedirectUrl( 'calypso-marketing-connections', {
-												site: this.props.siteRawUrl,
-											} ) }
 											compact
 											rna
 										>
-											<ExternalLink>{ __( 'Start sharing', 'jetpack' ) }</ExternalLink>
+											<ExternalLink
+												href={ getRedirectUrl( 'calypso-marketing-connections', {
+													site: this.props.siteRawUrl,
+												} ) }
+											>
+												{ __( 'Start sharing', 'jetpack' ) }
+											</ExternalLink>
 										</Button>
 									) : (
 										<Button
@@ -774,11 +800,16 @@ class MyPlanBody extends React.Component {
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'view_site_activity' ) }
-									href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
 									compact
 									rna
 								>
-									<ExternalLink>{ __( 'View your site activity', 'jetpack' ) }</ExternalLink>
+									<ExternalLink
+										href={ getRedirectUrl( 'calypso-activity-log', {
+											site: this.props.siteRawUrl,
+										} ) }
+									>
+										{ __( 'View your site activity', 'jetpack' ) }
+									</ExternalLink>
 								</Button>
 							</div>
 						</div>
@@ -803,11 +834,12 @@ class MyPlanBody extends React.Component {
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'free_support_documentation' ) }
-									href={ getRedirectUrl( 'jetpack-support' ) }
 									compact
 									rna
 								>
-									<ExternalLink>{ __( 'Search support docs', 'jetpack' ) }</ExternalLink>
+									<ExternalLink href={ getRedirectUrl( 'jetpack-support' ) }>
+										{ __( 'Search support docs', 'jetpack' ) }
+									</ExternalLink>
 								</Button>
 							</div>
 						</div>

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -566,13 +566,10 @@ class MyPlanHeader extends React.Component {
 						} ) }
 					>
 						{ showPurchasesLink && (
-							<Button
-								onClick={ this.trackAllPurchasesClick }
-								href={ getRedirectUrl( 'calypso-purchases' ) }
-								compact
-								rna
-							>
-								<ExternalLink>{ __( 'View all purchases', 'jetpack' ) }</ExternalLink>
+							<Button onClick={ this.trackAllPurchasesClick } compact rna>
+								<ExternalLink href={ getRedirectUrl( 'calypso-purchases' ) }>
+									{ __( 'View all purchases', 'jetpack' ) }
+								</ExternalLink>
 							</Button>
 						) }
 

--- a/projects/plugins/jetpack/changelog/update-my-plan-dashboard-js-errors-nested-tags-external-link
+++ b/projects/plugins/jetpack/changelog/update-my-plan-dashboard-js-errors-nested-tags-external-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+My Plan: Fix JS errors due to nested anchor tags


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #33814

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
As explained in the ticket, when navigating to My Plan Dashboard we were getting 
```
Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
```
This is because we use the `ExternalLink` component inside the `Button` component **passing the `href` to the `Button`**. In this case `Button` creates another `<a>` tag that wraps the one from `ExternalLink`.

**The changes in this PR** move the href from the `Button` to the `ExternalLink` props so that only one `<a>` tag will exist. 
This has been done in all places inside My Plan where such situation existed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In your testing site, check that before activating this branch the error is still reproduced.

* Open your browser's JavaScript console.
* Go to Jetpack > Dashboard > My Plan
* Notice the errors:

Once the branch is active no errors should appear and the links should appear and work in the same way as before.

