### PR TITLE
Promote Subscription: Replace use of subscription block

### DIFF
--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -632,10 +632,13 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	public function get_subscription_modal_data_to_parent( $url ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$current_user_email = isset( $_POST['email'] ) ? filter_var( wp_unslash( $_POST['email'] ) ) : null;
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$post_id = isset( $_POST['comment_post_ID'] ) ? filter_var( wp_unslash( $_POST['comment_post_ID'] ) ) : null;
 		return array(
 			'url'     => $url,
 			'email'   => $current_user_email,
 			'blog_id' => esc_attr( \Jetpack_Options::get_option( 'id' ) ),
+			'post_id' => esc_attr( $post_id ),
 			'lang'    => esc_attr( get_locale() ),
 		);
 	}

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -623,6 +623,24 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	}
 
 	/**
+	 * Get the data to send as an event to the parent window on subscription modal
+	 *
+	 * @param string $url url to redirect to.
+	 *
+	 * @return array
+	 */
+	public function get_subscription_modal_data_to_parent( $url ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$current_user_email = isset( $_POST['email'] ) ? filter_var( wp_unslash( $_POST['email'] ) ) : null;
+		return array(
+			'url'     => $url,
+			'email'   => $current_user_email,
+			'blog_id' => esc_attr( \Jetpack_Options::get_option( 'id' ) ),
+			'lang'    => esc_attr( get_locale() ),
+		);
+	}
+
+	/**
 	 * POST the submitted comment to the iframe
 	 *
 	 * @param string $url The comment URL origin.
@@ -742,9 +760,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 				window.parent.postMessage(
 					{
 						type: 'subscriptionModalShow',
-						data: {
-							url: <?php echo wp_json_encode( $url ); ?>
-						}
+						data: <?php echo wp_json_encode( $this->get_subscription_modal_data_to_parent( $url ) ); ?>,
 					},
 					window.location.origin
 				);

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -635,11 +635,12 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$post_id = isset( $_POST['comment_post_ID'] ) ? filter_var( wp_unslash( $_POST['comment_post_ID'] ) ) : null;
 		return array(
-			'url'     => $url,
-			'email'   => $current_user_email,
-			'blog_id' => esc_attr( \Jetpack_Options::get_option( 'id' ) ),
-			'post_id' => esc_attr( $post_id ),
-			'lang'    => esc_attr( get_locale() ),
+			'url'          => $url,
+			'email'        => $current_user_email,
+			'blog_id'      => esc_attr( \Jetpack_Options::get_option( 'id' ) ),
+			'post_id'      => esc_attr( $post_id ),
+			'lang'         => esc_attr( get_locale() ),
+			'is_logged_in' => isset( $_POST['hc_userid'] ),
 		);
 	}
 

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
@@ -135,6 +135,7 @@ class Jetpack_Subscription_Modal_On_Comment {
 	public function get_subscribe_template_content() {
 		$discover_more_from = __( 'Never miss a beat!', 'jetpack' );
 		$subscribe_text     = __( 'Interested in getting blog post updates? Simply click the button below to stay in the loop!', 'jetpack' );
+		$subscribe_button   = __( 'Subscribe', 'jetpack' );
 
 		return <<<HTML
 	<!-- wp:group {"style":{"spacing":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
@@ -152,8 +153,20 @@ class Jetpack_Subscription_Modal_On_Comment {
 		<p class='has-text-align-center' style='margin-top:4px;margin-bottom:0px;font-size:15px'>$subscribe_text</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:jetpack/subscriptions {"buttonBackgroundColor":"primary","textColor":"secondary","borderRadius":50,"borderColor":"primary","className":"is-style-compact"} /-->
-
+		<!-- wp:group {"style":{"spacing":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
+		<div class="jetpack-subscription-modal__form">
+			<input
+				class="jetpack-subscription-modal__form-email"
+				required="required"
+				type="email"
+				name="email"
+				/>
+			<button
+				class="jetpack-subscription-modal__form-submit"
+				type="submit"
+				name="jetpack_subscriptions_widget" >$subscribe_button</button>
+		</div>
+		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
 HTML;

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.css
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.css
@@ -47,6 +47,50 @@
 	text-wrap: pretty;
 }
 
+.jetpack-subscription-modal__form {
+	margin-top: 20px;
+	align-items: flex-start;
+	display: flex;
+}
+
+.jetpack-subscription-modal__form-email {
+flex: 1;
+    font-size: 16px;
+    line-height: 28px;
+    padding: 15px 23px 15px 23px !important;
+    border-radius: 50px !important;
+    border-width: 1px !important;
+    border-color: #113AF5 !important;
+    border-end-end-radius: 0 !important;
+    border-start-end-radius: 0 !important;
+    border-style: solid !important;
+    outline: none;
+}
+.jetpack-subscription-modal__form-submit {
+	font-size: 16px;
+	line-height: 28px;
+	padding: 15px 23px 15px 23px;
+	margin: 0px;
+	margin-left: 10px;
+	border-radius: 50px;
+	border-width: 1px;
+	border-end-start-radius: 0;
+	border-start-start-radius: 0;
+	margin-inline-start: 0;
+	background-color: #113AF5;
+	border-color: #113AF5;
+	border-style: solid;
+	color: #FFFFFF;
+}
+.jetpack-subscription-modal__form-submit:hover {
+	opacity: .9;
+	cursor: pointer;
+}
+.jetpack-subscription-modal__form-submit:disabled {
+	opacity: .7 !important;
+	cursor: not-allowed;
+}
+
 @media screen and (max-width: 640px) {
 	.jetpack-subscription-modal__modal-content {
 		width: 94%;

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
@@ -6,8 +6,66 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	}
 
 	const close = document.getElementsByClassName( 'jetpack-subscription-modal__close' )[ 0 ];
+	const subscribeBtn = document.getElementsByClassName(
+		'jetpack-subscription-modal__form-submit'
+	)[ 0 ];
 	let redirectUrl = '';
+	let subscriptionData = '';
 	let hasLoaded = false;
+
+	function reloadOnCloseSubscriptionModal() {
+		const destinationUrl = new URL( redirectUrl );
+
+		// current URL without hash
+		const currentUrlWithoutHash = location.href.replace( location.hash, '' );
+		// destination URL without hash
+		const destinationUrlWithoutHash = destinationUrl.href.replace( destinationUrl.hash, '' );
+		window.location.href = redirectUrl;
+
+		// reload the page if the user is already on the comment page
+		if ( currentUrlWithoutHash === destinationUrlWithoutHash ) {
+			window.location.reload();
+		}
+	}
+
+
+	function handleSubscriptionModalIframeResult( eventFromIframe ) {
+		if ( eventFromIframe.origin === 'https://subscribe.wordpress.com' && eventFromIframe.data ) {
+			const data = JSON.parse( eventFromIframe.data );
+			if ( data && data.action === 'close' ) {
+				window.removeEventListener( 'message', handleSubscriptionModalIframeResult );
+				reloadOnCloseSubscriptionModal();
+			}
+		}
+	}
+
+	function showSubscriptionIframe( subscriptionData ) {
+		const subscribeData = {
+			email: subscriptionData.email,
+			post_id: subscriptionData.post_id,
+			plan: 'newsletter',
+			blog: subscriptionData.blog_id,
+			source: 'jetpack_subscribe',
+			display: 'alternate',
+			app_source: 'verbum-subscription-modal',
+			locale: subscriptionData.lang,
+		};
+
+		const params = new URLSearchParams( subscribeData );
+
+		const url = 'https://subscribe.wordpress.com/memberships/?' + params.toString();
+
+		window.scrollTo( 0, 0 );
+		// eslint-disable-next-line no-undef
+		tb_show( null, url + '&TB_iframe=true', null );
+
+		window.addEventListener( 'message', handleSubscriptionModalIframeResult, false );
+		const tbWindow = document.querySelector( '#TB_window' );
+		tbWindow.classList.add( 'jetpack-memberships-modal' );
+
+		// This line has to come after the Thickbox has opened otherwise Firefox doesnt scroll to the top.
+		window.scrollTo( 0, 0 );
+	}
 
 	function JetpackSubscriptionModalOnCommentMessageListener( event ) {
 		let message = event && event.data;
@@ -30,6 +88,11 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			return;
 		}
 
+		if ( data.email ) {
+			const emailInput = document.querySelector( '.jetpack-subscription-modal__form-email' );
+			emailInput.value = data.email;
+		}
+
 		if ( ! hasLoaded ) {
 			const storedCount = parseInt(
 				sessionStorage.getItem( 'jetpack-subscription-modal-shown-count' )
@@ -43,33 +106,25 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 			modal.classList.toggle( 'open' );
 			hasLoaded = true;
-			redirectUrl = data.url;
+			redirectUrl = subscriptionData.url;
+			subscriptionData = data;
 			return;
 		}
 	}
 
 	window.addEventListener( 'message', JetpackSubscriptionModalOnCommentMessageListener );
 
-	function reloadOnCloseSubscriptionModal() {
-		const destinationUrl = new URL( redirectUrl );
-
-		// current URL without hash
-		const currentUrlWithoutHash = location.href.replace( location.hash, '' );
-		// destination URL without hash
-		const destinationUrlWithoutHash = destinationUrl.href.replace( destinationUrl.hash, '' );
-		window.location.href = redirectUrl;
-
-		// reload the page if the user is already on the comment page
-		if ( currentUrlWithoutHash === destinationUrlWithoutHash ) {
-			window.location.reload();
-		}
-	}
-
 	if ( close ) {
 		close.onclick = function ( event ) {
 			event.preventDefault();
 			modal.classList.toggle( 'open' );
 			reloadOnCloseSubscriptionModal();
+		};
+	}
+
+	if ( subscribeBtn ) {
+		subscribeBtn.onclick = function () {
+			showSubscriptionIframe( subscriptionData );
 		};
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack/pull/34659

## Proposed changes:
Use custom input + button for subscription modal instead of using the Subscriptions block.
The input is disabled for logged-in users as the subscription endpoint won't let you use another email when you are logged-in.

## Testing instructions:
* Follow instructions from here: https://github.com/Automattic/jetpack/pull/34659#issuecomment-1857257562
* Go to a post with a non-site user (admin or editor)
* Comment on the post
* You should see the subscription modal
