### PR TITLE
Fix like avatars being "cut" by the likes label in mobile view of P2

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-likes-in-mobile-view
+++ b/projects/plugins/jetpack/changelog/fix-likes-in-mobile-view
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: it's just a minor bug fix
+
+

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -176,6 +176,16 @@ a.comment-like-link.loading:before {
 	margin-right: 8px;
 	overflow: initial;
 }
+@media screen and (max-width: 782px) {
+	.wpl-likebox.wpl-new-layout .wpl-avatars,
+	.rtl .wpl-likebox.wpl-new-layout .wpl-avatars {
+		flex-wrap: wrap;
+	}
+	.wpl-likebox.wpl-new-layout .wpl-count,
+	.rtl .wpl-likebox.wpl-new-layout .wpl-count {
+		white-space: nowrap;
+	}
+}
 .wpl-likebox.wpl-new-layout .wpl-avatars li a {
 	position: relative; /* For z-index */
 	margin: 0;
@@ -206,7 +216,7 @@ a.comment-like-link.loading:before {
 .wpl-likebox {
 
 	// Prevents color conflict by
-	// .wp-block-post-content a:where(:not(.wp-element-button)) 
+	// .wp-block-post-content a:where(:not(.wp-element-button))
 	a {
 		color: #2C3338 !important;
 		text-decoration: none !important;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/85705

## Proposed changes:
In P2, the like button has more buttons by its side, which means the widget has less space. This makes the "x likes" label "cut" the last avatar like this:
<img width="921" alt="Screenshot 2023-12-28 at 19 24 59" src="https://github.com/Automattic/jetpack/assets/3832570/72d3fb63-b84b-42df-9236-ed7aec34da38">

This PR fixes that making the avatar not visible if there is no space for it to appear in full size. This PR also makes the number of likes, and the "likes" label always be in the same like (in the image, you can see it in two lines instead).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Not needed.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
- Apply this patch to your sandbox using `bin/jetpack-downloader test jetpack fix/likes-in-mobile-view`.
- Sandbox `widgets.wp.com`, and `s0.wp.com`.
- Go to a P2 post with more than 5 likes.
- Put the browser in mobile mode and check that the avatars are not cut by the "x likes" label.
