### PR TITLE
Update/anti spam plan check

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-anti-spam-plan-check
+++ b/projects/packages/my-jetpack/changelog/update-anti-spam-plan-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+add plan check to My Jetpack Akismet product card

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -265,7 +265,8 @@ class Wpcom_Products {
 
 		$body      = wp_remote_retrieve_body( $response );
 		$purchases = json_decode( $body );
-		set_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY, $purchases, MINUTE_IN_SECONDS / 2 );
+		// Set short transient to help with repeated lookups on the same page load
+		set_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY, $purchases, 5 );
 
 		return $purchases;
 	}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  This diff expands the plan check for the Akismet card on the My Jetpack page to include checks for the Jetpack anti-spam product and Complete/ Security bundles

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Apply this patch to your test site
- Confirm that the Akismet product card on My Jetpack no longer says "Learn More" if your site has a purchase that contains Jetpack Anti-Spam, even if you remove your Akismet API key.

