### PR TITLE
Backport mu-wpcom-plugin 2.0.9, jetpack 13.0-a.9 Changes

### DIFF
--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0] - 2023-12-25
+### Added
+- Contact Form: add accessible name to form [#34667]
+- Contact Form: add date format to date picker [#34743]
+
+### Fixed
+- Contact Form: suppress PHP warning [#34756]
+
 ## [0.28.0] - 2023-12-20
 ### Added
 - Contact Form: add extra field settings to base field. [#34704]
@@ -441,6 +449,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.29.0]: https://github.com/automattic/jetpack-forms/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/automattic/jetpack-forms/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/automattic/jetpack-forms/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/automattic/jetpack-forms/compare/v0.25.0...v0.26.0

--- a/projects/packages/forms/changelog/add-contact-form-accessible-name
+++ b/projects/packages/forms/changelog/add-contact-form-accessible-name
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Contact Form: add accessible name to form

--- a/projects/packages/forms/changelog/add-contact-form-date-format
+++ b/projects/packages/forms/changelog/add-contact-form-date-format
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Contact Form: add date format to date picker

--- a/projects/packages/forms/changelog/boost-fix-importmap-deferral
+++ b/projects/packages/forms/changelog/boost-fix-importmap-deferral
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Bumped version numbers
-
-

--- a/projects/packages/forms/changelog/udpate-contact-form-suppress-warning
+++ b/projects/packages/forms/changelog/udpate-contact-form-suppress-warning
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Contact Form: suppress PHP warning

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.29.0-alpha",
+	"version": "0.29.0",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.29.0-alpha';
+	const PACKAGE_VERSION = '0.29.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.0] - 2023-12-25
+### Removed
+- Remove a nag for domains without a verified email [#34385]
+- Removed Launchpad task for domain email verification. [#34387]
+
 ## [5.5.0] - 2023-12-15
 ### Changed
 - Updates the WC visibility check to use the `is_plugin_active` function. [#34648]
@@ -487,6 +492,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.6.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.5.0...v5.6.0
 [5.5.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.4.0...v5.5.0
 [5.4.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.3.0...v5.4.0
 [5.3.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.2.0...v5.3.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-confirm-domain-email-launchpad-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-confirm-domain-email-launchpad-task
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Removed Launchpad task for domain email verification.

--- a/projects/packages/jetpack-mu-wpcom/changelog/revert-33390-add-domains-email-nag
+++ b/projects/packages/jetpack-mu-wpcom/changelog/revert-33390-add-domains-email-nag
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Remove a nag for domains without a verified email

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.6.0-alpha",
+	"version": "5.6.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.6.0-alpha';
+	const PACKAGE_VERSION = '5.6.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.1 - 2023-12-25
+### Changed
+- Update dependencies.
+
 ## 0.15.0 - 2023-12-11
 ### Added
 - Introduced the plan usage API route porting to wpcom. [#34516]

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.15.0';
+	const VERSION = '0.15.1';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2023-12-25
+### Added
+- Stats: added passing select UTM parameters to Tracking Pixel requests. [#34431]
+
 ## [0.8.0] - 2023-12-11
 ### Changed
 - Permit overriding cache when retrieving top posts. [#34153]
@@ -114,6 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.9.0]: https://github.com/Automattic/jetpack-stats/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Automattic/jetpack-stats/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/Automattic/jetpack-stats/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/Automattic/jetpack-stats/compare/v0.7.0...v0.7.1

--- a/projects/packages/stats/changelog/add-utm-tracking
+++ b/projects/packages/stats/changelog/add-utm-tracking
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Stats: added passing select UTM parameters to Tracking Pixel requests.

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.6] - 2023-12-25
+### Changed
+- Internal updates.
+
 ## [0.21.5] - 2023-12-20
 ### Changed
 - Updated package dependencies. [#34694]
@@ -1217,9 +1221,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
-[0.21.3.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.3...v0.21.3.1
+[0.21.6]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.5...v0.21.6
 [0.21.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.4...v0.21.5
 [0.21.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.3...v0.21.4
+[0.21.3.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.3...v0.21.3.1
 [0.21.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.2...v0.21.3
 [0.21.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.1...v0.21.2
 [0.21.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.0...v0.21.1

--- a/projects/packages/videopress/changelog/prerelease
+++ b/projects/packages/videopress/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Janitorial changes.
-
-

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.21.6-alpha",
+	"version": "0.21.6",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.21.6-alpha';
+	const PACKAGE_VERSION = '0.21.6';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2] - 2023-12-25
+### Changed
+- Improve top-level WP-CLI command description [#34745]
+
 ## [0.12.1] - 2023-11-21
 
 ## [0.12.0] - 2023-11-20
@@ -245,6 +249,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.12.2]: https://github.com/Automattic/jetpack-waf/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/Automattic/jetpack-waf/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Automattic/jetpack-waf/compare/v0.11.15...v0.12.0
 [0.11.15]: https://github.com/Automattic/jetpack-waf/compare/v0.11.14...v0.11.15

--- a/projects/packages/waf/changelog/improve-jetpack-waf-command-description
+++ b/projects/packages/waf/changelog/improve-jetpack-waf-command-description
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Improve top-level WP-CLI command description

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.0-a.9 - 2023-12-25
+### Enhancements
+- Added description and link inviting to disable legacy sharing module if block is available [#34759]
+- Social Menu & Social Media Icons: Add support for the Bluesky service. [#34738]
+
+### Bug fixes
+- Subscribe Modal: Fix fatal under exceptional conditions [#34758]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Admin Page: remove alt attribute from decorative icon. [#34715]
+- On wpcom sites if SEO tools not supported by current plan we show upsell message. [#34725]
+- Remove the recommendations banner from non-jetpack wp-admin pages [#34769]
+
 ## 13.0-a.7 - 2023-12-20
 ### Enhancements
 - Sharing Buttons Block: update the admin's setting screen when the sharing block is available. [#34673]

--- a/projects/plugins/jetpack/changelog/add-bluesky-icon
+++ b/projects/plugins/jetpack/changelog/add-bluesky-icon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Social Menu & Social Media Icons: Add support for the Bluesky service.

--- a/projects/plugins/jetpack/changelog/fix-admin-plan-icon-alt
+++ b/projects/plugins/jetpack/changelog/fix-admin-plan-icon-alt
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Admin Page: remove alt attribute from decorative icon.

--- a/projects/plugins/jetpack/changelog/fix-subscribe-modal-fatal
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-modal-fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscribe Modal: Fix fatal under exceptional conditions

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.0-a.10
+
+

--- a/projects/plugins/jetpack/changelog/presale-seo-tools-feature
+++ b/projects/plugins/jetpack/changelog/presale-seo-tools-feature
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-On wpcom sites if SEO tools not supported by current plan we show upsell message. 

--- a/projects/plugins/jetpack/changelog/remove-jetpack-recommendation-banners
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-recommendation-banners
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Remove the recommendations banner from non-jetpack wp-admin pages

--- a/projects/plugins/jetpack/changelog/sharing-block-wp-settings-suggest-deactivating-module
+++ b/projects/plugins/jetpack/changelog/sharing-block-wp-settings-suggest-deactivating-module
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Added description and link inviting to disable legacy sharing module if block is available

--- a/projects/plugins/jetpack/changelog/update-ai-helper
+++ b/projects/plugins/jetpack/changelog/update-ai-helper
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Because it's not user-facing or something a user needs to know about.
-
-

--- a/projects/plugins/jetpack/changelog/update-react-sharing-settings-sharing-block
+++ b/projects/plugins/jetpack/changelog/update-react-sharing-settings-sharing-block
@@ -1,5 +1,0 @@
-Significance: patch
-Type: enhancement
-Comment: Sharing: update the display of the settings under Jetpack > Settings > Sharing to account for the new Sharing block.
-
-

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_9",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_10",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_8",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_9",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.8
+ * Version: 13.0-a.9
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.8' );
+define( 'JETPACK__VERSION', '13.0-a.9' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.9
+ * Version: 13.0-a.10
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.9' );
+define( 'JETPACK__VERSION', '13.0-a.10' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.9",
+	"version": "13.0.0-a.10",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.8",
+	"version": "13.0.0-a.9",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,17 +293,13 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.0-a.7 - 2023-12-20
+### 13.0-a.9 - 2023-12-25
 #### Enhancements
-- Sharing Buttons Block: update the admin's setting screen when the sharing block is available.
-
-#### Improved compatibility
-- Sharing Buttons: add the official X button to the list of supported services.
+- Added description and link inviting to disable legacy sharing module if block is available
+- Social Menu & Social Media Icons: Add support for the Bluesky service.
 
 #### Bug fixes
-- My Plan: Fix JS errors due to nested anchor tags.
-- Payments Block: show an error message when unable to render payment button.
-- Subscribers: fix the subscriber count display if above 1000 subscribers.
+- Subscribe Modal: Fix fatal under exceptional conditions
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.9 - 2023-12-25
+- Internal updates.
+
 ## 2.0.8 - 2023-12-20
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_8"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_9"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.8
+ * Version: 2.0.9
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.8",
+	"version": "2.0.9",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.9, jetpack 13.0-a.9

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.