### PR TITLE
Launchpad: Add WooCommerce setup task completion logic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-woocommerce-setup-task-completion-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-woocommerce-setup-task-completion-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add WooCommerce setup task completion logic.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1897,7 +1897,8 @@ function wpcom_launchpad_mark_customize_welcome_message_complete_on_add( $value 
 add_action( 'add_option_subscription_options', 'wpcom_launchpad_mark_customize_welcome_message_complete_on_add', 10, 1 );
 
 /**
- * Mark the WooCommerce setup task as complete if the value is changed.
+ * Mark the WooCommerce setup task as complete the setup task list is in
+ * the completed list or in the hidden list.
  *
  * @param string $old_value The old value of the option.
  * @param string $value The new value of the option.
@@ -1905,20 +1906,16 @@ add_action( 'add_option_subscription_options', 'wpcom_launchpad_mark_customize_w
  * @return void
  */
 function wpcom_launchpad_mark_woocommerce_setup_complete( $old_value, $value ) {
-	if ( defined( 'HEADSTART' ) && HEADSTART ) {
+	if ( ! in_array( 'setup', $value, true ) ) {
 		return;
 	}
 
-	if ( wp_installing() ) {
-		return;
-	}
-
-	if ( true === $value ) {
-		wpcom_mark_launchpad_task_complete( 'woocommerce_setup' );
-	}
+	wpcom_mark_launchpad_task_complete( 'woocommerce_setup' );
 }
-add_action( 'update_option_woocommerce_task_list_complete', 'wpcom_launchpad_mark_woocommerce_setup_complete', 10, 3 );
-add_action( 'add_option_woocommerce_task_list_complete', 'wpcom_launchpad_mark_woocommerce_setup_complete', 10, 3 );
+add_action( 'update_option_woocommerce_task_list_completed_lists', 'wpcom_launchpad_mark_woocommerce_setup_complete', 10, 3 );
+add_action( 'add_option_woocommerce_task_list_completed_lists', 'wpcom_launchpad_mark_woocommerce_setup_complete', 10, 3 );
+add_action( 'update_option_woocommerce_task_list_hidden_lists', 'wpcom_launchpad_mark_woocommerce_setup_complete', 10, 3 );
+add_action( 'add_option_woocommerce_task_list_hidden_lists', 'wpcom_launchpad_mark_woocommerce_setup_complete', 10, 3 );
 
 /**
  * When a page is updated, check to see if we've already completed the `add_new_page` task and mark the `edit_page` task complete accordingly.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1897,6 +1897,30 @@ function wpcom_launchpad_mark_customize_welcome_message_complete_on_add( $value 
 add_action( 'add_option_subscription_options', 'wpcom_launchpad_mark_customize_welcome_message_complete_on_add', 10, 1 );
 
 /**
+ * Mark the WooCommerce setup task as complete if the value is changed.
+ *
+ * @param string $old_value The old value of the option.
+ * @param string $value The new value of the option.
+ *
+ * @return void
+ */
+function wpcom_launchpad_mark_woocommerce_setup_complete( $old_value, $value ) {
+	if ( defined( 'HEADSTART' ) && HEADSTART ) {
+		return;
+	}
+
+	if ( wp_installing() ) {
+		return;
+	}
+
+	if ( true === $value ) {
+		wpcom_mark_launchpad_task_complete( 'woocommerce_setup' );
+	}
+}
+add_action( 'update_option_woocommerce_task_list_complete', 'wpcom_launchpad_mark_woocommerce_setup_complete', 10, 3 );
+add_action( 'add_option_woocommerce_task_list_complete', 'wpcom_launchpad_mark_woocommerce_setup_complete', 10, 3 );
+
+/**
  * When a page is updated, check to see if we've already completed the `add_new_page` task and mark the `edit_page` task complete accordingly.
  *
  * @param int     $post_id The ID of the post being updated.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to: paYKcK-3Hy-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds a hook into the WooCommerce option update and add hooks logic to mark the `Store setup` task as complete. This will allow us to replicate the completion logic for the Legacy Site Setup Launchpad. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox the public-api
* Add the following filter to your `0-sandbox.php` file
```
add_filter( 'enable_legacy_site_setup_launchpad', '__return_true' );
```
* Create a new site through the `/setup/free` flow, and then add the Business plan.
* Now, add your site to the WoA Developer list.
* Then, install the WooCommerce plugin, which should change your site to Atomic.
* Use the Jetpack Beta plugin to apply this PR to your site(You may have to update the files manually, as the plugin doesn't seem to work on my end)
* Go to the Customer Home and click on the `Show site setup` button on the banner.
* Then, click on the `Finish store setup` setup task and complete the setup. Make sure you complete the WooCommerce task list(/wp-admin/admin.php?page=wc-admin).
* Make sure the "Finish store setup" task is marked as complete.
* You can also test hiding the WooCommerce task list, which should also complete the "Finish store setup"

