### PR TITLE
CRM: start 6.3.3-alpha release cycle

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 6.3.2
+ * Version: 6.3.3-alpha
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/init-release-cycle
+++ b/projects/plugins/crm/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 6.3.3-alpha
+
+

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -42,7 +42,7 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_3_2",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_3_3_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "6.3.2",
+	"version": "6.3.3-alpha",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, kallehauge, cleacos, diegogarciarodrigues, bradshawtm, wpkaren, robertf4, woodyhayday, mikemayhem3030
 Tags: CRM, Invoice, Woocommerce CRM, Clients, Lead Generation, contacts, customers, billing, email marketing, Marketing Automation, contact form, automations
 Tested up to: 6.4
-Stable tag: 6.3.1
+Stable tag: 6.3.2
 Requires at least: 6.0
 Requires PHP: 7.4
 License: GPLv2

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -389,16 +389,10 @@ We offer a full, no-hassle refund within 14 days. You can read more about that, 
 
 
 == Changelog ==
-### 6.3.1 - 2023-12-14
-#### Security
-- Bulk actions: Stricter permissions checks.
-
-#### Added
-- WooSync: New `jpcrm_woo_sync_order_data` hook.
+### 6.3.2 - 2023-12-19
+#### Changed
+- Settings: Make support document links more consistent.
 
 #### Fixed
-- OAuth Connection: Updated typo to remove plural connection"s", and removed doc reference for whitelabel builds.
-- Placeholders: Fixing quote placeholders on the quote template, client portal, pdf and emails.
-- Quotes: Consistent rendering of dates in placeholders.
-- Quotes: Consistent rendering of values and currency in placeholders.
+- Segments: Fixed an issue preventing segments from being deleted.
 


### PR DESCRIPTION


## Proposed changes:

* This PR starts a new cycle after the 6.3.1 release.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read, check the versions have updated (including readme.txt stable tag to 6.3.2 - current live version). Similar PR for comparison: https://github.com/Automattic/jetpack/pull/34647

