### PR TITLE
Fix token subscription service name

### DIFF
--- a/projects/packages/videopress/changelog/fix-token-subscription-service-rename
+++ b/projects/packages/videopress/changelog/fix-token-subscription-service-rename
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Updated name of Abstract_Token_Subscription_Service

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -177,7 +177,12 @@ class Access_Control {
 			$paywall             = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
 
 			// Only paid subscribers should be granted access to the premium content.
-			$access_level                      = \Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
+			if ( class_exists( '\Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service' ) ) {
+				$access_level = \Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
+			} else {
+				$access_level = \Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
+			}
+
 			$can_view                          = $paywall->visitor_can_view_content( array( $selected_plan_id ), $access_level );
 			$restriction_details['can_access'] = $can_view || current_user_can( 'edit_post', $embedded_post_id ); // Editors can always view the content.
 		}

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
 use Automattic\Jetpack\Modules;
 use VIDEOPRESS_PRIVACY;
 
@@ -177,10 +179,10 @@ class Access_Control {
 			$paywall             = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
 
 			// Only paid subscribers should be granted access to the premium content.
-			if ( class_exists( '\Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service' ) ) {
-				$access_level = \Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
+			if ( class_exists( Abstract_Token_Subscription_Service::class ) ) {
+				$access_level = Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
 			} else {
-				$access_level = \Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
+				$access_level = Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
 			}
 
 			$can_view                          = $paywall->visitor_can_view_content( array( $selected_plan_id ), $access_level );

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -177,7 +177,7 @@ class Access_Control {
 			$paywall             = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
 
 			// Only paid subscribers should be granted access to the premium content.
-			$access_level                      = \Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
+			$access_level                      = \Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
 			$can_view                          = $paywall->visitor_can_view_content( array( $selected_plan_id ), $access_level );
 			$restriction_details['can_access'] = $can_view || current_user_can( 'edit_post', $embedded_post_id ); // Editors can always view the content.
 		}


### PR DESCRIPTION
Fixes p1703016191690759/1703015730.887629-slack-C01U2KGS2PQ
Fixes #34728

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the name of `Token_Subscription_Service` to `Abstract_Token_Subscription_Service`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test in both WPCOM and Jurassic Ninja sites.

**WPCOM**
1. Create a post that has paid access.
2. Add the VideoPress block to the post, and use the Upload function to load a video, or select an existing video from the Media Library. There is an existing issue with WPCOM where the Insert a URL choice is broken, so skip testing that for now.
3. Note that the video uploads correctly. Save the post.
4. Attempt to view the post in a incognito browser. The video should be blocked behind the subscription wall.
5. Subscribe to the site. Once subscribed, you should be able to see the video on the post.

**Jurassic Ninja**
1. Create a post that has paid access.
2. Add the VideoPress block to the post, and use the Upload function to load a video, or select an existing video from the Media Library. Add a second block that utilize the "Insert a URL" choice, and paste a video link (it can be the same video).
3. Note that the video uploads correctly. Save the post.
4. Attempt to view the post in a incognito browser. The video should be blocked behind the subscription wall.
5. Subscribe to the site. Once subscribed, you should be able to see the video on the post.
