### PR TITLE
Remove jetpack recommendation banners from non jetpack pages in wp-admin

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-jetpack-recommendation-banners
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-recommendation-banners
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove the recommendations banner from non-jetpack wp-admin pages

--- a/projects/plugins/jetpack/class-jetpack-recommendations-banner.php
+++ b/projects/plugins/jetpack/class-jetpack-recommendations-banner.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Displays the site type recommendations question as a banner.
+ * DEPRECATED in v 13.0
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -599,22 +599,6 @@ class Jetpack_Admin {
 			return false;
 		}
 
-		// Disable all JITMs on pages where the recommendations banner is displaying.
-		if (
-			in_array(
-				$screen_id,
-				array(
-					'dashboard',
-					'plugins',
-					'jetpack_page_stats',
-				),
-				true
-			)
-			&& \Jetpack_Recommendations_Banner::can_be_displayed()
-		) {
-			return false;
-		}
-
 		return $value;
 	}
 }

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -753,8 +753,6 @@ class Jetpack {
 
 		add_action( 'wp_ajax_jetpack_connection_banner', array( $this, 'jetpack_connection_banner_callback' ) );
 
-		add_action( 'wp_ajax_jetpack_recommendations_banner', array( 'Jetpack_Recommendations_Banner', 'ajax_callback' ) );
-
 		add_action( 'wp_loaded', array( $this, 'register_assets' ) );
 
 		/**
@@ -3341,8 +3339,6 @@ p {
 			$args = array();
 			Client::_wp_remote_request( self::connection()->api_url( 'test' ), $args, true );
 		}
-
-		Jetpack_Recommendations_Banner::init();
 
 		if ( current_user_can( 'manage_options' ) && ! self::permit_ssl() ) {
 			add_action( 'jetpack_notices', array( $this, 'alert_auto_ssl_fail' ) );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This diff removes the Jetpack recommendations banner from non-jetpack wp-admin pages

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbNhbs-922-p2#comment-19163

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to a fresh install using the beta plugin
* Connect Jetpack
* Typically, following connection, you are presented with a recommendations guide banner that shows on the admin dashboard and plugins page:
![Screenshot 2023-12-22 at 10 22 42 AM](https://github.com/Automattic/jetpack/assets/18016357/f434d4fb-f976-4fc7-a4a6-198a9efea157)
* Confirm that, with this patch, the recommendations banner no longer shows on the dashboard or plugins page after connecting Jetpack