### PR TITLE
Social | Hide conversion notice for Simple sites

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-hide-conversion-notice-wpcom
+++ b/projects/js-packages/publicize-components/changelog/update-social-hide-conversion-notice-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Hide conversion notice on Simple sites

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.43.1-alpha",
+	"version": "0.44.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/form/auto-conversion-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/auto-conversion-notice.tsx
@@ -1,3 +1,4 @@
+import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -16,6 +17,7 @@ export const AutoConversionNotice: React.FC = () => {
 	const { adminUrl, jetpackSharingSettingsUrl } = usePublicizeConfig();
 
 	return (
+		! isSimpleSite() &&
 		shouldShowNotice( NOTICES.autoConversion ) && (
 			<Notice
 				type={ 'warning' }

--- a/projects/js-packages/publicize-components/src/social-store/selectors/auto-conversion-settings.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/auto-conversion-settings.js
@@ -1,7 +1,8 @@
 const autoConversionSettingsSelectors = {
 	getAutoConversionSettings: state => state.autoConversionSettings,
 	isAutoConversionAvailable: state => state.autoConversionSettings.available,
-	isAutoConversionEnabled: state => state.autoConversionSettings.enabled,
+	isAutoConversionEnabled: state =>
+		state.autoConversionSettings.available && state.autoConversionSettings.enabled,
 	isAutoConversionSettingsUpdating: state => state.autoConversionSettings.isUpdating,
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We plan to turn on the auto-conversion for simple sites, where currently, they cannot turn the feature off. For now we hide the conversion notice for those sites.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/orgs/Automattic/projects/733/views/2?pane=issue&itemId=48088220
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On a Jetpack site
* Auto conversion should work as before, and you should see the conversion notice when the feature is on, and you select an invalid but convertible media.

On a simple site
* You can sandbox this change with the jetpack downloader below, and on Simple sites, the conversion notice should not appear. To have the feature as available you can download this change onto D131678-code

On Atomic sites you can use the Jetpack Beta plugin to test this