### PR TITLE
Like Block: Add support for Block Hooks API (Draft)

### DIFF
--- a/projects/plugins/jetpack/changelog/add-like-block-block-hooks-api
+++ b/projects/plugins/jetpack/changelog/add-like-block-block-hooks-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add support for Block Hooks API

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -78,54 +78,56 @@ function LikeEdit() {
 					</PanelBody>
 				) }
 			</InspectorControls>
-			<div className="wpl-likebox wpl-new-layout">
-				{ showReblogButton && (
-					<div className="wpl-button reblog">
-						<a
-							href="#"
-							title={ __( 'Reblog this post on your main site.', 'jetpack' ) }
-							className="reblog sd-button"
-							rel="nofollow"
-						>
-							<span>{ __( 'Reblog', 'jetpack' ) }</span>
+			<div className={ 'wp-block-group is-layout-constrained has-global-padding' }>
+				<div className="wpl-likebox wpl-new-layout">
+					{ showReblogButton && (
+						<div className="wpl-button reblog">
+							<a
+								href="#"
+								title={ __( 'Reblog this post on your main site.', 'jetpack' ) }
+								className="reblog sd-button"
+								rel="nofollow"
+							>
+								<span>{ __( 'Reblog', 'jetpack' ) }</span>
+							</a>
+						</div>
+					) }
+					<div className="wpl-button like">
+						<a href="#" className="sd-button like" rel="nofollow" onClick={ preventDefault }>
+							<span>{ __( 'Like', 'jetpack' ) }</span>
 						</a>
 					</div>
-				) }
-				<div className="wpl-button like">
-					<a href="#" className="sd-button like" rel="nofollow" onClick={ preventDefault }>
-						<span>{ __( 'Like', 'jetpack' ) }</span>
-					</a>
-				</div>
-				<ul className="wpl-avatars">
-					{ avatars.map( ( avatar, i ) => (
-						<li key={ `liker-${ i }` } className="wp-liker-me">
-							<a className="wpl-liker" href="#" rel="nofollow" onClick={ preventDefault }>
-								<img
-									src={ avatar }
-									className="avatar avatar-30"
-									width={ 30 }
-									height={ 30 }
-									alt=""
-								/>
+					<ul className="wpl-avatars">
+						{ avatars.map( ( avatar, i ) => (
+							<li key={ `liker-${ i }` } className="wp-liker-me">
+								<a className="wpl-liker" href="#" rel="nofollow" onClick={ preventDefault }>
+									<img
+										src={ avatar }
+										className="avatar avatar-30"
+										width={ 30 }
+										height={ 30 }
+										alt=""
+									/>
+								</a>
+							</li>
+						) ) }
+					</ul>
+					<div className="wpl-count">
+						<span className="wpl-count-text">
+							<a href="#" onClick={ preventDefault }>
+								{ createInterpolateElement(
+									sprintf(
+										// translators: %$1s: Number of likes
+										__( '<span>%1$d</span> likes', 'jetpack' ),
+										avatars.length
+									),
+									{
+										span: <span className="wpl-count-number"></span>,
+									}
+								) }
 							</a>
-						</li>
-					) ) }
-				</ul>
-				<div className="wpl-count">
-					<span className="wpl-count-text">
-						<a href="#" onClick={ preventDefault }>
-							{ createInterpolateElement(
-								sprintf(
-									// translators: %$1s: Number of likes
-									__( '<span>%1$d</span> likes', 'jetpack' ),
-									avatars.length
-								),
-								{
-									span: <span className="wpl-count-number"></span>,
-								}
-							) }
-						</a>
-					</span>
+						</span>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -116,11 +116,57 @@ function render_block( $attr, $content, $block ) {
 		. "<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='button'><span>" . esc_html__( 'Like', 'jetpack' ) . "</span></span> <span class='loading'>" . esc_html__( 'Loading...', 'jetpack' ) . '</span></div>'
 		. "<span class='sd-text-color'></span><a class='sd-link-color'></a>"
 		. '</div>';
-	return sprintf(
+
+	$group_block_start = '<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group">';
+	$output            = sprintf(
 		'<div class="%1$s">%2$s</div>',
 		esc_attr( Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) ),
 		$html
 	);
+	$group_block_end   = '</div><!-- /wp:group -->';
+
+	return do_blocks( $group_block_start . $output . $group_block_end );
+}
+
+/**
+ * Filters the list of blocks to be automatically inserted into the post content.
+ *
+ * This function is designed to hook certain types of blocks based on specific conditions.
+ * It checks the context and position relative to the anchor block and decides whether
+ * to add a new block type (e.g., 'jetpack/like') to the list of hooked blocks.
+ *
+ * @param array                     $hooked_blocks       The current array of blocks to be hooked.
+ * @param string                    $relative_position   The position relative to the anchor block ('before' or 'after').
+ * @param string                    $anchor_block        The anchor block type (e.g., 'core/post-content').
+ * @param WP_Block_Template | array $context             The block template, template part, or pattern that the anchor block belongs to.
+ *
+ * @return array The modified array of blocks to be hooked.
+ */
+function hooked_block_types( $hooked_blocks, $relative_position, $anchor_block, $context ) {
+	if (
+		'core/post-content' === $anchor_block &&
+		'after' === $relative_position &&
+		'single' === $context->slug &&
+		should_hook_block()
+	) {
+		$hooked_blocks[] = 'jetpack/like';
+	}
+	return $hooked_blocks;
+}
+
+add_filter( 'hooked_block_types', __NAMESPACE__ . '\hooked_block_types', 10, 4 );
+
+/**
+ * Determines whether a block should be hooked.
+ *
+ * This function is used to evaluate conditions under which a specific block
+ * should be hooked. Currently, it is set up to always return false, indicating
+ * that no blocks should be hooked.
+ *
+ * @return bool Returns false, indicating that no blocks should be hooked.
+ */
+function should_hook_block() {
+	return false;
 }
 
 /**


### PR DESCRIPTION
## Proposed changes:
- Add the hooked_block_types filter
- When `should_hook_block()` returns true it inserts the Like block inside a `wp:group` block, rendering correctly

![CleanShot 2023-12-20 at 10 37 31@2x](https://github.com/Automattic/jetpack/assets/528287/57670efa-609f-4b62-9eca-a5f7ee4e1bef)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this PR & make sure `jetpack watch` is running
2. Make `should_hook_block()` return true. (inside `extensions/blocks/like/like.php`)
3. A block should be auto-inserted in the frontend & the editor & look right