### PR TITLE
generate_documentation: Only split descriptions on ) if one exists

### DIFF
--- a/projects/plugins/jetpack/changelog/generate_documentation_fix
+++ b/projects/plugins/jetpack/changelog/generate_documentation_fix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: /rest/v1.1/help: Minor fix for endpoint descriptions missing close parenthesis.
+
+

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1257,7 +1257,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 						}
 					}
 					$type = '(' . implode( '|', $type ) . ')';
-					if ( str_contains( $description, ')' )  ) {
+					if ( str_contains( $description, ')' ) ) {
 						list( , $description ) = explode( ')', $description, 2 );
 					}
 					$description = trim( $description );

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1256,9 +1256,11 @@ abstract class WPCOM_JSON_API_Endpoint {
 							}
 						}
 					}
-					$type                  = '(' . implode( '|', $type ) . ')';
-					list( , $description ) = explode( ')', $description, 2 );
-					$description           = trim( $description );
+					$type = '(' . implode( '|', $type ) . ')';
+					if ( strpos( $description, ')' ) !== false ) {
+						list( , $description ) = explode( ')', $description, 2 );
+					}
+					$description = trim( $description );
 					if ( $default ) {
 						$description .= " Default: $default.";
 					}

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1257,7 +1257,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 						}
 					}
 					$type = '(' . implode( '|', $type ) . ')';
-					if ( strpos( $description, ')' ) !== false ) {
+					if ( str_contains( $description, ')' )  ) {
 						list( , $description ) = explode( ')', $description, 2 );
 					}
 					$description = trim( $description );


### PR DESCRIPTION
## Proposed changes:

* In `generate_documentation()`, only run `list( , $description ) = explode( ')', $description, 2 );` if the `$description` contains a `)`.

This fixes `Warning: Undefined array key 1 in ... class.json-api-endpoints.php on line 1260` warnings when requesting `/rest/v1.1/help` on PHP 8.1.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Visit `https://public-api.wordpress.com/rest/v1.1/help?http_envelope=1&` (directly in browser)
* Scroll or ctrl-f for "GET /nbi/social"
* Notice response parameter shows no description
* Apply D133774-code to sandbox, which has these changes on sun/moon
* Visit `https://public-api.wordpress.com/rest/v1.1/help?http_envelope=1&` (directly in browser)
* Notice response parameter now correctly shows description of `List of availability per social network`

