### PR TITLE
Fix Social CTA on My Jetpack

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-social-cta-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/fix-social-cta-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: This commit fixes a small bug that is mostly visual, where it was always rendering the "Activate" button for Social on My Jetpack.
+
+

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -128,6 +128,27 @@ class Social extends Hybrid_Product {
 	}
 
 	/**
+	 * Checks whether the current plan (or purchases) of the site already supports the product
+	 *
+	 * @return boolean
+	 */
+	public static function has_required_plan() {
+		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
+			return false;
+		}
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				// Social is available as standalone bundle and as part of the Complete plan.
+				if ( strpos( $purchase->product_slug, 'jetpack_social' ) !== false || str_starts_with( $purchase->product_slug, 'jetpack_complete' ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Get the URL where the user manages the product.
 	 *
 	 * If the standalone plugin is active,

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -124,7 +124,7 @@ class Social extends Hybrid_Product {
 	 * @return string
 	 */
 	public static function get_wpcom_product_slug() {
-		return 'jetpack_social';
+		return 'jetpack_social_basic_yearly';
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds `has_required_plan` to Social product class. This method is responsible for checking whether a site has a plan for a specific product. Adding this method, Social now also shows the "Learn More" button if the site doesn't have Social, instead of just the "Activate" button.
<img width="363" alt="image" src="https://github.com/Automattic/jetpack/assets/5714212/066b6cc5-4918-44fe-bda6-44a9e78d2aa7">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbNhbs-9bI-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch
* Connected to Jetpack, visit the My Jetpack page
* If you don't have a Social/Complete plan. Confirm that the CTA for Social says "Learn More" instead of "Activate"