### PR TITLE
Created a poc to validate user_is_subscribed

### DIFF
--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -315,6 +315,8 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			$commenter                     = wp_get_current_commenter();
 			$params['show_cookie_consent'] = (int) has_action( 'set_comment_cookies', 'wp_set_comment_cookies' );
 			$params['has_cookie_consent']  = (int) ! empty( $commenter['comment_author_email'] );
+			// Jetpack_Memberships for logged out users only checks for the jp-premium-content-session cookie
+			$params['is_current_user_subscribed'] = (int) Jetpack_Memberships::is_current_user_subscribed();
 		}
 
 		list( $token_key ) = explode( '.', $blog_token->secret, 2 );
@@ -612,12 +614,12 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	 */
 	public function should_show_subscription_modal() {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
-		$user_is_subscribed = (bool) isset( $_POST['hc_wpcom_user_is_subscribed'] ) ? filter_var( wp_unslash( $_POST['hc_wpcom_user_is_subscribed'] ) ) : null;
+		$is_current_user_subscribed = (bool) isset( $_POST['is_current_user_subscribed'] ) ? filter_var( wp_unslash( $_POST['is_current_user_subscribed'] ) ) : null;
 
 		// Atomic sites with jetpack_verbum_subscription_modal option enabled
 		$modal_enabled = ( new Host() )->is_woa_site() && get_option( 'jetpack_verbum_subscription_modal', true );
 
-		return $modal_enabled && ! $user_is_subscribed;
+		return $modal_enabled && ! $is_current_user_subscribed;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -611,10 +611,8 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	 * @return boolean
 	 */
 	public function should_show_subscription_modal() {
-		$post_array = stripslashes_deep( $_POST );
-
-		$user_is_subscribed = (bool) $post_array['hc_wpcom_user_is_subscribed'];
-		echo '<br><br>hc_wpcom_user_is_subscribed: ' . $user_is_subscribed . '<br><br>';
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		$user_is_subscribed = (bool) isset( $_POST['hc_wpcom_user_is_subscribed'] ) ? filter_var( wp_unslash( $_POST['hc_wpcom_user_is_subscribed'] ) ) : null;
 
 		// Atomic sites with jetpack_verbum_subscription_modal option enabled
 		$modal_enabled = ( new Host() )->is_woa_site() && get_option( 'jetpack_verbum_subscription_modal', true );

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -611,13 +611,13 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	 * @return boolean
 	 */
 	public function should_show_subscription_modal() {
-		// Atomic sites with jetpack_verbum_subscription_modal option enabled
-		$modal_enabled      = ( new Host() )->is_woa_site() && get_option( 'jetpack_verbum_subscription_modal', true );
-		$user_is_subscribed = false;
+		$post_array = stripslashes_deep( $_POST );
 
-		// if ( is_user_logged_in() ) {
-		// TODO: Check if user is subscribed
-		// }
+		$user_is_subscribed = (bool) $post_array['hc_wpcom_user_is_subscribed'];
+		echo '<br><br>hc_wpcom_user_is_subscribed: ' . $user_is_subscribed . '<br><br>';
+
+		// Atomic sites with jetpack_verbum_subscription_modal option enabled
+		$modal_enabled = ( new Host() )->is_woa_site() && get_option( 'jetpack_verbum_subscription_modal', true );
 
 		return $modal_enabled && ! $user_is_subscribed;
 	}

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
@@ -1,7 +1,4 @@
-// eslint-disable-next-line no-undef
-const smDomReady = typeof domReady !== 'undefined' ? domReady : wp.domReady;
-
-smDomReady( function () {
+document.addEventListener( 'DOMContentLoaded', function () {
 	const modal = document.getElementsByClassName( 'jetpack-subscription-modal' )[ 0 ];
 
 	if ( ! modal ) {

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
@@ -39,17 +39,33 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 	window.addEventListener( 'message', JetpackSubscriptionModalOnCommentMessageListener );
 
+	function reloadOnCloseSubscriptionModal() {
+		const destinationUrl = new URL( redirectUrl );
+
+		// current URL without hash
+		const currentUrlWithoutHash = location.href.replace( location.hash, '' );
+		// destination URL without hash
+		const destinationUrlWithoutHash = destinationUrl.href.replace( destinationUrl.hash, '' );
+		window.location.href = redirectUrl;
+
+		// reload the page if the user is already on the comment page
+		if ( currentUrlWithoutHash === destinationUrlWithoutHash ) {
+			window.location.reload();
+		}
+	}
+
 	if ( close ) {
-		close.onclick = function () {
+		close.onclick = function ( event ) {
+			event.preventDefault();
 			modal.classList.toggle( 'open' );
-			window.location.href = redirectUrl;
+			reloadOnCloseSubscriptionModal();
 		};
 	}
 
 	window.onclick = function ( event ) {
 		if ( event.target === modal ) {
 			modal.style.display = 'none';
-			window.location.href = redirectUrl;
+			reloadOnCloseSubscriptionModal();
 		}
 	};
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/pull/34659
Slack thread: p1703084453565229-slack-CKZHG0QCR

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*