### PR TITLE
Likes Widget: Make likes widget accessibility compatible across themes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-likes-accessibility
+++ b/projects/plugins/jetpack/changelog/fix-likes-accessibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Likes Widget: Make likes widget accessibility compatible across themes

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -43,6 +43,6 @@ function jetpack_likes_master_iframe() {
 	}
 	?>
 	<iframe src='<?php echo esc_url( $src ); ?>' scrolling='no' id='likes-master' name='likes-master' style='display:none;'></iframe>
-	<div id='likers-base-popover' class='likes-other-gravatars <?php echo esc_attr( $new_layout_class ); ?>'><div class="likes-text"><?php echo $likers_text; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>
+	<div id='likes-other-gravatars' class='<?php echo esc_attr( $new_layout_class ); ?>' role="dialog" aria-hidden="true" tabindex="-1"><div class="likes-text"><?php echo $likers_text; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>
 	<?php
 }

--- a/projects/plugins/jetpack/modules/likes/style.css
+++ b/projects/plugins/jetpack/modules/likes/style.css
@@ -51,7 +51,6 @@ div.jetpack-likes-widget-wrapper {
 	width: 100%;
 	min-height: 50px;	/* Previous height, 60px */
 	position: relative; /* Need to abs position placeholder and iframe so there isn't a jarring jump */
-	overflow: visible !important;
 }
 
 div.jetpack-likes-widget-wrapper .sd-link-color {
@@ -68,7 +67,7 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 	margin-bottom: 0;
 }
 
-.likes-other-gravatars {
+#likes-other-gravatars {
 	display: none;
 	position: absolute;
 	padding: 10px 10px 12px 10px;
@@ -80,7 +79,7 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 	z-index: 1000;
 }
 
-.likes-other-gravatars.wpl-new-layout {
+#likes-other-gravatars.wpl-new-layout {
 	display: none;
 	position: absolute;
 	padding: 9px 12px 10px 12px;
@@ -95,62 +94,62 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 	z-index: 1000;
 }
 
-.likes-other-gravatars * {
+#likes-other-gravatars * {
 	line-height: normal;
 }
 
-.likes-other-gravatars .likes-text {
+#likes-other-gravatars .likes-text {
 	color: white;
 	font-size: 12px;
 	padding-bottom: 8px;
 }
 
-.likes-other-gravatars.wpl-new-layout .likes-text {
+#likes-other-gravatars.wpl-new-layout .likes-text {
 	color: #101517;
 	font-size: 12px;
 	font-weight: 500;
 	padding-bottom: 8px;
 }
 
-.likes-other-gravatars ul,
-.likes-other-gravatars li {
+#likes-other-gravatars ul,
+#likes-other-gravatars li {
 	margin: 0;
 	padding: 0;
 	text-indent: 0;
 	list-style-type: none;
 }
 
-.likes-other-gravatars li::before {
+#likes-other-gravatars li::before {
 	content: "";
 }
 
-.likes-other-gravatars ul.wpl-avatars {
+#likes-other-gravatars ul.wpl-avatars {
 	overflow: auto;
 	display: block;
 	max-height: 190px;
 }
 
-.likes-other-gravatars ul.wpl-avatars li {
+#likes-other-gravatars ul.wpl-avatars li {
 	width: 32px;
 	height: 32px;
 	float: left;
 	margin: 0 5px 5px 0;
 }
 
-.likes-other-gravatars.wpl-new-layout ul.wpl-avatars li {
+#likes-other-gravatars.wpl-new-layout ul.wpl-avatars li {
 	width: 196px;
 	height: 28px;
 	float: none;
 	margin: 0 0 4px 0;
 }
 
-.likes-other-gravatars ul.wpl-avatars li a {
+#likes-other-gravatars ul.wpl-avatars li a {
 	margin: 0 2px 0 0;
 	border-bottom: none !important;
 	display: block;
 }
 
-.likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a {
+#likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a {
 	margin: 0 2px 0 0;
 	border-bottom: none !important;
 	display: flex;
@@ -159,7 +158,7 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 	text-decoration: none;
 }
 
-.likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a span {
+#likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a span {
 	font-size: 12px;
 	color: #2C3338;
 	overflow: hidden;
@@ -167,7 +166,7 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 	white-space: nowrap;
 }
 
-.likes-other-gravatars ul.wpl-avatars li a img {
+#likes-other-gravatars ul.wpl-avatars li a img {
 	background: none;
 	border: none;
 	margin: 0 !important;
@@ -176,7 +175,7 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 	box-sizing: border-box;
 }
 
-.likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a img {
+#likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a img {
 	background: none;
 	border: none;
 	border-radius: 50%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/85710

## Proposed changes:

The previous implementation added the popover right after the iframe to get the tab navigation for free. This approach has an unexpected side effect as some themes customize the iframe's position, leading to an overlap between the Like and sharing buttons on some themes. To come up with a solution for the theme compatibility issue, I decided to move back to the previous approach and handle the focus manually with the following scenarios:

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Should be tested together with D133681-code
* Open a post with enough likes on your site
* Navigate to the "x likes" button using tabs
* Click to open the popover and continue navigating with tabs
* The focus should move to the likes popover
* Leave the popover with tabs
* The popover should be closed, and the focus should be moved back to the "x likes" button
* Continue navigating with tabs, and it should focus on the following focusable items
* Enable the screen reader and follow the same steps
* You should have a similar result, being able to access the likers inside the popover and continue navigating on the page
* Check for regressions on the likes widget