### PR TITLE
Stats: remove trial support for stats

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-remove-trial-support-for-stats
+++ b/projects/packages/my-jetpack/changelog/fix-remove-trial-support-for-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: keep rediction to stats page for purchase

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -238,16 +238,6 @@ class Stats extends Module_Product {
 	}
 
 	/**
-	 * Checks whether the product supports trial or not.
-	 * Since Jetpack Stats has been widely available as a free product in the past, it "supports" a trial.
-	 *
-	 * @return boolean
-	 */
-	public static function has_trial_support() {
-		return true;
-	}
-
-	/**
 	 * Get the WordPress.com URL for purchasing Jetpack Stats for the current site.
 	 *
 	 * @return ?string


### PR DESCRIPTION
## Proposed changes:
Removes `trial` from the Stats products, so that the link on Stats card is not directed to the Stats purchase page, where users could choose tiers from.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a new JN site
* Connect the site
* Open My Jetpack
* Ensure it shows 'Upgrade' on Stats card and it redirects user to Stats purchase page

<img width="368" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/1af6c0fa-7581-447a-8123-53f12c0a6cc7">
