### PR TITLE
WAF: Use string for "needs update" option to prevent unnecessary database updates

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-update-option
+++ b/projects/packages/waf/changelog/fix-waf-update-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Optimize how the web application firewall checks for updates on admin screens.

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -98,7 +98,7 @@ class Waf_Compatibility {
 		}
 
 		// If the option hasn't been added yet, the WAF needs to be updated.
-		return true;
+		return '1';
 	}
 
 	/**
@@ -186,7 +186,7 @@ class Waf_Compatibility {
 		$brute_force_allow_list = Jetpack_Options::get_raw_option( 'jetpack_protect_whitelist', false );
 		if ( false !== $brute_force_allow_list ) {
 			$waf_allow_list = self::merge_ip_allow_lists( $waf_allow_list, $brute_force_allow_list );
-			update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, 1 );
+			update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, '1' );
 		}
 
 		return $waf_allow_list;
@@ -213,7 +213,7 @@ class Waf_Compatibility {
 		$brute_force_allow_list = Jetpack_Options::get_raw_option( 'jetpack_protect_whitelist', false );
 		if ( false !== $brute_force_allow_list ) {
 			$waf_allow_list = self::merge_ip_allow_lists( $waf_allow_list, $brute_force_allow_list );
-			update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, 1 );
+			update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, '1' );
 		}
 
 		return $waf_allow_list;

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -98,7 +98,7 @@ class Waf_Compatibility {
 		}
 
 		// If the option hasn't been added yet, the WAF needs to be updated.
-		return '1';
+		return true;
 	}
 
 	/**
@@ -186,7 +186,7 @@ class Waf_Compatibility {
 		$brute_force_allow_list = Jetpack_Options::get_raw_option( 'jetpack_protect_whitelist', false );
 		if ( false !== $brute_force_allow_list ) {
 			$waf_allow_list = self::merge_ip_allow_lists( $waf_allow_list, $brute_force_allow_list );
-			update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, '1' );
+			update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, true );
 		}
 
 		return $waf_allow_list;
@@ -213,7 +213,7 @@ class Waf_Compatibility {
 		$brute_force_allow_list = Jetpack_Options::get_raw_option( 'jetpack_protect_whitelist', false );
 		if ( false !== $brute_force_allow_list ) {
 			$waf_allow_list = self::merge_ip_allow_lists( $waf_allow_list, $brute_force_allow_list );
-			update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, '1' );
+			update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, true );
 		}
 
 		return $waf_allow_list;

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -166,7 +166,7 @@ class Waf_Initializer {
 	 * @return bool|WP_Error True if the WAF is up-to-date or was sucessfully updated, WP_Error if the update failed.
 	 */
 	public static function check_for_updates() {
-		if ( get_option( self::NEEDS_UPDATE_OPTION_NAME, true ) ) {
+		if ( get_option( self::NEEDS_UPDATE_OPTION_NAME ) ) {
 			if ( Waf_Runner::is_supported_environment() ) {
 				// Compatiblity patch for cases where an outdated WAF_Constants class has been
 				// autoloaded by the standalone bootstrap execution at the beginning of the current request.

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -155,7 +155,7 @@ class Waf_Initializer {
 			return;
 		}
 
-		update_option( self::NEEDS_UPDATE_OPTION_NAME, '1' );
+		update_option( self::NEEDS_UPDATE_OPTION_NAME, true );
 	}
 
 	/**
@@ -166,7 +166,7 @@ class Waf_Initializer {
 	 * @return bool|WP_Error True if the WAF is up-to-date or was sucessfully updated, WP_Error if the update failed.
 	 */
 	public static function check_for_updates() {
-		if ( get_option( self::NEEDS_UPDATE_OPTION_NAME ) ) {
+		if ( get_option( self::NEEDS_UPDATE_OPTION_NAME, true ) ) {
 			if ( Waf_Runner::is_supported_environment() ) {
 				// Compatiblity patch for cases where an outdated WAF_Constants class has been
 				// autoloaded by the standalone bootstrap execution at the beginning of the current request.
@@ -197,9 +197,10 @@ class Waf_Initializer {
 				// just migrate the IP allow list used by brute force protection.
 				Waf_Compatibility::migrate_brute_force_protection_ip_allow_list();
 			}
+
+			update_option( self::NEEDS_UPDATE_OPTION_NAME, false );
 		}
 
-		update_option( self::NEEDS_UPDATE_OPTION_NAME, '0' );
 		return true;
 	}
 

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -155,7 +155,7 @@ class Waf_Initializer {
 			return;
 		}
 
-		update_option( self::NEEDS_UPDATE_OPTION_NAME, 1 );
+		update_option( self::NEEDS_UPDATE_OPTION_NAME, '1' );
 	}
 
 	/**
@@ -199,7 +199,7 @@ class Waf_Initializer {
 			}
 		}
 
-		update_option( self::NEEDS_UPDATE_OPTION_NAME, 0 );
+		update_option( self::NEEDS_UPDATE_OPTION_NAME, '0' );
 		return true;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34765

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use a string instead of an integer to save the "jetpack_waf_needs_update" option. This allows the core `update_option` function to validate the new value against the saved one, and abort updates when they are identical. 
* The important change is the update that sets the value to `"0"`, but all other cases have been updated for consistency.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/issues/34765

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the WAF on a site with Jetpack Protect.
* Use Query Monitor on any admin page and validate the issue: an "UPDATE" is made to "jetpack_waf_needs_update" on every admin page load.
* Apply this patch with the Jetpack Beta plugin.
* Validate the unnecessary update is no longer occurring.

