### PR TITLE
CRM: 3407 - address database table error in SQLite

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3407-fix_log_error
+++ b/projects/plugins/crm/changelog/fix-crm-3407-fix_log_error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Database: Ensure logs table is initiated with all columns.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -396,6 +396,7 @@ function zeroBSCRM_createTables(){
   `zbsl_type` VARCHAR(200) NOT NULL,
   `zbsl_shortdesc` VARCHAR(300) NULL,
   `zbsl_longdesc` LONGTEXT NULL,
+	`zbsl_pinned` INT(1) NULL,
   `zbsl_created` INT(14) NOT NULL,
   `zbsl_lastupdated` INT(14) NOT NULL,
   PRIMARY KEY (`ID`),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3407 - address database table error in SQLite

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The actual change in this PR is simple: ensure the `zbsl_pinned` is part of the logs table definition.

The fuller context is a bit more complex. I discovered this when working on SQLite compatibility and viewing a contact, which gave `no such column: zbsl_pinned` on this query:
```
SELECT * FROM wp_zbs_logs WHERE zbsl_pinned = 1 AND zbsl_objid = 1 AND zbsl_objtype = 1 ORDER BY zbsl_created DESC
```

I'll note that we ran across a similar issue in p1702310841167429-slack-CL5UJ9ASE (7420694-zen) but didn't get enough information to take action. My suspicion is that they were using SQLite, which technically would be unsupported; they clearly had other database issues going on.

Anyway, for a normal install, it goes like this:

1. Create database tables.
2. Run migrations (which includes adding `zbsl_pinned` to the logs table if it doesn't exist).

The `zeroBSCRM_migration_54` migration has this specific query:
```
ALTER TABLE wp_zbs_logs ADD `zbsl_pinned` int(1) NULL AFTER `zbsl_longdesc`;
```

However, SQLite does not support adding column positions; it can only append columns to the end of a table, so the column was never added during the migration. Hence the error.

After this is merged, new installs will get the column from the start, and basically any install with SQLite will be a new one, so problem solved. The migration remains in place for legacy users that upgrade; removing that is out of scope.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The most painless way to do this is to set up SQLite via [the SQLite Database Integration plugin](https://wordpress.org/plugins/sqlite-database-integration/). Install that on a WordPress site, go through the WP site setup.

In `trunk`, add a contact. When viewing their profile you'll see the activity log section is blank. The PHP error logs will show database errors indicating that the `zbsl_pinned` column doesn't exist, and if you look in the database you can confirm that.

Delete the SQLite database to get an init state, and set up your WordPress site again.

In the `fix/crm/3407-fix_log_error` branch, if you add a contact and view their profile, the activity log shows correctly. There are no PHP errors, and the SQLite database has the expected structure.