### PR TITLE
CRM: 3405 - more robust local install detection

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3405-use_more_robust_IP_check
+++ b/projects/plugins/crm/changelog/fix-crm-3405-use_more_robust_IP_check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Backend: Add fallback for dev site detection.

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -417,9 +417,10 @@ function zeroBSCRM_wpb_lastlogin($uid ) {
 	    return ((float)$usec + (float)$sec);
 	}     
 
-	#} Does it's best to find the real IP for user
+	#} Does its best to find the real IP for user
 	function zeroBSCRM_getRealIpAddr()
 	{
+		$ip = false;
 		#} check ip from share internet
 		if (isset($_SERVER['HTTP_CLIENT_IP']) && !empty($_SERVER['HTTP_CLIENT_IP']))
 		{

--- a/projects/plugins/crm/includes/ZeroBSCRM.PluginUpdates.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.PluginUpdates.php
@@ -981,13 +981,12 @@ class zeroBSCRM_Plugin_Updater {
 // defaults to full check as of 2.97.9
 // SELECT * FROM `zbs_app_users_licenses_requests` WHERE action = 'localcheck'
 function zeroBSCRM_isLocal($fullCheck=true) {
-
 	// quick caching
 	if (jpcrm_is_devmode_override()) return false;
 
 	// is local, unless override setting set within past 48h
-    $whitelist = array( '127.0.0.1','localhost', '::1' );
-    if (in_array( $_SERVER['REMOTE_ADDR'], $whitelist)){
+	$whitelist = array( '127.0.0.1', 'localhost', '::1' );
+	if ( in_array( zeroBSCRM_getRealIpAddr(), $whitelist, true ) ) {
 
     	if ($fullCheck){
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3405 - more robust local install detection

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In WordPress Playground, `$_SERVER['REMOTE_ADDR']` is not set, so it was giving a PHP notice in the CRM. I switched the call to use the pre-existing `zeroBSCRM_getRealIpAddr()` (and added a fallback to that function just in case).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In `trunk` + WP Playground, one gets a PHP notice on the System Status page (`/wp-admin/admin.php?page=zerobscrm-systemstatus&tab=status`).

In the `fix/crm/3405-use_more_robust_IP_check` branch + WP Playground the PHP notice is no more.