### PR TITLE
Add `wpcom_ai_site_prompt` option to the site settings endpoint

### DIFF
--- a/projects/packages/sync/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/packages/sync/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add wpcom_ai_site_prompt option to the site settings endpoint

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.2.x-dev"
+			"dev-trunk": "2.3.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -178,6 +178,7 @@ class Defaults {
 		'wp_mobile_excerpt',
 		'wp_mobile_featured_images',
 		'wp_page_for_privacy_policy',
+		'wpcom_ai_site_prompt',
 		'wpcom_featured_image_in_email',
 		'wpcom_gifting_subscription',
 		'wpcom_is_fse_activated',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.2.2-alpha';
+	const PACKAGE_VERSION = '2.3.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/backup/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/plugins/backup/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -34,7 +34,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ2_3",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ2_4_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1405,7 +1405,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1336c2b2d1ca4b780142c047150ec14b00372167"
+                "reference": "7a318d1c460f1b36704856054e5a83455dc434d7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1437,7 +1437,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.2.x-dev"
+                    "dev-trunk": "2.3.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/backup/jetpack-backup.php
+++ b/projects/plugins/backup/jetpack-backup.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VaultPress Backup
  * Plugin URI: https://jetpack.com/jetpack-backup
  * Description: Easily restore or download a backup of your site from a specific moment in time.
- * Version: 2.3
+ * Version: 2.4-alpha
  * Author: Automattic - Jetpack Backup team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/jetpack/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/plugins/jetpack/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add wpcom_ai_site_prompt option to the site settings endpoint

--- a/projects/plugins/jetpack/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint#2
+++ b/projects/plugins/jetpack/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2519,7 +2519,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1336c2b2d1ca4b780142c047150ec14b00372167"
+                "reference": "7a318d1c460f1b36704856054e5a83455dc434d7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2551,7 +2551,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.2.x-dev"
+                    "dev-trunk": "2.3.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -118,6 +118,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 			'rss_use_excerpt'                         => '(bool) Whether the RSS feed will use post excerpts',
 			'launchpad_screen'                        => '(string) Whether or not launchpad is presented and what size it will be',
 			'sm_enabled'                              => '(bool) Whether the newsletter subscribe modal is enabled',
+			'wpcom_ai_site_prompt'                    => '(string) User input in the AI site prompt',
 		),
 
 		'response_format'     => array(

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -128,6 +128,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'page_for_posts'                          => '(string) The page ID of the page to use as the site\'s posts page. It will apply only if \'show_on_front\' is set to \'page\'.',
 			'subscription_options'                    => '(array) Array of three options used in subscription email templates: \'invitation\', \'welcome\' and \'comment_follow\' strings.',
 			'jetpack_verbum_subscription_modal'       => '(bool) Whether Subscription modal is enabled in Verbum comments',
+			'wpcom_ai_site_prompt'                    => '(string) User input in the AI site prompt',
 		),
 
 		'response_format' => array(

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -243,6 +243,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_reader_views_enabled'                   => true,
 			'wpcom_site_setup'                             => '',
 			'jetpack_verbum_subscription_modal'            => true,
+			'wpcom_ai_site_prompt'                         => '',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/projects/plugins/migration/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/plugins/migration/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1405,7 +1405,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1336c2b2d1ca4b780142c047150ec14b00372167"
+                "reference": "7a318d1c460f1b36704856054e5a83455dc434d7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1437,7 +1437,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.2.x-dev"
+                    "dev-trunk": "2.3.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/plugins/protect/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1318,7 +1318,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1336c2b2d1ca4b780142c047150ec14b00372167"
+                "reference": "7a318d1c460f1b36704856054e5a83455dc434d7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1350,7 +1350,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.2.x-dev"
+                    "dev-trunk": "2.3.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/plugins/search/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1407,7 +1407,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1336c2b2d1ca4b780142c047150ec14b00372167"
+                "reference": "7a318d1c460f1b36704856054e5a83455dc434d7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1439,7 +1439,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.2.x-dev"
+                    "dev-trunk": "2.3.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/plugins/social/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1338,7 +1338,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "1336c2b2d1ca4b780142c047150ec14b00372167"
+				"reference": "7a318d1c460f1b36704856054e5a83455dc434d7"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1370,7 +1370,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.2.x-dev"
+					"dev-trunk": "2.3.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/starter-plugin/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/plugins/starter-plugin/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1261,7 +1261,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1336c2b2d1ca4b780142c047150ec14b00372167"
+                "reference": "7a318d1c460f1b36704856054e5a83455dc434d7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1293,7 +1293,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.2.x-dev"
+                    "dev-trunk": "2.3.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/plugins/videopress/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1261,7 +1261,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1336c2b2d1ca4b780142c047150ec14b00372167"
+                "reference": "7a318d1c460f1b36704856054e5a83455dc434d7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1293,7 +1293,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.2.x-dev"
+                    "dev-trunk": "2.3.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds the `wpcom_ai_site_prompt` option to the site settings endpoint. This option stores the user input in the prompt screen in the WP.com's AI assembler flow (see pbxlJb-573-p2).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This PR doesn't implement any functional changes. Ensure that all checks pass successfully.