### PR TITLE
Subscribe Block: Fix height

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subs-block-height
+++ b/projects/plugins/jetpack/changelog/fix-subs-block-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions block: make it compatible with latest Gutenberg

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -84,6 +84,7 @@
 			input[type="email"] {
 				width: 100%;
 				margin: 0;
+				height: auto;
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes peKye1-zX-p2

## Proposed changes:
**Before**

![image](https://github.com/Automattic/jetpack/assets/104869/207ae464-2bee-49bd-95fd-bfb76fd67e90)

**After**

<img width="686" alt="Screenshot 2023-12-29 at 10 48 29" src="https://github.com/Automattic/jetpack/assets/104869/299a583a-ea46-48e3-97b0-30edd5fd0a56">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this branch on a wpcom sandbox: `bin/jetpack-downloader test jetpack fix/subs-block-height`.
* Wirte a new post and add a subscribe block and make sure it renders alright.