### PR TITLE
[Plugin Installer] Ensure language packs get installed when installing plugins

### DIFF
--- a/projects/packages/plugins-installer/changelog/fix-language-installation
+++ b/projects/packages/plugins-installer/changelog/fix-language-installation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure that language packs are installed after installing a new plugin

--- a/projects/packages/plugins-installer/src/class-plugins-installer.php
+++ b/projects/packages/plugins-installer/src/class-plugins-installer.php
@@ -74,6 +74,9 @@ class Plugins_Installer {
 			return new WP_Error( 'not_allowed', __( 'You are not allowed to install plugins on this site.', 'jetpack-plugins-installer' ) );
 		}
 
+		// Initialize admin filters to make sure WordPress post-install hooks run. Handles things like language packs.
+		include_once ABSPATH . '/wp-admin/includes/admin-filters.php';
+
 		$skin     = new Automatic_Install_Skin();
 		$upgrader = new Plugin_Upgrader( $skin );
 		$zip_url  = self::generate_wordpress_org_plugin_download_link( $slug );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jpop-issues/issues/8747

When installing Boost or CRM from My Jetpack, appropriate language packs were not being installed. This PR addresses this by allowing the usual admin-hooks that occur after installing a plugin to run when installing via My Jetpack / the plugin installer.

Props to @dilirity for doing the investigation work behind this.

## Proposed changes:
* Load admin-filters before installing plugins, so that WordPress can run post-install processes on installation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jetpack
* Set the language to French
* Make sure that Jetpack is properly in French
* Use "My Jetpack" to install Jetpack Boost
* Ensure that the appropriate language pack is installed automatically, and the Boost UI is in French.

**Notes**
I've noticed that My Jetpack shows Boost's plan selection page twice if you choose the free version.
- The first time it shows, Jetpack is showing the "Choose a plan" component itself without having installed Boost.
- It then installs Boost when you click on a plan / free
- Then Boost shows its getting started / choose a plan screen.

If you see that, please remember that the first screen will show in the language pack that *Jetpack* is using. The second time it is *Boost* and its language pack. I recommend getting past the "Getting started" process to ensure boost is in French appropriately while testing this issue.

I've filed a report of the duplicate-screen bug here: https://github.com/Automattic/jetpack/issues/34764