### PR TITLE
Added reblog query param to the Like Block iframe URL

### DIFF
--- a/projects/plugins/jetpack/changelog/add-reblog-query-param-to-like-block
+++ b/projects/plugins/jetpack/changelog/add-reblog-query-param-to-like-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Added the "reblog" query param to the iframe in the Like Block when the reblog button is enabled in the block.

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -82,13 +82,15 @@ function render_block( $attr, $content, $block ) {
 		$main_iframe_added = true;
 	}
 
+	$show_reblog_button = $attr['showReblogButton'] ?? false;
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$blog_id  = get_current_blog_id();
-		$bloginfo = get_blog_details( (int) $blog_id );
-		$domain   = $bloginfo->domain;
-		$version  = '20231201';
-		$src      = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1', $version, $blog_id, $post_id, $domain, $uniqid, $new_layout );
-		$headline = '';
+		$blog_id      = get_current_blog_id();
+		$bloginfo     = get_blog_details( (int) $blog_id );
+		$domain       = $bloginfo->domain;
+		$version      = '20231201';
+		$reblog_param = $show_reblog_button ? '&amp;reblog=1' : '';
+		$src          = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', $version, $blog_id, $post_id, $domain, $uniqid, $new_layout, $reblog_param );
+		$headline     = '';
 
 		// provide the mapped domain when needed
 		if ( isset( $_SERVER['HTTP_HOST'] ) && strpos( sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ), '.wordpress.com' ) === false ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/85936

## Proposed changes:
The Like Block works with an iframe. This PR adds the query param "reblog" to the iframe URL when the reblog button is enabled in that block. This query param will be read by the backend, and it will render the reblog button accordingly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- This change is only available on simple sites.
- Apply this PR to your sandbox by running `` there.
- Sandbox the URL of your simple site.
- Create a new post and add a Like block. The "show reblog button" toggle should be in the sidebar. Leave it OFF, and publish the post.
- Go to the post on the site and check the URL of the Like block iframe. It should end in "block=1".
- Edit the post and now check the toggle ON. Update the post.
- Go again to the post on the site and check the URL. This time, it should end in "reblog=1".
- Try to break this 😄 

