### PR TITLE
Subscriptions: disable toggle to send post as email when post was published once in the past

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriptions-email-toggle-published-posts
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-email-toggle-published-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriptions: disable email toggle when post was already published

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -32,6 +32,7 @@ import {
 	getShowMisconfigurationWarning,
 	MisconfigurationWarning,
 } from '../../shared/memberships/utils';
+import usePostWasPublished from '../../shared/use-post-was-published';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import metadata from './block.json';
 import EmailPreview from './email-preview';
@@ -114,10 +115,9 @@ function NewsletterPrePublishSettingsPanel( { accessLevel, isModuleActive, showP
 	};
 
 	// Subscriptions will not be triggered for a post that was already published in the past.
-	const shouldLoadSubscriptionPlaceholder = useSelect( select => {
-		const meta = select( editorStore ).getEditedPostAttribute( 'meta' );
-		return ! isModuleActive && ! isLoadingModules && ! meta?.jetpack_post_was_ever_published;
-	} );
+	const { postWasEverPublished } = usePostWasPublished();
+	const shouldLoadSubscriptionPlaceholder =
+		! isModuleActive && ! isLoadingModules && ! postWasEverPublished;
 
 	const postVisibility = useSelect( select => select( editorStore ).getEditedPostVisibility() );
 	const showMisconfigurationWarning = getShowMisconfigurationWarning( postVisibility, accessLevel );

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -20,6 +20,7 @@ import paywallBlockMetadata from '../../blocks/paywall/block.json';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import './settings.scss';
 import PlansSetupDialog from '../components/plans-setup-dialog';
+import usePostWasPublished from '../use-post-was-published';
 import {
 	accessOptions,
 	META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
@@ -293,6 +294,9 @@ export function NewsletterEmailDocumentSettings() {
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const [ postMeta, setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
 
+	// Subscriptions will not be triggered for a post that was already published in the past.
+	const { postWasEverPublished } = usePostWasPublished();
+
 	const toggleSendEmail = value => {
 		const postMetaUpdate = {
 			...postMeta,
@@ -314,7 +318,7 @@ export function NewsletterEmailDocumentSettings() {
 				return (
 					<ToggleControl
 						checked={ isSendEmailEnabled }
-						disabled={ isPostPublished || ! canEdit }
+						disabled={ isPostPublished || postWasEverPublished || ! canEdit }
 						label={ __( 'Send an email', 'jetpack' ) }
 						onChange={ toggleSendEmail }
 					/>

--- a/projects/plugins/jetpack/extensions/shared/use-post-was-published.js
+++ b/projects/plugins/jetpack/extensions/shared/use-post-was-published.js
@@ -1,0 +1,15 @@
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+const usePostWasPublished = () => {
+	const postWasEverPublished = useSelect( select => {
+		const meta = select( editorStore ).getEditedPostAttribute( 'meta' );
+		return ! meta?.jetpack_post_was_ever_published;
+	} );
+
+	return {
+		postWasEverPublished,
+	};
+};
+
+export default usePostWasPublished;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to https://github.com/Automattic/jetpack/pull/34592#discussion_r1427945450

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

