### PR TITLE
Dedicated sync fall back to default only after unsuccesful spawn sync test

### DIFF
--- a/projects/packages/sync/changelog/fix-dedicated-sync-fall-back-to-default-only-after-unsuccesful-spawn-aync-test
+++ b/projects/packages/sync/changelog/fix-dedicated-sync-fall-back-to-default-only-after-unsuccesful-spawn-aync-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Dedicated sync now disabled for high queue lags only if test request fails.

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -152,7 +152,7 @@ class Dedicated_Sender {
 		$queue_lag = $queue->lag();
 
 		// Check if a test request fails the queue lag is longer than the threshold. If so disable Dedicated Sync.
-		if ( ! self::can_spawn_dedicated_sync_request() && $queue_lag > $queue_send_time_threshold ) {
+		if ( $queue_lag > $queue_send_time_threshold && ! self::can_spawn_dedicated_sync_request() ) {
 			self::on_dedicated_sync_lag_not_sending_threshold_reached();
 			return new WP_Error( 'dedicated_sync_not_sending', 'Dedicated Sync is not successfully sending events' );
 		}
@@ -338,7 +338,6 @@ class Dedicated_Sender {
 				$sender->send_action( 'jetpack_sync_flow_error_enable', $data );
 			}
 		}
-
 		return self::DEDICATED_SYNC_VALIDATION_STRING === $dedicated_sync_response_body;
 	}
 

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.4.0';
+	const PACKAGE_VERSION = '2.4.1-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/tests/php/test-dedicated-sender.php
+++ b/projects/packages/sync/tests/php/test-dedicated-sender.php
@@ -112,9 +112,9 @@ class Test_Dedicated_Sender extends BaseTestCase {
 	}
 
 	/**
-	 * Tests Dedicated_Sender::spawn_sync with a laggy queue and failed spawn sync test.
+	 * Tests Dedicated_Sender::spawn_sync with no transient laggy queue and failed spawn sync test disables dedicated sync.
 	 */
-	public function test_spawn_sync_with_laggy_queue_and_failed_spawn_sync_test_disable_dedicated_sync() {
+	public function test_spawn_sync_with_laggy_queue_no_transient_and_failed_spawn_sync_test_disables_dedicated_sync() {
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
 
 		$this->queue->method( 'lag' )->willReturn( 33 * MINUTE_IN_SECONDS );
@@ -132,11 +132,12 @@ class Test_Dedicated_Sender extends BaseTestCase {
 	}
 
 	/**
-	 * Tests Dedicated_Sender::spawn_sync with a laggy queue but successful spawn sync test.
+	 * Tests Dedicated_Sender::spawn_sync with a laggy queue but successful spawn sync test does not disable dedicated sync.
 	 */
-	public function test_spawn_sync_with_sync_not_sending_disable_dedicated_sync() {
+	public function test_spawn_sync_with_lagging_queue_no_transient_and_succesfull_spawn_sync_test_not_sending_disable_dedicated_sync() {
 
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
+		delete_transient( Dedicated_Sender::DEDICATED_SYNC_CHECK_TRANSIENT );
 
 		$this->queue->method( 'lag' )->willReturn( 33 * MINUTE_IN_SECONDS );
 
@@ -146,6 +147,23 @@ class Test_Dedicated_Sender extends BaseTestCase {
 
 		$dedicated_sync_transient = get_transient( Dedicated_Sender::DEDICATED_SYNC_TEMPORARY_DISABLE_FLAG );
 		$this->assertFalse( $dedicated_sync_transient );
+
+		$this->assertTrue( $result );
+		$this->assertTrue( $this->dedicated_sync_request_spawned );
+	}
+
+	/**
+	 * Tests Dedicated_Sender::spawn_sync with a laggy queue and transient does not spawn test request but it does spawn sync.
+	 */
+	public function test_spawn_sync_with_laggy_queue_and_transient_does_not_spawn_test_request_and_spawns_sync() {
+		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
+
+		$this->queue->method( 'lag' )->willReturn( 33 * MINUTE_IN_SECONDS );
+
+		set_transient( Dedicated_Sender::DEDICATED_SYNC_CHECK_TRANSIENT, '' );
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ), 10, 3 );
+		$result = Dedicated_Sender::spawn_sync( $this->queue );
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 
 		$this->assertTrue( $result );
 		$this->assertTrue( $this->dedicated_sync_request_spawned );

--- a/projects/packages/sync/tests/php/test-dedicated-sender.php
+++ b/projects/packages/sync/tests/php/test-dedicated-sender.php
@@ -112,14 +112,17 @@ class Test_Dedicated_Sender extends BaseTestCase {
 	}
 
 	/**
-	 * Tests Dedicated_Sender::spawn_sync with a laggy queue.
+	 * Tests Dedicated_Sender::spawn_sync with a laggy queue and failed spawn sync test.
 	 */
-	public function test_spawn_sync_with_laggy_queue_disable_dedicated_sync() {
+	public function test_spawn_sync_with_laggy_queue_and_failed_spawn_sync_test_disable_dedicated_sync() {
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
 
 		$this->queue->method( 'lag' )->willReturn( 33 * MINUTE_IN_SECONDS );
 
+		delete_transient( Dedicated_Sender::DEDICATED_SYNC_CHECK_TRANSIENT );
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request_failure' ), 10, 3 );
 		$result = Dedicated_Sender::spawn_sync( $this->queue );
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_failure' ) );
 
 		$this->assertTrue( is_wp_error( $result ) );
 		$this->assertSame( 'dedicated_sync_not_sending', $result->get_error_code() );
@@ -129,26 +132,23 @@ class Test_Dedicated_Sender extends BaseTestCase {
 	}
 
 	/**
-	 * Tests Dedicated_Sender::spawn_sync when Sync has not been sending for a while.
+	 * Tests Dedicated_Sender::spawn_sync with a laggy queue but successful spawn sync test.
 	 */
 	public function test_spawn_sync_with_sync_not_sending_disable_dedicated_sync() {
+
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
 
 		$this->queue->method( 'lag' )->willReturn( 33 * MINUTE_IN_SECONDS );
 
-		// Set the last succesful sync time to be 3 hours ago, since the threshold is 1 hour.
-		update_option( Actions::LAST_SUCCESS_PREFIX . 'sync', time() - 3 * HOUR_IN_SECONDS, false );
-
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ), 10, 3 );
 		$result = Dedicated_Sender::spawn_sync( $this->queue );
-
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertSame( 'dedicated_sync_not_sending', $result->get_error_code() );
-
-		$dedicated_sync_status = Settings::get_setting( 'dedicated_sync_enabled' );
-		$this->assertFalse( (bool) $dedicated_sync_status );
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 
 		$dedicated_sync_transient = get_transient( Dedicated_Sender::DEDICATED_SYNC_TEMPORARY_DISABLE_FLAG );
-		$this->assertTrue( $dedicated_sync_transient );
+		$this->assertFalse( $dedicated_sync_transient );
+
+		$this->assertTrue( $result );
+		$this->assertTrue( $this->dedicated_sync_request_spawned );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Continuation of  https://github.com/Automattic/jetpack/pull/27632 which disabled Dedicated Sync when the queue lag grows high.
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR simplifies the check to disable dedicated sync. Now if the queue is too high and a `spawn-sync` test request fails, dedicated sync will be disabled.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Dedicated Sync is fine & lag exceeds threshold:**
- Modify `$queue_send_time_threshold` to 1 minute to facilitate testing
- Modify `do_sync_and_set_delays` to return an error so that the queue lag grows
- Delete the `DEDICATED_SYNC_CHECK_TRANSIENT`: `wp transient delete jetpack_sync_dedicated_sync_spawn_check` 
- Confirm a blocking request to `jetpack/v4/sync/spawn-sync` (no time param or via debugging statements)
- Confirm Dedicated Sync is still enabled

**Dedicated Sync is not working & lag exceeds threshold:**
- Break Dedicated Sync by modifying `do_dedicated_sync_and_exit` to echo a random value instead of `Dedicated_Sender::DEDICATED_SYNC_VALIDATION_STRING`
- Modify `$queue_send_time_threshold` to 1 minute to facilitate testing
- Modify `do_sync_and_set_delays` to return an error so that the queue lag grows
- Delete the `DEDICATED_SYNC_CHECK_TRANSIENT`: `wp transient delete jetpack_sync_dedicated_sync_spawn_check` 
- Confirm a blocking request to `jetpack/v4/sync/spawn-sync` (no time param or via debugging statements)
- Confirm Dedicated Sync is disabled
- Confirm the corresponding error is sent to WPCOM via `immediate-send` queue