### PR TITLE
Launchpad: Remove the "Set up your Professional Email" task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-professional-email-setup-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-professional-email-setup-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removes the `Set up your Professional Email` task

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.8.0",
+	"version": "5.8.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.8.0';
+	const PACKAGE_VERSION = '5.8.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -13,7 +13,7 @@
 function wpcom_launchpad_get_task_definitions() {
 	$task_definitions = array(
 		// Core tasks.
-		'design_edited'                      => array(
+		'design_edited'                   => array(
 			'get_title'             => function () {
 				return __( 'Edit site design', 'jetpack-mu-wpcom' );
 			},
@@ -26,7 +26,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 		// design_completed checks for task completion while design_selected always returns true.
-		'design_completed'                   => array(
+		'design_completed'                => array(
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );
 			},
@@ -36,7 +36,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/setup/update-design/designSetup?siteSlug=' . $data['site_slug_encoded'] . '&flow=' . $flow;
 			},
 		),
-		'design_selected'                    => array(
+		'design_selected'                 => array(
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );
 			},
@@ -46,7 +46,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/setup/update-design/designSetup?siteSlug=' . $data['site_slug_encoded'];
 			},
 		),
-		'domain_claim'                       => array(
+		'domain_claim'                    => array(
 			'get_title'            => function () {
 				return __( 'Claim your free one-year domain', 'jetpack-mu-wpcom' );
 			},
@@ -56,7 +56,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/domains/add/' . $data['site_slug_encoded'];
 			},
 		),
-		'domain_upsell'                      => array(
+		'domain_upsell'                   => array(
 			'id_map'               => 'domain_upsell_deferred',
 			'get_title'            => function () {
 				return __( 'Choose a domain', 'jetpack-mu-wpcom' );
@@ -72,7 +72,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/setup/domain-upsell/domains?siteSlug=' . $data['site_slug_encoded'];
 			},
 		),
-		'first_post_published'               => array(
+		'first_post_published'            => array(
 			'get_title'             => function () {
 				return __( 'Write your first post', 'jetpack-mu-wpcom' );
 			},
@@ -90,7 +90,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return $base_path;
 			},
 		),
-		'plan_completed'                     => array(
+		'plan_completed'                  => array(
 			'get_title'            => function () {
 				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
 			},
@@ -102,7 +102,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/setup/' . $flow . '/plans?siteSlug=' . $data['site_slug_encoded'];
 			},
 		),
-		'plan_selected'                      => array(
+		'plan_selected'                   => array(
 			'get_title'            => function () {
 				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
 			},
@@ -113,7 +113,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/plans/' . $data['site_slug_encoded'];
 			},
 		),
-		'setup_general'                      => array(
+		'setup_general'                   => array(
 			'get_title'            => function () {
 				return __( 'Give your site a name', 'jetpack-mu-wpcom' );
 			},
@@ -123,14 +123,14 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},
 		),
-		'site_launched'                      => array(
+		'site_launched'                   => array(
 			'get_title'             => function () {
 				return __( 'Launch your site', 'jetpack-mu-wpcom' );
 			},
 			'isLaunchTask'          => true,
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
-		'verify_email'                       => array(
+		'verify_email'                    => array(
 			'get_title'            => function () {
 				return __( 'Verify email address', 'jetpack-mu-wpcom' );
 			},
@@ -142,7 +142,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Newsletter pre-launch tasks.
-		'first_post_published_newsletter'    => array(
+		'first_post_published_newsletter' => array(
 			'id_map'                => 'first_post_published',
 			'get_title'             => function () {
 				return __( 'Start writing', 'jetpack-mu-wpcom' );
@@ -154,7 +154,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/post/' . $data['site_slug_encoded'];
 			},
 		),
-		'newsletter_plan_created'            => array(
+		'newsletter_plan_created'         => array(
 			'get_title'           => function () {
 				return __( 'Create paid Newsletter', 'jetpack-mu-wpcom' );
 			},
@@ -163,7 +163,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/earn/payments/' . $data['site_slug_encoded'] . '#add-newsletter-payment-plan';
 			},
 		),
-		'setup_newsletter'                   => array(
+		'setup_newsletter'                => array(
 			'id'                   => 'setup_newsletter',
 			'get_title'            => function () {
 				return __( 'Personalize newsletter', 'jetpack-mu-wpcom' );
@@ -173,7 +173,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},
 		),
-		'set_up_payments'                    => array(
+		'set_up_payments'                 => array(
 			'get_title'           => function () {
 				return __( 'Set up payment method', 'jetpack-mu-wpcom' );
 			},
@@ -190,7 +190,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/earn/payments/' . $data['site_slug_encoded'];
 			},
 		),
-		'subscribers_added'                  => array(
+		'subscribers_added'               => array(
 			'get_title'            => function () {
 				return __( 'Add subscribers', 'jetpack-mu-wpcom' );
 			},
@@ -200,7 +200,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
 			},
 		),
-		'migrate_content'                    => array(
+		'migrate_content'                 => array(
 			'get_title'            => function () {
 				return __( 'Migrate content', 'jetpack-mu-wpcom' );
 			},
@@ -212,7 +212,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Link in bio tasks.
-		'link_in_bio_launched'               => array(
+		'link_in_bio_launched'            => array(
 			'get_title'             => function () {
 				return __( 'Launch your site', 'jetpack-mu-wpcom' );
 			},
@@ -220,7 +220,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_disabled_callback'  => 'wpcom_launchpad_is_link_in_bio_launch_disabled',
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
-		'links_added'                        => array(
+		'links_added'                     => array(
 			'get_title'             => function () {
 				return __( 'Add links', 'jetpack-mu-wpcom' );
 			},
@@ -232,7 +232,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/site-editor/' . $data['site_slug_encoded'];
 			},
 		),
-		'setup_link_in_bio'                  => array(
+		'setup_link_in_bio'               => array(
 			'get_title'            => function () {
 				return __( 'Personalize Link in Bio', 'jetpack-mu-wpcom' );
 			},
@@ -243,7 +243,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Videopress tasks.
-		'videopress_launched'                => array(
+		'videopress_launched'             => array(
 			'id_map'                => 'site_launched',
 			'get_title'             => function () {
 				return __( 'Launch site', 'jetpack-mu-wpcom' );
@@ -251,13 +251,13 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_disabled_callback'  => 'wpcom_launchpad_is_videopress_launch_disabled',
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
-		'videopress_setup'                   => array(
+		'videopress_setup'                => array(
 			'get_title'            => function () {
 				return __( 'Set up your video site', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
 		),
-		'videopress_upload'                  => array(
+		'videopress_upload'               => array(
 			'id_map'                => 'video_uploaded',
 			'get_title'             => function () {
 				return __( 'Upload your first video', 'jetpack-mu-wpcom' );
@@ -276,7 +276,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Blog tasks.
-		'blog_launched'                      => array(
+		'blog_launched'                   => array(
 			'get_title'             => function () {
 				return __( 'Launch your blog', 'jetpack-mu-wpcom' );
 			},
@@ -284,7 +284,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_disabled_callback'  => 'wpcom_launchpad_is_blog_launched_task_disabled',
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
-		'setup_blog'                         => array(
+		'setup_blog'                      => array(
 			'get_title'            => function () {
 				return __( 'Name your blog', 'jetpack-mu-wpcom' );
 			},
@@ -296,7 +296,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Free plan tasks.
-		'setup_free'                         => array(
+		'setup_free'                      => array(
 			'get_title'            => function () {
 				return __( 'Personalize your site', 'jetpack-mu-wpcom' );
 			},
@@ -307,7 +307,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Write tasks.
-		'setup_write'                        => array(
+		'setup_write'                     => array(
 			'get_title'            => function () {
 				return __( 'Set up your site', 'jetpack-mu-wpcom' );
 			},
@@ -316,7 +316,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Keep Building tasks.
-		'site_title'                         => array(
+		'site_title'                      => array(
 			'get_title'            => function () {
 				return __( 'Give your site a name', 'jetpack-mu-wpcom' );
 			},
@@ -327,7 +327,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 
-		'drive_traffic'                      => array(
+		'drive_traffic'                   => array(
 			'get_title'            => function () {
 				return __( 'Drive traffic to your site', 'jetpack-mu-wpcom' );
 			},
@@ -337,7 +337,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 
-		'add_new_page'                       => array(
+		'add_new_page'                    => array(
 			'get_title'            => function () {
 				return __( 'Add a new page', 'jetpack-mu-wpcom' );
 			},
@@ -347,7 +347,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 
-		'update_about_page'                  => array(
+		'update_about_page'               => array(
 			'get_title'            => function () {
 				return __( 'Update your About page', 'jetpack-mu-wpcom' );
 			},
@@ -363,7 +363,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 
-		'edit_page'                          => array(
+		'edit_page'                       => array(
 			'get_title'            => function () {
 				return __( 'Edit a page', 'jetpack-mu-wpcom' );
 			},
@@ -374,7 +374,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 
-		'domain_customize'                   => array(
+		'domain_customize'                => array(
 			'id_map'               => 'domain_customize_deferred',
 			'get_title'            => function () {
 				return __( 'Customize your domain', 'jetpack-mu-wpcom' );
@@ -390,7 +390,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 
-		'share_site'                         => array(
+		'share_site'                      => array(
 			'get_title'            => function () {
 				return __( 'Share your site', 'jetpack-mu-wpcom' );
 			},
@@ -398,7 +398,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Newsletter post-launch tasks.
-		'earn_money'                         => array(
+		'earn_money'                      => array(
 			'get_title'            => function () {
 				return __( 'Earn money with your newsletter', 'jetpack-mu-wpcom' );
 			},
@@ -408,7 +408,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 
-		'customize_welcome_message'          => array(
+		'customize_welcome_message'       => array(
 			'get_title'            => function () {
 				return __( 'Customize welcome message', 'jetpack-mu-wpcom' );
 			},
@@ -417,7 +417,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/settings/newsletter/' . $data['site_slug_encoded'];
 			},
 		),
-		'enable_subscribers_modal'           => array(
+		'enable_subscribers_modal'        => array(
 			'get_title'            => function () {
 				return __( 'Enable subscribers modal', 'jetpack-mu-wpcom' );
 			},
@@ -426,7 +426,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/settings/newsletter/' . $data['site_slug_encoded'];
 			},
 		),
-		'add_10_email_subscribers'           => array(
+		'add_10_email_subscribers'        => array(
 			'get_title'                 => function () {
 				return __( 'Get your first 10 subscribers', 'jetpack-mu-wpcom' );
 			},
@@ -438,7 +438,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/subscribers/' . $data['site_slug_encoded'];
 			},
 		),
-		'write_3_posts'                      => array(
+		'write_3_posts'                   => array(
 			'get_title'                 => function () {
 				return __( 'Write 3 posts', 'jetpack-mu-wpcom' );
 			},
@@ -448,7 +448,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/post/' . $data['site_slug_encoded'];
 			},
 		),
-		'manage_subscribers'                 => array(
+		'manage_subscribers'              => array(
 			'get_title'            => function () {
 				return __( 'Manage your subscribers', 'jetpack-mu-wpcom' );
 			},
@@ -458,7 +458,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/subscribers/' . $data['site_slug_encoded'];
 			},
 		),
-		'connect_social_media'               => array(
+		'connect_social_media'            => array(
 			'id_map'           => 'drive_traffic',
 			'get_title'        => function () {
 				return __( 'Connect your social media accounts', 'jetpack-mu-wpcom' );
@@ -467,7 +467,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/marketing/connections/' . $data['site_slug_encoded'];
 			},
 		),
-		'manage_paid_newsletter_plan'        => array(
+		'manage_paid_newsletter_plan'     => array(
 			'get_title'            => function () {
 				return __( 'Manage your paid Newsletter plan', 'jetpack-mu-wpcom' );
 			},
@@ -477,7 +477,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/earn/payments/' . $data['site_slug_encoded'];
 			},
 		),
-		'add_about_page'                     => array(
+		'add_about_page'                  => array(
 			'get_title'            => function () {
 				return __( 'Add your About page', 'jetpack-mu-wpcom' );
 			},
@@ -489,7 +489,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Earn tasks
-		'stripe_connected'                   => array(
+		'stripe_connected'                => array(
 			'get_title'            => function () {
 				return __( 'Connect a Stripe account to collect payments', 'jetpack-mu-wpcom' );
 			},
@@ -506,7 +506,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/earn/payments/' . $data['site_slug_encoded'];
 			},
 		),
-		'paid_offer_created'                 => array(
+		'paid_offer_created'              => array(
 			'get_title'            => function () {
 				return __( 'Set up an offer for your supporters', 'jetpack-mu-wpcom' );
 			},
@@ -518,7 +518,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Hosting flow tasks
-		'site_theme_selected'                => array(
+		'site_theme_selected'             => array(
 			'get_title'            => function () {
 				return __( 'Choose a theme', 'jetpack-mu-wpcom' );
 			},
@@ -527,7 +527,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/themes/' . $data['site_slug_encoded'];
 			},
 		),
-		'install_custom_plugin'              => array(
+		'install_custom_plugin'           => array(
 			'get_title'            => function () {
 				return __( 'Install a custom plugin', 'jetpack-mu-wpcom' );
 			},
@@ -536,7 +536,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/plugins/' . $data['site_slug_encoded'];
 			},
 		),
-		'setup_ssh'                          => array(
+		'setup_ssh'                       => array(
 			'get_title'            => function () {
 				return __( 'Set up ssh', 'jetpack-mu-wpcom' );
 			},
@@ -545,7 +545,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/hosting-config/' . $data['site_slug_encoded'] . '#sftp-credentials';
 			},
 		),
-		'site_monitoring_page'               => array(
+		'site_monitoring_page'            => array(
 			'get_title'            => function () {
 				return __( 'View site metrics', 'jetpack-mu-wpcom' );
 			},
@@ -554,7 +554,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/site-monitoring/' . $data['site_slug_encoded'];
 			},
 		),
-		'import_subscribers'                 => array(
+		'import_subscribers'              => array(
 			'get_title'            => function () {
 				return __( 'Import existing subscribers', 'jetpack-mu-wpcom' );
 			},
@@ -565,7 +565,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
 			},
 		),
-		'add_subscribe_block'                => array(
+		'add_subscribe_block'             => array(
 			'get_title'            => function () {
 				return __( 'Add the Subscribe Block to your site', 'jetpack-mu-wpcom' );
 			},
@@ -575,7 +575,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/site-editor/' . $data['site_slug_encoded'] . '/?canvas=edit&help-center=subscribe-block';
 			},
 		),
-		'mobile_app_installed'               => array(
+		'mobile_app_installed'            => array(
 			'get_title'            => function () {
 				return __( 'Install the mobile app', 'jetpack-mu-wpcom' );
 			},
@@ -584,16 +584,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/me/get-apps';
 			},
 		),
-		'professional_email_mailbox_created' => array(
-			'get_title'            => function () {
-				return __( 'Set up professional email', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/email/' . $data['site_slug_encoded'];
-			},
-		),
-		'post_sharing_enabled'               => array(
+		'post_sharing_enabled'            => array(
 			'get_title'            => function () {
 				return __( 'Enable post sharing', 'jetpack-mu-wpcom' );
 			},
@@ -602,7 +593,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/marketing/connections/' . $data['site_slug_encoded'];
 			},
 		),
-		'front_page_updated'                 => array(
+		'front_page_updated'              => array(
 			'get_title'            => function () {
 				return __( "Update your site's design", 'jetpack-mu-wpcom' );
 			},
@@ -615,7 +606,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/site-editor/' . $data['site_slug_encoded'] . '?canvas=edit';
 			},
 		),
-		'woocommerce_setup'                  => array(
+		'woocommerce_setup'               => array(
 			'get_title'            => function () {
 				return __( 'Finish store setup', 'jetpack-mu-wpcom' );
 			},
@@ -625,7 +616,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return site_url( '/wp-admin/admin.php?page=wc-admin' );
 			},
 		),
-		'sensei_setup'                       => array(
+		'sensei_setup'                    => array(
 			'get_title'            => function () {
 				return __( 'Finish Sensei setup', 'jetpack-mu-wpcom' );
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -278,7 +278,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'verify_domain_email',
 				'verify_email',
 				'mobile_app_installed',
-				'setup_professional_email',
 				'post_sharing_enabled',
 				'site_launched',
 			),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

More context: p1704463397882879-slack-C01TJT42PMM

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In the discussion above, we relate the reasons for removing this task from the migration.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visual inspection is enough in this case since the task was not being used and the key on the task list was not matching the task definition key.