### PR TITLE
Gutenberg: enqueue assets for editor UI with enqueue_block_editor_assets to fix block styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-editor-assets-in-canvas
+++ b/projects/plugins/jetpack/changelog/fix-editor-assets-in-canvas
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Gutenberg: enqueue assets for editor UI with enqueue_block_editor_assets to fix block styles

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -711,15 +711,12 @@ class Jetpack {
 		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_independent_blocks' ) );
 		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_block_editor_extensions' ), 9 );
 		/**
-		 * We've switched from enqueue_block_editor_assets to enqueue_block_assets in WP-Admin because the assets with the former are loaded on the main site-editor.php.
-		 *
-		 * With the latter, the assets are now loaded in the SE iframe; the implementation is now faster because Gutenberg doesn't need to inject the assets in the iframe on client-side.
+		 * Jetpack assets include styles for the admin like wp-admin/css/common.css with styles for elements like h2, h3 that are applied globally.
+		 * Those admin styles should not apply to the editor canvas (iframe) but only to the editor UI to avoid affecting the content styles (blocks).
+		 * Read more in https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/#scenarios-for-enqueuing-assets
 		 */
-		if ( is_admin() ) {
-			add_action( 'enqueue_block_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
-		} else {
-			add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
-		}
+		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
+
 		add_filter( 'render_block', array( 'Jetpack_Gutenberg', 'display_deprecated_block_message' ), 10, 2 );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/jetpack/pull/32706 https://github.com/Automattic/jetpack/pull/32641 https://github.com/Automattic/jetpack/pull/34268 D119952-code D119650-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enqueue assets for editor UI with `enqueue_block_editor_assets` to fix style issues on the Heading block (h2, h3)

|BEFORE|AFTER|
|-|-|
|<img width="1255" alt="Screenshot 2567-01-09 at 18 24 51" src="https://github.com/Automattic/jetpack/assets/1881481/457fd845-9ef2-4bbb-a01d-5c728026e0e0">|<img width="1282" alt="Screenshot 2567-01-09 at 18 24 39" src="https://github.com/Automattic/jetpack/assets/1881481/97aff063-8637-436a-a2a7-f200348cd8fb">|


> [!NOTE]
> The issue is that the assets include styles for the WP Admin like `wp-admin/css/common.css` with styles for heading elements like h2, h3 that were applied to the editor canvas (iframe) when they should only apply to the editor UI to avoid affecting the editor content in the canvas. 
>
> Read more about why those changes were introduced in this comment from @BogdanUngureanu : https://github.com/Automattic/jetpack/pull/34268/files#r1404387087

> [!WARNING]
> You will see warnings on the JS console because there are Jetpack assets like `jp-forms-blocks-css`, `jetpack-blocks-editor-css`, and `help-center-style-css` using the selectors `.editor-styles-wrapper, .wp-block, or .wp-block-*` and Gutenberg detects that to add those styles into the editor canvas as a fallback because that is no longer recommended.
>
> This is fine for now because it's also the approach in Jetpack sites, and there is no performance issue reproducible in the editor on Dotcom after merging https://github.com/Automattic/jetpack/pull/32641 and https://github.com/Automattic/jetpack/pull/34268.
>
> Read more in [Backward compatibility and known issues](https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/#backward-compatibility-and-known-issues)

> [!CAUTION]
> I believe the styles in `wp-admin/css/common.css` should not be enqueued on the editor `/wp-admin/site-editor.php`. I am not sure if that has to be fixed in core. cc: @jeyip @Automattic/t-rex @Automattic/lego WDYT?
> On the other hand, assets only required for blocks should be enqueued separately to be applied directly in the canvas using `enqueue_block_assets `.
>
> Read more in [Scenarios for enqueuing assets](https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/#scenarios-for-enqueuing-assets)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a site
* Apply these changes in your sandbox with `jetpack-downloader test jetpack fix/editor-assets-in-canvas`
* Create a pattern from `{ SITE }/wp-admin/site-editor.php&path=%2Fpatterns` with a h2 and h3 heading blocks. You can paste the following content using the code editor: 
```
<!-- wp:heading -->
<h2 class="wp-block-heading">Testing header h2</h2>
<!-- /wp:heading -->

<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Testing header h3</h3>
<!-- /wp:heading -->
```
* Inspect the h2 or h3 element to verify the following styles are NOT applied
 
<img width="1260" alt="Screenshot 2567-01-09 at 18 32 37" src="https://github.com/Automattic/jetpack/assets/1881481/0f36736f-4f3b-4b9a-8a48-65bd07fde09b">

* Apply margin or padding styles to the heading to verify the UI is responsive. The changes should be applied without any noticeable performance issues.
 
https://github.com/Automattic/jetpack/assets/1881481/fcf098d0-8bb5-4ef7-ba87-6e27334173a1

* Add a Donation Form block to verify that Jetpack blocks look and work as expected.


https://github.com/Automattic/jetpack/assets/1881481/b598f131-185d-44f8-ad79-56ab3fbff710

* Sandbox a P2 site
* Verify you can draft a post and a comment with a GIF block to verify that Jetpack blocks work as expected. See https://github.com/Automattic/jetpack/pull/32641#issuecomment-1695073973


https://github.com/Automattic/jetpack/assets/1881481/7d841163-cb3b-4dfd-b7fe-bca37a766563


https://github.com/Automattic/jetpack/assets/1881481/d322efdb-5217-43a5-82df-2070806f08e6