### PR TITLE
Remove jetpack connection banners from non-Jetpack pages

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -118,29 +118,6 @@ abstract class Jetpack_Admin_Page {
 
 		// Attach page specific actions in addition to the above.
 		$this->add_page_actions( $hook );
-
-		// If the current user can connect Jetpack, Jetpack isn't connected, and is not in offline mode, let's prompt!
-		if ( current_user_can( 'jetpack_connect' ) && $connectable ) {
-			$this->add_connection_banner_actions();
-		}
-	}
-
-	/**
-	 * Hooks to add when Jetpack is not active or in offline mode for an user capable of connecting.
-	 */
-	private function add_connection_banner_actions() {
-		global $pagenow;
-		// If someone just activated Jetpack, let's show them a fullscreen connection banner.
-		if ( ( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'jetpack' === $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_banner_scripts' ) );
-			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_connect_button_scripts' ) );
-			delete_transient( 'activated_jetpack' );
-		}
-
-		// If Jetpack not yet connected, but user is viewing one of the pages with a Jetpack connection banner.
-		if ( ( 'index.php' === $pagenow || 'plugins.php' === $pagenow ) ) {
-			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_connect_button_scripts' ) );
-		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/remove-jetpack-connection-banners
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-connection-banners
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove Jetpack connection banners from WP dashboard and plugins page

--- a/projects/plugins/jetpack/class-jetpack-connection-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-connection-widget.php
@@ -5,6 +5,7 @@ use Automattic\Jetpack\Assets\Logo;
 
 /**
  * Jetpack connection dashboard widget.
+ * DEPRECATED in v 13.0
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/class.jetpack-connection-banner.php
+++ b/projects/plugins/jetpack/class.jetpack-connection-banner.php
@@ -1,6 +1,7 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * Jetpack connection banner.
+ * DEPRECATED
  *
  * @package automattic/jetpack
  */
@@ -11,6 +12,7 @@ use Automattic\Jetpack\Licensing;
 
 /**
  * Jetpack connection banner.
+ * DEPRECATED - this banner has been removed as of version 13.0
  */
 class Jetpack_Connection_Banner {
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -751,6 +751,7 @@ class Jetpack {
 		// Returns HTTPS support status.
 		add_action( 'wp_ajax_jetpack-recheck-ssl', array( $this, 'ajax_recheck_ssl' ) );
 
+		// TODO: the conneciton banner has been deprecated - this can be removed in 13.1+
 		add_action( 'wp_ajax_jetpack_connection_banner', array( $this, 'jetpack_connection_banner_callback' ) );
 
 		add_action( 'wp_loaded', array( $this, 'register_assets' ) );
@@ -3327,11 +3328,6 @@ p {
 		$fallback_no_verify_ssl_certs = Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' );
 		/** Already documented in automattic/jetpack-connection::src/class-client.php */
 		$client_verify_ssl_certs = apply_filters( 'jetpack_client_verify_ssl_certs', false );
-
-		if ( ! $is_offline_mode ) {
-			Jetpack_Connection_Banner::init();
-			Jetpack_Connection_Widget::init();
-		}
 
 		if ( ( self::is_connection_ready() || $is_offline_mode ) && false === $fallback_no_verify_ssl_certs && ! $client_verify_ssl_certs ) {
 			// Upgrade: 1.1 -> 1.1.1

--- a/projects/plugins/jetpack/tests/e2e/specs/pre-connection/pre-connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/pre-connection/pre-connection.test.js
@@ -1,10 +1,4 @@
-import {
-	Sidebar,
-	PluginsPage,
-	DashboardPage,
-	JetpackPage,
-} from 'jetpack-e2e-commons/pages/wp-admin/index.js';
-import { execWpCommand } from 'jetpack-e2e-commons/helpers/utils-helper.js';
+import { Sidebar, DashboardPage, JetpackPage } from 'jetpack-e2e-commons/pages/wp-admin/index.js';
 import { prerequisitesBuilder } from 'jetpack-e2e-commons/env/index.js';
 import { test, expect } from 'jetpack-e2e-commons/fixtures/base-test.js';
 import playwrightConfig from '../../playwright.config.mjs';
@@ -17,29 +11,6 @@ test.beforeAll( async ( { browser } ) => {
 
 test.beforeEach( async ( { page } ) => {
 	await DashboardPage.visit( page );
-} );
-
-test( 'Connect button is displayed on plugins page', async ( { page } ) => {
-	await ( await Sidebar.init( page ) ).selectInstalledPlugins();
-
-	const pluginsPage = await PluginsPage.init( page );
-	await execWpCommand( 'transient set activated_jetpack true 120' );
-	await pluginsPage.reload();
-
-	expect(
-		await pluginsPage.isFullScreenPopupShown(),
-		'Full screen pop-up should be displayed'
-	).toBeTruthy();
-} );
-
-test( 'Connect button is displayed on dashboard page', async ( { page } ) => {
-	await ( await Sidebar.init( page ) ).selectDashboard();
-
-	const dashboard = await DashboardPage.init( page );
-	expect(
-		await dashboard.isConnectBannerVisible(),
-		'Connect banner should be visible'
-	).toBeTruthy();
 } );
 
 test( 'Connect button is displayed  on Jetpack page', async ( { page } ) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This diff removes the Jetpack connection banners from wp-admin pages that are not Jetpack pages.
* The banner currently shows on the wp-admin dashboard and plugins page if Jetpack is not connected (see image below)
![Screenshot 2023-12-22 at 9 36 48 AM](https://github.com/Automattic/jetpack/assets/18016357/b955bf1f-1016-4d2f-bcd9-2e99d67cd9a9)

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbNhbs-922-p2#comment-19163

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch locally or using the Jetpack Beta plugin. If you are testing on your local install, you may need to reset the Jetpack Options
* DO NOT Connect Jetpack 
* Visit the wp-admin dashboard and plugins page and confirm that the connection banner (shown above) does not appear
* Make sure the full-screen connection component still shows at Jetpack > dashboard and that you can connect the site from here.