### PR TITLE
Modules store fill initial state

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/modules-store-fill-initial-state
+++ b/projects/js-packages/shared-extension-utils/changelog/modules-store-fill-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fill jetpack modules data for initializing store

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.13.5",
+	"version": "0.13.6-alpha",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/src/modules-state/index.js
+++ b/projects/js-packages/shared-extension-utils/src/modules-state/index.js
@@ -25,8 +25,6 @@ const initialData =
 // TODO: Create a proper solution after fixing initial issue (https://github.com/Automattic/jetpack/issues/34793).
 if ( initialData !== null ) {
 	dispatch( JETPACK_MODULES_STORE_ID ).setJetpackModules( {
-		isLoading: false,
-		isUpdating: false,
 		data: { ...initialData },
 	} );
 }

--- a/projects/js-packages/shared-extension-utils/src/modules-state/index.js
+++ b/projects/js-packages/shared-extension-utils/src/modules-state/index.js
@@ -7,11 +7,26 @@ import selectors from './selectors';
 
 export const JETPACK_MODULES_STORE_ID = 'jetpack-modules';
 
+const initialData =
+	window?.Initial_State?.getModules || // Jetpack Dashboard
+	window?.Jetpack_Editor_Initial_State?.modules || // Gutenberg
+	null;
+
 const store = createReduxStore( JETPACK_MODULES_STORE_ID, {
 	reducer,
 	actions,
 	controls,
 	resolvers,
 	selectors,
+	initialState: {
+		isLoading: false,
+		isUpdating: false,
+		data: { ...initialData },
+	},
 } );
-register( store );
+
+// This is a temporary fix to prevent the store from being registered early.
+// TODO: Remove this once we have a proper solution (https://github.com/Automattic/jetpack/issues/34793).
+if ( initialData !== null ) {
+	register( store );
+}

--- a/projects/js-packages/shared-extension-utils/src/modules-state/index.js
+++ b/projects/js-packages/shared-extension-utils/src/modules-state/index.js
@@ -1,4 +1,4 @@
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, dispatch } from '@wordpress/data';
 import actions from './actions';
 import controls from './controls';
 import reducer from './reducer';
@@ -6,26 +6,27 @@ import resolvers from './resolvers';
 import selectors from './selectors';
 
 export const JETPACK_MODULES_STORE_ID = 'jetpack-modules';
+const store = createReduxStore( JETPACK_MODULES_STORE_ID, {
+	reducer,
+	actions,
+	controls,
+	resolvers,
+	selectors,
+} );
+
+register( store );
 
 const initialData =
 	window?.Initial_State?.getModules || // Jetpack Dashboard
 	window?.Jetpack_Editor_Initial_State?.modules || // Gutenberg
 	null;
 
-// This is a temporary fix to prevent the store from being registered early.
-// TODO: Remove this once we have a proper solution (https://github.com/Automattic/jetpack/issues/34793).
+// This is a temporary fix to have store filled properly.
+// TODO: Create a proper solution after fixing initial issue (https://github.com/Automattic/jetpack/issues/34793).
 if ( initialData !== null ) {
-	const store = createReduxStore( JETPACK_MODULES_STORE_ID, {
-		reducer,
-		actions,
-		controls,
-		resolvers,
-		selectors,
-		initialState: {
-			isLoading: false,
-			isUpdating: false,
-			data: { ...initialData },
-		},
+	dispatch( JETPACK_MODULES_STORE_ID ).setJetpackModules( {
+		isLoading: false,
+		isUpdating: false,
+		data: { ...initialData },
 	} );
-	register( store );
 }

--- a/projects/js-packages/shared-extension-utils/src/modules-state/index.js
+++ b/projects/js-packages/shared-extension-utils/src/modules-state/index.js
@@ -12,21 +12,20 @@ const initialData =
 	window?.Jetpack_Editor_Initial_State?.modules || // Gutenberg
 	null;
 
-const store = createReduxStore( JETPACK_MODULES_STORE_ID, {
-	reducer,
-	actions,
-	controls,
-	resolvers,
-	selectors,
-	initialState: {
-		isLoading: false,
-		isUpdating: false,
-		data: { ...initialData },
-	},
-} );
-
 // This is a temporary fix to prevent the store from being registered early.
 // TODO: Remove this once we have a proper solution (https://github.com/Automattic/jetpack/issues/34793).
 if ( initialData !== null ) {
+	const store = createReduxStore( JETPACK_MODULES_STORE_ID, {
+		reducer,
+		actions,
+		controls,
+		resolvers,
+		selectors,
+		initialState: {
+			isLoading: false,
+			isUpdating: false,
+			data: { ...initialData },
+		},
+	} );
 	register( store );
 }

--- a/projects/js-packages/shared-extension-utils/src/modules-state/reducer.js
+++ b/projects/js-packages/shared-extension-utils/src/modules-state/reducer.js
@@ -1,4 +1,10 @@
-const setModulesData = ( state = {}, action ) => {
+const defaultState = {
+	isLoading: false,
+	isUpdating: false,
+	data: {},
+};
+
+const setModulesData = ( state = defaultState, action ) => {
 	switch ( action.type ) {
 		case 'SET_JETPACK_MODULES':
 			return {

--- a/projects/js-packages/shared-extension-utils/src/modules-state/reducer.js
+++ b/projects/js-packages/shared-extension-utils/src/modules-state/reducer.js
@@ -1,10 +1,4 @@
-const defaultState = {
-	isLoading: false,
-	isUpdating: false,
-	data: {},
-};
-
-const setModulesData = ( state = defaultState, action ) => {
+const setModulesData = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case 'SET_JETPACK_MODULES':
 			return {

--- a/projects/js-packages/shared-extension-utils/src/modules-state/resolvers.js
+++ b/projects/js-packages/shared-extension-utils/src/modules-state/resolvers.js
@@ -1,4 +1,4 @@
-import { setJetpackModules, fetchModules } from './actions';
+import { setJetpackModules } from './actions';
 import { fetchJetpackModules } from './controls';
 
 /**
@@ -18,13 +18,4 @@ export function* getJetpackModules() {
 	}
 }
 
-/**
- * When requesting data on particular module
- * we want to make sure to have the latest state
- * @returns {boolean} - if action was completed successfully.
- */
-export function isModuleActive() {
-	return fetchModules();
-}
-
-export default { getJetpackModules, isModuleActive };
+export default { getJetpackModules };

--- a/projects/plugins/jetpack/changelog/modules-store-fill-initial-state
+++ b/projects/plugins/jetpack/changelog/modules-store-fill-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use default store value pased from backend

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -699,8 +699,11 @@ class Jetpack_Gutenberg {
 			$screen_base = get_current_screen()->base;
 		}
 
-		$module_list_endpoint = new Jetpack_Core_API_Module_List_Endpoint();
-		$modules              = $module_list_endpoint->get_modules();
+		$modules = array();
+		if ( class_exists( 'Jetpack_Core_API_Module_List_Endpoint' ) ) {
+			$module_list_endpoint = new Jetpack_Core_API_Module_List_Endpoint();
+			$modules              = $module_list_endpoint->get_modules();
+		}
 
 		$initial_state = array(
 			'available_blocks' => self::get_availability(),

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -699,8 +699,12 @@ class Jetpack_Gutenberg {
 			$screen_base = get_current_screen()->base;
 		}
 
+		$module_list_endpoint = new Jetpack_Core_API_Module_List_Endpoint();
+		$modules              = $module_list_endpoint->get_modules();
+
 		$initial_state = array(
 			'available_blocks' => self::get_availability(),
+			'modules'          => $modules,
 			'jetpack'          => array(
 				'is_active'                     => Jetpack::is_connection_ready(),
 				'is_current_user_connected'     => $is_current_user_connected,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34590

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
For blocks (Jetpack Gutenberg) fill modules state and consume it in `shared-extension-utils/jetpack-modules` redux store.
This will remove the need to load modules when added to the page.

Note: added a check to register store only with initial state. 

**Before:**

https://github.com/Automattic/jetpack/assets/60262784/9e3530ab-bf39-434b-8493-4739e2fade1a


**After:**

https://github.com/Automattic/jetpack/assets/60262784/cb82b30f-5d6d-4a96-8e8b-ca1a9e87bdf0


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up your site with local changes
- Due to https://github.com/Automattic/jetpack/issues/34793, need to build all modules that use this package for proper testing (`jetpack build packages/forms`, `jetpack build plugins/jetpack`, `jetpack build packages/videopress`)
- Create a new post and add contact form. Observe the behavior. (there would be no change on Simple).
