### PR TITLE
Block patterns: use category name Testimonials rather than Quotes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/chore-revert-rename-testimonials-to-quotes
+++ b/projects/packages/jetpack-mu-wpcom/changelog/chore-revert-rename-testimonials-to-quotes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Block patterns: use category name testimonials rather than quotes

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -135,7 +135,6 @@ class Wpcom_Block_Patterns_From_Api {
 			}
 		}
 
-		$this->update_core_patterns_with_wpcom_categories();
 		$this->update_pattern_block_types();
 
 		// Temporarily removing the call to `update_pattern_post_types` while we investigate

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -102,11 +102,6 @@ class Wpcom_Block_Patterns_From_Api {
 						'Blog Posts',
 						'jetpack-mu-wpcom'
 					);
-				} elseif ( 'testimonials' === $slug ) {
-					$category_properties['label'] = __(
-						'Quotes',
-						'jetpack-mu-wpcom'
-					);
 				}
 				register_block_pattern_category( $slug, $category_properties );
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -31,15 +31,6 @@ class Wpcom_Block_Patterns_From_Api {
 	private $utils;
 
 	/**
-	 * A dictionary to map existing WPCOM pattern categories to core patterns.
-	 * These should match the categories in $patterns_sources,
-	 * which are registered in $this->register_patterns()
-	 *
-	 * @var array
-	 */
-	private $core_to_wpcom_categories_dictionary;
-
-	/**
 	 * Block_Patterns constructor.
 	 *
 	 * @param Wpcom_Block_Patterns_Utils|null $utils       A class dependency containing utils methods.
@@ -48,14 +39,6 @@ class Wpcom_Block_Patterns_From_Api {
 		$this->patterns_sources = array( 'block_patterns' );
 
 		$this->utils = empty( $utils ) ? new Wpcom_Block_Patterns_Utils() : $utils;
-
-		// Add categories to this array using the core pattern name as the key for core patterns we wish to "recategorize".
-		$this->core_to_wpcom_categories_dictionary = array(
-			'core/quote' => array(
-				'quotes' => __( 'Quotes', 'jetpack-mu-wpcom' ),
-				'text'   => __( 'Text', 'jetpack-mu-wpcom' ),
-			),
-		);
 	}
 
 	/**
@@ -249,33 +232,6 @@ class Wpcom_Block_Patterns_From_Api {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Update categories for core patterns if a records exists in $this->core_to_wpcom_categories_dictionary
-	 * and re-registers them.
-	 */
-	private function update_core_patterns_with_wpcom_categories() {
-		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
-			foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
-				$wpcom_categories =
-					$pattern['name'] && isset( $this->core_to_wpcom_categories_dictionary[ $pattern['name'] ] )
-					? $this->core_to_wpcom_categories_dictionary[ $pattern['name'] ]
-					: null;
-				if ( $wpcom_categories ) {
-					unregister_block_pattern( $pattern['name'] );
-					$pattern_properties = array_merge(
-						$pattern,
-						array( 'categories' => array_keys( $wpcom_categories ) )
-					);
-					unset( $pattern_properties['name'] );
-					register_block_pattern(
-						$pattern['name'],
-						$pattern_properties
-					);
-				}
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related p1702625675735679-slack-CRWCHQGUB

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove code related to `core_to_wpcom_categories_dictionary` because it's not being used anymore
* Revert change to use category name testimonials rather than quotes 

### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a site
* Apply these changes to your sandbox
* Visit the Site editor on your site to confirm the category "Quotes" is now "Testimonials"