### PR TITLE
Backport mu-wpcom-plugin 2.0.11, jetpack 13.0-a.13 changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [0.3.0] - 2023-12-20
 ### Changed
 - AI Client: improved usability with new block positioning, prompt and suggestion action buttons. [#34383]
@@ -176,6 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.3.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.16...v0.2.0

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.3.1-alpha",
+	"version": "0.3.1",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.16.8] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [0.16.7] - 2023-12-03
 ### Changed
 - Updated package dependencies. [#34411]
@@ -286,6 +290,7 @@
 - Add the API methods left behind by the previous PR.
 - Initial release of jetpack-api package
 
+[0.16.8]: https://github.com/Automattic/jetpack-api/compare/v0.16.7...v0.16.8
 [0.16.7]: https://github.com/Automattic/jetpack-api/compare/v0.16.6...v0.16.7
 [0.16.6]: https://github.com/Automattic/jetpack-api/compare/v0.16.5...v0.16.6
 [0.16.5]: https://github.com/Automattic/jetpack-api/compare/v0.16.4...v0.16.5

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.16.8-alpha",
+	"version": "0.16.8",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.15] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [0.6.14] - 2023-12-03
 ### Changed
 - Updated package dependencies. [#34411]
@@ -238,6 +242,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.15]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.14...0.6.15
 [0.6.14]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.13...0.6.14
 [0.6.13]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.12...0.6.13
 [0.6.12]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.11...0.6.12

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.15-alpha",
+	"version": "0.6.15",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.19] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [0.1.18] - 2023-12-03
 ### Changed
 - Updated package dependencies. [#34411] [#34427]
@@ -87,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.19]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.17...v0.1.18
 [0.1.17]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.15...v0.1.16

--- a/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.19-alpha",
+	"version": "0.1.19",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.45.10] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815] [#34816]
+
+### Fixed
+- Added consistency for Jetpack footer links [#34787]
+
 ## [0.45.9] - 2024-01-02
 ### Changed
 - Updated the design and fixed a11y for Quick Share buttons. [#34754]
@@ -910,6 +917,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.45.10]: https://github.com/Automattic/jetpack-components/compare/0.45.9...0.45.10
 [0.45.9]: https://github.com/Automattic/jetpack-components/compare/0.45.8...0.45.9
 [0.45.8]: https://github.com/Automattic/jetpack-components/compare/0.45.7...0.45.8
 [0.45.7]: https://github.com/Automattic/jetpack-components/compare/0.45.6...0.45.7

--- a/projects/js-packages/components/changelog/fix-jetpack-footer-inconsistent-behavior
+++ b/projects/js-packages/components/changelog/fix-jetpack-footer-inconsistent-behavior
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Added consistency for Jetpack footer links

--- a/projects/js-packages/components/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/components/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.45.10-alpha",
+	"version": "0.45.10",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.30.12] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815] [#34816]
+
 ## [0.30.11] - 2023-12-19
 ### Changed
 - Updated package dependencies. [#34694, #34696]
@@ -676,6 +680,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.30.12]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.11...v0.30.12
 [0.30.11]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.10...v0.30.11
 [0.30.10]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.9...v0.30.10
 [0.30.9]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.8...v0.30.9

--- a/projects/js-packages/connection/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/connection/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.30.12-alpha",
+	"version": "0.30.12",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.43] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [2.0.42] - 2023-12-03
 ### Changed
 - Updated package dependencies. [#34411] [#34427]
@@ -197,6 +201,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.43]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.42...v2.0.43
 [2.0.42]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.41...v2.0.42
 [2.0.41]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.40...v2.0.41
 [2.0.40]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.39...v2.0.40

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.43-alpha",
+	"version": "2.0.43",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.56 - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## 0.10.55 - 2023-12-06
 ### Changed
 - Updated package dependencies. [#34416]

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.56-alpha",
+	"version": "0.10.56",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.17 - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815] [#34816]
+
 ## 0.11.16 - 2023-12-20
 ### Changed
 - Updated package dependencies. [#34694]

--- a/projects/js-packages/licensing/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/licensing/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.11.17-alpha",
+	"version": "0.11.17",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.65 - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815] [#34816]
+
 ## 0.2.64 - 2023-12-20
 ### Changed
 - Updated package dependencies. [#34694]

--- a/projects/js-packages/partner-coupon/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/partner-coupon/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.65-alpha",
+	"version": "0.2.65",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.2] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815] [#34816]
+
 ## [0.44.1] - 2024-01-02
 ### Changed
 - Updated the design for Quick Share buttons and fixed its a11y [#34754]
@@ -556,6 +560,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.44.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.44.1...v0.44.2
 [0.44.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.44.0...v0.44.1
 [0.44.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.42.0...v0.43.0

--- a/projects/js-packages/publicize-components/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/publicize-components/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.44.2-alpha",
+	"version": "0.44.2",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.7] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815] [#34816]
+
 ## [0.13.6] - 2024-01-02
 ### Added
 - Added prefilling for jetpack modules data during store initialization. [#34794]
@@ -309,6 +313,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.13.7]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.6...0.13.7
 [0.13.6]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.5...0.13.6
 [0.13.5]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.4...0.13.5
 [0.13.4]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.3...0.13.4

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.13.7-alpha",
+	"version": "0.13.7",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.5 - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## 3.0.4 - 2023-12-06
 ### Changed
 - Updated package dependencies. [#34416]

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.0.5-alpha",
+	"version": "3.0.5",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/action-bar/CHANGELOG.md
+++ b/projects/packages/action-bar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [0.2.2] - 2023-12-11
 ### Changed
 - Updated package dependencies. [#34416]
@@ -150,6 +154,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds the Action Bar package and Jetpack plugin module for follows, likes, and comments. Just a scaffold to build on, for now. [#25447]
 
+[0.2.3]: https://github.com/Automattic/jetpack-action-bar/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Automattic/jetpack-action-bar/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Automattic/jetpack-action-bar/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.32...v0.2.0

--- a/projects/packages/action-bar/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/action-bar/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/action-bar/package.json
+++ b/projects/packages/action-bar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-action-bar",
-	"version": "0.2.3-alpha",
+	"version": "0.2.3",
 	"description": "An easy way for visitors to follow, like, and comment on your WordPress site.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/action-bar/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [2.0.3] - 2023-12-11
 ### Changed
 - Updated package dependencies. [#34492]
@@ -392,6 +396,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[2.0.4]: https://github.com/Automattic/jetpack-assets/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/Automattic/jetpack-assets/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-assets/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-assets/compare/v2.0.0...v2.0.1

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815] [#34816]
+
 ## [2.0.4] - 2023-12-20
 ### Changed
 - Updated package dependencies. [#34694]
@@ -530,6 +534,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[2.0.5]: https://github.com/Automattic/jetpack-backup/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/Automattic/jetpack-backup/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/Automattic/jetpack-backup/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-backup/compare/v2.0.1...v2.0.2

--- a/projects/packages/backup/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/backup/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.0.5-alpha';
+	const PACKAGE_VERSION = '2.0.5';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.3] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [0.14.2] - 2023-12-11
 ### Changed
 - Updated package dependencies. [#34416]
@@ -257,6 +261,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.14.3]: https://github.com/automattic/jetpack-blaze/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/automattic/jetpack-blaze/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/automattic/jetpack-blaze/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/automattic/jetpack-blaze/compare/v0.13.0...v0.14.0

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.14.3-alpha",
+	"version": "0.14.3",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.14.3-alpha';
+	const PACKAGE_VERSION = '0.14.3';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [2.1.0] - 2023-12-03
 ### Added
 - Added the welcome banner to My Jetpack. [#34384]
@@ -939,6 +943,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.1.1]: https://github.com/Automattic/jetpack-connection/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/Automattic/jetpack-connection/compare/v2.0.3...v2.1.0
 [2.0.3]: https://github.com/Automattic/jetpack-connection/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-connection/compare/v2.0.1...v2.0.2

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.1.1-alpha';
+	const PACKAGE_VERSION = '2.1.1';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.2] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [0.29.1] - 2024-01-02
 ### Changed
 - Made module updates more precise in the modules store. [#34801]
@@ -453,6 +457,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.29.2]: https://github.com/automattic/jetpack-forms/compare/v0.29.1...v0.29.2
 [0.29.1]: https://github.com/automattic/jetpack-forms/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/automattic/jetpack-forms/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/automattic/jetpack-forms/compare/v0.27.0...v0.28.0

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.29.2-alpha",
+	"version": "0.29.2",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.29.2-alpha';
+	const PACKAGE_VERSION = '0.29.2';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [0.14.0] - 2023-12-06
 ### Added
 - Send a verifcation secret when URL is IP. [#34436]
@@ -465,6 +469,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.14.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.12.0...v0.12.1

--- a/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.14.1-alpha",
+	"version": "0.14.1",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.14.1-alpha';
+	const PACKAGE_VERSION = '0.14.1';
 
 	/**
 	 * Persistent WPCOM blog ID that stays in the options after disconnect.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.8.0] - 2024-01-04
+### Added
+- Add WooCommerce setup task completion logic. [#34791]
+- Dashboard Link: Allow to customize the url via the query parameter. [#34836]
+
+### Changed
+- Launchpad: Rename the title of the setup_general to Give your site a name. [#34826]
+- Update launchpad methods docs. [#34829]
+- Update package dependencies. [#34815]
+- Use the Site Title task instead of the blogname_set task. [#34799]
+
 ## [5.7.0] - 2024-01-02
 ### Added
 - Added Sensei setup completion logic. [#34789]
@@ -500,6 +511,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.8.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.7.0...v5.8.0
 [5.7.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.6.0...v5.7.0
 [5.6.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.5.0...v5.6.0
 [5.5.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.4.0...v5.5.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-woocommerce-setup-task-completion-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-woocommerce-setup-task-completion-logic
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add WooCommerce setup task completion logic.

--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-customize-editor-back-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-customize-editor-back-url
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Dashboard Link: Allow to customize the url via the query parameter

--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-rename-setup-general-task-title
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-rename-setup-general-task-title
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Launchpad: Rename the title of the setup_general to Give your site a name

--- a/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-method-docs
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-method-docs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated launchpad methods docs

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-use-site-title-task-site-setup-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-use-site-title-task-site-setup-launchpad
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Uses the Site Title task instead of the blogname_set task.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.8.0-alpha",
+	"version": "5.8.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.8.0-alpha';
+	const PACKAGE_VERSION = '5.8.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [3.0.1] - 2023-12-03
 ### Changed
 - Updated package dependencies. [#34411]
@@ -658,6 +662,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.0.2]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/Automattic/jetpack-jitm/compare/v2.5.3...v3.0.0
 [2.5.3]: https://github.com/Automattic/jetpack-jitm/compare/v2.5.2...v2.5.3

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.0.2-alpha';
+	const PACKAGE_VERSION = '3.0.2';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.1] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815] [#34816]
+
+### Fixed
+- My Jetpack: Jetpack footer links are now consistent with footers in rest of Jetpack screens. [#34787]
+
 ## [4.2.0] - 2024-01-02
 ### Fixed
 - Show JP Creator as active when JP Complete is purchased. [#34806]
@@ -1166,6 +1173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.2.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.2.0...4.2.1
 [4.2.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.1.4...4.2.0
 [4.1.4]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.1.3...4.1.4
 [4.1.3]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.1.2...4.1.3

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-footer-inconsistent-behavior
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-footer-inconsistent-behavior
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Jetpack footer links are now consistent with footers in rest of Jetpack screens.

--- a/projects/packages/my-jetpack/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/my-jetpack/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.2.1-alpha",
+	"version": "4.2.1",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -32,7 +32,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.2.1-alpha';
+	const PACKAGE_VERSION = '4.2.1';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.0] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
+### Removed
+- Social: Remove obsolete tweetstorm files. [#34330]
+
 ## [0.38.3] - 2023-12-20
 ### Fixed
 - Fixed backwards compatibility with Social store refactor. [#34566]
@@ -447,6 +454,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.39.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.3...v0.39.0
 [0.38.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.2...v0.38.3
 [0.38.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.1...v0.38.2
 [0.38.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.0...v0.38.1

--- a/projects/packages/publicize/changelog/remove-social-obsolete-twitter-helpers
+++ b/projects/packages/publicize/changelog/remove-social-obsolete-twitter-helpers
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Social: Remove obsolete tweetstorm files

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.39.0-alpha",
+	"version": "0.39.0",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.0] - 2024-01-04
+### Added
+- Search: Add a filter to prevent tracking cookie reset. [#34803]
+
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [0.40.4] - 2023-12-20
 ### Changed
 - Updated package dependencies. [#34694]
@@ -865,6 +872,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.41.0]: https://github.com/Automattic/jetpack-search/compare/v0.40.4...v0.41.0
 [0.40.4]: https://github.com/Automattic/jetpack-search/compare/v0.40.3...v0.40.4
 [0.40.3]: https://github.com/Automattic/jetpack-search/compare/v0.40.2...v0.40.3
 [0.40.2]: https://github.com/Automattic/jetpack-search/compare/v0.40.1...v0.40.2

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/update-stop-reset-cookie-for-a8c-sites
+++ b/projects/packages/search/changelog/update-stop-reset-cookie-for-a8c-sites
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Search: add a filter to prevent tracking cookie reset

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.41.0-alpha",
+	"version": "0.41.0",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.41.0-alpha';
+	const VERSION = '0.41.0';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2024-01-04
+### Removed
+- Social: Removed sync option for tweetstorm. [#34330]
+
 ## [2.3.0] - 2023-12-20
 ### Added
 - Add wpcom_ai_site_prompt option to the site settings endpoint. [#34709]
@@ -1010,6 +1014,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.4.0]: https://github.com/Automattic/jetpack-sync/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/Automattic/jetpack-sync/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/Automattic/jetpack-sync/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Automattic/jetpack-sync/compare/v2.1.2...v2.2.0

--- a/projects/packages/sync/changelog/remove-social-obsolete-twitter-helpers
+++ b/projects/packages/sync/changelog/remove-social-obsolete-twitter-helpers
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Social: Removed sync option for tweetstorm

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.4.0-alpha';
+	const PACKAGE_VERSION = '2.4.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.7] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815] [#34816]
+
 ## [0.21.6] - 2023-12-25
 ### Changed
 - Internal updates.
@@ -1221,6 +1225,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.21.7]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.6...v0.21.7
 [0.21.6]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.5...v0.21.6
 [0.21.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.4...v0.21.5
 [0.21.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.3...v0.21.4

--- a/projects/packages/videopress/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/videopress/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.21.7-alpha",
+	"version": "0.21.7",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.21.7-alpha';
+	const PACKAGE_VERSION = '0.21.7';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2024-01-04
+### Changed
+- Updated package dependencies. [#34815]
+
 ## [0.3.3] - 2023-12-20
 ### Changed
 - Updated package dependencies. [#34694]
@@ -287,6 +291,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.4]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.0...v0.3.1

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.4-alpha",
+	"version": "0.3.4",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.4-alpha';
+	const VERSION = '0.3.4';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.0-a.13 - 2024-01-04
+### Bug fixes
+- Jetpack footer links are now consistent within different pages. [#34787]
+- Notification Accessibility: THe notification icon is not a link. [#34810]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Added the "reblog" query param to the iframe in the Like Block when the reblog button is enabled in the block. [#34838]
+- Fix failing E2E tests [#34796]
+- In editor view, the Like block now shows or hides the reblog button according to sidebar config [#34831]
+- Social: Removed obsolete code for Tweetstorms [#34330]
+- Updated package dependencies. [#34815]
+- Updated package dependencies. [#34816]
+
 ## 13.0-a.11 - 2024-01-02
 ### Bug fixes
 - Editor: Fixed missing fonts issue inside the block editor. [#34776]

--- a/projects/plugins/jetpack/changelog/add-like-block-reblog-button
+++ b/projects/plugins/jetpack/changelog/add-like-block-reblog-button
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-In editor view, the Like block now shows or hides the reblog button according to sidebar config

--- a/projects/plugins/jetpack/changelog/add-reblog-query-param-to-like-block
+++ b/projects/plugins/jetpack/changelog/add-reblog-query-param-to-like-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Added the "reblog" query param to the iframe in the Like Block when the reblog button is enabled in the block.

--- a/projects/plugins/jetpack/changelog/fix-admin-bar-when-notifications-are-disabled
+++ b/projects/plugins/jetpack/changelog/fix-admin-bar-when-notifications-are-disabled
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: wp-admin Site Default: Fix WP classic style admin bar when Jetpack Notifications module is off
-
-

--- a/projects/plugins/jetpack/changelog/fix-failing-e2e-tests
+++ b/projects/plugins/jetpack/changelog/fix-failing-e2e-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix failing E2E tests

--- a/projects/plugins/jetpack/changelog/fix-jetpack-footer-inconsistent-behavior
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-footer-inconsistent-behavior
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Jetpack footer links are now consistent within different pages

--- a/projects/plugins/jetpack/changelog/fix-notifications-accessibility
+++ b/projects/plugins/jetpack/changelog/fix-notifications-accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Notification Accessibility: Turn notification icon into a link

--- a/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers
+++ b/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Social: Removed obsolete code for Tweetstorms

--- a/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers#2
+++ b/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers#3
+++ b/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers#4
+++ b/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers#5
+++ b/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers#5
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers#6
+++ b/projects/plugins/jetpack/changelog/remove-social-obsolete-twitter-helpers#6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/renovate-js-unit-testing-packages
+++ b/projects/plugins/jetpack/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/update-stop-reset-cookie-for-a8c-sites
+++ b/projects/plugins/jetpack/changelog/update-stop-reset-cookie-for-a8c-sites
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_13",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_14",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_12",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_13",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.12
+ * Version: 13.0-a.13
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.12' );
+define( 'JETPACK__VERSION', '13.0-a.13' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.13
+ * Version: 13.0-a.14
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.13' );
+define( 'JETPACK__VERSION', '13.0-a.14' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.13",
+	"version": "13.0.0-a.14",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.12",
+	"version": "13.0.0-a.13",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,10 +293,10 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.0-a.11 - 2024-01-02
+### 13.0-a.13 - 2024-01-04
 #### Bug fixes
-- Editor: Fixed missing fonts issue inside the block editor.
-- Subscriptions Block: Added compatibility for the latest Gutenberg.
+- Jetpack footer links are now consistent within different pages.
+- Notification Accessibility: THe notification icon is not a link.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.11 - 2024-01-04
+### Changed
+- Internal updates.
+
 ## 2.0.10 - 2024-01-02
 ### Added
 - Bumped the composer version. [#34789]

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_11_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_11"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.11-alpha
+ * Version: 2.0.11
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.11-alpha",
+	"version": "2.0.11",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.11, jetpack 13.0-a.13

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.