### PR TITLE
Forms: Avoid PHP warnings when post is not set

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-warning
+++ b/projects/packages/forms/changelog/fix-forms-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid PHP warnings when post is not set.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -354,7 +354,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$url                     = apply_filters( 'grunion_contact_form_form_action', "{$url}#contact-form-{$id}", $GLOBALS['post'], $id );
 			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' );
 			$form_classes            = 'contact-form commentsblock';
-			$form_accessible_name    = ! empty( $attributes['formTitle'] ) ? $attributes['formTitle'] : $post->post_title;
+			$post_title              = $post->post_title ?? '';
+			$form_accessible_name    = ! empty( $attributes['formTitle'] ) ? $attributes['formTitle'] : $post_title;
 			$form_aria_label         = isset( $form_accessible_name ) && ! empty( $form_accessible_name ) ? 'aria-label="' . esc_attr( $form_accessible_name ) . '"' : '';
 
 			if ( $has_submit_button_block ) {


### PR DESCRIPTION
Follow-up to #34756

## Proposed changes:

This should avoid warnings like this one:

```
PHP Warning:  Attempt to read property "post_title" on null in wp-content/plugins/jetpack-dev/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-contact-form.php on line 357
```
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* no

## Testing instructions:

* Activate the Form module
* On my site, I was seeing this warning when loading any wp-admin page that does not list posts, like Appearance > Themes.
