### PR TITLE
Fix fonts not loading in editor when Gutenberg not activated, or when the post type has any metabox registered for it

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fonts-not-loading-in-gutenberg-editor
+++ b/projects/plugins/jetpack/changelog/fix-fonts-not-loading-in-gutenberg-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Editor: Fix missing fonts issue in Gutenberg editor

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -43,12 +43,11 @@ class Jetpack_Google_Font_Face {
 	 * Turn off hooks to print fonts on wp-admin, except for GB editor pages.
 	 */
 	public function current_screen() {
-		if ( $this->is_block_editor() ) {
-			return;
-		}
-
 		remove_action( 'admin_print_styles', 'wp_print_fonts', 50 );
-		remove_action( 'admin_print_styles', 'wp_print_font_faces', 50 );
+
+		if ( ! $this->is_block_editor() ) {
+			remove_action( 'admin_print_styles', 'wp_print_font_faces', 50 );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -24,6 +24,7 @@ class Jetpack_Google_Font_Face {
 	public function __construct() {
 		// Turns off hooks to print fonts
 		add_action( 'wp_loaded', array( $this, 'wp_loaded' ) );
+		add_action( 'current_screen', array( $this, 'current_screen' ), 10 );
 
 		// Collect and print fonts in use
 		add_action( 'wp_head', array( $this, 'print_font_faces' ), 50 );
@@ -36,6 +37,18 @@ class Jetpack_Google_Font_Face {
 	public function wp_loaded() {
 		remove_action( 'wp_head', 'wp_print_fonts', 50 );
 		remove_action( 'wp_head', 'wp_print_font_faces', 50 );
+	}
+
+	/**
+	 * Turn off hooks to print fonts on wp-admin, except for GB editor pages.
+	 */
+	public function current_screen() {
+		if ( $this->is_block_editor() ) {
+			return;
+		}
+
+		remove_action( 'admin_print_styles', 'wp_print_fonts', 50 );
+		remove_action( 'admin_print_styles', 'wp_print_font_faces', 50 );
 	}
 
 	/**
@@ -191,5 +204,21 @@ class Jetpack_Google_Font_Face {
 		}
 
 		return $font_family;
+	}
+
+	/**
+	 * Check if the current screen is the block editor.
+	 *
+	 * @return bool
+	 */
+	public function is_block_editor() {
+		if ( function_exists( 'get_current_screen' ) ) {
+			$current_screen = get_current_screen();
+			if ( ! empty( $current_screen ) && method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -28,6 +28,7 @@ class Jetpack_Google_Font_Face {
 
 		// Collect and print fonts in use
 		add_action( 'wp_head', array( $this, 'print_font_faces' ), 50 );
+		add_action( 'admin_head', array( $this, 'print_font_faces' ), 50 );
 		add_filter( 'pre_render_block', array( $this, 'collect_block_fonts' ), 10, 2 );
 	}
 

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -24,11 +24,9 @@ class Jetpack_Google_Font_Face {
 	public function __construct() {
 		// Turns off hooks to print fonts
 		add_action( 'wp_loaded', array( $this, 'wp_loaded' ) );
-		add_action( 'admin_init', array( $this, 'admin_init' ), 10 );
 
 		// Collect and print fonts in use
 		add_action( 'wp_head', array( $this, 'print_font_faces' ), 50 );
-		add_action( 'admin_head', array( $this, 'print_font_faces' ), 50 );
 		add_filter( 'pre_render_block', array( $this, 'collect_block_fonts' ), 10, 2 );
 	}
 
@@ -38,14 +36,6 @@ class Jetpack_Google_Font_Face {
 	public function wp_loaded() {
 		remove_action( 'wp_head', 'wp_print_fonts', 50 );
 		remove_action( 'wp_head', 'wp_print_font_faces', 50 );
-	}
-
-	/**
-	 * Turn off hooks to print fonts on wp-admin
-	 */
-	public function admin_init() {
-		remove_action( 'admin_print_styles', 'wp_print_fonts', 50 );
-		remove_action( 'admin_print_styles', 'wp_print_font_faces', 50 );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34777

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We noticed that when we installed Sensei on WPCOM, the fonts on in the editors of any of our custom post types (Courses, Lessons, Questions etc) didn't match the Theme's fonts. They always fell back to the default themes. So the editor looked broken.

But the Posts and Pages post type editors look alright and the fonts were loading. So it appeared that there was something wrong with Sensei's CPTs. I created a couple more new CPTs and they were good too. So, the issue was with Sensei's CPTs only, not just any CPT. So I tried to find what's wrong with Sensei's CPT. I created a couple of new CPTs with matching CPT configuration of Sensei's Course and Lesson CPT, but to no avail, the issue wasn't reproduced. It also wasn't reproduced locally. So the issue could be caused from anywhere, Sensei, Calypso, Gutenberg, Jetpack or somewhere very specific to WPCOM.

So, then I tried finding differences visually in the editor. And noticed that all of Sensei's editable post types have one or more metaboxes registered to them (using `add_meta_box`). So I added a metabox to one of my new CPTs with a snippet, and only then, I could replicate, fonts were not loading for that particular CPT in editor now as well.

So, the issue boiled down to - If a CPT has any metabox attached, the fonts don't load.

But out of curiosity, I tried another thing. I deactivated Gutenberg plugin. And after that, fonts stopped loading for all Posts and Pages as well. So now no Gutenberg editor for any post types were loading any fonts and was falling back to default.

So it's not only metabox issue, also Gutenberg had something to do with it. But happens only on wpcom, so based on everything, it looked like it could be on Calypso or Jetpack.

So after digging in, I found this code, where fonts are removed from both frontend and backend ('wp_head' and 'admin_print_styles') but then re-added only for 'wp_head', which means fonts don't get printed on the Admin side. Which explained why we didn't get the fonts in the editor side. That's why I've attached the font print action to 'admin_head' and that fixed the issue.

https://github.com/Automattic/jetpack/blob/47a0f6903d08f429e17c6c1a6c7eb60d4e3309fb/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php#L30-L48

Though it got fixed, a question remained. Why did it only happen with CPTs with metaboxes when Gutenberg was activated? And why it started happening all over after Gutenberg was disabled?

Well, this answer is not in Jetpack's code, it's in Gutenberg, and in two different places there -

In Gutenberg, there's this following piece of compat code that manually attaches the fonts to the CSS of the editor.
https://github.com/WordPress/gutenberg/blob/c2a54cd28ecab83d7f770cfbf9e8db3649f0f960/lib/compat/wordpress-6.4/fonts/fonts.php#L65-L78

So even though we removed the font printing in Jetpack, we can't see the effect of it as it gets attached from a separate place.

But that still doesn't explain the metabox. This was probably the final piece in the puzzle. The code above attaches the fonts only to the iframe of the editor. But when the CPT has any metaboxes, Gutenberg editor is not loaded in an iframe, that's why these font styles didn't get attached. You can see the logic for loading iframe below -
https://github.com/WordPress/gutenberg/blob/c2a54cd28ecab83d7f770cfbf9e8db3649f0f960/packages/edit-post/src/components/visual-editor/index.js#L74-L77

So this is how it looks before and after the fix -

#### Before
https://github.com/Automattic/jetpack/assets/6820724/d9c3f2cf-1861-4374-8522-4905dc55c0e6

#### After
https://github.com/Automattic/jetpack/assets/6820724/3d04985d-a87d-489d-b433-5ab24f15558d

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Could be related https://github.com/Automattic/wp-calypso/issues/84611

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply this to your WoA site
2. Add a metabox to the `post` Post Type. You can use the snippet added below
```
add_action( 'init', function() {
	add_action( 'add_meta_boxes', 'add_metas', 1 );
} );

function add_metas() {
	add_meta_box( 'random-metabox', 'RandomMetabox', 'add_a_metabox', 'post', 'side', 'high' );
}

function add_a_metabox() {

}
```
3. Install Course theme (You can use any other theme also)
4. Go to Posts -> Add New Post
5. Add a Header block (h1)
6. Make sure the font looks the same as it does in the **After** video above (League Gothic font)
7. Now deactivate Gutenberg and make sure the font still looks the same
8. Now switch to Trunk and apply those changes to your WoA
9. Check that the fonts have changed
10. Enable Gutenberg, the font should still not be the correct one
11. Now remove the snippet. It should be alright again.
