### PR TITLE
Composing Setting: Rename copy post to duplicate in module description

### DIFF
--- a/projects/plugins/jetpack/changelog/enhance-rename-copy-post-duplicate-settings
+++ b/projects/plugins/jetpack/changelog/enhance-rename-copy-post-duplicate-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Composing Setting: Rename copy post to duplicate in module description

--- a/projects/plugins/jetpack/modules/copy-post.php
+++ b/projects/plugins/jetpack/modules/copy-post.php
@@ -1,7 +1,7 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
- * Module Name: Copy Post
- * Module Description: Enable the option to copy entire posts and pages, including tags and settings
+ * Module Name: Duplicate Post
+ * Module Description: Enable the option to duplicate entire posts and pages, including tags and settings
  * Sort Order: 15
  * First Introduced: 7.0
  * Requires Connection: No


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/5078.

## Proposed changes:

Renames the option to "... duplicate entire ..." instead "... copy entire ..."

| Before | After |
| -------|------|
| <img width="467" alt="image" src="https://github.com/Automattic/jetpack/assets/26530524/7f226d2e-8871-406b-b087-1d3eb151ffca"> | <img width="467" alt="image" src="https://github.com/Automattic/jetpack/assets/26530524/9f55f46e-16a8-4be3-aae7-c705f098b3e4"> |

### Other information:

~- [ ] Have you written new tests for your changes, if applicable?~
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Run this plugin as a beta tester as indicated in https://github.com/Automattic/jetpack/pull/34904#issuecomment-1881894711

Go to Jetpack > Settings > Writing and check that the setting description is renamed accordingly.