### PR TITLE
CRM: 3401 - robustify custom date handling from Jetpack Forms

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3401-robustify_custom_date_handling_from_jetpack_forms
+++ b/projects/plugins/crm/changelog/fix-crm-3401-robustify_custom_date_handling_from_jetpack_forms
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+Jetpack Forms: Detect and process custom date fields correctly.
+Custom fields: Gracefully handle invalid date field data.

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -481,7 +481,7 @@ function zeroBSCRM_pages_admin_display_custom_fields_table($id = -1, $objectType
 		     		break;
 
 		     	case 'date':
-		     		$html .= '<td class="zbs-view-vital-customfields-'.esc_attr($v['type']).'">' . ( $v['value'] !== '' ? zeroBSCRM_date_i18n( -1, $v['value'], false, true ) : '' )  . '</td>';
+						$html .= '<td class="zbs-view-vital-customfields-' . esc_attr( $v['type'] ) . '">' . ( $v['value'] !== '' ? jpcrm_uts_to_date_str( $v['value'], false, true ) : '' ) . '</td>';
 		     		break;
 
 		     	case 'checkbox':

--- a/projects/plugins/crm/includes/ZeroBSCRM.Jetpack.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Jetpack.php
@@ -4,7 +4,6 @@
  * https://jetpackcrm.com
  * V1.20
  *
- *
  * Date: 24th January 2020
  *
  * This file will house any functionality related to Jetpack
@@ -80,7 +79,7 @@ function zero_bs_crm_capture_jetpack_form( $post_id, $all_field_data, $is_spam, 
 	 */
 	$jpcrm_field_prefix = 'jetpackcrm-';
 
-	foreach ( (array) $all_field_data as $field => $field_data ) {
+	foreach ( (array) $all_field_data as $field_data ) {
 		$field_id = $field_data->get_attribute( 'id' );
 
 		if ( str_starts_with( $field_id, $jpcrm_field_prefix ) && isset( $field_data->value ) && $field_data->value !== '' ) {
@@ -90,12 +89,10 @@ function zero_bs_crm_capture_jetpack_form( $post_id, $all_field_data, $is_spam, 
 				if ( $data_key === 'tags' ) {
 					if ( is_array( $field_data->value ) ) {
 						$contact_data[ $data_key ] = $field_data->value;
-					}
-					else {
+					} else {
 						$contact_data[ $data_key ] = explode( ',', $field_data->value );
 					}
-				}
-				else {
+				} else {
 					$contact_data[ $data_key ] = $field_data->value;
 				}
 			}
@@ -107,7 +104,7 @@ function zero_bs_crm_capture_jetpack_form( $post_id, $all_field_data, $is_spam, 
 		 * If the field ids aren't prefixed with 'jetpackcrm-', try to get an
 		 * email, phone, and name using the field types.
 		 */
-		foreach ( (array) $all_field_data as $field => $field_data ) {
+		foreach ( (array) $all_field_data as $field_data ) {
 			if ( 'email' === $field_data->get_attribute( 'type' )
 				&& ! isset( $contact_data['email'] )
 				&& ! empty( $field_data->value )
@@ -131,7 +128,7 @@ function zero_bs_crm_capture_jetpack_form( $post_id, $all_field_data, $is_spam, 
 				// Use the first name field that's found.
 				$name                  = explode( ' ', $field_data->value, 2 );
 				$contact_data['fname'] = $name[0];
-				if ( !empty( $name[1] ) ) {
+				if ( ! empty( $name[1] ) ) {
 					$contact_data['lname'] = $name[1];
 				}
 			}
@@ -147,7 +144,7 @@ function zero_bs_crm_capture_jetpack_form( $post_id, $all_field_data, $is_spam, 
 	$contact_data['externalSources'] = array(
 		array(
 			'source' => 'jetpack_form',
-			'origin' => $zbs->DAL->add_origin_prefix( site_url(), 'domain' ),
+			'origin' => $zbs->DAL->add_origin_prefix( site_url(), 'domain' ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			'uid'    => $contact_data['email'],
 		),
 	);

--- a/projects/plugins/crm/includes/ZeroBSCRM.Jetpack.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Jetpack.php
@@ -83,11 +83,11 @@ function zero_bs_crm_capture_jetpack_form( $post_id, $all_field_data, $is_spam, 
 	foreach ( (array) $all_field_data as $field => $field_data ) {
 		$field_id = $field_data->get_attribute( 'id' );
 
-		if ( str_starts_with( $field_id, $jpcrm_field_prefix ) && ! empty( $field_data->value ) ) {
+		if ( str_starts_with( $field_id, $jpcrm_field_prefix ) && isset( $field_data->value ) && $field_data->value !== '' ) {
 			$data_key = substr( $field_id, strlen( $jpcrm_field_prefix ) );
 
 			if ( ! in_array( $data_key, $restricted_keys, true ) ) {
-				if ( $data_key == 'tags' ) {
+				if ( $data_key === 'tags' ) {
 					if ( is_array( $field_data->value ) ) {
 						$contact_data[ $data_key ] = $field_data->value;
 					}

--- a/projects/plugins/crm/includes/ZeroBSCRM.Jetpack.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Jetpack.php
@@ -92,6 +92,8 @@ function zero_bs_crm_capture_jetpack_form( $post_id, $all_field_data, $is_spam, 
 					} else {
 						$contact_data[ $data_key ] = explode( ',', $field_data->value );
 					}
+				} elseif ( $field_data->get_attribute( 'type' ) === 'date' ) {
+					$contact_data[ $data_key ] = jpcrm_date_str_wp_format_to_uts( $field_data->value, true );
 				} else {
 					$contact_data[ $data_key ] = $field_data->value;
 				}

--- a/projects/plugins/crm/includes/jpcrm-localisation.php
+++ b/projects/plugins/crm/includes/jpcrm-localisation.php
@@ -189,14 +189,15 @@ function jpcrm_date_str_to_uts( $date_str, $format = false, $use_utc = false ) {
  * Creates a UTS from a WP-formatted date string
  * This is a wrapper of jpcrm_datetime_str_to_uts()
  *
- * @param str $date_str String containing date (in WP timezone).
+ * @param string  $date_str String containing date (in WP timezone).
+ * @param boolean $use_utc Treat input as UTC timezone or WP timezone.
  *
  * @return int $uts
  */
-function jpcrm_date_str_wp_format_to_uts( $date_str ) {
+function jpcrm_date_str_wp_format_to_uts( $date_str, $use_utc = false ) {
 	// use WP format
 	$format = '!' . get_option( 'date_format' );
-	return jpcrm_datetime_str_to_uts( $date_str, $format );
+	return jpcrm_datetime_str_to_uts( $date_str, $format, $use_utc );
 }
 
 /**

--- a/projects/plugins/crm/includes/jpcrm-localisation.php
+++ b/projects/plugins/crm/includes/jpcrm-localisation.php
@@ -29,7 +29,12 @@ function jpcrm_uts_to_datetime_str( $timestamp, $format = false, $use_utc = fals
 	}
 
 	// create DateTime object from UTS
-	$date_obj = new DateTime( '@' . $timestamp );
+	try {
+		$date_obj = new DateTime( '@' . $timestamp );
+	} catch ( Exception $e ) {
+		// Unable to parse timestamp, so probably not a UTS.
+		return false;
+	}
 
 	// something's wrong, so abort
 	if ( ! $date_obj ) {

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -134,7 +134,6 @@
 	"projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.Inventory.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php",
-	"projects/plugins/crm/includes/ZeroBSCRM.Jetpack.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.List.Columns.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.List.Tasks.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.List.php",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3401 - robustify custom date handling from Jetpack Forms

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR fixes a few interconnected issues:

1. If CRM is set to ingest a Jetpack Form that has a Datepicker block mapped to a custom date field in the CRM, the value is stored in the database a WP-formatted date string. We now detect this field type and convert it to a Unix timestamp (in UTC) with `jpcrm_date_str_wp_format_to_uts()`.
2. If there's an invalid timestamp passed to `jpcrm_uts_to_datetime_str()` (e.g. in the scenario where we're outputting the result of the point above), it gave a PHP fatal error. We now have a `try`/`catch` to gracefully handle invalid data.
3. The custom date output was using a legacy localisation function that didn't account for timezone variations. We now use the modern function.
4. In cases where the Jetpack Form passed a `0` value to the CRM, it was ignored because we were discarding "empty" data. We now explicitly check for an empty string.
 
See also Automattic/zero-bs-crm#2968, which was closed for lack of information but may have had the same root cause and either way should be fixed per point 2.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a custom date field: `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=customfields`
2. Create a page with a Jetpack Form, with a Datepicker block mapped to the CRM custom date field.
3. Fill out the form and submit.

In `trunk`, the value in the database will show the WP-formatted date string, and the contact listview can no longer load.

In the `fix/crm/3401-robustify_custom_date_handling_from_jetpack_forms` branch, the value in the database is a UTS, and the contact listview + contact display the value correctly.

Note that the submission while on `trunk` will still have bad data in the database, so will gracefully show nothing on the that contact's profile.