### PR TITLE
Protect: Fix Modal and Popover z-index conflict

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-modal-popover-z-index-conflict
+++ b/projects/plugins/protect/changelog/fix-protect-modal-popover-z-index-conflict
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix Modal and Popover component styling conflict
+
+

--- a/projects/plugins/protect/src/js/components/modal/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/modal/styles.module.scss
@@ -9,7 +9,7 @@
     align-items: flex-start;
     padding-top: calc( var( --spacing-base ) * 12 + 2px ); // 98px
     background-color: rgba(0, 0, 0, 0.25);
-    z-index: 999999;
+    z-index: 1000001;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Currently, when a Modal and Popover component are active and overlap, the Popover sits on top of the Modal overlay.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Increase the Modal component z-index position to surpass that of the Popover

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/849

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch and start your Jurassic Tube
* Install Protect and proceed to upgrade
* From the Firewall tab, when the post-upgrade messaging Popover appears, verify that when you trigger the Standalone Mode Modal from the footer section, the Modal is displayed on top of the Popover

