### PR TITLE
Subscriptions: update "verify your email" wall copy

### DIFF
--- a/projects/plugins/jetpack/changelog/update-copy-for-verify-email
+++ b/projects/plugins/jetpack/changelog/update-copy-for-verify-email
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriptions: update "verify your email" wall copy

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1114,9 +1114,18 @@ function is_user_auth() {
  * @return string
  */
 function get_paywall_blocks_subscribe_pending() {
-	$access_heading = esc_html__( 'Verify your email to continue reading', 'jetpack' );
+	$subscribe_email = Jetpack_Memberships::get_current_user_email();
 
-	$subscribe_text = esc_html__( 'Please check your inbox to confirm your subscription.', 'jetpack' );
+	/** This filter is documented in modules/contact-form/grunion-contact-form.php */
+	if ( is_wpcom() || false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
+		$current_user    = wp_get_current_user();
+		$subscribe_email = ! empty( $current_user->user_email ) ? $current_user->user_email : '';
+	}
+
+	$access_heading = esc_html__( 'Confirm your subscription to continue reading', 'jetpack' );
+
+	/* translators: %s: email address */
+	$subscribe_text = wp_kses( sprintf( __( 'Head to your inbox and confirm your email address %s.', 'jetpack' ), $subscribe_email ), array() );
 
 	$lock_svg = plugins_url( 'images/lock-paywall.svg', JETPACK__PLUGIN_FILE );
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1125,7 +1125,7 @@ function get_paywall_blocks_subscribe_pending() {
 	$access_heading = esc_html__( 'Confirm your subscription to continue reading', 'jetpack' );
 
 	/* translators: %s: email address */
-	$subscribe_text = wp_kses( sprintf( __( 'Head to your inbox and confirm your email address %s.', 'jetpack' ), $subscribe_email ), array() );
+	$subscribe_text = sprintf( esc_html__( 'Head to your inbox and confirm your email address %s.', 'jetpack' ), $subscribe_email );
 
 	$lock_svg = plugins_url( 'images/lock-paywall.svg', JETPACK__PLUGIN_FILE );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Updates copy to be more about "confirming their subscription" rather than "confirming email" per-se, and aligns copy with email they received.

See https://github.com/Automattic/wp-calypso/issues/84773#issuecomment-1845026885

Doesn't update the actual modal where we also nudge to check email.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update copy
* Add email to the copy

Before
<img width="689" alt="Screenshot 2023-12-19 at 14 47 38" src="https://github.com/Automattic/jetpack/assets/87168/831cd28c-bbd7-4eec-aab2-0d943cf55680">

After
<img width="698" alt="Screenshot 2023-12-19 at 14 46 10" src="https://github.com/Automattic/jetpack/assets/87168/fec89128-e4ba-4fef-90c3-99f9d52df370">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Subscribe to post requiring subscription, but don't confirm your email. 
* Email does not get cached for others to see because the whole page isn't cached (https://github.com/Automattic/jetpack/pull/34242#issuecomment-1838479034)
