### PR TITLE
Subscribe Block: Add source attribute.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-usage-tracking
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-usage-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscribe Block: add source attribute so we can track how it performs on different situations

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/block.json
@@ -108,6 +108,10 @@
 		"successMessage": {
 			"type": "string",
 			"default": "Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing."
+		},
+		"source": {
+			"type": "string",
+			"default": "subscribe-block"
 		}
 	},
 	"example": {}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -825,7 +825,7 @@ function add_paywall( $the_content ) {
 
 	if ( has_block( \Automattic\Jetpack\Extensions\Paywall\BLOCK_NAME ) ) {
 		if ( strpos( $the_content, \Automattic\Jetpack\Extensions\Paywall\BLOCK_HTML ) ) {
-			return strstr( $the_content, \Automattic\Jetpack\Extensions\Paywall\BLOCK_HTML, true ) . get_paywall_content( $post_access_level, 'block' );
+			return strstr( $the_content, \Automattic\Jetpack\Extensions\Paywall\BLOCK_HTML, true ) . get_paywall_content( $post_access_level, 'paywall_block' );
 		}
 		// WordPress generates excerpts by either rendering or stripping blocks before invoking the `the_content` filter.
 		// In the context of generating an excerpt, the Paywall block specifically renders THE_EXCERPT_BLOCK.
@@ -834,7 +834,7 @@ function add_paywall( $the_content ) {
 		}
 	}
 
-	return get_paywall_content( $post_access_level, 'full_content' );
+	return get_paywall_content( $post_access_level, 'access_paywall' );
 }
 
 /**
@@ -880,7 +880,7 @@ function maybe_gate_existing_comments( $comment ) {
  * @param string $context           The context in which the paywall is being rendered.
  * @return string
  */
-function get_paywall_content( $post_access_level, $context = 'all_content' ) {
+function get_paywall_content( $post_access_level, $context = 'access_paywall' ) {
 	if ( Jetpack_Memberships::user_is_pending_subscriber() ) {
 		return get_paywall_blocks_subscribe_pending();
 	}
@@ -975,7 +975,7 @@ function sanitize_submit_text( $text ) {
  * @param string $context                 The context in which the paywall is being rendered.
  * @return string
  */
-function get_paywall_blocks( $newsletter_access_level, $context = 'all_content' ) {
+function get_paywall_blocks( $newsletter_access_level, $context = 'access_paywall' ) {
 	$custom_paywall = apply_filters( 'jetpack_custom_paywall_blocks', false );
 	if ( ! empty( $custom_paywall ) ) {
 		return $custom_paywall;
@@ -1039,7 +1039,6 @@ function get_paywall_blocks( $newsletter_access_level, $context = 'all_content' 
 	}
 
 	$lock_svg = plugins_url( 'images/lock-paywall.svg', JETPACK__PLUGIN_FILE );
-	$source   = $context === 'all_content' ? 'paywall-all-content' : 'paywall-block';
 
 	return '
 <!-- wp:group {"style":{"border":{"width":"1px","radius":"4px"},"spacing":{"padding":{"top":"32px","bottom":"32px","left":"32px","right":"32px"}}},"borderColor":"primary","className":"jetpack-subscribe-paywall","layout":{"type":"constrained","contentSize":"400px"}} -->
@@ -1056,7 +1055,7 @@ function get_paywall_blocks( $newsletter_access_level, $context = 'all_content' 
 <p class="has-text-align-center" style="margin-top:10px;margin-bottom:10px;font-size:14px">' . $subscribe_text . '</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact","isPaidSubscriber":' . ( $is_paid_subscriber ? 'true' : 'false' ) . ', "source":"' . $source . '"} /-->
+<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact","isPaidSubscriber":' . ( $is_paid_subscriber ? 'true' : 'false' ) . ', "source":"' . $context . '"} /-->
 ' . $sign_in . '
 ' . $switch_accounts . '
 </div>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -68,6 +68,7 @@ domReady( function () {
 
 					const post_id = form.querySelector( 'input[name=post_id]' )?.value ?? '';
 					const tier_id = form.querySelector( 'input[name=tier_id]' )?.value ?? '';
+					const app_source = form.querySelector( 'input[name="sub-type"]' ).value;
 
 					show_iframe( {
 						email,
@@ -78,6 +79,7 @@ domReady( function () {
 						source: 'jetpack_subscribe',
 						post_access_level: form.dataset.post_access_level,
 						display: 'alternate',
+						app_source,
 					} );
 				}
 			} );

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -147,7 +147,7 @@ class Jetpack_Subscribe_Modal {
 		<p class='has-text-align-center' style='margin-top:4px;margin-bottom:0px;font-size:15px'>$subscribe_text</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:jetpack/subscriptions {"buttonBackgroundColor":"primary","textColor":"secondary","borderRadius":50,"borderColor":"primary","className":"is-style-compact"} /-->
+		<!-- wp:jetpack/subscriptions {"buttonBackgroundColor":"primary","textColor":"secondary","borderRadius":50,"borderColor":"primary","className":"is-style-compact","source":"subscribe-modal"} /-->
 
 		<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"20px"}},"typography":{"fontSize":"14px"}},"className":"jetpack-subscribe-modal__close"} -->
 		<p class="has-text-align-center jetpack-subscribe-modal__close" style="margin-top:20px;font-size:14px"><a href="#">$continue_reading</a></p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a source attribute to the Subscribe Block so we can better understand its usage.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Pull this into your wpcom sandbox `bin/jetpack-downloader test jetpack update/subscribe-block-usage-tracking`
* Check that `wpcom_memberships_checkout_view` gets the `app_source` attribute assigned correctly
