### PR TITLE
Backport mu-wpcom-plugin 2.0.12, jetpack 13.0-beta Changes

### DIFF
--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.8] - 2024-01-08
+### Added
+- Remove unused logic from the modules store and cover store with tests. [#34835]
+
+### Changed
+- Updated useModuleStatus hook to use module_status redux store. [#34845]
+
 ## [0.13.7] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815] [#34816]
@@ -313,6 +320,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.13.8]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.7...0.13.8
 [0.13.7]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.6...0.13.7
 [0.13.6]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.5...0.13.6
 [0.13.5]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.4...0.13.5

--- a/projects/js-packages/shared-extension-utils/changelog/add-modules-store-tests
+++ b/projects/js-packages/shared-extension-utils/changelog/add-modules-store-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-In modules_store we remove unused logic and cover store with tests

--- a/projects/js-packages/shared-extension-utils/changelog/update-use-redux-store-for-module-data
+++ b/projects/js-packages/shared-extension-utils/changelog/update-use-redux-store-for-module-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated use-module-status hook to use module_status redux store

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.13.8-alpha",
+	"version": "0.13.8",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.0] - 2024-01-08
+### Changed
+- Updated useModuleStatus hook to use module_status redux store. [#34845]
+- Use useModuleStatus hook instead of direct call of store selectors. [#34856]
+
+### Fixed
+- Avoid PHP warnings when post is not set. [#34886]
+
 ## [0.29.2] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]
@@ -457,6 +465,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.0]: https://github.com/automattic/jetpack-forms/compare/v0.29.2...v0.30.0
 [0.29.2]: https://github.com/automattic/jetpack-forms/compare/v0.29.1...v0.29.2
 [0.29.1]: https://github.com/automattic/jetpack-forms/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/automattic/jetpack-forms/compare/v0.28.0...v0.29.0

--- a/projects/packages/forms/changelog/fix-forms-warning
+++ b/projects/packages/forms/changelog/fix-forms-warning
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Avoid PHP warnings when post is not set.

--- a/projects/packages/forms/changelog/update-contact-form-using-modules-hook
+++ b/projects/packages/forms/changelog/update-contact-form-using-modules-hook
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use useModuleStatus hook instead of direct call of store selectors

--- a/projects/packages/forms/changelog/update-use-redux-store-for-module-data
+++ b/projects/packages/forms/changelog/update-use-redux-store-for-module-data
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated use-module-status hook to use module_status redux store. This one is to make sure that package is re-built.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.0-alpha",
+	"version": "0.30.0",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.0-alpha';
+	const PACKAGE_VERSION = '0.30.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.8.1] - 2024-01-08
+### Added
+- Adds the is_dismissible prop to the Launchpad task list definition. [#34839]
+
 ## [5.8.0] - 2024-01-04
 ### Added
 - Add WooCommerce setup task completion logic. [#34791]
@@ -511,6 +515,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.8.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.0...v5.8.1
 [5.8.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.7.0...v5.8.0
 [5.7.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.6.0...v5.7.0
 [5.6.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.5.0...v5.6.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-is-dismissible-prop-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-is-dismissible-prop-launchpad
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Adds the is_dismissible prop to the Launchpad task list definition

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.8.1",
+	"version": "5.8.2-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.8.1-alpha",
+	"version": "5.8.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.8.1';
+	const PACKAGE_VERSION = '5.8.2-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.8.1-alpha';
+	const PACKAGE_VERSION = '5.8.1';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.0] - 2024-01-08
+### Added
+- Add a check to determine if a user is "new" to Jetpack. [#34821]
+- Add a button that links to the connection screen to the Welcome Banner in My Jetpack. [#34858]
+
+### Changed
+- Add a product interstitial in My Jetpack for stats. [#34772]
+- Added an image to Social interstitial. [#34814]
+- Update Akismet card on My Jetpack to go to interstitial screen when there is no API key. [#34817]
+
 ## [4.2.1] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815] [#34816]
@@ -1173,6 +1183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.3.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.2.1...4.3.0
 [4.2.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.2.0...4.2.1
 [4.2.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.1.4...4.2.0
 [4.1.4]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.1.3...4.1.4

--- a/projects/packages/my-jetpack/changelog/add-connection-button-to-welcome-banner
+++ b/projects/packages/my-jetpack/changelog/add-connection-button-to-welcome-banner
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add to the Welcome banner in My Jetpack a button that links to the connection screen. Making it easier for user to find that page.

--- a/projects/packages/my-jetpack/changelog/add-interstitial-for-stats
+++ b/projects/packages/my-jetpack/changelog/add-interstitial-for-stats
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Add a product interstiail in My Jetpack for stats

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-new-user-check
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-new-user-check
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-add a check to determine if a user is "new" to Jetpack

--- a/projects/packages/my-jetpack/changelog/fix-social-interstitial
+++ b/projects/packages/my-jetpack/changelog/fix-social-interstitial
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Added an image to Social interstitial

--- a/projects/packages/my-jetpack/changelog/update-akismet-card-to-interstitial
+++ b/projects/packages/my-jetpack/changelog/update-akismet-card-to-interstitial
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-update Akismet card on My Jetpack to go to interstitial screen when there is no API key

--- a/projects/packages/my-jetpack/changelog/update-fix-jetpack-ai-interstitial-on-disconnected-site
+++ b/projects/packages/my-jetpack/changelog/update-fix-jetpack-ai-interstitial-on-disconnected-site
@@ -1,3 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Fixed a bug on how the Jetpack AI interstitial shows when the site is disconnected.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.3.0-alpha",
+	"version": "4.3.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.3.0",
+	"version": "4.3.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -33,7 +33,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.3.0-alpha';
+	const PACKAGE_VERSION = '4.3.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -33,7 +33,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.3.0';
+	const PACKAGE_VERSION = '4.3.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - 2024-01-08
+### Changed
+- Remove unused logic from the modules store. [#34835]
+- Updated useModuleStatus hook to use module_status redux store. [#34845]
+
 ## [0.21.7] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815] [#34816]
@@ -1225,6 +1230,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.22.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.7...v0.22.0
 [0.21.7]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.6...v0.21.7
 [0.21.6]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.5...v0.21.6
 [0.21.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.21.4...v0.21.5

--- a/projects/packages/videopress/changelog/add-modules-store-tests
+++ b/projects/packages/videopress/changelog/add-modules-store-tests
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-In modules_store we remove unused logic. This changelog is to make sure package is re-built.

--- a/projects/packages/videopress/changelog/update-use-redux-store-for-module-data
+++ b/projects/packages/videopress/changelog/update-use-redux-store-for-module-data
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated use-module-status hook to use module_status redux store. This changelog to make sure videopress package is re-built.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.22.0-alpha",
+	"version": "0.22.0",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.22.0-alpha';
+	const PACKAGE_VERSION = '0.22.0';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.0-beta - 2024-01-08
+### Enhancements
+- Subscription Modal: Display thesubscription modal when a user makes a comment. [#34659]
+
+### Bug fixes
+- Likes Widget: Fix accessibility on likes popover. [#34800]
+- Likes Widget: Make likes widget accessibility compatible across themes. [#34857]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Use useModuleStatus hook instead of direct call of store selectors. [#34856]
+- AI Excerpt: remove GPT model selector since it's not possible to change models anymore. [#34855]
+- Backup: Add namespace versioning to Helper_Script_Manager and other classes. [#34739]
+- Fix the sidebar toggle on mobile displays. [#34807]
+- Like Widget: Fix caching issue. [#34860]
+- Updated package dependencies. [#34882]
+
 ## 13.0-a.13 - 2024-01-04
 ### Bug fixes
 - Jetpack footer links are now consistent within different pages. [#34787]

--- a/projects/plugins/jetpack/changelog/add-interstitial-for-stats
+++ b/projects/plugins/jetpack/changelog/add-interstitial-for-stats
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-modules-store-tests
+++ b/projects/plugins/jetpack/changelog/add-modules-store-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-new-user-check
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-new-user-check
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-subscription-modal-on-comment
+++ b/projects/plugins/jetpack/changelog/add-subscription-modal-on-comment
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Promote Subscription: Add subscription modal when user comment

--- a/projects/plugins/jetpack/changelog/add-welcome-banner-connection-button
+++ b/projects/plugins/jetpack/changelog/add-welcome-banner-connection-button
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/backup-helper-script-manager-class-versioning
+++ b/projects/plugins/jetpack/changelog/backup-helper-script-manager-class-versioning
@@ -1,4 +1,0 @@
-Significance: major
-Type: other
-
-Backup: Add namespace versioning to Helper_Script_Manager and other classes

--- a/projects/plugins/jetpack/changelog/fix-comment-reply-link
+++ b/projects/plugins/jetpack/changelog/fix-comment-reply-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-

--- a/projects/plugins/jetpack/changelog/fix-dashboard-protect-card-activation
+++ b/projects/plugins/jetpack/changelog/fix-dashboard-protect-card-activation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix protect card text on activation.
-
-

--- a/projects/plugins/jetpack/changelog/fix-enable-the-menu-toggle
+++ b/projects/plugins/jetpack/changelog/fix-enable-the-menu-toggle
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixes the sidebar toggle on mobile displays.

--- a/projects/plugins/jetpack/changelog/fix-likes-accessibility
+++ b/projects/plugins/jetpack/changelog/fix-likes-accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Likes Widget: Make likes widget accessibility compatible across themes

--- a/projects/plugins/jetpack/changelog/fix-likes-widget-accessibility
+++ b/projects/plugins/jetpack/changelog/fix-likes-widget-accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Likes Widget: Fix accessibility on likes popover

--- a/projects/plugins/jetpack/changelog/fix-likes-widget-caching-issue
+++ b/projects/plugins/jetpack/changelog/fix-likes-widget-caching-issue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Like widget: Fix caching issue

--- a/projects/plugins/jetpack/changelog/generate_documentation_fix
+++ b/projects/plugins/jetpack/changelog/generate_documentation_fix
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: /rest/v1.1/help: Minor fix for endpoint descriptions missing close parenthesis.
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.1-a.0
+
+

--- a/projects/plugins/jetpack/changelog/modify-backup-helper-script-manager-class-versioning
+++ b/projects/plugins/jetpack/changelog/modify-backup-helper-script-manager-class-versioning
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/update-akismet-card-to-interstitial
+++ b/projects/plugins/jetpack/changelog/update-akismet-card-to-interstitial
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-contact-form-using-modules-hook
+++ b/projects/plugins/jetpack/changelog/update-contact-form-using-modules-hook
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
- Use useModuleStatus hook instead of direct call of store selectors 

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-remove-model-selector-excerpt
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-remove-model-selector-excerpt
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Excerpt: remove GPT model selector since it's not possible to change models anymore.

--- a/projects/plugins/jetpack/changelog/update-use-redux-store-for-module-data
+++ b/projects/plugins/jetpack/changelog/update-use-redux-store-for-module-data
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_a_14",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_beta",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_0_beta",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-a.14
+ * Version: 13.0-beta
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-a.14' );
+define( 'JETPACK__VERSION', '13.0-beta' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.0-beta
+ * Version: 13.1-a.0
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.0-beta' );
+define( 'JETPACK__VERSION', '13.1-a.0' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-a.14",
+	"version": "13.0.0-beta",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.0.0-beta",
+	"version": "13.1.0-a.0",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -295,11 +295,40 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 == Changelog ==
 ### 13.0-beta - 2024-01-08
 #### Enhancements
+- Added description and link inviting to disable legacy sharing module if block is available
+- AI Usage panel: Added yellow color to indicate going over the soft limit.
+- Gutenberg: Added Top Posts & Pages block.
+- Sharing Buttons Block: update the admin's setting screen when the sharing block is available.
+- Social Menu & Social Media Icons: Add support for the Bluesky service.
 - Subscription Modal: Display thesubscription modal when a user makes a comment.
+- Subscriptions: adds toggle to disable email sending.
+
+#### Improved compatibility
+- Contact Form: avoid PHP warnings in the WordPress dashboard when used alongside other plugins making changes to admin pages.
+- Patreon: Updated Patreon icon to match the updated Patreon branding guidelines.
+- Sharing Buttons: add the official X button to the list of supported services.
+- Sharing Buttons Block: Improved consistency for how the button icons are rendered on different pages.
 
 #### Bug fixes
+- Calendly Block: Fixed custom colours being stripped.
+- Dashboard: Disabled VideoPress card in offline mode.
+- Editor: Fixed missing fonts issue inside the block editor.
+- Jetpack footer links are now consistent within different pages.
+- Launchpad: Fixed the save modal not showing after saving changes in the editor.
+- Likes: Fixed popover closing area.
 - Likes Widget: Fix accessibility on likes popover.
 - Likes Widget: Make likes widget accessibility compatible across themes.
+- My Plan: Fix JS errors due to nested anchor tags.
+- Newsletter: Updated post-publish panel text for scheduled posts.
+- Notification Accessibility: THe notification icon is not a link.
+- Payments Block: show an error message when unable to render payment button.
+- Paywall: Fix stuck pending subscription state when email isn't verified.
+- Subscribe Modal: Fix fatal under exceptional conditions
+- Subscribers: fix the subscriber count display if above 1000 subscribers.
+- Subscribers: pre/post-publish panel, show correct subscription count when using paywall.
+- Subscriptions Block: Added compatibility for the latest Gutenberg.
+- Widgets: Fix console JS error in EU Cookie Widget.
+- WoA: Updated SEO Tools on Atomic sites to show only for Business plan and higher.
 
 --------
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,10 +293,13 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.0-a.13 - 2024-01-04
+### 13.0-beta - 2024-01-08
+#### Enhancements
+- Subscription Modal: Display thesubscription modal when a user makes a comment.
+
 #### Bug fixes
-- Jetpack footer links are now consistent within different pages.
-- Notification Accessibility: THe notification icon is not a link.
+- Likes Widget: Fix accessibility on likes popover.
+- Likes Widget: Make likes widget accessibility compatible across themes.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.12 - 2024-01-08
+### Changed
+- Updated package dependencies. [#34882]
+
 ## 2.0.11 - 2024-01-04
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_12_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_12"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.12-alpha
+ * Version: 2.0.12
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.12-alpha",
+	"version": "2.0.12",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.12, jetpack 13.0-beta

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.