### PR TITLE
Jetpack AI: Remove model selector from AI Excerpt generator

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-remove-model-selector-excerpt
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-remove-model-selector-excerpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Excerpt: remove GPT model selector since it's not possible to change models anymore.

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
@@ -16,7 +16,6 @@ import {
 	PROMPT_TONES_MAP,
 	ToneDropdownMenu,
 } from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
-import AiModelSelectorControl from '../../../../shared/components/ai-model-selector-control';
 /**
  * Types and constants
  */
@@ -75,9 +74,6 @@ export function AiExcerptControl( {
 
 	tone,
 	onToneChange,
-
-	model,
-	onModelChange,
 }: AiExcerptControlProps ) {
 	const [ isSettingActive, setIsSettingActive ] = React.useState( false );
 
@@ -121,12 +117,6 @@ export function AiExcerptControl( {
 						label={ toneLabel }
 						value={ tone }
 						onChange={ onToneChange }
-					/>
-
-					<AiModelSelectorControl
-						model={ model }
-						onModelChange={ onModelChange }
-						disabled={ disabled }
 					/>
 				</>
 			) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { AI_MODEL_GPT_4, useAiSuggestions } from '@automattic/jetpack-ai-client';
+import { useAiSuggestions } from '@automattic/jetpack-ai-client';
 import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { TextareaControl, ExternalLink, Button, Notice, BaseControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -59,7 +59,7 @@ function AiPostExcerpt() {
 	const [ reenable, setReenable ] = useState( false );
 	const [ language, setLanguage ] = useState< LanguageProp >();
 	const [ tone, setTone ] = useState< ToneProp >();
-	const [ model, setModel ] = useState< AiModelTypeProp >( AI_MODEL_GPT_4 );
+	const [ model, setModel ] = useState< AiModelTypeProp >( null );
 
 	const { request, stopSuggestion, suggestion, requestingState, error, reset } = useAiSuggestions( {
 		onDone: useCallback( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34851.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the control element from the UI
* Set the default value of the model as `null`, so it's not present on the HTTP request anymore; it's already being ignored, it's just a matter of not misleading who is reading the code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pe4Cmx-21h-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and write a couple of paragraphs about something (tip: use AI Assistant to generate the text for you, "2 paragraphs about the history of steam powered machines", for example)
* Open the editor sidebar on the "Post" tab:

<img width="200" alt="Screenshot 2024-01-04 at 15 27 50" src="https://github.com/Automattic/jetpack/assets/6760046/9f3e9cc3-53af-4a58-a0b1-0a6b33433017">

* Look for the "Excerpt" section and click the "Advanced AI options" menu:

<img width="250" alt="Screenshot 2024-01-04 at 15 28 34" src="https://github.com/Automattic/jetpack/assets/6760046/aee47f32-337f-43ce-a737-8ca4a8f14100">

* **Before** this change, the "Advanced AI options" would show the model selector:

<img width="250" alt="Screenshot 2024-01-04 at 15 45 38" src="https://github.com/Automattic/jetpack/assets/6760046/e8fed4ee-354e-4456-ab5b-a2e31b591c38">

* **After** this change, the "Advanced AI options" will not show the model selector anymore:

<img width="250" alt="Screenshot 2024-01-04 at 15 29 02" src="https://github.com/Automattic/jetpack/assets/6760046/8cf25dd8-532b-4e72-9e10-ea8da5ae4694">

* Confirm the excerpt generation still works as expected:

<img width="250" alt="Screenshot 2024-01-04 at 15 47 33" src="https://github.com/Automattic/jetpack/assets/6760046/292c58cc-c051-4ead-8612-f3b415b3f982">

* Confirm the model parameter is not included on the request:

<img width="500" alt="Screenshot 2024-01-04 at 15 48 02" src="https://github.com/Automattic/jetpack/assets/6760046/ae4e8620-90be-40af-a075-4d5337a6e256">

* Check the request logs on logstash and confirm the model being used is still the `gpt-3.5-turbo-1106 `:

<img width="300" alt="Screenshot 2024-01-04 at 15 48 24" src="https://github.com/Automattic/jetpack/assets/6760046/5345436f-ea80-442b-97ae-f50a89d2b0dd">