### PR TITLE
Contact Form: add date format to date picker

### DIFF
--- a/projects/packages/forms/changelog/add-contact-form-date-format
+++ b/projects/packages/forms/changelog/add-contact-form-date-format
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Contact Form: add date format to date picker

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -7,6 +7,7 @@ import { filter, isEmpty, map, startsWith, trim } from 'lodash';
 import JetpackField from './components/jetpack-field';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
 import JetpackFieldConsent from './components/jetpack-field-consent';
+import JetpackDatePicker from './components/jetpack-field-datepicker';
 import JetpackDropdown from './components/jetpack-field-dropdown';
 import JetpackFieldMultiple from './components/jetpack-field-multiple';
 import { JetpackFieldOptionEdit } from './components/jetpack-field-option';
@@ -490,12 +491,16 @@ export const childBlocks = [
 					d="M4.5 7H19.5V19C19.5 19.2761 19.2761 19.5 19 19.5H5C4.72386 19.5 4.5 19.2761 4.5 19V7ZM3 5V7V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V7V5C21 3.89543 20.1046 3 19 3H5C3.89543 3 3 3.89543 3 5ZM11 9.25H7V13.25H11V9.25Z"
 				/>
 			),
-			edit: editField( 'text' ),
+			edit: JetpackDatePicker,
 			attributes: {
 				...FieldDefaults.attributes,
 				label: {
 					type: 'string',
 					default: 'Date',
+				},
+				dateFormat: {
+					type: 'string',
+					default: 'yy-mm-dd',
 				},
 			},
 		},

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -1,0 +1,119 @@
+import { SelectControl } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import { useFormStyle, useFormWrapper } from '../util/form';
+import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
+import JetpackFieldControls from './jetpack-field-controls';
+import JetpackFieldLabel from './jetpack-field-label';
+import { useJetpackFieldStyles } from './use-jetpack-field-styles';
+
+const currentYear = new Date().getFullYear();
+
+// WARNING: sync data with Contact_Form_Field::render_date_field in class-contact-form-field.php
+const DATE_FORMATS = [
+	{
+		value: 'mm/dd/yy',
+		/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 12/31/2023). */
+		label: __( 'MM/DD/YYYY', 'jetpack-forms' ),
+		example: `12/31/${ currentYear }`,
+	},
+	{
+		value: 'dd/mm/yy',
+		/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 31/12/2023). */
+		label: __( 'DD/MM/YYYY', 'jetpack-forms' ),
+		example: `21/12/${ currentYear }`,
+	},
+	{
+		value: 'yy-mm-dd',
+		/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 2023-12-31). */
+		label: __( 'YYYY-MM-DD', 'jetpack-forms' ),
+		example: `${ currentYear }-12-31`,
+	},
+];
+
+const JetpackDatePicker = props => {
+	const { attributes, clientId, isSelected, name, setAttributes } = props;
+	const { id, label, required, requiredText, width, placeholder, dateFormat } = attributes;
+
+	useFormWrapper( { attributes, clientId, name } );
+
+	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
+	const formStyle = useFormStyle( clientId );
+
+	const classes = classnames( 'jetpack-field', {
+		'is-selected': isSelected,
+		'has-placeholder': !! placeholder,
+	} );
+
+	return (
+		<>
+			<div className={ classes } style={ blockStyle }>
+				<JetpackFieldLabel
+					attributes={ attributes }
+					label={ label }
+					suffix={ `(${ DATE_FORMATS.find( f => f.value === dateFormat )?.label })` }
+					required={ required }
+					requiredText={ requiredText }
+					setAttributes={ setAttributes }
+					style={ formStyle }
+				/>
+				<input
+					className="jetpack-field__input"
+					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
+					style={ fieldStyle }
+					type="text"
+					value={ placeholder }
+				/>
+			</div>
+
+			<JetpackFieldControls
+				id={ id }
+				required={ required }
+				width={ width }
+				setAttributes={ setAttributes }
+				placeholder={ placeholder }
+				attributes={ attributes }
+				extraFieldSettings={ [
+					{
+						index: 1,
+						element: (
+							<SelectControl
+								label={ __( 'Date Format', 'jetpack-forms' ) }
+								options={ DATE_FORMATS.map( ( { value, label: optionLabel, example } ) => ( {
+									value,
+									label: `${ optionLabel } (${ example })`,
+								} ) ) }
+								onChange={ value =>
+									setAttributes( {
+										dateFormat: value,
+									} )
+								}
+								value={ attributes.dateFormat }
+								help={ __(
+									'Select the format in which the date will be displayed.',
+									'jetpack-forms'
+								) }
+							/>
+						),
+					},
+				] }
+			/>
+		</>
+	);
+};
+
+export default compose(
+	withSharedFieldAttributes( [
+		'borderRadius',
+		'borderWidth',
+		'labelFontSize',
+		'fieldFontSize',
+		'lineHeight',
+		'labelLineHeight',
+		'inputColor',
+		'labelColor',
+		'fieldBackgroundColor',
+		'borderColor',
+	] )
+)( JetpackDatePicker );

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-label.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-label.js
@@ -10,6 +10,7 @@ const FieldLabel = ( {
 	attributes,
 	className,
 	label,
+	suffix,
 	labelFieldName,
 	placeholder,
 	resetFocus,
@@ -37,6 +38,7 @@ const FieldLabel = ( {
 				withoutInteractiveFormatting
 				allowedFormats={ [ 'core/bold', 'core/italic' ] }
 			/>
+			{ suffix && <span className="jetpack-field-label__suffix">{ suffix }</span> }
 			{ required && (
 				<RichText
 					tagName="span"

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -271,12 +271,18 @@
 		margin-bottom: 0.25em;
 	}
 
+	.jetpack-field-label__suffix {
+		margin-inline-start: 0.25em;
+
+		font-weight: 700;
+	}
+
 	.required {
 		word-break: normal;
 		color: unset;
 		opacity: 0.6;
 		font-size: 85%;
-		margin-left: 0.25em;
+		margin-inline-start: 0.25em;
 		font-weight: normal;
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -101,6 +101,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'class'                  => null,
 				'width'                  => null,
 				'consenttype'            => null,
+				'dateformat'             => null,
 				'implicitconsentmessage' => null,
 				'explicitconsentmessage' => null,
 				'borderradius'           => null,
@@ -820,8 +821,29 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 */
 	public function render_date_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
 
+		// WARNING: sync data with DATE_FORMATS in jetpack-field-datepicker.js
+		$formats = array(
+			'mm/dd/yy' => array(
+				/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 12/31/2023). */
+				'label' => __( 'MM/DD/YYYY', 'jetpack-forms' ),
+			),
+			'dd/mm/yy' => array(
+				/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 31/12/2023). */
+				'label' => __( 'DD/MM/YYYY', 'jetpack-forms' ),
+			),
+			'yy-mm-dd' => array(
+				/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 2023-12-31). */
+				'label' => __( 'YYYY-MM-DD', 'jetpack-forms' ),
+			),
+		);
+
+		$date_format = $this->get_attribute( 'dateformat' );
+		$date_format = isset( $date_format ) && ! empty( $date_format ) ? $date_format : 'yy-mm-dd';
+		$label       = isset( $formats[ $date_format ] ) ? $label . ' (' . $formats[ $date_format ]['label'] . ')' : $label;
+		$extra_attrs = array( 'data-format' => $date_format );
+
 		$field  = $this->render_label( 'date', $id, $label, $required, $required_field_text );
-		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required );
+		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required, $extra_attrs );
 
 		/* For AMP requests, use amp-date-picker element: https://amp.dev/documentation/components/amp-date-picker */
 		if ( class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request() ) {

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -23,6 +23,8 @@ const L10N = {
 	invalidForm: __( 'Please make sure all fields are valid.', 'jetpack-forms' ),
 	/* translators: error message shown when a multiple choice field requires at least one option to be selected. */
 	checkboxMissingValue: __( 'Please select at least one option.', 'jetpack-forms' ),
+	/* translators: error message shown when a user enters an invalid date */
+	invalidDate: __( 'The date is not valid.', 'jetpack-forms' ),
 	/* translators: text read by a screen reader when a form is being submitted */
 	submittingForm: __( 'Submitting form', 'jetpack-forms' ),
 	/* translators: generic error message */
@@ -109,6 +111,15 @@ const isFormValid = form => {
 		}
 	}
 
+	// Handle Date Picker fields
+	const datePickerFields = getDatePickerFields( form );
+
+	for ( const field of datePickerFields ) {
+		if ( ! isDateFieldValid( field ) ) {
+			return false;
+		}
+	}
+
 	return isValid;
 };
 
@@ -145,6 +156,15 @@ const isSingleChoiceField = elt => {
 };
 
 /**
+ * Check if an element is Date Picker field
+ * @param {HTMLElement} elt Element
+ * @returns {boolean}
+ */
+const isDatePickerField = elt => {
+	return elt.tagName.toLowerCase() === 'input' && elt.classList.contains( 'jp-contact-form-date' );
+};
+
+/**
  * Check if a Multiple Choice field is required.
  * @param {HTMLFieldSetElementi} fieldset Fieldset element
  * @returns {boolean}
@@ -171,6 +191,10 @@ const isSingleChoiceFieldRequired = fieldset => {
  * @returns {boolean}
  */
 const isSimpleFieldValid = input => {
+	if ( isDatePickerField( input ) && input.value ) {
+		return isDateFieldValid( input );
+	}
+
 	return input.validity.valid;
 };
 
@@ -206,6 +230,29 @@ const isMultipleChoiceFieldValid = fieldset => {
 	}
 
 	return false;
+};
+
+/**
+ * Check if a Date Picker field is valid.
+ * @param {HTMLInputElement} input Input element
+ * @returns {boolean}
+ */
+const isDateFieldValid = input => {
+	const format = input.getAttribute( 'data-format' );
+	const value = input.value;
+	const $ = window.jQuery;
+
+	if ( value && format && typeof $ !== 'undefined' ) {
+		try {
+			$.datepicker.parseDate( format, value );
+		} catch ( e ) {
+			input.setCustomValidity( L10N.invalidDate );
+
+			return false;
+		}
+	}
+
+	return true;
 };
 
 /**
@@ -250,6 +297,15 @@ const getFormSubmitBtn = form => {
  */
 const getMultipleChoiceFields = form => {
 	return Array.from( form.querySelectorAll( '.grunion-checkbox-multiple-options' ) );
+};
+
+/**
+ * Return the Date Picker fields of a form.
+ * @param {HTMLFormElement} form Form element
+ * @returns {HTMLInputElement[]} Input elements
+ */
+const getDatePickerFields = form => {
+	return Array.from( form.querySelectorAll( 'input.jp-contact-form-date' ) );
 };
 
 /**

--- a/projects/packages/forms/src/contact-form/js/grunion-frontend.js
+++ b/projects/packages/forms/src/contact-form/js/grunion-frontend.js
@@ -5,5 +5,6 @@ jQuery( function ( $ ) {
 	$input.datepicker( {
 		dateFormat,
 		constrainInput: false,
+		showOptions: { direction: 'down' },
 	} );
 } );

--- a/projects/packages/forms/src/contact-form/js/grunion-frontend.js
+++ b/projects/packages/forms/src/contact-form/js/grunion-frontend.js
@@ -1,3 +1,9 @@
 jQuery( function ( $ ) {
-	$( '.contact-form input.jp-contact-form-date' ).datepicker();
+	const $input = $( '.contact-form input.jp-contact-form-date' );
+	const dateFormat = $input.attr( 'data-format' ) || 'yy-mm-dd';
+
+	$input.datepicker( {
+		dateFormat,
+		constrainInput: false,
+	} );
 } );

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -818,6 +818,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 			'default'     => 'foo',
 			'placeholder' => 'PLACEHOLDTHIS!',
 			'id'          => 'funID',
+			'format'      => '(YYYY-MM-DD)',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'text' ) );
@@ -991,10 +992,12 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 *                                                       and radio buttons.
 	 */
 	public function assertFieldLabel( $wrapper_div, $attributes, $tag_name = 'label' ) {
-		$label = $this->getFirstElement( $wrapper_div, $tag_name );
+		$type     = $attributes['type'];
+		$label    = $this->getFirstElement( $wrapper_div, $tag_name );
+		$expected = 'date' === $type ? $attributes['label'] . ' ' . $attributes['format'] : $attributes['label'];
 
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$this->assertEquals( trim( $label->nodeValue ), $attributes['label'], 'Label is not what we expect it to be...' );
+		$this->assertEquals( $expected, trim( $label->nodeValue ), 'Label is not what we expect it to be...' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34501

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The jQuery UI Datepicker widget used by the _Date Picker_ field of the Contact Form can't be used with a keyboard. This PR adds a date format to the field so keyboard users know how to fill out the form without opening the picker.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-87-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
- Spin up a test site with this branch
- If you run this locally, make sure to build the package: `cd projects/packages/forms && npm run build`

### Editor
- Create a new post
- Add the _Contact Form_ block
- Add a _Date Picker_ field
<img width="394" alt="Screenshot 2023-12-20 at 4 50 52 PM" src="https://github.com/Automattic/jetpack/assets/1620183/71b93257-c5e0-4a37-a324-a2ae3321a16d">

- Notice the default format added in the label
<img width="233" alt="Screenshot 2023-12-20 at 4 51 32 PM" src="https://github.com/Automattic/jetpack/assets/1620183/ecc3ac66-2584-4306-9810-49afd8ae4b13">

- Make sure the field is selected
- Notice the _Date Format_ setting in the sidebar
<img width="283" alt="Screenshot 2023-12-20 at 4 52 22 PM" src="https://github.com/Automattic/jetpack/assets/1620183/d5265c54-5e3f-4ca2-817f-c504c6155816">

- Update the value, save the draft, and refresh the page
- Check the value was saved

### Site
- Open the preview
- Check that the date field label mentions the date format
- Enter an invalid date and notice the error message
<img width="263" alt="Screenshot 2023-12-20 at 4 58 00 PM" src="https://github.com/Automattic/jetpack/assets/1620183/e3c14fec-fc0b-46f3-8915-a588f9f0f090">

- Enter a valid date and verify there's no error message
