### PR TITLE
[Boost] Fix importmap deferral

### DIFF
--- a/projects/packages/forms/changelog/boost-fix-importmap-deferral
+++ b/projects/packages/forms/changelog/boost-fix-importmap-deferral
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Bumped version numbers
+
+

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -62,7 +62,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.28.x-dev"
+			"dev-trunk": "0.29.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.28.0",
+	"version": "0.29.0-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.28.0';
+	const PACKAGE_VERSION = '0.29.0-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -218,8 +218,9 @@ class Render_Blocking_JS implements Pluggable {
 			// Scripts inside HTML comments.
 			'~<!--.*?-->~si',
 
-			// Scripts with application/json type
-			'~<script\s+[^\>]*type=(?<q>["\']*)application/json\k<q>.*?>.*?</script>~si',
+			// Scripts with types that do not execute complex code. Moving them down can be dangerous
+			// and does not benefit performance. Includes types: application/json and importmap.
+			'~<script\s+[^\>]*type=(?<q>["\']*)(application/json|importmap)\k<q>.*?>.*?</script>~si',
 		);
 
 		return preg_replace_callback(

--- a/projects/plugins/boost/changelog/boost-fix-importmap-deferral
+++ b/projects/plugins/boost/changelog/boost-fix-importmap-deferral
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Defer JS: added importmap to the exclusion list to fix compatibility issues.

--- a/projects/plugins/jetpack/changelog/boost-fix-importmap-deferral
+++ b/projects/plugins/jetpack/changelog/boost-fix-importmap-deferral
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1167,7 +1167,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "c72fbe74edbc293518b22c39de5c8f609e2f235b"
+                "reference": "0d1ea60cf2c7a86d515ae071330395de358d3791"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1193,7 +1193,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.28.x-dev"
+                    "dev-trunk": "0.29.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes compatibility with Gutenberg plugin / upcoming Gutenberg code.

`<script type="importmap">` blocks generally need to be at the top of the page, before anything that depends on them. They don't run complex code and moving them down the page can break it.

This PR addresses the problem by adding `importmap` to the set of script types excluded when deferring JS.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `type="importmap"` to the set of exclusions from deferred JS.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
** To replicate **
* Install the Gutenberg plugin
* Turn on Deferred JS
* Use an interactive block, like the Jetpack podcast player
* Spot an error in the console output -- `An import map is added after module script load was triggered.`

Then install this patch and verify the issue is resolved.

