### PR TITLE
Like widget / block: Fix caching issue

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-likes-widget-caching-issue
+++ b/projects/plugins/jetpack/changelog/fix-likes-widget-caching-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Like widget: Fix caching issue

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -102,7 +102,7 @@ function render_block( $attr, $content, $block ) {
 		$url       = home_url();
 		$url_parts = wp_parse_url( $url );
 		$domain    = $url_parts['host'];
-		$src       = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s&amp;block=1', $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src       = sprintf( 'https://widgets.wp.com/likes/?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1', JETPACK__VERSION, $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$headline  = sprintf(
 			/** This filter is already documented in modules/sharedaddy/sharing-service.php */
 			apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>', esc_html__( 'Like this:', 'jetpack' ), 'likes' ),

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -102,7 +102,7 @@ function render_block( $attr, $content, $block ) {
 		$url       = home_url();
 		$url_parts = wp_parse_url( $url );
 		$domain    = $url_parts['host'];
-		$src       = sprintf( 'https://widgets.wp.com/likes/?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1', JETPACK__VERSION, $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src       = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1', JETPACK__VERSION, $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$headline  = sprintf(
 			/** This filter is already documented in modules/sharedaddy/sharing-service.php */
 			apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>', esc_html__( 'Like this:', 'jetpack' ), 'likes' ),

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -444,7 +444,7 @@ class Jetpack_Likes {
 		 */
 		$new_layout = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
 
-		$src      = sprintf( 'https://widgets.wp.com/likes/?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s', JETPACK__VERSION, $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src      = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s', JETPACK__VERSION, $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$name     = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$wrapper  = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$headline = sprintf(
@@ -521,7 +521,7 @@ class Jetpack_Likes {
 		// Make sure to include the scripts before the iframe otherwise weird things happen.
 		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
 
-		$src = sprintf( 'https://widgets.wp.com/likes/?ver=%1$d#blog_id=%3$d&amp;post_id=%4$d&amp;origin=%2$s://%5$s', JETPACK_VERSION, $protocol, $blog_id, $post_id, $domain );
+		$src = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%3$d&amp;post_id=%4$d&amp;origin=%2$s://%5$s', JETPACK__VERSION, $protocol, $blog_id, $post_id, $domain );
 
 		$html = "<iframe class='admin-bar-likes-widget jetpack-likes-widget' scrolling='no' frameBorder='0' name='admin-bar-likes-widget' src='$src'></iframe>";
 

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -444,7 +444,7 @@ class Jetpack_Likes {
 		 */
 		$new_layout = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
 
-		$src      = sprintf( 'https://widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s%5$s', $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src      = sprintf( 'https://widgets.wp.com/likes/?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s', JETPACK__VERSION, $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$name     = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$wrapper  = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$headline = sprintf(
@@ -521,7 +521,7 @@ class Jetpack_Likes {
 		// Make sure to include the scripts before the iframe otherwise weird things happen.
 		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
 
-		$src = sprintf( 'https://widgets.wp.com/likes/#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%1$s://%4$s', $protocol, $blog_id, $post_id, $domain );
+		$src = sprintf( 'https://widgets.wp.com/likes/?ver=%1$d#blog_id=%3$d&amp;post_id=%4$d&amp;origin=%2$s://%5$s', JETPACK_VERSION, $protocol, $blog_id, $post_id, $domain );
 
 		$html = "<iframe class='admin-bar-likes-widget jetpack-likes-widget' scrolling='no' frameBorder='0' name='admin-bar-likes-widget' src='$src'></iframe>";
 

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -9,7 +9,7 @@
  * This function needs to get loaded after the like scripts get added to the page.
  */
 function jetpack_likes_master_iframe() {
-	$version = gmdate( 'YWd' );
+	$version = gmdate( 'Ymd' );
 
 	$_locale = get_locale();
 

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -9,7 +9,7 @@
  * This function needs to get loaded after the like scripts get added to the page.
  */
 function jetpack_likes_master_iframe() {
-	$version = gmdate( 'YW' );
+	$version = gmdate( 'YWd' );
 
 	$_locale = get_locale();
 


### PR DESCRIPTION
Fixes p1704452319462799/1704420940.584919-slack-C02TCEHP3HA

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* add `?ver` parameter to all `https://widgets.wp.com/likes` requests (set to `JETPACK__VERSION`) - to make sure the updated scripts and styles are loaded on new Jetpack version
* change the `?ver` parameter of the `https://widgets.wp.com/likes/master.html` request to use `Ymd` instead of `YW` date stamp - to speed up refreshing the cached iframe code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

* p1704452319462799/1704420940.584919-slack-C02TCEHP3HA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Jetpack site**

1. Check out the PR and build it.
2. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
3. Launch Jurassic Tube to make your local site available publicly.
4. Connect Jetpack to your WordPress.com account and enable Likes feature.
5. Enable Likes (in _WP Admin → Jetpack → Settings → Sharing_).
6. Add the new Like block to a post on your test site.
7. Review the post in the front-end. Both the Like block and Like widget should be loading correctly and should be operational.

**Atomic site**

1. Check out the PR - you can use the Jetpack Beta plugin for instance.
2. Since this new block is in beta, make sure your WordPress site has `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` line in its `wp-config.php`.
3. Enable Likes (in _Calypso → Tools → Marketing → Sharing Buttons_).
4. Add the new Like block to a post on your test site.
5. Review the post in the front-end. Both the Like block and Like widget should be loading correctly and should be operational.