### PR TITLE
AI Helper: Add moderation and max tokens

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -208,7 +208,25 @@ class Jetpack_AI_Helper {
 				),
 			);
 
-			$result = ( new OpenAI( 'openai', array( 'post_id' => $post_id ) ) )->request_chat_completion( $data );
+			$openai            = new OpenAI( 'openai', array( 'post_id' => $post_id ) );
+			$moderation_result = $openai->moderate(
+				implode(
+					' ',
+					array_map(
+						function ( $msg ) {
+							return $msg['role'] === 'user' ? $msg['content'] : '';
+						},
+						$data
+					)
+				)
+			);
+
+			if ( is_wp_error( $moderation_result ) ) {
+				return $moderation_result;
+			}
+
+			$max_tokens = 480; // Default
+			$result     = $openai->request_chat_completion( $data, $max_tokens );
 
 			if ( is_wp_error( $result ) ) {
 				return $result;

--- a/projects/plugins/jetpack/changelog/update-ai-helper
+++ b/projects/plugins/jetpack/changelog/update-ai-helper
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Because it's not user-facing or something a user needs to know about.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Moves the moderation check and sets the max_tokens from OpenAI()->request_chat_completion() to the client. 

### Other information:
In D132096-code we updated the jetpack-ai-query endpoint to not hardcode `openai` as the default feature. A side effect of that was making these checks required for every feature calling `request_chat_completion`, which in turn had side effects of some internal features not working, since they needed more tokens - also, some of the features were already doing their own moderation calls, so making that default behavior in a shared method adds unnecessary latency and requests. 

Once this code is deployed to wpcom, we'll be able to remove the default checks from request_chat_completion method and update the jetpack-ai-query endpoint to do the same. This is being handled in D132925-code. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1703182024064289-slack-C069HLHBMRP

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

jetpack rsync to wpcom 
I'm not actually sure what feature uses this. 
It sounds like there is nothing currently actually using this. p1703187120335959-slack-C054LN8RNVA 