### PR TITLE
Jetpack Dashboard: Fix protect card text on activation

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
@@ -124,7 +124,7 @@ class DashProtect extends Component {
 		return (
 			this.props.isModuleAvailable && (
 				<div className="jp-dash-item__interior">
-					<QueryProtectCount />
+					<QueryProtectCount isActive={ this.props.getOptionValue( 'protect' ) } />
 					{ this.getContent() }
 				</div>
 			)

--- a/projects/plugins/jetpack/_inc/client/components/data/query-dash-protect/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/data/query-dash-protect/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -5,8 +6,22 @@ import { isFetchingProtectData, fetchProtectCount } from 'state/at-a-glance';
 import { isModuleActivated as _isModuleActivated } from 'state/modules';
 
 class QueryProtectCount extends Component {
+	static propTypes = {
+		isActive: PropTypes.bool,
+	};
+
 	UNSAFE_componentWillMount() {
 		if ( ! this.props.fetchingProtectData && this.props.isModuleActivated( 'protect' ) ) {
+			this.props.fetchProtectCount();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if (
+			! this.props.fetchingProtectData &&
+			true === this.props.isActive &&
+			false === prevProps.isActive
+		) {
 			this.props.fetchProtectCount();
 		}
 	}

--- a/projects/plugins/jetpack/changelog/fix-dashboard-protect-card-activation
+++ b/projects/plugins/jetpack/changelog/fix-dashboard-protect-card-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix protect card text on activation.
+
+


### PR DESCRIPTION
Fixes #34875

## Proposed changes:
Fix Jetpack Dashboard "Protect" card, where content is stuck on "Loading..." upon activation.

<img width="533" alt="Screenshot 2024-01-05 at 21 31 49" src="https://github.com/Automattic/jetpack/assets/1341249/370a7c6b-fb97-4cec-99e1-0250f9adb13d">

The "Loading..." text shows up because the React component is missing the number of blocked attacks after the module is activated.
The PR will make it re-fetch the number from the API upon module activation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack, go to Jetpack Dashboard
2. Deactivate "Brute force protection" card if active, reload the Dashboard.
3. Activate the card.
4. Confirm that the content switches to either "Jetpack is actively blocking...", or displays the number of blocked attempts.
