### PR TITLE
Launchpad: Accept the is_dismissible prop in the task list definition

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-is-dismissible-prop-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-is-dismissible-prop-launchpad
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds the is_dismissible prop to the Launchpad task list definition

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.8.0",
+	"version": "5.8.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.8.0';
+	const PACKAGE_VERSION = '5.8.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -166,6 +166,20 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
+	 * Check if a task list is dismissible.
+	 *
+	 * @param string $id Task List id.
+	 * @return bool True if dismissible, false if not.
+	 */
+	public function is_task_list_dismissible( $id ) {
+		$task_list = $this->get_task_list( $id );
+		if ( ! isset( $task_list['is_dismissible'] ) ) {
+			return false;
+		}
+		return $task_list['is_dismissible'];
+	}
+
+	/**
 	 * Set wether a task list is dismissed or not for a site.
 	 *
 	 * @param string $id Task List id.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -717,6 +717,9 @@ function wpcom_launchpad_is_task_list_dismissed( $checklist_slug ) {
  * @return bool True if the Launchpad is dismissible, false otherwise.
  */
 function wpcom_launchpad_is_task_list_dismissible( $checklist_slug ) {
+	if ( false === $checklist_slug ) {
+		return false;
+	}
 	return wpcom_launchpad_checklists()->is_task_list_dismissible( $checklist_slug );
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -267,10 +267,11 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'legacy-site-setup'      => array(
-			'get_title' => function () {
+			'get_title'      => function () {
 				return __( 'Site setup', 'jetpack-mu-wpcom' );
 			},
-			'task_ids'  => array(
+			'is_dismissible' => true,
+			'task_ids'       => array(
 				'woocommerce_setup',
 				'sensei_setup',
 				'site_title',
@@ -707,6 +708,16 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
  */
 function wpcom_launchpad_is_task_list_dismissed( $checklist_slug ) {
 	return wpcom_launchpad_checklists()->is_task_list_dismissed( $checklist_slug );
+}
+
+/**
+ * Checks if the Launchpad is dismissible.
+ *
+ * @param string $checklist_slug The slug of the launchpad task list to check.
+ * @return bool True if the Launchpad is dismissible, false otherwise.
+ */
+function wpcom_launchpad_is_task_list_dismissible( $checklist_slug ) {
+	return wpcom_launchpad_checklists()->is_task_list_dismissible( $checklist_slug );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -154,6 +154,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context ),
 			'is_enabled'         => wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ),
 			'is_dismissed'       => wpcom_launchpad_is_task_list_dismissed( $checklist_slug ),
+			'is_dismissible'     => wpcom_launchpad_is_task_list_dismissible( $checklist_slug ),
 			'title'              => wpcom_get_launchpad_checklist_title_by_checklist_slug( $checklist_slug ),
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/85037

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the `is_dismissible` property to support flagging task lists as dismissible, thus allowing the dismissal without completing all the tasks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox using the command below:
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/is-dismissible-prop-launchpad
```
* Make sure you are sandboxed
* Navigate to the Developer Console https://developer.wordpress.com/docs/api/console/
* Make a `GET` request to `WP REST API` -> `wpcom/v2` -> `/sites/:siteSlug/launchpad?checklist_slug=legacy-site-setup`
* Confirm the `is_dismissible` is present in the response.
![Screenshot 2024-01-03 at 17 58 09](https://github.com/Automattic/jetpack/assets/1234758/5575a13e-f57c-4a47-a41d-996648a4e897)

