### PR TITLE
Subscriptions: only show checkboxes under posts

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-checkboxes-cpt
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-checkboxes-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: do not display subscription checkboxes in comment forms displayed on Custom Post Type pages.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -850,6 +850,11 @@ class Jetpack_Subscriptions {
 	public function comment_subscribe_init( $submit_button ) {
 		global $post;
 
+		// Subscriptions are only available for posts so far.
+		if ( ! $post || 'post' !== $post->post_type ) {
+			return $submit_button;
+		}
+
 		$comments_checked = '';
 		$blog_checked     = '';
 


### PR DESCRIPTION
Fixes #34859

## Proposed changes:

Subscriptions only work for posts so far, so we should never attempt to display subscription checkboxes for non-posts, to avoid confusion.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Install the WooCommerce plugin on your site.
* Publish a product
* Go to Jetpack > Settings and enable the subscriptions module.
* Ensure checkboxes are enabled in the subscriptions settings.
* View the comment form under one of your posts; you should see the boxes.
* View the comment form in the Reviews section of the product you published; you should not see the boxes.
