### PR TITLE
Launchpad: Add Verify Domain Email task logic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-verify_domain_email-task-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-verify_domain_email-task-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the Verify Domain Email task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -990,6 +990,12 @@ function wpcom_launchpad_is_sensei_setup_visible() {
  * @return bool True if the verify domain email task should be visible.
  */
 function wpcom_launchpad_is_verify_domain_email_visible() {
+	// If the task is complete, we should show it and prevent the logic below
+	// to be executed.
+	if ( wpcom_is_checklist_task_complete( 'verify_domain_email' ) ) {
+		return true;
+	}
+
 	// For Atomic sites we need to get the domain list from
 	// the public API.
 	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1022,7 +1022,14 @@ function wpcom_launchpad_is_verify_domain_email_visible() {
 
 	$domains = \Domain_Management::get_paid_domains_with_icann_verification_status();
 
-	return ! empty( $domains );
+	$domains_pending_icann_verification = array_filter(
+		$domains,
+		function ( $domain ) {
+			return isset( $domain['is_pending_icann_verification'] ) && $domain['is_pending_icann_verification'];
+		}
+	);
+
+	return ! empty( $domains_pending_icann_verification );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1000,7 +1000,8 @@ function wpcom_launchpad_is_verify_domain_email_visible() {
 
 	// For Atomic sites we need to get the domain list from
 	// the public API.
-	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
+	if ( $is_atomic_site ) {
 		$domains = wpcom_request_domains_list();
 
 		if ( is_wp_error( $domains ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -627,7 +627,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return site_url( '/wp-admin/admin.php?page=sensei' );
 			},
 		),
-		'verify_domain_email'                => array(
+		'verify_domain_email'             => array(
 			'get_title'            => function () {
 				return __( 'Verify the email address for your domains', 'jetpack-mu-wpcom' );
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -1078,39 +1078,3 @@ function wpcom_get_launchpad_checklist_title_by_checklist_slug( $checklist_slug 
 
 	return wpcom_launchpad_checklists()->get_task_list_title( $checklist_slug );
 }
-
-/**
- * Make a request to the WordPress.com API to get the domain list for the current site.
- *
- * @return array|WP_Error Array of domains and their verification status or WP_Error if the request fails.
- */
-function wpcom_request_domains_list() {
-	$site_id       = \Jetpack_Options::get_option( 'id' );
-	$request_path  = sprintf( '/sites/%d/domains', $site_id );
-	$wpcom_request = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
-		$request_path,
-		'1.2',
-		array(
-			'method'  => 'GET',
-			'headers' => array(
-				'content-type'    => 'application/json',
-				'X-Forwarded-For' => ( new Automattic\Jetpack\Status\Visitor() )->get_ip( true ),
-			),
-		),
-		null,
-		'rest'
-	);
-
-	$response_code = wp_remote_retrieve_response_code( $wpcom_request );
-	if ( 200 !== $response_code ) {
-		return new \WP_Error(
-			'failed_to_fetch_data',
-			esc_html__( 'Unable to fetch the requested data.', 'jetpack-mu-wpcom' ),
-			array( 'status' => $response_code )
-		);
-	}
-
-	$body   = wp_remote_retrieve_body( $wpcom_request );
-	$status = json_decode( $body );
-	return $status;
-}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -1085,18 +1085,20 @@ function wpcom_get_launchpad_checklist_title_by_checklist_slug( $checklist_slug 
  * @return array|WP_Error Array of domains and their verification status or WP_Error if the request fails.
  */
 function wpcom_request_domains_list() {
-	$site_id       = get_current_blog_id();
+	$site_id       = \Jetpack_Options::get_option( 'id' );
 	$request_path  = sprintf( '/sites/%d/domains', $site_id );
-	$wpcom_request = Client::wpcom_json_api_request_as_user(
+	$wpcom_request = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
 		$request_path,
-		'2',
+		'1.2',
 		array(
 			'method'  => 'GET',
 			'headers' => array(
 				'content-type'    => 'application/json',
-				'X-Forwarded-For' => ( new Visitor() )->get_ip( true ),
+				'X-Forwarded-For' => ( new Automattic\Jetpack\Status\Visitor() )->get_ip( true ),
 			),
-		)
+		),
+		null,
+		'rest'
 	);
 
 	$response_code = wp_remote_retrieve_response_code( $wpcom_request );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #84409

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* As part of the Site Setup Checklist migration, we need to replicate the logic of the "Verify Domain Email" task.
* This task is required for some domain registrations.
* In an internal conversation, we decided to simplify the task visibility check by making a request to WPCOM to fetch the domain information. More context: p1704465548099689-slack-C0BNMNMNG 
* I decided to tackle the completion logic on a follow-up PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Testing Simple Site

* Apply the D134142-code diff to your sandbox
* Apply this patch to your sandbox with the following command:
 ```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/verify_domain_email-task-logic
```
* Apply the following filter on your `0-sandbox.php` file:
```
add_filter( 'enable_legacy_site_setup_launchpad', '__return_true' );
```
* Create a new site through `/setup/free` flow.
* Go through the flow until you launch your site and land on the Customer Home page.
* Click on the `Show site setup` button in the banner.
* You should see the Launchpad.
* Add a domain to your site.
* I wasn't sure how to make my Domain request the ICANN verification, so I updated the following check to return true in my Sandbox:
fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Snqzva%2Qcyhtvaf%2Sqbznvaf%2Sznantrzrag.cuc%3Se%3Q2q5nns96%23308-og
* Visit the Customer Home page and verify you can see the `Verify the email address for your domains` task.

### Testing Atomic site

* Sandbox the public-api
* Apply the D134142-code diff to your sandbox
* Add the following filter to your `0-sandbox.php` file
```
add_filter( 'enable_legacy_site_setup_launchpad', '__return_true' );
```
* Create a new site through the `/setup/free` flow, and then add the Business plan.
* Add a domain to your site.
* Now, add your site to the WoA Developer list.
* Transfer it to Atomic by navigating to `/hosting-config/:siteSlug` and activating the SSH.
* Edit your `~/htdocs/wp-config.php` to add the `JETPACK__SANDBOX_DOMAIN` constant. This will make the requests from your Atomic site hit your sandbox.
```
define( 'JETPACK__SANDBOX_DOMAIN', 'YOU_SANDBOX_HOST' );
```
* Use the Jetpack Beta plugin to apply this PR to your site(You may have to update the files manually, as the plugin doesn't seem to work on my end)
* Go to the Customer Home and click on the `Show site setup` button on the banner.
* I wasn't sure how to make my Domain request the ICANN verification, so I added the line below in the first line of the load method fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Snqzva%2Qcyhtvaf%2Sqbznvaf%2Sqbznva%2Qznantrzrag%2Qqbznva.cuc%3Se%3Qn0q22pr7%23302-og
```
$this->is_pending_icann_verification  = true;
```
* Visit the Customer Home page and verify you can see the `Verify the email address for your domains` task.