### PR TITLE
Social | Fix the media validation notice shown even when auto conversion is eabled

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-media-validation-notice
+++ b/projects/js-packages/publicize-components/changelog/fix-media-validation-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the media validation notice shown even when auto conversion is enabled.

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -118,6 +118,7 @@ export default function PublicizeForm() {
 							<ValidationNotice
 								connectionsCount={ connections.length }
 								invalidConnectionIdsCount={ invalidIds.length }
+								shouldAutoConvert={ shouldAutoConvert }
 							/>
 						) ) }
 				</>

--- a/projects/js-packages/publicize-components/src/components/form/validation-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/validation-notice.tsx
@@ -6,13 +6,15 @@ import Notice from '../notice';
 export type ValidationNoticeProps = {
 	connectionsCount: number;
 	invalidConnectionIdsCount: number;
+	shouldAutoConvert: boolean;
 };
 
 export const ValidationNotice: React.FC< ValidationNoticeProps > = ( {
 	connectionsCount,
 	invalidConnectionIdsCount,
+	shouldAutoConvert,
 } ) => {
-	return (
+	return shouldAutoConvert ? null : (
 		<Notice type={ 'warning' }>
 			<p>
 				{ connectionsCount === invalidConnectionIdsCount


### PR DESCRIPTION
#34612 caused a slight regression which resulted in media validation notice being shown even when auto conversion is enabled.

![CleanShot 2023-12-15 at 10 14 51 png](https://github.com/Automattic/jetpack/assets/18226415/8d353831-f8ac-4c98-ad61-aee5ad098251)


## Proposed changes:
* Hide the media validation notice when auto conversion is ON

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Turn ON Auto Conversion for a site
* Goto post edit page
* Upload an invalid media
* Confirm that the validation notice is not shown
* Turn OFF auto conversion
* Goto post edit page
* Upload an invalid media
* Confirm that the validation notice IS shown


