### PR TITLE
Launchpad: Use Site Title task in the Site Setup Launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-use-site-title-task-site-setup-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-use-site-title-task-site-setup-launchpad
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Uses the Site Title task instead of the blogname_set task.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -575,15 +575,6 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/site-editor/' . $data['site_slug_encoded'] . '/?canvas=edit&help-center=subscribe-block';
 			},
 		),
-		'blogname_set'                       => array(
-			'get_title'            => function () {
-				return __( 'Give your site a name', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/settings/general/' . $data['site_slug_encoded'];
-			},
-		),
 		'mobile_app_installed'               => array(
 			'get_title'            => function () {
 				return __( 'Install the mobile app', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -273,7 +273,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'task_ids'  => array(
 				'woocommerce_setup',
 				'sensei_setup',
-				'blogname_set',
+				'site_title',
 				'front_page_updated',
 				'verify_domain_email',
 				'verify_email',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to paYKcK-3Hy-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We should reuse the Site Title task instead of duplicating the task with the `blogname_set` task. Since it would have exactly the same end, we should avoid duplicating it.
* I thought about creating a new task so it could facilitate the migration, but since we are adding the Launchpad only for new sites, it is not necessary to keep the same name.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox the public-api
* Add the following filter to your `0-sandbox.php` file
```
add_filter( 'enable_legacy_site_setup_launchpad', '__return_true' );
```
* Apply this patch to your sandbox
* Create a new site through the `/setup/free` flow, and leave the site name empty or fill it with `Site Title`.
* Go through the flow until you reach the Customer Home. Then, click on the `Show site setup` button in the main banner.
* The Site setup launchpad should be displayed
* Click on the `Give your site a name` task and add a new title
* Go back to the Customer Home, the task should be marked as complete