### PR TITLE
CRM: 3406 - address SQLite table creation error

### DIFF
--- a/projects/plugins/crm/admin/system/system-status.page.php
+++ b/projects/plugins/crm/admin/system/system-status.page.php
@@ -247,10 +247,6 @@ function zeroBSCRM_render_systemstatus_page() {
 
 		global $ZBSCRM_t,$wpdb;
 		$missingTables = array();
-		$tablesExist   = $wpdb->get_results( "SHOW TABLES LIKE '" . $ZBSCRM_t['keys'] . "'" );
-		if ( count( $tablesExist ) < 1 ) {
-			$missingTables[] = $ZBSCRM_t['keys'];
-		}
 
 		// then we cycle through our tables :) - means all keys NEED to be kept up to date :)
 		foreach ( $ZBSCRM_t as $tableKey => $tableName ) {

--- a/projects/plugins/crm/changelog/fix-crm-3406-address_sqlite_table_creation_error
+++ b/projects/plugins/crm/changelog/fix-crm-3406-address_sqlite_table_creation_error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -30,7 +30,6 @@ global $wpdb, $ZBSCRM_t;
   $ZBSCRM_t['tags']                   = $wpdb->prefix . "zbs_tags";
   $ZBSCRM_t['taglinks']               = $wpdb->prefix . "zbs_tags_links";
   $ZBSCRM_t['settings']               = $wpdb->prefix . "zbs_settings";
-  $ZBSCRM_t['keys']                   = $wpdb->prefix . "zbscrm_api_keys";
   $ZBSCRM_t['segments']               = $wpdb->prefix . "zbs_segments";
   $ZBSCRM_t['segmentsconditions']     = $wpdb->prefix . "zbs_segments_conditions";
   $ZBSCRM_t['adminlog']               = $wpdb->prefix . "zbs_admlog";
@@ -94,15 +93,6 @@ function zeroBSCRM_createTables(){
     // we log the last error before we start, in case another plugin has left an error in the buffer
     $zbsDB_lastError = ''; if (isset($wpdb->last_error)) $zbsDB_lastError = $wpdb->last_error;
     $zbsDB_creationErrors = array();
-    
-  #} Keys zbs_perm = {0 = revoked, 1 = read_only, 2 = read_and_write 
-  $sql = "CREATE TABLE IF NOT EXISTS ". $ZBSCRM_t['keys'] ."(
-  `zbs_id` INT NOT NULL AUTO_INCREMENT ,
-  `zbs_key` VARCHAR(200) CHARACTER SET 'utf8' COLLATE 'utf8_general_ci' NULL ,
-  `zbs_perm` INT(1) NULL ,       
-  PRIMARY KEY (`zbs_id`))
-  ".$storageEngineLine.";";
-  zeroBSCRM_db_runDelta($sql);
 
   // Contacts
   $sql = "CREATE TABLE IF NOT EXISTS ". $ZBSCRM_t['contacts'] ."(
@@ -938,11 +928,6 @@ function zeroBSCRM_checkTablesExist(){
 	global $ZBSCRM_t, $wpdb;
 
 	$create = false;
-	$tablesExist = $wpdb->get_results("SHOW TABLES LIKE '".$ZBSCRM_t['keys']."'");
-
-	if ( count($tablesExist) < 1 ) {
-		$create = true;
-	}
 
 	// then we cycle through our tables :) - means all keys NEED to be kept up to date :)
 	// No need to add to this ever now :)

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -987,6 +987,10 @@ function zeroBSCRM_db_runDelta($sql=''){
  */
 function zeroBSCRM_DB_canInnoDB(){
 
+	if ( jpcrm_database_engine() === 'sqlite' ) {
+		return false;
+	}
+
     global $wpdb;
 
     // attempt to cycle through MySQL's ENGINES & discern InnoDB


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3406 - address SQLite table creation error

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If using SQLite, the System Status page (`/wp-admin/admin.php?page=zerobscrm-systemstatus&tab=status`) will show a notice that there were issues creating database tables.

This addresses the above by short-circuiting the InnoDB check if using SQLite, as we already know SQLite has no InnoDB support and the `SHOW ENGINES` query used is not valid in SQLite.

This was a bit complicated, as it was supposed to output the errors but they were always blank. Digging around, I learned that if a database query was determined to be invalid prior to running, it just returns `false` rather than actually running and providing the error. In this case, it seems it was because `SHOW ENGINES` was not deemed valid.

While investigating the cause, I managed to trigger some errors around a `zbscrm_api_keys` table; this was probably incidental because it was the first table created, but said table is never actually used other than hard-coded checks for its existence (don't ask me why), so I removed code related to its creation and detection. Removing it from existing installs is out of scope here.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The most painless way to do this is to set up SQLite via [the SQLite Database Integration plugin](https://wordpress.org/plugins/sqlite-database-integration/). Install that on a WordPress site, initialise the site, and then you should be good to go.

Go to the System Status page: `/wp-admin/admin.php?page=zerobscrm-systemstatus&tab=status`

In `trunk`, you'll see this message:

```
Jetpack CRM experienced errors while trying to build it's database tables. Please contact support sharing the following errors: (#306sql)
```

In the `fix/crm/3406-address_sqlite_table_creation_error` branch, the error is no more.