### PR TITLE
Jetpack Boost: Add Action Endpoints

### DIFF
--- a/projects/js-packages/react-data-sync-client/changelog/update-boost-datasync-actions
+++ b/projects/js-packages/react-data-sync-client/changelog/update-boost-datasync-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add DataSync Actions

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -70,7 +70,13 @@ export function useDataSync<
 	params: Record< string, string | number > = {}
 ): DataSyncHook< Schema, Value > {
 	const datasync = new DataSync( namespace, key, schema );
-	const queryKey = [ key, ...Object.values( params ).sort() ];
+	const queryKey = [
+		key,
+		...Object.entries( params )
+			.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+			.map( ( [ , v ] ) => v ),
+	];
+
 	/**
 	 * Defaults for `useQuery`:
 	 * - `queryKey` is the key of the value that's being synced.

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -29,9 +29,11 @@ export function DataSyncProvider( props: { children: React.ReactNode } ) {
 /**
  * React Query configuration type for DataSync.
  */
+type DataSyncMutation< Value > = Omit< UseMutationOptions< Value >, 'mutationKey' >;
+type DataSyncQuery< Value > = Omit< UseQueryOptions< Value >, 'queryKey' >;
 type DataSyncConfig< Schema extends z.ZodSchema, Value extends z.infer< Schema > > = {
-	query?: Omit< UseQueryOptions< Value >, 'queryKey' >;
-	mutation?: Omit< UseMutationOptions< Value >, 'mutationKey' >;
+	query?: DataSyncQuery< Value >;
+	mutation?: DataSyncMutation< Value >;
 };
 /**
  * This is what `useDataSync` returns
@@ -47,6 +49,7 @@ type DataSyncHook< Schema extends z.ZodSchema, Value extends z.infer< Schema > >
  * @param key - The key of the value that's being synced.
  * @param schema - The Zod schema to validate the value against.
  * @param config - React Query configuration.
+ * @param params - key/value pairs to be used as GET parameters.
  * @returns A tuple of React Query hooks.
  * @see https://tanstack.com/query/v5/docs/react/reference/useQuery
  * @see https://tanstack.com/query/v5/docs/react/reference/useMutation
@@ -63,7 +66,7 @@ export function useDataSync<
 	params: Record< string, string | number > = {}
 ): DataSyncHook< Schema, Value > {
 	const datasync = new DataSync( namespace, key, schema );
-	const queryKey = [ key, ...Object.values( params ) ];
+	const queryKey = [ key, ...Object.values( params ).sort() ];
 	/**
 	 * Defaults for `useQuery`:
 	 * - `queryKey` is the key of the value that's being synced.
@@ -124,4 +127,163 @@ export function useDataSync<
 		useQuery( { ...queryConfigDefaults, ...config.query } ),
 		useMutation( { ...mutationConfigDefaults, ...config.mutation } ),
 	];
+}
+
+/**
+ * Use React Query mutations to dispatch custom DataSync Actions.
+ */
+
+export type DataSyncActionConfig<
+	ActionRequestSchema extends z.ZodSchema,
+	ActionRequestData extends z.infer< ActionRequestSchema >,
+	StateSchema extends z.ZodSchema,
+	ActionSchema extends z.ZodSchema,
+	ActionResult extends z.infer< ActionSchema >,
+	CurrentState extends z.infer< StateSchema >,
+> = {
+	/**
+	 * The project namespace, fore example: 'jetpack_boost_ds'
+	 */
+	namespace: string;
+
+	/**
+	 * The name of the DataSync option.
+	 */
+	key: string;
+
+	/**
+	 * The name of the DataSync action.
+	 */
+	action_name: string;
+
+	/**
+	 * The Zod schema for the DataSync state.
+	 */
+	schema: {
+		/**
+		 * The DataSync state schema
+		 */
+		state: StateSchema;
+		/**
+		 * The action endpoint response schema.
+		 */
+		action_response: ActionSchema;
+		/**
+		 * Data that's sent to the action endpoint.
+		 */
+		action_request: ActionRequestSchema;
+	};
+	callbacks?: {
+		/**
+		 * Callback that's called when the action is dispatched.
+		 * This is useful for optimistic updates, must return the new state.
+		 */
+		optimisticUpdate?: ( requestData: ActionRequestData, state: CurrentState ) => CurrentState;
+		/**
+		 * Callback that's called after the action endpoint response is received.
+		 * If a state object is returned, it will be used to update the state.
+		 */
+		onResult?: ( result: ActionResult, state: CurrentState ) => void | CurrentState;
+	};
+	/**
+	 * React Query mutation options passed to `useMutate`.
+	 * @see https://tanstack.com/query/v5/docs/react/reference/useMutation
+	 */
+	mutationOptions?: UseMutationOptions<
+		ActionResult,
+		unknown,
+		ActionRequestData,
+		{ previousValue: CurrentState }
+	>;
+	/**
+	 * GET parameters to be passed to the action endpoint.
+	 * These are used to build the query key.
+	 * @see https://tanstack.com/query/v5/docs/guides/query-keys
+	 */
+	params?: Record< string, string | number >;
+};
+export function useDataSyncAction<
+	StateSchema extends z.ZodSchema,
+	ActionSchema extends z.ZodSchema,
+	ActionRequestSchema extends z.ZodSchema,
+	ActionRequestData extends z.infer< ActionRequestSchema >,
+	ActionResult extends z.infer< ActionSchema >,
+	CurrentState extends z.infer< StateSchema >,
+>( {
+	namespace,
+	key,
+	action_name,
+	schema,
+	callbacks,
+	mutationOptions,
+	params,
+}: DataSyncActionConfig<
+	ActionRequestSchema,
+	ActionRequestData,
+	StateSchema,
+	ActionSchema,
+	ActionResult,
+	CurrentState
+> ) {
+	// @TODO: order sensitive bug is hiding in Object.values
+	// This `sort` of fixes it, but I'd like a more elegant solution.
+	const mutationKey = [ key, ...Object.values( params ).sort() ];
+	const datasync = new DataSync( namespace, key, schema.state );
+	const mutationConfigDefaults: UseMutationOptions<
+		ActionResult,
+		unknown,
+		ActionRequestData,
+		{
+			previousValue: CurrentState;
+		}
+	> = {
+		mutationKey,
+		mutationFn: async ( value: ActionRequestData ) => {
+			const result = await datasync.ACTION(
+				action_name,
+				schema.action_request.parse( value ),
+				schema.action_response
+			);
+			try {
+				const currentValue = queryClient.getQueryData< CurrentState >( mutationKey );
+				const processedResult = await callbacks.onResult( result, currentValue );
+
+				const data =
+					processedResult === undefined ? currentValue : schema.state.parse( processedResult );
+				if ( processedResult !== undefined ) {
+					queryClient.setQueryData( mutationKey, data );
+				}
+				return data;
+			} catch ( e ) {
+				return queryClient.getQueryData( mutationKey );
+			}
+		},
+		onMutate: async ( requestData: ActionRequestData ) => {
+			// Cancel any outgoing refetches
+			// (so they don't overwrite our optimistic update)
+			await queryClient.cancelQueries( { queryKey: mutationKey } );
+
+			// Snapshot the previous value
+			const previousValue = queryClient.getQueryData< CurrentState >( mutationKey );
+
+			if ( callbacks.optimisticUpdate ) {
+				const value = await callbacks.optimisticUpdate( requestData, previousValue );
+				queryClient.setQueryData( mutationKey, value );
+			}
+
+			// Return a context object with the snapshotted value
+			return { previousValue };
+		},
+		onError: ( _, __, context ) => {
+			queryClient.setQueryData( mutationKey, context.previousValue );
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( { queryKey: mutationKey } );
+		},
+	};
+
+	return useMutation< DataSyncMutation< CurrentState >, unknown, ActionRequestData >( {
+		...mutationConfigDefaults,
+		...mutationOptions,
+	} );
 }

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -83,7 +83,7 @@ export function useDataSync<
 	const queryConfigDefaults = {
 		queryKey,
 		queryFn: ( { signal } ) => datasync.GET( params, signal ),
-		initialData: datasync.getInitialValue(),
+		initialData: () => datasync.getInitialValue(),
 	};
 
 	/**

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -216,7 +216,7 @@ export function useDataSyncAction<
 	schema,
 	callbacks,
 	mutationOptions,
-	params,
+	params = {},
 }: DataSyncActionConfig<
 	ActionRequestSchema,
 	ActionRequestData,

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -12,7 +12,11 @@ import React from 'react';
 import { z } from 'zod';
 import { DataSync } from './DataSync';
 
-const queryClient = new QueryClient();
+/**
+ * @REACT-TODO This is temporary. We need to allow each app to define their own QueryClient.
+ * All of the functions below will have to be moved to a factory wrapper
+ */
+export const queryClient = new QueryClient();
 
 /**
  * React Query Provider for DataSync.
@@ -225,7 +229,7 @@ export function useDataSyncAction<
 	ActionResult,
 	CurrentState
 > ) {
-	// @TODO: order sensitive bug is hiding in Object.values
+	// @REACT-TODO: order sensitive bug is hiding in Object.values
 	// This `sort` of fixes it, but I'd like a more elegant solution.
 	const mutationKey = [ key, ...Object.values( params ).sort() ];
 	const datasync = new DataSync( namespace, key, schema.state );

--- a/projects/packages/wp-js-data-sync/changelog/update-boost-datasync-actions
+++ b/projects/packages/wp-js-data-sync/changelog/update-boost-datasync-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add DataSync Actions

--- a/projects/packages/wp-js-data-sync/src/class-data-sync.php
+++ b/projects/packages/wp-js-data-sync/src/class-data-sync.php
@@ -105,6 +105,27 @@ final class Data_Sync {
 	}
 
 	/**
+	 * Retrieve nonces for all action endpoints associated with a given entry.
+	 *
+	 * @param string $entry_key The key for the entry.
+	 * @return array An associative array of action nonces.
+	 */
+	private function get_action_nonces_for_entry( $entry_key ) {
+		// Assuming a method in Registry class to retrieve all action names for an entry
+		$action_names = $this->registry->get_action_names_for_entry( $entry_key );
+		$nonces       = array();
+
+		foreach ( $action_names as $action_name ) {
+			$nonce = $this->registry->get_action_nonce( $entry_key, $action_name );
+			if ( $nonce ) {
+				$nonces[ $action_name ] = $nonce;
+			}
+		}
+
+		return $nonces;
+	}
+
+	/**
 	 * Don't call this method directly.
 	 * It's only public so that it can be called as a hook
 	 *
@@ -127,6 +148,12 @@ final class Data_Sync {
 
 			if ( $entry->is( Lazy_Entry::class ) ) {
 				$data[ $key ]['lazy'] = true;
+			}
+
+			// Include nonces for action endpoints associated with this entry
+			$action_nonces = $this->get_action_nonces_for_entry( $key );
+			if ( ! empty( $action_nonces ) ) {
+				$data[ $key ]['actions'] = $action_nonces;
 			}
 		}
 
@@ -197,5 +224,9 @@ final class Data_Sync {
 		 */
 		$entry_adapter = new Data_Sync_Entry_Adapter( $entry, $parser );
 		$this->registry->register( $key, $entry_adapter );
+	}
+
+	public function register_action( $key, $action_name, $instance ) {
+		$this->registry->register_action( $key, $action_name, $instance );
 	}
 }

--- a/projects/packages/wp-js-data-sync/src/class-registry.php
+++ b/projects/packages/wp-js-data-sync/src/class-registry.php
@@ -11,6 +11,7 @@ namespace Automattic\Jetpack\WP_JS_Data_Sync;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Data_Sync_Entry;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
+use Automattic\Jetpack\WP_JS_Data_Sync\Endpoints\Action_Endpoint;
 use Automattic\Jetpack\WP_JS_Data_Sync\Endpoints\Endpoint;
 
 class Registry {
@@ -28,6 +29,8 @@ class Registry {
 	 * @var Data_Sync_Entry_Adapter[]
 	 */
 	private $entries = array();
+
+	private $action_endpoints = array();
 
 	/**
 	 * Store references for every Endpoint instance.
@@ -96,6 +99,59 @@ class Registry {
 		add_action( 'rest_api_init', array( $endpoint, 'register_rest_routes' ) );
 
 		return $entry;
+	}
+
+	/**
+	 * Register an action endpoint.
+	 *
+	 * @param string $key          The base key for the endpoint.
+	 * @param string $action_name  The name of the action.
+	 * @param mixed  $action_class The class handling the action logic.
+	 */
+	public function register_action( $key, $action_name, $action_class ) {
+		// Create and store the action endpoint instance
+		$action_endpoint = new Action_Endpoint(
+			$this->get_namespace_http(),
+			$this->sanitize_url_key( $key ),
+			$this->sanitize_url_key( $action_name ),
+			$action_class
+		);
+
+		// Store the action endpoint instance for nonce retrieval
+		$this->action_endpoints[ $key ][ $action_name ] = $action_endpoint;
+
+		// Register the REST route for the action endpoint
+		add_action( 'rest_api_init', array( $action_endpoint, 'register_rest_routes' ) );
+	}
+
+	/**
+	 * Retrieve all action names for a given entry.
+	 *
+	 * @param string $entry_key The key for the entry.
+	 *
+	 * @return array An array of action names.
+	 */
+	public function get_action_names_for_entry( $entry_key ) {
+		if ( isset( $this->action_endpoints[ $entry_key ] ) ) {
+			return array_keys( $this->action_endpoints[ $entry_key ] );
+
+		}
+		return array();
+	}
+
+	/**
+	 * Get the nonce for a specific action endpoint.
+	 *
+	 * @param string $key         The base key for the endpoint.
+	 * @param string $action_name The name of the action.
+	 *
+	 * @return false|string The nonce or false if not found.
+	 */
+	public function get_action_nonce( $key, $action_name ) {
+		if ( isset( $this->action_endpoints[ $key ][ $action_name ] ) ) {
+			return $this->action_endpoints[ $key ][ $action_name ]->create_nonce();
+		}
+		return false;
 	}
 
 	/**

--- a/projects/packages/wp-js-data-sync/src/contracts/interface-data-sync-action.php
+++ b/projects/packages/wp-js-data-sync/src/contracts/interface-data-sync-action.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Interface for action classes in the data sync system.
+ *
+ * @package automattic/jetpack-wp-js-data-sync
+ */
+
+namespace Automattic\Jetpack\WP_JS_Data_Sync\Contracts;
+
+/**
+ * Interface Action_Interface
+ */
+interface Data_Sync_Action {
+	/**
+	 * Handles the action logic.
+	 *
+	 * @param mixed $data JSON Data passed to the action.
+	 * @param \WP_REST_Request $request The request object.
+	 * @return mixed
+	 */
+	public function handle( $data, $request );
+}

--- a/projects/packages/wp-js-data-sync/src/endpoints/class-action-endpoint.php
+++ b/projects/packages/wp-js-data-sync/src/endpoints/class-action-endpoint.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Register and handle custom action REST API Endpoints for data sync entries.
+ *
+ * @package automattic/jetpack-wp-js-data-sync
+ */
+
+namespace Automattic\Jetpack\WP_JS_Data_Sync\Endpoints;
+
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Data_Sync_Action;
+
+class Action_Endpoint {
+
+	/**
+	 * @var Data_Sync_Action  - The class that handles the action.
+	 */
+	private $action_class;
+	/**
+	 * @var string $rest_namespace - The namespace for the REST API endpoint.
+	 */
+	private $rest_namespace;
+
+	/**
+	 * @var string $route - The route for the REST API endpoint.
+	 */
+	private $route;
+
+	/**
+	 * @var Authenticated_Nonce $nonce - The nonce for the REST API endpoint.
+	 */
+	private $nonce;
+
+	/**
+	 * @param $namespace
+	 * @param $route
+	 * @param $action_class
+	 */
+	public function __construct( $namespace, $key, $action_name, $action_class ) {
+		$this->action_class   = $action_class;
+		$this->rest_namespace = $namespace;
+		$this->route          = $key . '/action/' . $action_name;
+		$this->nonce          = new Authenticated_Nonce( "{$namespace}_{$this->route}_action" );
+	}
+
+	public function register_rest_routes() {
+		register_rest_route(
+			$this->rest_namespace,
+			$this->route,
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'handle_action' ),
+				'permission_callback' => array( $this, 'permissions' ),
+			)
+		);
+	}
+
+	public function handle_action( $request ) {
+		try {
+			$params = $request->get_json_params();
+			$data   = isset( $params['JSON'] ) ? $params['JSON'] : null;
+			// Delegate to the action handler
+			$result = $this->action_class->handle( $data, $request );
+			if ( is_wp_error( $result ) ) {
+				throw new \RuntimeException( $result->get_error_message() );
+			}
+			return rest_ensure_response(
+				array(
+					'status' => 'success',
+					'JSON'   => $result,
+				)
+			);
+		} catch ( \Error $e ) {
+			return rest_ensure_response(
+				new \WP_Error( 500, $e->getMessage(), array( 'status' => 500 ) )
+			);
+		}
+	}
+
+	public function create_nonce() {
+		return $this->nonce->create();
+	}
+
+	/**
+	 * @param \WP_REST_Request $request
+	 */
+	public function permissions( $request ) {
+		$nonce = $request->get_header( 'X-Jetpack-WP-JS-Sync-Nonce' );
+		return $this->nonce->verify( $nonce ) && current_user_can( 'manage_options' );
+	}
+}


### PR DESCRIPTION
## Proposed changes:
This adds `useDataSyncAction` and the PHP endpoint handlers, allowing to create custom endpoints that can mutate data if necessary without passing the whole state back & forth.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
This patch is scoped to only include the package code - there's no direct implementation to test.

For implementation example, see #34599

* `jetpack_boost_register_action()` utility function: https://github.com/Automattic/jetpack/blob/49cd57ce20b8affed327e8794aaa6ccfe647bfdd/projects/plugins/boost/wp-js-data-sync.php#L32-L43

* Register PHP Endpoint: https://github.com/Automattic/jetpack/blob/49cd57ce20b8affed327e8794aaa6ccfe647bfdd/projects/plugins/boost/app/modules/image-size-analysis/data-sync/init.php#L78

* PHP Endpoint: https://github.com/Automattic/jetpack/blob/49cd57ce20b8affed327e8794aaa6ccfe647bfdd/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Fixer_Action.php#L12-L66

* useDataSyncAction implementation: https://github.com/Automattic/jetpack/blob/49cd57ce20b8affed327e8794aaa6ccfe647bfdd/projects/plugins/boost/app/assets/src/js/features/image-size-analysis/lib/image-fixer.ts#L22-L58

* React usage: https://github.com/Automattic/jetpack/blob/49cd57ce20b8affed327e8794aaa6ccfe647bfdd/projects/plugins/boost/app/assets/src/js/features/image-size-analysis/recommendations/table/table.tsx#L43-L50
