### PR TITLE
Social: Fix review prompt initial state

### DIFF
--- a/projects/plugins/social/changelog/fix-social-review-prompt-initial-state
+++ b/projects/plugins/social/changelog/fix-social-review-prompt-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug with the initial state script

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -110,9 +110,9 @@ class Jetpack_Social {
 		add_action( 'rest_api_init', array( new Automattic\Jetpack\Social\REST_Settings_Controller(), 'register_rest_routes' ) );
 
 		// Add block editor assets
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_scripts' ) );
+		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_editor_scripts' ) );
 		// Adds the review prompt initial state
-		add_action( 'enqueue_block_editor_assets', array( $this, 'add_review_initial_state' ), 30 );
+		add_action( 'enqueue_block_assets', array( $this, 'add_review_initial_state' ), 30 );
 
 		// Add meta tags.
 		add_action( 'wp_head', array( new Automattic\Jetpack\Social\Meta_Tags(), 'render_tags' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

With changing the action for enquiring block scripts in #32641, the Social review prompts got messed up

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the action in `class-jetpack-social.php`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/orgs/Automattic/projects/733/views/2?pane=issue&itemId=44702234
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do this with Social+Jetpack enabled, but it should also work with only Social enabled
* Open the editor on trunk and run `window.Jetpack_Editor_Initial_State.social.reviewRequestDismissed` in the console
* It should return undefined, and publishing should not show the review prompt.
* With this change applied, the command above should return false, and the review prompt should be visible in the post-publish sidebar

