### PR TITLE
Notification Accessibility: Turn notification icon into a link

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-notifications-accessibility
+++ b/projects/plugins/jetpack/changelog/fix-notifications-accessibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Notification Accessibility: Turn notification icon into a link

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -611,6 +611,7 @@ class Masterbar {
 					'class' => 'menupop mb-trackable',
 				),
 				'parent' => 'top-secondary',
+				'href'   => 'https://wordpress.com/notifications',
 			)
 		);
 	}

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -199,6 +199,7 @@ class Jetpack_Notifications {
 					'class' => 'menupop',
 				),
 				'parent' => 'top-secondary',
+				'href'   => 'https://wordpress.com/notifications',
 			)
 		);
 	}

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -192,6 +192,7 @@ class Jetpack_Notifications {
 			array(
 				'id'     => 'notes',
 				'title'  => '<span id="wpnt-notes-unread-count" class="' . esc_attr( $classes ) . '">
+					<span class="screen-reader-text">' . esc_html__( 'Notifications', 'jetpack' ) . '</span>
 					<span class="noticon noticon-notification"></span>
 					</span>',
 				'meta'   => array(


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/85710

## Proposed changes:

* This patch turns the notification icon into a link; with that, the icon is clickable from the screen reader's perspective.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

- Apply this PR to your local
- Spin up a JT site
- Open the site on a logged-in window
- Inspect the notification icon, the href point to `https://wordpress.com/notifications`
- Enabled the VoiceOver
- Navigate to the notification icon and click it (ctrl + opt + space)
- It should open the notification area
- Check on different browsers, the behavior should be similar
- Switch to [WordPress.com Toolbar](https://jetpack.com/support/masterbar/) and perform the same tests with that