### PR TITLE
Whitelist Image Creation on WPCOM for Blaze

### DIFF
--- a/projects/packages/blaze/changelog/whitelist-image-uploading-to-wpcom
+++ b/projects/packages/blaze/changelog/whitelist-image-uploading-to-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blaze: Whiteliste /media/new WPCOM REST API call for image uploading

--- a/projects/packages/blaze/composer.json
+++ b/projects/packages/blaze/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.15.x-dev"
+			"dev-trunk": "0.16.x-dev"
 		},
 		"textdomain": "jetpack-blaze",
 		"version-constants": {

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.15.4-alpha",
+	"version": "0.16.0-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -407,21 +407,22 @@ class Dashboard_REST_Controller {
 			return array( 'error' => $site_id->get_error_message() );
 		}
 
-		$file = sanitize_file_name( $_FILES['image'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		if ( ! $file ) {
+		if ( empty( $_FILES['image'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return array( 'error' => 'File is missed' );
 		}
-		if ( ! is_uploaded_file( $file['tmp_name'] ?? '' ) ) {
-			return array( 'error' => 'Specified file was not upload' );
+		$file      = $_FILES['image']; // phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$temp_name = $file['tmp_name'] ?? ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( ! $temp_name || ! is_uploaded_file( $temp_name ) ) {
+			return array( 'error' => 'Specified file was not uploaded' );
 		}
 
 		// Getting the original file name.
-		$filename = basename( $file['full_path'] );
+		$filename = sanitize_file_name( basename( $file['full_path'] ) );
 		// Upload contents to the Upload folder locally.
 		$upload = wp_upload_bits(
 			$filename,
 			null,
-			file_get_contents( $file['tmp_name'] ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			file_get_contents( $temp_name ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		);
 
 		// Check the type of file. We'll use this as the 'post_mime_type'.

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -417,13 +417,17 @@ class Dashboard_REST_Controller {
 		}
 
 		// Getting the original file name.
-		$filename = sanitize_file_name( basename( $file['full_path'] ) );
+		$filename = sanitize_file_name( basename( $file['name'] ) );
 		// Upload contents to the Upload folder locally.
 		$upload = wp_upload_bits(
 			$filename,
 			null,
 			file_get_contents( $temp_name ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		);
+
+		if ( ! empty( $upload['error'] ) ) {
+			return array( 'error' => $upload['error'] );
+		}
 
 		// Check the type of file. We'll use this as the 'post_mime_type'.
 		$filetype = wp_check_filetype( $filename, null );

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.15.4-alpha';
+	const PACKAGE_VERSION = '0.16.0-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/plugins/jetpack/changelog/add-whitelist-wpcom-image-uploading-for-blaze
+++ b/projects/plugins/jetpack/changelog/add-whitelist-wpcom-image-uploading-for-blaze
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -456,7 +456,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/blaze",
-				"reference": "a5c46dc3b1d15cf3ed299f1b7021b9fed418173e"
+				"reference": "8eb5301f37af61edc86a39ec129eac85d3f0d779"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -484,7 +484,7 @@
 					"link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.15.x-dev"
+					"dev-trunk": "0.16.x-dev"
 				},
 				"textdomain": "jetpack-blaze",
 				"version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes issue from Tumblr's Github `a8c-dsp/issues792`

The change we want to introduce is for DSP (Advertising) Widget that is available in Calypso and Jetpack. 

Long story short, in order to create a new Ad Campaign, DSP Widget uploads images, that provided as files, as base64-encoded string. It makes request heavier and can lead to failure.

Our goal is to make that request more lightweight, so instead of base64-encoded string we want to pass a URL to that image. When it comes to opening DSP Widget in Calypso, to create an image we send 2 requests to reach WPCOM and eventually store an image there to use its URL afterwards.

By contrast, DSP Widget in Jetpack uses a proxy calls to reach DSP API, so sending an image turns into a chain of 4 requests instead (more details in Slack p1706293301666149-slack-C0351BKR0M6), like: `https://Username.jurassic.tube/wp-json/jetpack/v4/blaze-app/sites/SiteID/wordads/dsp/api/v1/templates/article/urn:wpcom:post:PostId:CampaignId?widget_origin=jetpack`

Originally, as it was implemented in Calypso it works this way:
![image](https://github.com/Automattic/jetpack/assets/115007291/30b3d4fd-b8a4-4a8d-8864-5125e25c22c6)

For Jetpack, the same implementation would look like:
![image](https://github.com/Automattic/jetpack/assets/115007291/3042a342-9930-41f0-aadf-d63bb5a52776)

So, since our goal is to provide a URL for a public site that can be used during Ad Campaign creation, we have decided to use Media Library of a Jetpack site (instead of WPCOM) to provide that URL.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* For requests from DSP widget like `https://Domain.com/wp-json/jetpack/v4/blaze-app/sites/SiteID/wordads/dsp/api/v1/wpcom/sites/SiteID/media` upload the attached file to local Media Library and respond with its URL. 

## Testing instructions
This PR needs DSP widget and DSP API, thorough testing instructions are described in Tumblr's GH at `/Tumblr/a8c-dsp/pull/882`.

There's 2-minute long demo video on how it should work:
- An image is uploaded to DSP widget as a file,
- By temporary button click we uploads that file,
- Instead of sending this file to DSP API, Jetpack stores that file locally and provide its URL,
- URL was returned within the response like:
```json
{
    "url": "https:\/\/jetpack-site.com\/wp-content\/uploads\/2024\/02\/some-file.jpg"
}
```

https://github.com/Automattic/jetpack/assets/115007291/dcece2df-518e-4ad7-b608-10acc89acfba

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
