### PR TITLE
Premium Content: fix missing class fatal related to PR #34635

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-34635-2
+++ b/projects/plugins/jetpack/changelog/fix-34635-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix fatal for missing Abstract_Token_Subscription_Service class.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Extensions\Premium_Content;
 
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34635

## Proposed changes:

Fix missing class reference.

```
PHP Fatal error:  Uncaught Error: Class "Automattic\Jetpack\Extensions\Premium_Content\Abstract_Token_Subscription_Service" not found in /srv/htdocs/jetpack-staging/jetpack/extensions/blocks/premium-content/login-button/login-button.php:46
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1702943798252359-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Before patching, add paid content block to local dev on latest trunk. Opening that post should throw the fatal.
* After patching, fatal should not occur.