### PR TITLE
Fix reply link when comment_registration is set

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-comment-reply-link
+++ b/projects/plugins/jetpack/changelog/fix-comment-reply-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+


### PR DESCRIPTION
This PR fixes an issue when comment_registration and we load the jetpack commenting experience via iframe.
This is done by extending the comment class to override the 'comment_reply_link' return value when the setting is set.

Fixes #
126-gh-Automattic/verbum

## Proposed changes:
* Add a filter to apply the override for the specific scenario.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- On atomic or self-hosted site, set `comment_registration` to be on. This is done in Settings -> Discussion.
- Visit a post of your testing site without being logged in.
- The reply link of the post comments should be "Reply" instead of "Login to Reply".
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

| Before  | After |
| ------------- | ------------- |
| <img width="688" alt="Screenshot 2024-01-08 at 13 05 39" src="https://github.com/Automattic/jetpack/assets/7000684/7066d364-7da2-41d6-a8f3-f69854687559">  |  <img width="652" alt="Screenshot 2024-01-08 at 13 15 26" src="https://github.com/Automattic/jetpack/assets/7000684/a3dd46ac-d4a7-4a4b-93cb-7258cdb934cb"> |

