### PR TITLE
Backport mu-wpcom-plugin 2.0.8, jetpack 13.0-a.7 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-12-20
+### Changed
+- AI Client: improved usability with new block positioning, prompt and suggestion action buttons. [#34383]
+- Updated package dependencies. [#34696]
+
 ## [0.2.1] - 2023-12-03
 ### Changed
 - Updated the prompt shadow for a better sense of depth. [#34362]
@@ -171,6 +176,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.3.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.16...v0.2.0
 [0.1.16]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.15...v0.1.16

--- a/projects/js-packages/ai-client/changelog/improved-ui-ux
+++ b/projects/js-packages/ai-client/changelog/improved-ui-ux
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-AI Client: improved usability with new block positioning, prompt and suggestion action buttons

--- a/projects/js-packages/ai-client/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.3.0-alpha",
+	"version": "0.3.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.16 - 2023-12-20
+### Changed
+- Updated package dependencies. [#34694]
+
 ## 0.11.15 - 2023-12-06
 ### Changed
 - Updated package dependencies. [#34416]

--- a/projects/js-packages/licensing/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/licensing/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.11.16-alpha",
+	"version": "0.11.16",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.64 - 2023-12-20
+### Changed
+- Updated package dependencies. [#34694]
+
 ## 0.2.63 - 2023-12-11
 ### Changed
 - Updated package dependencies. [#34416]

--- a/projects/js-packages/partner-coupon/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/partner-coupon/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.64-alpha",
+	"version": "0.2.64",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.0] - 2023-12-20
+### Changed
+- Hide conversion notice on Simple sites. [#34733]
+- Updated package dependencies. [#34694]
+
+### Fixed
+- Fixed the media validation notice shown even when auto conversion is enabled. [#34730]
+
 ## [0.43.0] - 2023-12-14
 ### Changed
 - Moved `usePostMeta` hook to `/hooks/` directory. [#34611]
@@ -544,6 +552,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.44.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.9...v0.42.0
 [0.41.9]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.41.8...v0.41.9

--- a/projects/js-packages/publicize-components/changelog/fix-media-validation-notice
+++ b/projects/js-packages/publicize-components/changelog/fix-media-validation-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed the media validation notice shown even when auto conversion is enabled.

--- a/projects/js-packages/publicize-components/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/publicize-components/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/update-social-hide-conversion-notice-wpcom
+++ b/projects/js-packages/publicize-components/changelog/update-social-hide-conversion-notice-wpcom
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Hide conversion notice on Simple sites

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.44.0-alpha",
+	"version": "0.44.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2023-12-20
+### Changed
+- Updated package dependencies. [#34694]
+
 ## [2.0.3] - 2023-12-13
 ### Fixed
 - Backup: Bug fixes in helper script installation class. [#34297]
@@ -526,6 +530,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[2.0.4]: https://github.com/Automattic/jetpack-backup/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/Automattic/jetpack-backup/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-backup/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-backup/compare/v2.0.0...v2.0.1

--- a/projects/packages/backup/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/backup/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.0.4-alpha';
+	const PACKAGE_VERSION = '2.0.4';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.0] - 2023-12-20
+### Added
+- Contact Form: add extra field settings to base field. [#34704]
+
+### Changed
+- Contact Form: minify stylesheets in prod. [#34672]
+
 ## [0.27.0] - 2023-12-15
 ### Added
 - Contact Form: improve form error message [#34629]
@@ -434,6 +441,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.28.0]: https://github.com/automattic/jetpack-forms/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/automattic/jetpack-forms/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/automattic/jetpack-forms/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/automattic/jetpack-forms/compare/v0.24.2...v0.25.0

--- a/projects/packages/forms/changelog/add-contact-form-minify-css
+++ b/projects/packages/forms/changelog/add-contact-form-minify-css
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Contact Form: minify stylesheets in prod

--- a/projects/packages/forms/changelog/update-contact-form-extra-field-settings
+++ b/projects/packages/forms/changelog/update-contact-form-extra-field-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Contact Form: add extra field settings to base field

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.28.0-alpha",
+	"version": "0.28.0",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.28.0-alpha';
+	const PACKAGE_VERSION = '0.28.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.4] - 2023-12-20
+### Changed
+- Updated package dependencies. [#34694]
+
 ## [4.1.3] - 2023-12-11
 ### Changed
 - Updated Jetpack AI interstitial to repeat the feature's list on all the tiers. [#34541]
@@ -1158,6 +1162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.1.4]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.1.3...4.1.4
 [4.1.3]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.1.2...4.1.3
 [4.1.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.1.1...4.1.2
 [4.1.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.1.0...4.1.1

--- a/projects/packages/my-jetpack/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/my-jetpack/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/renovate-storybook-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.1.4-alpha",
+	"version": "4.1.4",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.1.4-alpha';
+	const PACKAGE_VERSION = '4.1.4';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.38.3] - 2023-12-20
+### Fixed
+- Fixed backwards compatibility with Social store refactor. [#34566]
+
 ## [0.38.2] - 2023-12-15
 ### Fixed
 - Social: Fixed issue with auto-conversion option logic. [#34666]
@@ -443,6 +447,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.38.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.2...v0.38.3
 [0.38.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.1...v0.38.2
 [0.38.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.0...v0.38.1
 [0.38.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.37.2...v0.38.0

--- a/projects/packages/publicize/changelog/fix-social-store-endpoint-backwards-compatibility
+++ b/projects/packages/publicize/changelog/fix-social-store-endpoint-backwards-compatibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed backwards compatibility with Social store refactor

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.38.3-alpha",
+	"version": "0.38.3",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.4] - 2023-12-20
+### Changed
+- Updated package dependencies. [#34694]
+
 ## [0.40.3] - 2023-12-11
 ### Changed
 - Updated package dependencies. [#34416]
@@ -861,6 +865,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.40.4]: https://github.com/Automattic/jetpack-search/compare/v0.40.3...v0.40.4
 [0.40.3]: https://github.com/Automattic/jetpack-search/compare/v0.40.2...v0.40.3
 [0.40.2]: https://github.com/Automattic/jetpack-search/compare/v0.40.1...v0.40.2
 [0.40.1]: https://github.com/Automattic/jetpack-search/compare/v0.40.0...v0.40.1

--- a/projects/packages/search/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/search/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.40.4-alpha",
+	"version": "0.40.4",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.40.4-alpha';
+	const VERSION = '0.40.4';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2023-12-20
+### Added
+- Add wpcom_ai_site_prompt option to the site settings endpoint. [#34709]
+
+### Fixed
+- Added preemptive check to break expanding metadata for posts loop in Full Sync. [#34661]
+
 ## [2.2.1] - 2023-12-13
 ### Changed
 - Refactored loop to improve efficiency and code readability [#34565]
@@ -1003,6 +1010,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.3.0]: https://github.com/Automattic/jetpack-sync/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/Automattic/jetpack-sync/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Automattic/jetpack-sync/compare/v2.1.2...v2.2.0
 [2.1.2]: https://github.com/Automattic/jetpack-sync/compare/v2.1.1...v2.1.2

--- a/projects/packages/sync/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/packages/sync/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add wpcom_ai_site_prompt option to the site settings endpoint

--- a/projects/packages/sync/changelog/update-added-preemptive-check-full-sync-posts-processing
+++ b/projects/packages/sync/changelog/update-added-preemptive-check-full-sync-posts-processing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Added preemptive check to break expanding metadata for posts loop in Full Sync

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.3.0-alpha';
+	const PACKAGE_VERSION = '2.3.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.5] - 2023-12-20
+### Changed
+- Updated package dependencies. [#34694]
+
+### Fixed
+- Updated name of Abstract_Token_Subscription_Service [#34723]
+
 ## [0.21.4] - 2023-12-06
 ### Changed
 - Updated package dependencies. [#34416]
@@ -1206,6 +1213,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.21.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.4...v0.21.5
 [0.21.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.3...v0.21.4
 [0.21.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.2...v0.21.3
 [0.21.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.1...v0.21.2

--- a/projects/packages/videopress/changelog/fix-token-subscription-service-rename
+++ b/projects/packages/videopress/changelog/fix-token-subscription-service-rename
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Updated name of Abstract_Token_Subscription_Service

--- a/projects/packages/videopress/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/videopress/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-storybook-monorepo
+++ b/projects/packages/videopress/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.21.5-alpha",
+	"version": "0.21.5",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.21.5-alpha';
+	const PACKAGE_VERSION = '0.21.5';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2023-12-20
+### Changed
+- Updated package dependencies. [#34694]
+
 ## [0.3.2] - 2023-12-11
 ### Changed
 - Updated package dependencies. [#34416]
@@ -283,6 +287,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.3]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.58...v0.3.0

--- a/projects/packages/wordads/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/wordads/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.3-alpha",
+	"version": "0.3.3",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.3-alpha';
+	const VERSION = '0.3.3';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.0-a.7 - 2023-12-20
+### Enhancements
+- Sharing Buttons Block: update the admin's setting screen when the sharing block is available. [#34673]
+
+### Improved compatibility
+- Sharing Buttons: add the official X button to the list of supported services. [#34719]
+
+### Bug fixes
+- My Plan: Fix JS errors due to nested anchor tags. [#34707]
+- Payments Block: show an error message when unable to render payment button. [#34380]
+- Subscribers: fix the subscriber count display if above 1000 subscribers. [#34689]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add wpcom_ai_site_prompt option to the site settings endpoint [#34709]
+- AI Assistant: handle new AI Control UI/UX improvements, fix DOM manipulation, remove "Try Again" toolbar button [#34383]
+- Carousel: fix unresponsive navigation [#34678]
+- Dashboard: avoid React warning when loading the VideoPress card. [#34713]
+- Jetpack Google Fonts: Don't print font definition if the font is provided by the active theme. [#34608]
+- Remove like block dependency on Like module and insert iframe once. [#34664]
+- Small refactor Subscription services [#34635]
+- Subscriptions: localize number format in access panel [#34691]
+- Subscriptions: update "verify your email" wall copy [#34716]
+- Updated package dependencies. [#34694]
+- update feature not released yet [#34724]
+
 ## 13.0-a.5 - 2023-12-15
 ### Enhancements
 - Subscriptions: adds toggle to disable email sending. [#34592]

--- a/projects/plugins/jetpack/changelog/add-like-block-no-deps
+++ b/projects/plugins/jetpack/changelog/add-like-block-no-deps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Remove like block dependency on Like module and insert iframe once.

--- a/projects/plugins/jetpack/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
+++ b/projects/plugins/jetpack/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add wpcom_ai_site_prompt option to the site settings endpoint

--- a/projects/plugins/jetpack/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint#2
+++ b/projects/plugins/jetpack/changelog/add-wpcom_ai_site_prompt-option-settings-endpoint#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/ai-assistant-client-handling
+++ b/projects/plugins/jetpack/changelog/ai-assistant-client-handling
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-AI Assistant: handle new AI Control UI/UX improvements, fix DOM manipulation, remove "Try Again" toolbar button

--- a/projects/plugins/jetpack/changelog/fix-34635-2
+++ b/projects/plugins/jetpack/changelog/fix-34635-2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix fatal for missing Abstract_Token_Subscription_Service class.
-
-

--- a/projects/plugins/jetpack/changelog/fix-fatal-pr-34635
+++ b/projects/plugins/jetpack/changelog/fix-fatal-pr-34635
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix fatal for missing Abstract_Token_Subscription_Service class.
-
-

--- a/projects/plugins/jetpack/changelog/fix-frozen-carousel-buttons
+++ b/projects/plugins/jetpack/changelog/fix-frozen-carousel-buttons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
- Carousel: fix unresponsive navigation

--- a/projects/plugins/jetpack/changelog/fix-google-fonts-exclude-theme-fonts
+++ b/projects/plugins/jetpack/changelog/fix-google-fonts-exclude-theme-fonts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Jetpack Google Fonts: Don't print font definition if the font is provided by the active theme

--- a/projects/plugins/jetpack/changelog/fix-sharing-buttons-window-open
+++ b/projects/plugins/jetpack/changelog/fix-sharing-buttons-window-open
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: This feature is not visible for users, so won't affect them. We simply adjusting when does function run.
-
-

--- a/projects/plugins/jetpack/changelog/fix-subscription-reach-count
+++ b/projects/plugins/jetpack/changelog/fix-subscription-reach-count
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscribers: fix the reach count above 1000

--- a/projects/plugins/jetpack/changelog/fix-warning-videopress-card
+++ b/projects/plugins/jetpack/changelog/fix-warning-videopress-card
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Dashboard: avoid React warning when loading the VideoPress card.

--- a/projects/plugins/jetpack/changelog/improve-sharing-buttons-events-performance
+++ b/projects/plugins/jetpack/changelog/improve-sharing-buttons-events-performance
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: This feature is not awailable for users yet and should not affect visual representation. It's only inner performance improvements.
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.0-a.6
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.0-a.8
+
+

--- a/projects/plugins/jetpack/changelog/membership-abstract-token-class
+++ b/projects/plugins/jetpack/changelog/membership-abstract-token-class
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Small refactor Subscription services

--- a/projects/plugins/jetpack/changelog/refactor-make-render-button-errors-available
+++ b/projects/plugins/jetpack/changelog/refactor-make-render-button-errors-available
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Show an error message when unable to render payment button.

--- a/projects/plugins/jetpack/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/plugins/jetpack/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/sharing-buttons-block-alternate-settings-screen
+++ b/projects/plugins/jetpack/changelog/sharing-buttons-block-alternate-settings-screen
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-When using Sharing Buttons block we will show different settings screen

--- a/projects/plugins/jetpack/changelog/update-apply-locale-string-to-numbers
+++ b/projects/plugins/jetpack/changelog/update-apply-locale-string-to-numbers
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriptions: localize number format in access panel

--- a/projects/plugins/jetpack/changelog/update-contact-form-extra-field-settings
+++ b/projects/plugins/jetpack/changelog/update-contact-form-extra-field-settings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-content-lens-move-to-beta
+++ b/projects/plugins/jetpack/changelog/update-content-lens-move-to-beta
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-

--- a/projects/plugins/jetpack/changelog/update-copy-for-verify-email
+++ b/projects/plugins/jetpack/changelog/update-copy-for-verify-email
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriptions: update "verify your email" wall copy

--- a/projects/plugins/jetpack/changelog/update-my-plan-dashboard-js-errors-nested-tags-external-link
+++ b/projects/plugins/jetpack/changelog/update-my-plan-dashboard-js-errors-nested-tags-external-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-My Plan: Fix JS errors due to nested anchor tags

--- a/projects/plugins/jetpack/changelog/update-newsletter-prepanel
+++ b/projects/plugins/jetpack/changelog/update-newsletter-prepanel
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-update feature not released yet

--- a/projects/plugins/jetpack/changelog/update-official-x-button
+++ b/projects/plugins/jetpack/changelog/update-official-x-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Sharing Buttons: add the official X button to the list of supported X services.

--- a/projects/plugins/jetpack/changelog/update-supports-checks
+++ b/projects/plugins/jetpack/changelog/update-supports-checks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Inside baseball item for VIP, not needing in an user-facing changelog.
-
-

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_6",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.6
+ * Version: 13.0-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.6' );
+define( 'JETPACK__VERSION', '13.0-a.7' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.7
+ * Version: 13.0-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.7' );
+define( 'JETPACK__VERSION', '13.0-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.6",
+	"version": "13.0.0-a.7",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.7",
+	"version": "13.0.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,72 +293,17 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 12.9-beta - 2023-12-03
+### 13.0-a.7 - 2023-12-20
 #### Enhancements
-- Added subscribers count to pre- and post- publish panels when publishing posts in Newsletter Categories.
-- AI Assistant: Updated AI Assistant to display an upgrade banner when the feature endpoint returns with 'quota exceeded'.
-- AI Assistant: Updated the AI Assistant block to display the upgrade banner only once a block is selected.
-- Blocks: Added capability for editing Subscription block placeholder text and button label.
-- Blocks: Added the Jetpack Sharing Buttons block.
-- Blogroll: Allowed non-WP.com sites to be suggested.
-- CSS Concatenation: Avoid optimizing CSS loading when less than 2 modules that require it are active.
-- Jetpack AI: Enabled the AI Assistant usage panel.
-- Likes: Updated the likes popover design and added RTL support.
-- My Jetpack: Added Creator to My Jetpack overview.
-- Newsletters: Updated the pre-publish and post-publish panels to display the newsletter categories that the post will be sent to.
-- Paid Content Block: Added support for selecting multiple plans.
-- Subscribe Block: Improved the redirect logic after confirming a subscriptions.
-- Subscribe Modal: Added a subscribe modal toggle to the Newsletter settings.
-- Subscribe Modal: The modal is not shown at all after being dismissed, not just limited to the post it was dismissed on.
-- Subscribe modal: Updated the modal to not show when previewing post or theme.
-- VideoPress: Added support for gated content.
-- WoA: Added "Subscribers" and "My profile" under the "Users" menu in the Calypso sidebar.
-- WoA: Updated the wording on the profile menu for WoA sites using the classic style.
+- Sharing Buttons Block: update the admin's setting screen when the sharing block is available.
 
 #### Improved compatibility
-- Added a check for connected plugins before cleaning up plugin options or uninstalling Jetpack.
-- Block Editor: Dequeued editor assets when they aren't in use.
-- Blocks: Fixed lack of spacing for the Paywall block in some themes.
-- Google Fonts: Resolved occasional bug resulting in fatal errors on PHP 8 with latest Gutenberg.
-- Improved the consistency of the "Users" admin menu across all environments.
-- Subscribe Modal: Fixed lack of spacing in the modal for some themes.
-- Updated PHP version reqirements to PHP 7.0 or newer.
-- Updated WordPress version requirements to WordPress 6.3.
+- Sharing Buttons: add the official X button to the list of supported services.
 
 #### Bug fixes
-- Added missing BLOCK_NAME constant to SimplePayments block.
-- AI Assistant: Fixed an AI error sometimes being rendered for prompts marked unclear.
-- Block Editor: Fixed console errors being thrown for Jetpack blocks inside the Full Site Editor.
-- Contact Form: Prevented errors when a saved submitted contact form is requested but does not exist anymore.
-- Custom-CSS: Disabled loading `@import` directives from the filesystem. `@import` of CSS from URLs can still be done.
-- Dashboard: Fixed the display of Subscriptions and WordPress.com Toolbar controls when the user is not connected to WordPress.com.
-- Dashboard: Fixed the display of the Auto-sharing feature toggle when the user is not connected to WordPress.com.
-- Dashboard: Fixed the display of the settings for Markdown for comments.
-- EU Cookie Widget: Moved away from deprecated jQuery methods.
-- Fixed all Google font definitions being printed in the head, instead only printing fonts that are used in global styles or required by block settings.
-- Fixed a PHP Warning triggered when WooCommerce templates were not found due to a name change.
-- Fixed fatal error triggered by not checking get_product_list() result correctly.
-- Fixed sending email preview when content in the editor is different from the latest version in the database.
-- Fixed wrong like count in the like dialog after liking.
-- Font Library: Fixed PHP warnings that happen when the font name is not defined.
-- Google Fonts: Added filtering for old google fonts data in the user's global styles.
-- Media: Fixed VideoPress videos and media length not being displayed when available.
-- Mobile: Ensured text is always visible in Contact Info block on mobile.
-- Mobile: Fix a regression preventing correct block registration on mobile.
-- Mobile: Prevented converted video blocks from displaying empty thumbnails on mobile.
-- Monetize: Fixed membership products resolver not filtering tiers correctly.
-- Monetize: Updated the link to the plans page.
-- Related Posts: Ensured the Related Posts Block can be displayed properly.
-- Related Posts Block: Fixed thumbnails opening in the same tab.
-- Shortcode embeds: Fixed and updated the display of Gravatars and Gravatar profiles.
-- Subscribe Block: Fix display in the editor.
-- Subscribe Block: Fixed incorrect redirects from the block when shown outside of a post page.
-- Subscribe Block: Fixed the button in a new line option not working.
-- Subscribe Modal: Fixed the issue with the block being shown to subscribers.
-- Subscribe Widget: Fixed nonce validation.
-- VaultPress: Fixed an issue with the VaultPress submenu not being registered when the standalone plugin is inactive and the product is active.
-- WoA: Added back the "Stats" menu item for WoA sites in Calypso.
-- WoA: Restored Woo Express free trial upgrade JITM.
+- My Plan: Fix JS errors due to nested anchor tags.
+- Payments Block: show an error message when unable to render payment button.
+- Subscribers: fix the subscriber count display if above 1000 subscribers.
 
 --------
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack - WP Security, Backup, Speed, & Growth ===
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, barry, batmoo, beaulebens, bindlegirl, biskobe, bjorsch, blobaugh, brbrr, cainm, cena, cfinke, cgastrell, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, daniloercoli, davoraltman, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jasmussen, jblz, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lhkowalski, lschuyler, macmanx, martinremy, matt, mattwiebe, matveb, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, nunyvega, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, renatoagds, retrofox, richardmtl, richardmuscat, robertbpugh, roccotripaldi, ryancowles, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, thehenridev, tmoorewp, tyxla, Viper007Bond, westi, williamvianas, wpkaren, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, spam, CDN, search, social
-Stable tag: 12.7
+Stable tag: 12.9.1
 Requires at least: 6.3
 Requires PHP: 7.0
 Tested up to: 6.4

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.8 - 2023-12-20
+### Changed
+- Internal updates.
+
 ## 2.0.7 - 2023-12-15
 ### Changed
 - Version bump [#34648]

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_7"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_8"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.7
+ * Version: 2.0.8
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.7",
+	"version": "2.0.8",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.8, jetpack 13.0-a.7

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.