### PR TITLE
Add the block=1 query param to the iframe url when called from the Likes Block

### DIFF
--- a/projects/plugins/jetpack/changelog/add-query-param-to-like-frame-url
+++ b/projects/plugins/jetpack/changelog/add-query-param-to-like-frame-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Only a query param is added. The core of the logic goes into a different PR
+
+

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -87,7 +87,7 @@ function render_block( $attr, $content, $block ) {
 		$bloginfo = get_blog_details( (int) $blog_id );
 		$domain   = $bloginfo->domain;
 		$version  = '20231201';
-		$src      = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&block=1', $version, $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src      = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1', $version, $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$headline = '';
 
 		// provide the mapped domain when needed
@@ -100,7 +100,7 @@ function render_block( $attr, $content, $block ) {
 		$url       = home_url();
 		$url_parts = wp_parse_url( $url );
 		$domain    = $url_parts['host'];
-		$src       = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s&block=1', $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src       = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s&amp;block=1', $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$headline  = sprintf(
 			/** This filter is already documented in modules/sharedaddy/sharing-service.php */
 			apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>', esc_html__( 'Like this:', 'jetpack' ), 'likes' ),

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -87,7 +87,7 @@ function render_block( $attr, $content, $block ) {
 		$bloginfo = get_blog_details( (int) $blog_id );
 		$domain   = $bloginfo->domain;
 		$version  = '20231201';
-		$src      = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s', $version, $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src      = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&block=1', $version, $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$headline = '';
 
 		// provide the mapped domain when needed
@@ -100,7 +100,7 @@ function render_block( $attr, $content, $block ) {
 		$url       = home_url();
 		$url_parts = wp_parse_url( $url );
 		$domain    = $url_parts['host'];
-		$src       = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s', $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src       = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s&block=1', $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$headline  = sprintf(
 			/** This filter is already documented in modules/sharedaddy/sharing-service.php */
 			apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>', esc_html__( 'Like this:', 'jetpack' ), 'likes' ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/85707

## Proposed changes:
No functional change is added. The likes widget URL is called in an iframe. When the iframe is called from the new Likes Block, we want to signal that call with a &block=1 at the end of the URL.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Don't apply this PR yet.
- Setup your jt site.
- Make sure you have the like button activated in the jetpack setup screen.
- Go to one of your posts in your jt site.
- Check the like button widget URL in the iframe. It shouldn't have a `&block=1` parameter at the end.
- Apply this PR.
- Activate the beta blocks (`define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`).
- Build the jetpack plugin.
- Create or edit a post and add the Like Block. Publish or update the post.
- Go to the URL of your post and check the HTML code. The iframe of the like widget should include a `&block=1` at the end.

