### PR TITLE
CRM: 3409 - general cosmetic fixes

### DIFF
--- a/projects/plugins/crm/admin/system/assistant.page.php
+++ b/projects/plugins/crm/admin/system/assistant.page.php
@@ -87,7 +87,7 @@ function jpcrm_render_system_assistant_page() {
 				'title'           => __( 'Try Invoicing II', 'zero-bs-crm' ),
 				'icon'            => 'file',
 				'desc_incomplete' => __( 'Add your first invoice to see how the CRM invoicing system works.', 'zero-bs-crm' ),
-				'desc_complete'   => __( 'Great, you\'re using Invoices.', 'zero-bs-crm' ),
+				'desc_complete'   => __( "Great, you're using Invoices.", 'zero-bs-crm' ),
 				'button_url'      => $zbs->urls['kbinvoicebuilder'],
 				'state'           => zeroBS_invCount() > 0,
 
@@ -102,7 +102,7 @@ function jpcrm_render_system_assistant_page() {
 			'desc_incomplete' => sprintf( __( 'If you have any team members who might need access to the CRM, <a href="%s">add them now</a>.', 'zero-bs-crm' ), zeroBSCRM_getAdminURL( $zbs->slugs['team'] ) ),
 			'desc_complete'   => __( 'Great, it looks like you have several users who can access the CRM.', 'zero-bs-crm' ),
 			'button_url'      => $zbs->urls['kbteam'],
-			'state'           => count( zeroBSCRM_crm_users_list() ) > 0,
+			'state'           => count( zeroBSCRM_crm_users_list() ) > 1,
 
 		);
 
@@ -146,7 +146,7 @@ function jpcrm_render_system_assistant_page() {
 
 		);
 
-		foreach ( $job_list as $job_key => $job ) {
+		foreach ( $job_list as $job ) {
 
 			jpcrm_render_system_assistant_job( $job );
 
@@ -162,6 +162,7 @@ function jpcrm_render_system_assistant_page() {
  * Render a single system assistant job
  */
 function jpcrm_render_system_assistant_job( $job = array() ) {
+	global $zbs;
 
 	// if no help txt, use default:
 	if ( empty( $job['button_txt'] ) ) {
@@ -179,8 +180,8 @@ function jpcrm_render_system_assistant_job( $job = array() ) {
 				</div>
 				<div class="fourteen wide column">
 					<h4 class="ui header"><i class="<?php echo esc_attr( $job['icon'] ); ?> icon"></i> <?php echo esc_html( $job['title'] ); ?></h4>
-					<p class="job-desc state-incomplete"><?php echo esc_html( $job['desc_incomplete'] ); ?></p>
-					<p class="job-desc state-complete"><?php echo esc_html( $job['desc_complete'] ); ?></p>
+					<p class="job-desc state-incomplete"><?php echo wp_kses( $job['desc_incomplete'], $zbs->acceptable_restricted_html ); ?></p>
+					<p class="job-desc state-complete"><?php echo wp_kses( $job['desc_complete'], $zbs->acceptable_restricted_html ); ?></p>
 					<?php
 					if ( ! empty( $job['button_txt'] ) ) {
 						?>

--- a/projects/plugins/crm/admin/system/system-status.page.php
+++ b/projects/plugins/crm/admin/system/system-status.page.php
@@ -332,12 +332,6 @@ function zeroBSCRM_render_systemstatus_page() {
 							'fontinstalled' => 'Noto Sans Font installed',
 						);
 
-						// only show these for legacy users using DAL<3
-						// #backward-compatibility
-						if ( ! $zbs->isDAL3() ) {
-							$zbsEnvList['autodraftgarbagecollect'] = 'Auto-draft Garbage Collection';
-						}
-
 						if ( count( $zbsEnvList ) ) {
 							?>
 				<table class="table table-bordered table-striped wtab">

--- a/projects/plugins/crm/admin/system/system-status.page.php
+++ b/projects/plugins/crm/admin/system/system-status.page.php
@@ -273,7 +273,7 @@ function zeroBSCRM_render_systemstatus_page() {
 		if ( is_array( $creationErrors ) && isset( $creationErrors['lasttried'] ) ) {
 
 			// has persistent SQL creation errors
-			$generalErrors['creationsql'] = __( 'Jetpack CRM experienced errors while trying to build it\'s database tables. Please contact support sharing the following errors:', 'zero-bs-crm' ) . ' (#306sql)';
+			$generalErrors['creationsql'] = __( 'Jetpack CRM experienced errors while trying to build its database tables. Please contact support sharing the following errors:', 'zero-bs-crm' ) . ' (#306sql)'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			if ( is_array( $creationErrors['errors'] ) ) {
 				foreach ( $creationErrors['errors'] as $err ) {
 

--- a/projects/plugins/crm/changelog/fix-crm-3409-various_general_fixes
+++ b/projects/plugins/crm/changelog/fix-crm-3409-various_general_fixes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+System Assistant: Fix broken links on some tasks.
+Migrations: task_offset_fix migration would not mark as complete on some timezones

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -1133,15 +1133,13 @@ function zeroBSCRM_migration_task_offset_fix() { // phpcs:ignore WordPress.Namin
 
 	$timezone_offset_in_secs = jpcrm_get_wp_timezone_offset_in_seconds();
 
-	if ( empty( $timezone_offset_in_secs ) ) {
-		return;
+	if ( ! empty( $timezone_offset_in_secs ) ) {
+		// remove offset from stored task dates
+		$sql = sprintf( 'UPDATE %s SET zbse_start = zbse_start - %d;', $ZBSCRM_t['events'], $timezone_offset_in_secs ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$sql = sprintf( 'UPDATE %s SET zbse_end = zbse_end - %d;', $ZBSCRM_t['events'], $timezone_offset_in_secs ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
-
-	// remove offset from stored task dates
-	$sql = sprintf( 'UPDATE %s SET zbse_start = zbse_start - %d;', $ZBSCRM_t['events'], $timezone_offset_in_secs ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-	$sql = sprintf( 'UPDATE %s SET zbse_end = zbse_end - %d;', $ZBSCRM_t['events'], $timezone_offset_in_secs ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 	zeroBSCRM_migrations_markComplete( 'task_offset_fix', array( 'updated' => 1 ) );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3409 - general cosmetic fixes

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
1. Fix a typo on the error from Automattic/zero-bs-crm#3406 (`it's` → `its`).
2. The `task_offset_fix` migration never ran if the WP timezone is set to UTC or equivalent, because we returned earlier if the timezone offset in seconds was `empty()`. Since UTC's timezone offset in seconds is 0, it would be empty and return early, never marking as complete. We now ensure it's marked complete if empty.
3. Some System Assistant steps had links that were broken when `esc_html` was added. They've been updated to use `wp_kses`.
4. I chopped a tiny pre-DAL3 code block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Easiest thing here is to look at the code and confirm all seems well.
