### PR TITLE
Admin Page: avoid react warning with VideoPress card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -128,8 +128,7 @@ class DashVideoPress extends Component {
 				className="jp-dash-item__is-inactive"
 				noToggle={ ! hasConnectedOwner }
 				overrideContent={
-					! hasConnectedOwner &&
-					! isOffline && (
+					! hasConnectedOwner && ! isOffline ? (
 						<JetpackBanner
 							callToAction={ __( 'Connect', 'jetpack' ) }
 							title={ __(
@@ -143,7 +142,7 @@ class DashVideoPress extends Component {
 							plan={ getJetpackProductUpsellByFeature( FEATURE_VIDEOPRESS ) }
 							icon="video"
 						/>
-					)
+					) : null
 				}
 			>
 				<p className="jp-dash-item__description">

--- a/projects/plugins/jetpack/changelog/fix-warning-videopress-card
+++ b/projects/plugins/jetpack/changelog/fix-warning-videopress-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: avoid React warning when loading the VideoPress card.


### PR DESCRIPTION
## Proposed changes:

This should avoid us getting the following warning:

```
Warning: Failed prop type: Invalid prop `overrideContent` of type `boolean` supplied to `DashItem`, expected a single ReactElement.
DashItem@wp-content/plugins/jetpack/_inc/build/admin.js?ver=28b3a12169ab227bdcfa:36878:1
SettingsForm@wp-content/plugins/jetpack/_inc/build/admin.js?ver=28b3a12169ab227bdcfa:43524:3
ConnectFunction@wp-content/plugins/jetpack/_inc/build/admin.js?ver=28b3a12169ab227bdcfa:8870:68
ConnectFunction@wp-content/plugins/jetpack/_inc/build/admin.js?ver=28b3a12169ab227bdcfa:8870:68
DashVideoPress@wp-content/plugins/jetpack/_inc/build/admin.js?ver=28b3a12169ab227bdcfa:34467:1
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test here; 

* Go to Jetpack > Dashboard on a site that's connected with WordPress.com
* Check your browser's console for errors
