### PR TITLE
CRM: 3408 - detect and expose SQLite usage

### DIFF
--- a/projects/plugins/crm/admin/system/system-status.page.php
+++ b/projects/plugins/crm/admin/system/system-status.page.php
@@ -247,10 +247,6 @@ function zeroBSCRM_render_systemstatus_page() {
 
 		global $ZBSCRM_t,$wpdb;
 		$missingTables = array();
-		$tablesExist   = $wpdb->get_results( "SHOW TABLES LIKE '" . $ZBSCRM_t['keys'] . "'" );
-		if ( count( $tablesExist ) < 1 ) {
-			$missingTables[] = $ZBSCRM_t['keys'];
-		}
 
 		// then we cycle through our tables :) - means all keys NEED to be kept up to date :)
 		foreach ( $ZBSCRM_t as $tableKey => $tableName ) {

--- a/projects/plugins/crm/admin/system/system-status.page.php
+++ b/projects/plugins/crm/admin/system/system-status.page.php
@@ -319,7 +319,7 @@ function zeroBSCRM_render_systemstatus_page() {
 							'corever'       => 'CRM Core Version',
 							'dbver'         => 'Database Version',
 							'dalver'        => 'DAL Version',
-							'mysql'         => 'MySQL Version',
+							'dbserver'      => 'Database Server (version)',
 							'innodb'        => 'InnoDB Storage Engine',
 							'sqlrights'     => 'SQL Permissions',
 							'locale'        => 'Locale',

--- a/projects/plugins/crm/changelog/fix-crm-3404-sqlite_transactions
+++ b/projects/plugins/crm/changelog/fix-crm-3404-sqlite_transactions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Transactions: Better support for SQLite.

--- a/projects/plugins/crm/changelog/fix-crm-3406-address_sqlite_table_creation_error
+++ b/projects/plugins/crm/changelog/fix-crm-3406-address_sqlite_table_creation_error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/plugins/crm/changelog/fix-crm-3408-detect_sqlite_usage
+++ b/projects/plugins/crm/changelog/fix-crm-3408-detect_sqlite_usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Database: Added preliminary support for SQLite.

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -562,8 +562,8 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
                 #} Aliases
                 if ($withAliases){
 
-                    #} Retrieve these as a CSV :)
-                    $extraSelect .= ",(SELECT GROUP_CONCAT(aka_alias SEPARATOR ',') FROM ".$ZBSCRM_t['aka']." WHERE aka_type = ".ZBS_TYPE_CONTACT." AND aka_id = contact.ID) aliases";
+					#} Retrieve these as a CSV :)
+					$extraSelect .= ',(SELECT ' . $this->DAL()->build_group_concat( 'aka_alias', ',' ) . ' FROM ' . $ZBSCRM_t['aka'] . ' WHERE aka_type = ' . ZBS_TYPE_CONTACT . ' AND aka_id = contact.ID) aliases'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
                 }
 
@@ -1182,8 +1182,8 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
             #} Aliases
             if ($withAliases){
 
-                #} Retrieve these as a CSV :)
-                $extraSelect .= ",(SELECT GROUP_CONCAT(aka_alias SEPARATOR ',') FROM ".$ZBSCRM_t['aka']." WHERE aka_type = ".ZBS_TYPE_CONTACT." AND aka_id = contact.ID) aliases";
+				#} Retrieve these as a CSV :)
+				$extraSelect .= ',(SELECT ' . $this->DAL()->build_group_concat( 'aka_alias', ',' ) . ' FROM ' . $ZBSCRM_t['aka'] . ' WHERE aka_type = ' . ZBS_TYPE_CONTACT . ' AND aka_id = contact.ID) aliases'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
             }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Transactions.php
@@ -9,6 +9,8 @@
  * Date: 14/01/19
  */
 
+// phpcs:disable Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
 /* ======================================================
   Breaking Checks ( stops direct access )
    ====================================================== */
@@ -393,7 +395,7 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
                     if (is_array($custFields)) foreach ($custFields as $cK => $cF){
 
                         // add as subquery
-                        $extraSelect .= ',(SELECT zbscf_objval FROM '.$ZBSCRM_t['customfields']." WHERE zbscf_objid = transaction.ID AND zbscf_objkey = %s AND zbscf_objtype = %d LIMIT 1) '".$cK."'";
+												$extraSelect .= ',(SELECT zbscf_objval FROM ' . $ZBSCRM_t['customfields'] . " WHERE zbscf_objid = transactions.ID AND zbscf_objkey = %s AND zbscf_objtype = %d LIMIT 1) '" . $cK . "'";
                         
                         // add params
                         $params[] = $cK; $params[] = ZBS_TYPE_TRANSACTION;
@@ -402,26 +404,30 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
 
                 }
 
-                $selector = 'transaction.*';
+								$selector = 'transactions.*';
                 if (isset($fields) && is_array($fields)) {
                     $selector = '';
 
-                    // always needs id, so add if not present
-                    if (!in_array('ID',$fields)) $selector = 'transaction.ID';
+					// always needs id, so add if not present
+					if ( ! in_array( 'ID', $fields, true ) ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+						$selector = 'transactions.ID';
+					}
 
-                    foreach ($fields as $f) {
-                        if (!empty($selector)) $selector .= ',';
-                        $selector .= 'transaction.'.$f;
-                    }
-                } else if ($onlyID){
-                    $selector = 'transaction.ID';
-                }
+					foreach ( $fields as $f ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+						if ( ! empty( $selector ) ) {
+							$selector .= ',';
+						}
+						$selector .= 'transactions.' . $f;
+					}
+				} elseif ( $onlyID ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+					$selector = 'transactions.ID';
+					}
 
             #} ============ / PRE-QUERY ===========
 
 
             #} Build query
-            $query = "SELECT ".$selector.$extraSelect." FROM ".$ZBSCRM_t['transactions'].' as transaction';
+						$query = 'SELECT ' . $selector . $extraSelect . ' FROM ' . $ZBSCRM_t['transactions'] . ' AS transactions'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
             #} ============= WHERE ================
 
                 if (!empty($id) && $id > 0){
@@ -728,7 +734,7 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
                     }
 
                     // add as subquery
-                    $extraSelect .= ',(SELECT zbscf_objval FROM '.$ZBSCRM_t['customfields']." WHERE zbscf_objid = transaction.ID AND zbscf_objkey = %s AND zbscf_objtype = %d LIMIT 1) ".$cKey;
+                    $extraSelect .= ',(SELECT zbscf_objval FROM ' . $ZBSCRM_t['customfields'] . ' WHERE zbscf_objid = transactions.ID AND zbscf_objkey = %s AND zbscf_objtype = %d LIMIT 1) ' . $cKey;
                     
                     // add params
                     $params[] = $cK; $params[] = ZBS_TYPE_TRANSACTION;
@@ -742,26 +748,28 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
 				$joinQ .= '  LEFT JOIN (
 								SELECT 
 									extsrcs.zbss_objid external_source_objid,
-									GROUP_CONCAT(extsrcs.zbss_uid SEPARATOR "\n") AS external_source_uids,
-									GROUP_CONCAT(extsrcs.zbss_source SEPARATOR "\n") AS external_source_sources
+									' . $this->DAL()->build_group_concat( 'extsrcs.zbss_uid', '\n' ) . ' AS external_source_uids,
+									' . $this->DAL()->build_group_concat( 'extsrcs.zbss_source', '\n' ) . ' AS external_source_sources
 								FROM 
 									' . $ZBSCRM_t['externalsources'] . ' extsrcs
 								WHERE 
 								  extsrcs.zbss_objtype = %s
 								GROUP BY extsrcs.zbss_objid
 							) external_source ON
-								transaction.ID = external_source.external_source_objid' ;
+								transactions.ID = external_source.external_source_objid';
 				$params[] = ZBS_TYPE_TRANSACTION;
 			}
 
         #} ============ / PRE-QUERY ===========
 
-        #} Build query
-        $query = "SELECT transaction.*".$extraSelect." FROM ".$ZBSCRM_t['transactions'].' as transaction'.$joinQ;
+			#} Build query
+			$query = 'SELECT transactions.*' . $extraSelect . ' FROM ' . $ZBSCRM_t['transactions'] . ' AS transactions' . $joinQ;
 
-        #} Count override
-        if ($count) $query = "SELECT COUNT(transaction.ID) FROM ".$ZBSCRM_t['transactions'].' as transaction'.$joinQ;
-        
+			#} Count override
+			if ( $count ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+				$query = 'SELECT COUNT(transactions.ID) FROM ' . $ZBSCRM_t['transactions'] . ' AS transactions' . $joinQ;
+			}
+
         #} onlyColumns override
         if ($onlyColumns && is_array($onlyColumnsFieldArr) && count($onlyColumnsFieldArr) > 0){
 
@@ -774,14 +782,14 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
 
             }
 
-            $query = "SELECT ".$columnStr." FROM ".$ZBSCRM_t['transactions'].' as transaction'.$joinQ;
+				$query = 'SELECT ' . $columnStr . ' FROM ' . $ZBSCRM_t['transactions'] . ' AS transactions' . $joinQ;
 
         }
 
         // $total only override
         if ( $total ){
-        
-            $query = "SELECT SUM(transaction.zbst_total) total FROM ".$ZBSCRM_t['transactions'].' as transaction'.$joinQ;
+
+				$query = 'SELECT SUM(transactions.zbst_total) total FROM ' . $ZBSCRM_t['transactions'] . ' AS transactions' . $joinQ;
 
         }
 
@@ -924,9 +932,12 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
 
             if (!is_array($isTagged) && !empty($isTagged) && $isTagged > 0){
 
-                // add where tagged                 
-                // 1 int: 
-                $wheres['direct'][] = array('((SELECT COUNT(ID) FROM '.$ZBSCRM_t['taglinks'].' WHERE zbstl_objtype = %d AND zbstl_objid = transaction.ID AND zbstl_tagid = %d) > 0)',array(ZBS_TYPE_TRANSACTION,$isTagged));
+				// add where tagged
+				// 1 int:
+				$wheres['direct'][] = array(
+					'((SELECT COUNT(ID) FROM ' . $ZBSCRM_t['taglinks'] . ' WHERE zbstl_objtype = %d AND zbstl_objid = transactions.ID AND zbstl_tagid = %d) > 0)',
+					array( ZBS_TYPE_TRANSACTION, $isTagged ),
+				);
 
             } else if (is_array($isTagged) && count($isTagged) > 0){
 
@@ -941,8 +952,11 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
                     }
                 }
                 if (!empty($tagStr)){
-                    
-                    $wheres['direct'][] = array('((SELECT COUNT(ID) FROM '.$ZBSCRM_t['taglinks'].' WHERE zbstl_objtype = %d AND zbstl_objid = transaction.ID AND zbstl_tagid IN (%s)) > 0)',array(ZBS_TYPE_TRANSACTION,$tagStr));
+
+					$wheres['direct'][] = array(
+						'((SELECT COUNT(ID) FROM ' . $ZBSCRM_t['taglinks'] . ' WHERE zbstl_objtype = %d AND zbstl_objid = transactions.ID AND zbstl_tagid IN (%s)) > 0)',
+						array( ZBS_TYPE_TRANSACTION, $tagStr ),
+					);
 
                 }
 
@@ -954,9 +968,12 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
                 
             if (!is_array($isNotTagged) && !empty($isNotTagged) && $isNotTagged > 0){
 
-                // add where tagged                 
-                // 1 int: 
-                $wheres['direct'][] = array('((SELECT COUNT(ID) FROM '.$ZBSCRM_t['taglinks'].' WHERE zbstl_objtype = %d AND zbstl_objid = transaction.ID AND zbstl_tagid = %d) = 0)',array(ZBS_TYPE_TRANSACTION,$isNotTagged));
+					// add where tagged
+					// 1 int:
+					$wheres['direct'][] = array(
+						'((SELECT COUNT(ID) FROM ' . $ZBSCRM_t['taglinks'] . ' WHERE zbstl_objtype = %d AND zbstl_objid = transactions.ID AND zbstl_tagid = %d) = 0)',
+						array( ZBS_TYPE_TRANSACTION, $isNotTagged ),
+					);
 
             } else if (is_array($isNotTagged) && count($isNotTagged) > 0){
 
@@ -971,8 +988,11 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
                     }
                 }
                 if (!empty($tagStr)){
-                    
-                    $wheres['direct'][] = array('((SELECT COUNT(ID) FROM '.$ZBSCRM_t['taglinks'].' WHERE zbstl_objtype = %d AND zbstl_objid = transaction.ID AND zbstl_tagid IN (%s)) = 0)',array(ZBS_TYPE_TRANSACTION,$tagStr));
+
+						$wheres['direct'][] = array(
+							'((SELECT COUNT(ID) FROM ' . $ZBSCRM_t['taglinks'] . ' WHERE zbstl_objtype = %d AND zbstl_objid = transactions.ID AND zbstl_tagid IN (%s)) = 0)',
+							array( ZBS_TYPE_TRANSACTION, $tagStr ),
+						);
 
                 }
 
@@ -990,12 +1010,12 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
 
             // Mapped sorts
             // This catches listview and other exception sort cases
-            $sort_map = array(
+					$sort_map = array(
 
-                // Note: "customer" here could be company or contact, so it's not a true sort (as no great way of doing this beyond some sort of prefix comparing)               
-                'customer'          => '(SELECT ID FROM '.$ZBSCRM_t['contacts'].' WHERE ID IN (SELECT zbsol_objid_to FROM '.$ZBSCRM_t['objlinks'].' WHERE zbsol_objtype_from = '.ZBS_TYPE_TRANSACTION.' AND zbsol_objtype_to = '.ZBS_TYPE_CONTACT.' AND zbsol_objid_from = transaction.ID))',
+						// Note: "customer" here could be company or contact, so it's not a true sort (as no great way of doing this beyond some sort of prefix comparing)
+						'customer' => '(SELECT ID FROM ' . $ZBSCRM_t['contacts'] . ' WHERE ID IN (SELECT zbsol_objid_to FROM ' . $ZBSCRM_t['objlinks'] . ' WHERE zbsol_objtype_from = ' . ZBS_TYPE_TRANSACTION . ' AND zbsol_objtype_to = ' . ZBS_TYPE_CONTACT . ' AND zbsol_objid_from = transactions.ID))',
 
-            );
+					);
             
             if ( array_key_exists( $sortByField, $sort_map ) ) {
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -7405,6 +7405,23 @@ class zbsDAL {
 
         }
 
+	/**
+	 * Generates GROUP_CONCAT SQL compatible with both SQLite and MySQL
+	 *
+	 * @param string $field Field that will be concatenated.
+	 * @param string $separator Separator added between concatenated fields.
+	 *
+	 * @return string
+	 */
+	public function build_group_concat( $field, $separator ) {
+		$db_engine = jpcrm_database_engine();
+		if ( $db_engine === 'sqlite' ) {
+			return sprintf( 'GROUP_CONCAT(%s, "%s")', $field, $separator );
+		} else {
+			return sprintf( 'GROUP_CONCAT(%s SEPARATOR "%s")', $field, $separator );
+		}
+	}
+
         // this returns %s etc. for common field names, will default to %s unless somt obv a date
         public function getTypeStr($fieldKey=''){
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -1016,24 +1016,40 @@ function zeroBSCRM_DB_canInnoDB(){
 
 }
 
-function zeroBSCRM_database_getVersion(){
+/**
+ * Get info about the database engine.
+ *
+ * @param boolean $pretty Retrieve a user-friendly label instead of a slug.
+ *
+ * @return string
+ */
+function jpcrm_database_engine( $pretty = false ) {
 	global $zbs;
-	return $zbs->database_server_info['raw_version'];
+	if ( $pretty ) {
+		return $zbs->database_server_info['db_engine_label'];
+	}
+	return $zbs->database_server_info['db_engine'];
 }
 
-// determine if current database server is MariaDB
-function jpcrm_database_server_is_mariadb() {
+/**
+ * Get the database version.
+ *
+ * @return string
+ */
+function zeroBSCRM_database_getVersion() {
 	global $zbs;
-	return $zbs->database_server_info['is_mariadb'];
+	return $zbs->database_server_info['raw_version'];
 }
 
 function jpcrm_database_server_has_ability( $ability_name ) {
 	global $zbs;
 	$db_server_version = zeroBSCRM_database_getVersion();
-	$is_mariadb = jpcrm_database_server_is_mariadb();
+	$db_engine         = $zbs->database_server_info['db_engine'];
 
 	if ( $ability_name === 'fulltext_index' ) {
-		if ( $is_mariadb ) {
+		if ( $db_engine === 'sqlite' ) {
+			return false;
+		} elseif ( $db_engine === 'mariadb' ) {
 			// first stable 10.x release
 			return version_compare( $db_server_version, '10.0.10', '>=' );
 		} else {

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -30,7 +30,6 @@ global $wpdb, $ZBSCRM_t;
   $ZBSCRM_t['tags']                   = $wpdb->prefix . "zbs_tags";
   $ZBSCRM_t['taglinks']               = $wpdb->prefix . "zbs_tags_links";
   $ZBSCRM_t['settings']               = $wpdb->prefix . "zbs_settings";
-  $ZBSCRM_t['keys']                   = $wpdb->prefix . "zbscrm_api_keys";
   $ZBSCRM_t['segments']               = $wpdb->prefix . "zbs_segments";
   $ZBSCRM_t['segmentsconditions']     = $wpdb->prefix . "zbs_segments_conditions";
   $ZBSCRM_t['adminlog']               = $wpdb->prefix . "zbs_admlog";
@@ -94,15 +93,6 @@ function zeroBSCRM_createTables(){
     // we log the last error before we start, in case another plugin has left an error in the buffer
     $zbsDB_lastError = ''; if (isset($wpdb->last_error)) $zbsDB_lastError = $wpdb->last_error;
     $zbsDB_creationErrors = array();
-    
-  #} Keys zbs_perm = {0 = revoked, 1 = read_only, 2 = read_and_write 
-  $sql = "CREATE TABLE IF NOT EXISTS ". $ZBSCRM_t['keys'] ."(
-  `zbs_id` INT NOT NULL AUTO_INCREMENT ,
-  `zbs_key` VARCHAR(200) CHARACTER SET 'utf8' COLLATE 'utf8_general_ci' NULL ,
-  `zbs_perm` INT(1) NULL ,       
-  PRIMARY KEY (`zbs_id`))
-  ".$storageEngineLine.";";
-  zeroBSCRM_db_runDelta($sql);
 
   // Contacts
   $sql = "CREATE TABLE IF NOT EXISTS ". $ZBSCRM_t['contacts'] ."(
@@ -938,11 +928,6 @@ function zeroBSCRM_checkTablesExist(){
 	global $ZBSCRM_t, $wpdb;
 
 	$create = false;
-	$tablesExist = $wpdb->get_results("SHOW TABLES LIKE '".$ZBSCRM_t['keys']."'");
-
-	if ( count($tablesExist) < 1 ) {
-		$create = true;
-	}
 
 	// then we cycle through our tables :) - means all keys NEED to be kept up to date :)
 	// No need to add to this ever now :)
@@ -1001,6 +986,10 @@ function zeroBSCRM_db_runDelta($sql=''){
  * @return bool (if InnoDB available)
  */
 function zeroBSCRM_DB_canInnoDB(){
+
+	if ( jpcrm_database_engine() === 'sqlite' ) {
+		return false;
+	}
 
     global $wpdb;
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.SystemChecks.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.SystemChecks.php
@@ -59,7 +59,7 @@ function zeroBSCRM_checkSystemFeat( $key = '', $with_info = false ) {
 		'sqlrights',
 		'devmode',
 		'permalinks',
-		'mysql',
+		'dbserver',
 		'innodb',
 		'fontinstalled',
 		'encryptionmethod',
@@ -309,15 +309,18 @@ function zeroBSCRM_checkSystemFeat( $key = '', $with_info = false ) {
 		}
 	}
 
-	// what mysql we running
-	function zeroBSCRM_checkSystemFeat_mysql($withInfo=false){
-
-		if (!$withInfo)
-			return zeroBSCRM_database_getVersion();
-		else
-			return array(1, zeroBSCRM_database_getVersion());
-
+/**
+ * Get info about the database server engine and version.
+ *
+ * @param boolean $with_info Provides extra info.
+ */
+function zeroBSCRM_checkSystemFeat_dbserver( $with_info = false ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+	if ( ! $with_info ) {
+		return zeroBSCRM_database_getVersion();
+	} else {
+		return array( 1, jpcrm_database_engine( true ) . ' (' . zeroBSCRM_database_getVersion() . ')' );
 	}
+}
 
 	// got InnoDB?
 	function zeroBSCRM_checkSystemFeat_innodb($withInfo=false){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3408 - detect and expose SQLite usage

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
WordPress Playground uses SQLite as its database engine. This PR adjusts our system to be able to detect SQLite, and exposes this via the System Status page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The most painless way to do this is to set up SQLite via [the SQLite Database Integration plugin](https://wordpress.org/plugins/sqlite-database-integration/). Install that on a WordPress site, initialise the site, and then you should be good to go.

Go to the System Status page: `/wp-admin/admin.php?page=zerobscrm-systemstatus&tab=status`

In `trunk`, the incorrect information shows:

![image](https://github.com/Automattic/jetpack/assets/32492176/aec57ed3-90a6-4114-96fe-7a7f42919199)

In the `fix/crm/3408-detect_sqlite_usage` branch, the database engine and version show correctly (with some slight wording tweaks):
![image](https://github.com/Automattic/jetpack/assets/32492176/062b3a35-bf8d-44e2-9424-018450af97fa)

As a bonus, feel free to test on a MariaDB instance if you have one (it worked fine on my end).