### PR TITLE
WP.com API: Allow Users to Insert Header Code 

### DIFF
--- a/projects/plugins/jetpack/changelog/add-header-code
+++ b/projects/plugins/jetpack/changelog/add-header-code
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+API: Allow users to insert code to the Header element of their site from WP.com Calypso.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -458,7 +458,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'page_for_posts'                   => (string) get_option( 'page_for_posts' ),
 						'subscription_options'             => (array) get_option( 'subscription_options' ),
 						'jetpack_verbum_subscription_modal' => (bool) get_option( 'jetpack_verbum_subscription_modal', true ),
-						'jetpack_header_code'              => get_option( 'jetpack_header_code', true ),
+						'jetpack_header_code'              => get_option( 'jetpack_header_code', '' ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -458,6 +458,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'page_for_posts'                   => (string) get_option( 'page_for_posts' ),
 						'subscription_options'             => (array) get_option( 'subscription_options' ),
 						'jetpack_verbum_subscription_modal' => (bool) get_option( 'jetpack_verbum_subscription_modal', true ),
+						'jetpack_header_code'              => get_option( 'jetpack_header_code', true ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -1109,6 +1110,13 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						break;
 					}
 
+					if ( update_option( $key, $value ) ) {
+						$updated[ $key ] = $value;
+					}
+
+					break;
+
+				case 'jetpack_header_code':
 					if ( update_option( $key, $value ) ) {
 						$updated[ $key ] = $value;
 					}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -129,6 +129,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'subscription_options'                    => '(array) Array of three options used in subscription email templates: \'invitation\', \'welcome\' and \'comment_follow\' strings.',
 			'jetpack_verbum_subscription_modal'       => '(bool) Whether Subscription modal is enabled in Verbum comments',
 			'wpcom_ai_site_prompt'                    => '(string) User input in the AI site prompt',
+			'jetpack_header_code'                     => '(string) User code to include in the site Header element',
 		),
 
 		'response_format' => array(

--- a/projects/plugins/jetpack/modules/header-code.php
+++ b/projects/plugins/jetpack/modules/header-code.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Header Code.
+ *
+ * Let users insert code snippets into their site header.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Header_Code;
+
+/**
+ * Add code to the head.
+ *
+ * @since $$next-version$$
+ */
+function jetpack_insert_head_code() {
+	$option = get_option( 'jetpack_header_code' );
+
+	// Ensure no code is added on Simple sites.
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		return;
+	}
+
+	if ( ! empty( $option ) && ! is_admin() ) {
+		echo wp_unslash( $option, 'post' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+}
+add_action( 'wp_head', __NAMESPACE__ . '\jetpack_insert_head_code', 999 );

--- a/projects/plugins/jetpack/modules/header-code.php
+++ b/projects/plugins/jetpack/modules/header-code.php
@@ -23,6 +23,7 @@ function jetpack_insert_head_code() {
 	}
 
 	if ( ! empty( $option ) && ! is_admin() ) {
+		// No escaping because it's user-inputted code intended to allow <script> tags.
 		echo wp_unslash( $option, 'post' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }

--- a/projects/plugins/jetpack/modules/module-extras.php
+++ b/projects/plugins/jetpack/modules/module-extras.php
@@ -41,6 +41,7 @@ $tools = array(
 $connected_tools = array(
 	'calypsoify/class-jetpack-calypsoify.php',
 	'cloudflare-analytics/cloudflare-analytics.php',
+	'header-code.php',
 	'plugin-search.php',
 	'scan/scan.php', // Shows Jetpack Scan alerts in the admin bar if threats found.
 	'simple-payments/simple-payments.php',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Required for Automattic/wp-calypso#86079

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This adds an endpoint that ultimately allows users to include Header code on their site. 

I thought about adding a separate endpoint like Custom CSS in case it handles a large amount of code, but I decided against it for a few reasons: realistically, I think this will mainly be used for a couple of meta tags; the endpoint already handles large amounts of data (including subscription email HTML and post categories!) and this isn't any larger relative to those, and also I don't think I can add another endpoint on the Calypso side since that's not open-source.  

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Automattic/wp-calypso#56023.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I always need help testing endpoints. :) I haven't actually been able to do this from an Atomic site, but I have from a Jetpack one. 

1. Load the Calypso PR and navigate to `/settings/header-code/site`
2. Include some header code 
3. Confirm that it's run when you load the site 

For example - saving this on the Calypso side:
<img width="748" alt="Screenshot 2024-01-06 at 15 26 22" src="https://github.com/Automattic/jetpack/assets/43215253/62156dae-c53e-4d91-a779-1d2d7ddd3803">

Should lead to this:
<img width="376" alt="Screenshot 2024-01-06 at 15 47 13" src="https://github.com/Automattic/jetpack/assets/43215253/79e5638a-f32f-4fb0-96c7-16ed4faec36a">
