### PR TITLE
Search: stop reseting tracking cookies for a8c sites

### DIFF
--- a/projects/packages/search/changelog/update-stop-reset-cookie-for-a8c-sites
+++ b/projects/packages/search/changelog/update-stop-reset-cookie-for-a8c-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: add a filter to prevent tracking cookie reset

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.40.x-dev"
+			"dev-trunk": "0.41.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.40.5-alpha",
+	"version": "0.41.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -849,7 +849,7 @@ class Helper {
 		$is_jetpack_photon_enabled = method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'photon' );
 
 		$options = array(
-			'overlayOptions'        => array(
+			'overlayOptions'              => array(
 				'colorTheme'                  => get_option( $prefix . 'color_theme', 'light' ),
 				'enableInfScroll'             => get_option( $prefix . 'inf_scroll', '1' ) === '1',
 				'enableFilteringOpensOverlay' => get_option( $prefix . 'filtering_opens_overlay', '1' ) === '1',
@@ -866,26 +866,36 @@ class Helper {
 			),
 
 			// core config.
-			'homeUrl'               => home_url(),
-			'locale'                => str_replace( '_', '-', self::is_valid_locale( get_locale() ) ? get_locale() : 'en_US' ),
-			'postsPerPage'          => $posts_per_page,
-			'siteId'                => self::get_wpcom_site_id(),
-			'postTypes'             => $post_type_labels,
-			'webpackPublicPath'     => plugins_url( '/build/instant-search/', __DIR__ ),
-			'isPhotonEnabled'       => ( $is_wpcom || $is_jetpack_photon_enabled ) && ! $is_private_site,
-			'isFreePlan'            => ( new Plan() )->is_free_plan(),
+			'homeUrl'                     => home_url(),
+			'locale'                      => str_replace( '_', '-', self::is_valid_locale( get_locale() ) ? get_locale() : 'en_US' ),
+			'postsPerPage'                => $posts_per_page,
+			'siteId'                      => self::get_wpcom_site_id(),
+			'postTypes'                   => $post_type_labels,
+			'webpackPublicPath'           => plugins_url( '/build/instant-search/', __DIR__ ),
+			'isPhotonEnabled'             => ( $is_wpcom || $is_jetpack_photon_enabled ) && ! $is_private_site,
+			'isFreePlan'                  => ( new Plan() )->is_free_plan(),
 
 			// config values related to private site support.
-			'apiRoot'               => esc_url_raw( rest_url() ),
-			'apiNonce'              => wp_create_nonce( 'wp_rest' ),
-			'isPrivateSite'         => $is_private_site,
-			'isWpcom'               => $is_wpcom,
+			'apiRoot'                     => esc_url_raw( rest_url() ),
+			'apiNonce'                    => wp_create_nonce( 'wp_rest' ),
+			'isPrivateSite'               => $is_private_site,
+			'isWpcom'                     => $is_wpcom,
 
 			// widget info.
-			'hasOverlayWidgets'     => is_countable( $overlay_widget_ids ) && count( $overlay_widget_ids ) > 0,
-			'widgets'               => array_values( $widgets ),
-			'widgetsOutsideOverlay' => array_values( $widgets_outside_overlay ),
-			'hasNonSearchWidgets'   => $has_non_search_widgets,
+			'hasOverlayWidgets'           => is_countable( $overlay_widget_ids ) && count( $overlay_widget_ids ) > 0,
+			'widgets'                     => array_values( $widgets ),
+			'widgetsOutsideOverlay'       => array_values( $widgets_outside_overlay ),
+			'hasNonSearchWidgets'         => $has_non_search_widgets,
+			/**
+			 * Whether to prevent tracking cookie reset. More information `pbmxuV-39H-p2`.
+			 *
+			 * @module search
+			 *
+			 * @since $next-version$
+			 *
+			 * @param bool Prevent cookie reset for automattic sites as default value.
+			 */
+			'preventTrackingCookiesReset' => apply_filters( 'jetpack_instant_search_prevent_tracking_cookies_reset', function_exists( 'is_automattic' ) && is_automattic() ),
 		);
 
 		/**

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.40.5-alpha';
+	const VERSION = '0.41.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -121,7 +121,7 @@ class SearchApp extends Component {
 
 	initializeAnalytics() {
 		initializeTracks();
-		window[ SERVER_OBJECT_NAME ].preventTrackingCookiesReset && resetTrackingCookies();
+		! window[ SERVER_OBJECT_NAME ].preventTrackingCookiesReset && resetTrackingCookies();
 		identifySite( this.props.options.siteId );
 	}
 

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -6,7 +6,11 @@ import debounce from 'lodash/debounce';
 import React, { Component, Fragment } from 'react';
 import { createPortal } from 'react-dom';
 import { connect } from 'react-redux';
-import { MULTISITE_NO_GROUP_VALUE, RESULT_FORMAT_EXPANDED } from '../lib/constants';
+import {
+	MULTISITE_NO_GROUP_VALUE,
+	RESULT_FORMAT_EXPANDED,
+	SERVER_OBJECT_NAME,
+} from '../lib/constants';
 import { getAvailableStaticFilters } from '../lib/filters';
 import { getResultFormatQuery, restorePreviousHref } from '../lib/query-string';
 import {
@@ -117,7 +121,7 @@ class SearchApp extends Component {
 
 	initializeAnalytics() {
 		initializeTracks();
-		resetTrackingCookies();
+		window[ SERVER_OBJECT_NAME ].preventTrackingCookiesReset && resetTrackingCookies();
 		identifySite( this.props.options.siteId );
 	}
 

--- a/projects/plugins/jetpack/changelog/update-stop-reset-cookie-for-a8c-sites
+++ b/projects/plugins/jetpack/changelog/update-stop-reset-cookie-for-a8c-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2250,7 +2250,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "0e2b32ed9aca2b858c42fedfae5ae78f7a7f1017"
+                "reference": "b8e216a03dc91f606b87fab82d6663f2b03dd3c5"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -2278,7 +2278,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.40.x-dev"
+                    "dev-trunk": "0.41.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/update-stop-reset-cookie-for-a8c-sites
+++ b/projects/plugins/search/changelog/update-stop-reset-cookie-for-a8c-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1208,7 +1208,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "0e2b32ed9aca2b858c42fedfae5ae78f7a7f1017"
+                "reference": "b8e216a03dc91f606b87fab82d6663f2b03dd3c5"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1236,7 +1236,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.40.x-dev"
+                    "dev-trunk": "0.41.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
Fixes #34645

## Proposed changes:

Add a filter to prevent tracking cookie reset and prevent cookie reset for Automattic sites as default value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pbmxuV-39H-p2

## Does this pull request change what data or activity we track or use?
Yes - it stops tracking cookie reset for A8C sites

## Testing instructions:
* Install the PR on WPCOM
* Sandbox `wordpress.com`
* Open `https://wordpress.com/support/com-vs-org/`
* Inspect site cookies
* Ensure `tk_ai` for wordpress.com is not reset anymore

<img width="795" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/e567d765-f926-446e-b8fe-6f39497051d3">

cc @Automattic/jetpack-data-team 


