### PR TITLE
Add/catch duplicated comment error

### DIFF
--- a/projects/plugins/jetpack/changelog/add-catch-duplicated-comment-error
+++ b/projects/plugins/jetpack/changelog/add-catch-duplicated-comment-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: It's a design improvement
+
+

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -800,13 +800,13 @@ HTML;
 		<script type="text/javascript">
 			function backToComments() {
 				const test = regexp => {
-					return regexp.test(navigator.userAgent);
+						return regexp.test(navigator.userAgent);
 				};
-				if (test(/firefox|fxios/i)) {
-					history.back();
-					return;
+				if (test(/chrome|chromium|crios|safari|edg/i)) {
+						history.go(-2);
+						return;
 				}
-				history.go(-2);
+				history.back();
 			}
 		</script>
 

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -783,7 +783,7 @@ HTML;
 					font-weight: normal;
 				}
 				a {
-					text-decoration: none;
+					text-decoration: underline;
 					color: #333 !important;
 				}
 			</style>

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -799,11 +799,8 @@ HTML;
 		</div>
 		<script type="text/javascript">
 			function backToComments() {
-				if (history.length > 3) {
-					history.go(-2);
-					return;
-				}
 				history.back();
+				return;
 			}
 		</script>
 

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -764,21 +764,21 @@ HTML;
 					left: 0;
 					overflow: hidden;
 					color: #333;
+					padding-top: 3%;
 				}
 				div {
-					text-align: center;
+					text-align: left;
 					margin: 0;
 					padding: 0;
 					display: table-cell;
-					vertical-align: middle;
+					vertical-align: top;
 					font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", sans-serif;
 					font-weight: normal;
 				}
 
 				h3 {
-					text-align: center;
 					margin: 0;
-					padding: 3% 0;
+					padding-bottom: 3%;
 					font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", sans-serif;
 					font-weight: normal;
 				}
@@ -859,6 +859,7 @@ HTML;
 					left: 0;
 					overflow: hidden;
 					color: #333;
+					padding-top: 3%;
 				}
 
 				h3 {
@@ -866,7 +867,7 @@ HTML;
 					margin: 0;
 					padding: 0;
 					display: table-cell;
-					vertical-align: middle;
+					vertical-align: top;
 					font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", sans-serif;
 					font-weight: normal;
 				}

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -792,10 +792,10 @@ HTML;
 		<div>
 			<h1>
 				<?php
-					echo esc_html__( 'Duplicate comment detected; it looks as though you&#8217;ve already said that!', 'jetpack' );
+					esc_html_e( 'Duplicate comment detected; it looks as though you’ve already said that!', 'jetpack' );
 				?>
 			</h1>
-			<a href="javascript:history.go(-2)"><?php echo esc_html__( '&laquo; Back', 'jetpack' ); ?></a>
+			<a href="javascript:history.go(-2)"><?php esc_html_e( '&laquo; Back', 'jetpack' ); ?></a>
 		</div>
 		</body>
 		</html>

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -151,6 +151,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		parent::setup_filters();
 
 		add_filter( 'comment_post_redirect', array( $this, 'capture_comment_post_redirect_to_reload_parent_frame' ), 100 );
+		add_filter( 'comment_duplicate_trigger', array( $this, 'capture_comment_duplicate_trigger' ), 100 );
 		add_filter( 'get_avatar', array( $this, 'get_avatar' ), 10, 4 );
 		// Fix comment reply link when `comment_registration` is required.
 		add_filter( 'comment_reply_link', array( $this, 'comment_reply_link' ), 10, 4 );
@@ -724,6 +725,82 @@ HTML;
 		// $jetpack->stat automatically prepends the stat group with 'jetpack-'
 		$jetpack->stat( 'subscribe-modal-comm', $tracking_event );
 		$jetpack->do_stats( 'server_side' );
+	}
+
+	/**
+	 * Catch the duplicated comment error and show a custom error page
+	 *
+	 * @return void
+	 */
+	public function capture_comment_duplicate_trigger() {
+		if ( ! isset( $_GET['for'] ) || 'jetpack' !== $_GET['for'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			exit;
+		}
+
+		?>
+		<!DOCTYPE html>
+		<html <?php language_attributes(); ?>>
+		<!--<![endif]-->
+		<head>
+			<meta charset="<?php bloginfo( 'charset' ); ?>" />
+			<title>
+				<?php
+					wp_kses_post(
+						printf(
+							/* translators: %s is replaced by an ellipsis */
+							__( 'Submitting Comment%s', 'jetpack' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							'&hellip;'
+						)
+					);
+				?>
+				</title>
+			<style type="text/css">
+				body {
+					display: table;
+					width: 100%;
+					height: 60%;
+					position: absolute;
+					top: 0;
+					left: 0;
+					overflow: hidden;
+					color: #333;
+				}
+				div {
+					text-align: center;
+					margin: 0;
+					padding: 0;
+					display: table-cell;
+					vertical-align: middle;
+					font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", sans-serif;
+					font-weight: normal;
+				}
+
+				h1 {
+					text-align: center;
+					margin: 0;
+					padding: 3% 0;
+					font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", sans-serif;
+					font-weight: normal;
+				}
+				a {
+					text-decoration: none;
+					color: #333 !important;
+				}
+			</style>
+		</head>
+		<body>
+		<div>
+			<h1>
+				<?php
+					echo esc_html__( 'Duplicate comment detected; it looks as though you&#8217;ve already said that!', 'jetpack' );
+				?>
+			</h1>
+			<a href="javascript:history.go(-2)"><?php echo esc_html__( '&laquo; Back', 'jetpack' ); ?></a>
+		</div>
+		</body>
+		</html>
+		<?php
+		exit;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -775,7 +775,7 @@ HTML;
 					font-weight: normal;
 				}
 
-				h1 {
+				h3 {
 					text-align: center;
 					margin: 0;
 					padding: 3% 0;
@@ -790,11 +790,11 @@ HTML;
 		</head>
 		<body>
 		<div>
-			<h1>
+			<h3>
 				<?php
 					esc_html_e( 'Duplicate comment detected; it looks as though you’ve already said that!', 'jetpack' );
 				?>
-			</h1>
+			</h3>
 			<a href="javascript:backToComments()"><?php esc_html_e( '&laquo; Back', 'jetpack' ); ?></a>
 		</div>
 		<script type="text/javascript">
@@ -861,7 +861,7 @@ HTML;
 					color: #333;
 				}
 
-				h1 {
+				h3 {
 					text-align: center;
 					margin: 0;
 					padding: 0;
@@ -875,7 +875,7 @@ HTML;
 					opacity: 0;
 				}
 
-				h1 span {
+				h3 span {
 					-moz-transition-property: opacity;
 					-moz-transition-duration: 1s;
 					-moz-transition-timing-function: ease-in-out;
@@ -900,7 +900,7 @@ HTML;
 		</head>
 		<body>
 		<?php if ( ! $should_show_subscription_modal ) { ?>
-		<h1>
+		<h3>
 			<?php
 				wp_kses_post(
 					printf(
@@ -910,7 +910,7 @@ HTML;
 					)
 				);
 			?>
-		</h1>
+		</h3>
 		<script type="text/javascript">
 			try {
 				window.parent.location = <?php echo wp_json_encode( $url ); ?>;
@@ -928,13 +928,13 @@ HTML;
 			setInterval(toggleEllipsis, 1200);
 		</script>
 		<?php } else { ?>
-		<h1>
+		<h3>
 			<?php
 				wp_kses_post(
 					print __( 'Comment sent', 'jetpack' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				);
 			?>
-		</h1>
+		</h3>
 		<script type="text/javascript">
 			if ( window.parent && window.parent !== window ) {
 

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -799,8 +799,14 @@ HTML;
 		</div>
 		<script type="text/javascript">
 			function backToComments() {
-				history.back();
-				return;
+				const test = regexp => {
+					return regexp.test(navigator.userAgent);
+				};
+				if (test(/firefox|fxios/i)) {
+					history.back();
+					return;
+				}
+				history.go(-2);
 			}
 		</script>
 

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -795,8 +795,18 @@ HTML;
 					esc_html_e( 'Duplicate comment detected; it looks as though you’ve already said that!', 'jetpack' );
 				?>
 			</h1>
-			<a href="javascript:history.go(-2)"><?php esc_html_e( '&laquo; Back', 'jetpack' ); ?></a>
+			<a href="javascript:backToComments()"><?php esc_html_e( '&laquo; Back', 'jetpack' ); ?></a>
 		</div>
+		<script type="text/javascript">
+			function backToComments() {
+				if (history.length > 3) {
+					history.go(-2);
+					return;
+				}
+				history.back();
+			}
+		</script>
+
 		</body>
 		</html>
 		<?php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5074

## Proposed changes:
We catch the duplicated comment error message and show it with a custom design (like we are doing when submitting a comment)
This also fixes that in certain cases, the back button is not returning to the comment form.

| Before | After |
| --- | --- |
| https://github.com/Automattic/jetpack/assets/402286/e8d46519-61e6-481d-bc33-5f1c570f096e | https://github.com/Automattic/jetpack/assets/402286/808f4f14-f75a-46dc-ad4c-28926a175b9f |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* You need to enable the `Let visitors use a WordPress.com or Facebook account to comment.` option on `wordpress.com/settings/discussion/:your-site`
* Go to a post
* Comment something
* After reloading, comment the same comment as before
* You should receive a Duplicated comment error with better look.
* The back button should return you to the comment form.
* Test it in Chrome, Firefox, Safari, Brave...



