### PR TITLE
Contact Form: suppress PHP warning

### DIFF
--- a/projects/packages/forms/changelog/udpate-contact-form-suppress-warning
+++ b/projects/packages/forms/changelog/udpate-contact-form-suppress-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: suppress PHP warning

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -354,7 +354,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$url                     = apply_filters( 'grunion_contact_form_form_action', "{$url}#contact-form-{$id}", $GLOBALS['post'], $id );
 			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' );
 			$form_classes            = 'contact-form commentsblock';
-			$form_accessible_name    = $attributes['formTitle'] ? $attributes['formTitle'] : $post->post_title;
+			$form_accessible_name    = isset( $attributes['formTitle'] ) && ! empty( $attributes['formTitle'] ) ? $attributes['formTitle'] : $post->post_title;
 			$form_aria_label         = isset( $form_accessible_name ) && ! empty( $form_accessible_name ) ? 'aria-label="' . esc_attr( $form_accessible_name ) . '"' : '';
 
 			if ( $has_submit_button_block ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -354,7 +354,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$url                     = apply_filters( 'grunion_contact_form_form_action', "{$url}#contact-form-{$id}", $GLOBALS['post'], $id );
 			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' );
 			$form_classes            = 'contact-form commentsblock';
-			$form_accessible_name    = isset( $attributes['formTitle'] ) && ! empty( $attributes['formTitle'] ) ? $attributes['formTitle'] : $post->post_title;
+			$form_accessible_name    = ! empty( $attributes['formTitle'] ) ? $attributes['formTitle'] : $post->post_title;
 			$form_aria_label         = isset( $form_accessible_name ) && ! empty( $form_accessible_name ) ? 'aria-label="' . esc_attr( $form_accessible_name ) . '"' : '';
 
 			if ( $has_submit_button_block ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR suppresses the following PHP warning triggered by the Contact Form: `Undefined array key "formTitle" in /usr/local/src/jetpack-monorepo/projects/packages/forms/src/contact-form/class-contact-form.php on line 357`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Make sure you can see the server logs: `jetpack docker tail`
- Create a new post
- Add a _Contact Form_ block
- Open the preview
- Notice you don't see the warning mentioned above
- Go back to the editor
- Add a heading 2 before the form
- In the preview, check that the form has an `aria-label` attribute of which the value is the content of the heading 2
