### PR TITLE
Update akismet card on My Jetpack to show interstitial screen

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-akismet-card-to-interstitial
+++ b/projects/packages/my-jetpack/changelog/update-akismet-card-to-interstitial
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+update Akismet card on My Jetpack to go to interstitial screen when there is no API key

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -93,6 +93,18 @@ class Anti_Spam extends Product {
 	}
 
 	/**
+	 * Determine if the site has an Akismet plan by checking for an API key
+	 *
+	 * @return bool - whether an API key was found
+	 */
+	public static function has_required_plan() {
+		// Check if the site has an API key for Akismet
+		$akismet_api_key = apply_filters( 'akismet_get_api_key', defined( 'WPCOM_API_KEY' ) ? constant( 'WPCOM_API_KEY' ) : get_option( 'wordpress_api_key' ) );
+
+		return ! empty( $akismet_api_key );
+	}
+
+	/**
 	 * Get the product princing details
 	 *
 	 * @return array Pricing details

--- a/projects/plugins/backup/changelog/update-akismet-card-to-interstitial
+++ b/projects/plugins/backup/changelog/update-akismet-card-to-interstitial
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/changelog/update-akismet-card-to-interstitial
+++ b/projects/plugins/boost/changelog/update-akismet-card-to-interstitial
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/update-akismet-card-to-interstitial
+++ b/projects/plugins/jetpack/changelog/update-akismet-card-to-interstitial
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/changelog/update-akismet-card-to-interstitial
+++ b/projects/plugins/migration/changelog/update-akismet-card-to-interstitial
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/changelog/update-akismet-card-to-interstitial
+++ b/projects/plugins/protect/changelog/update-akismet-card-to-interstitial
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/changelog/update-akismet-card-to-interstitial
+++ b/projects/plugins/search/changelog/update-akismet-card-to-interstitial
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/changelog/update-akismet-card-to-interstitial
+++ b/projects/plugins/social/changelog/update-akismet-card-to-interstitial
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/changelog/update-akismet-card-to-interstitial
+++ b/projects/plugins/starter-plugin/changelog/update-akismet-card-to-interstitial
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/changelog/update-akismet-card-to-interstitial
+++ b/projects/plugins/videopress/changelog/update-akismet-card-to-interstitial
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* To start the test, make sure that you have a test Jetpack site without an Akismet API key
* Navigate to My Jetpack from the wp-admin menu by clicking on "Jetpack"
* On My Jetpack, the "Akismet Anti-Spam" card should now read "Learn More" - previously it said "Activate"
![Screenshot 2024-01-01 at 11 16 08 AM](https://github.com/Automattic/jetpack/assets/18016357/ce8cab5c-5f09-4e9c-baad-8488e157a365)
* If you click on "Learn More" from the Akismet card, you should see this interstitial screen:
![Screenshot 2024-01-01 at 11 16 16 AM](https://github.com/Automattic/jetpack/assets/18016357/62d1502a-a3d1-4a18-98e1-5c8872f9c5be)
* Clicking on "Get Akismet Anti-Spam" should activate the Akismet plugin in the background and send you to the wordpress.com cart with Jetpack Akismet Anti-Spam in the cart
* Return to your test site and navigate to Jetpack > Akismet Anti-Spam
* Either connect your Jetpack Account here or manually add an API key for Akismet
* After adding an Akismet API key, confirm that the card on My Jetpack now says "View"
![Screenshot 2024-01-01 at 11 20 20 AM](https://github.com/Automattic/jetpack/assets/18016357/761cc03d-e005-433a-9981-49b974a98cb0)


