### PR TITLE
jetpack_spotify_shortcode: Prevent fatal error in PHP 8.1 if $atts is not an array

### DIFF
--- a/projects/plugins/jetpack/changelog/update-spotify-shortcode
+++ b/projects/plugins/jetpack/changelog/update-spotify-shortcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+jetpack_spotify_shortcode: Prevent fatal error in PHP 8.1 if $atts is not an array

--- a/projects/plugins/jetpack/changelog/update-spotify-shortcode
+++ b/projects/plugins/jetpack/changelog/update-spotify-shortcode
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-jetpack_spotify_shortcode: Prevent fatal error in PHP 8.1 if $atts is not an array
+Spotify shortcode: Prevent a fatal error in PHP 8.1 if no attributes are passed.

--- a/projects/plugins/jetpack/modules/shortcodes/spotify.php
+++ b/projects/plugins/jetpack/modules/shortcodes/spotify.php
@@ -23,6 +23,9 @@ if ( ! shortcode_exists( 'spotify' ) ) {
  * @return string
  */
 function jetpack_spotify_shortcode( $atts = array(), $content = '' ) {
+	if ( ! is_array( $atts ) ) {
+		$atts = array();
+	}
 
 	if ( ! empty( $content ) ) {
 		$id = $content;


### PR DESCRIPTION
## Proposed changes:

* In `jetpack_spotify_shortcode()`, instead of assuming `$atts` is always an array, check if it is not an array and set it to a blank array if needed.

In php 7.4, setting `$atts['width'] = ...` when `$atts` is an empty string is only a warning. In 8.1+, it's upgraded to a fatal error.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* (Optional). Switch sandbox to 8.1
* Sandbox and visit `https://wordpress.com/blog/2012/04/18/spotify-rdio-and-github-embeds/?h=2000`
* Notice: Fatal error while rendering the comments on 8.1.  (If you're on 7.4, there will still be warnings in the comments, like `Warning: Illegal string offset 'width'...`).
* Apply D133905-code (helper patch that contains these changes)
* Notice: All comments render without fatal errors (or warnings if on 7.4).


