### PR TITLE
AI Assistant: fix upgrade and connect nudge positioning

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-ai-assistant-upgrade-nudge-positioning
+++ b/projects/js-packages/ai-client/changelog/fix-ai-assistant-upgrade-nudge-positioning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Client: introduce bannerComponent prop, React.Element, to render on top of the AI Control

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.3.1",
+	"version": "0.4.0-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -42,6 +42,7 @@ type AiControlProps = {
 	onAccept?: () => void;
 	onDiscard?: () => void;
 	showRemove?: boolean;
+	bannerComponent?: React.ReactElement;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -72,6 +73,7 @@ export function AIControl(
 		onAccept = noop,
 		onDiscard = null,
 		showRemove = false,
+		bannerComponent = null,
 	}: AiControlProps,
 	ref: React.MutableRefObject< null > // eslint-disable-line @typescript-eslint/ban-types
 ): React.ReactElement {
@@ -153,6 +155,7 @@ export function AIControl(
 	return (
 		<div className="jetpack-components-ai-control__container-wrapper">
 			<div className="jetpack-components-ai-control__container">
+				{ bannerComponent }
 				<div
 					className={ classNames( 'jetpack-components-ai-control__wrapper', {
 						'is-transparent': isTransparent,

--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-upgrade-nudge-positioning
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-upgrade-nudge-positioning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Assistant: compose ConnectPrompt and UpgradePrompt and pass it as bannerComponent prop to AI Client

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -409,6 +409,14 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 
 	const promptPlaceholder = __( 'Ask Jetpack AI…', 'jetpack' );
 	const promptPlaceholderWithSamples = __( 'Write about… Make a table for…', 'jetpack' );
+
+	const banner = (
+		<>
+			{ isOverLimit && isSelected && <UpgradePrompt /> }
+			{ ! connected && <ConnectPrompt /> }
+		</>
+	);
+
 	return (
 		<KeyboardShortcuts
 			bindGlobal
@@ -514,8 +522,6 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					</InspectorControls>
 				) }
 
-				{ isOverLimit && isSelected && <UpgradePrompt /> }
-				{ ! connected && <ConnectPrompt /> }
 				{ ! isWaitingState && connected && ! requireUpgrade && (
 					<ToolbarControls
 						isWaitingState={ isWaitingState }
@@ -565,6 +571,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					acceptLabel={ acceptLabel }
 					showGuideLine={ contentIsLoaded }
 					showRemove={ attributes?.content?.length > 0 }
+					bannerComponent={ banner }
 				/>
 
 				{ ! loadingImages && resultImages.length > 0 && (


### PR DESCRIPTION
The connect and upgrade nudges are being rendered as part of the AI Assistant control, hence missing the sticky positioning

Fixes #34906

## Proposed changes:
This PR introduces a new prop `bannerComponent` for the AI Control package component to allow a React.Element to be provided. The provided component is then rendered on top of the AI Control.

The PR also includes a fix for the nudges positioning within the AI Assistant context, where the Connect and Upgrade nudges would be provided as `bannerComponent` to the AI Control instead of rendering as part of the AI Assistant content.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1704805654243389-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the editor and mock 2 scenarios (together or separately):
- a disconnected site (this might be hard to test as we no longer register the block if the site is not connected, you might edit the `{ ! isConnected && <ConnectPrompt /> }`, remove the first condition and build again)
- a site with exhausted AI requests ( you can simulate this by running in the console `wp.data.dispatch( 'wordpress-com/plans' ).increaseAiAssistantRequestsCount( 20 )` where "20" is whatever you need to go over limit )

Each case should render the corresponding (or both) prompts on top of the AI Control, hence inheriting the positioning and sticking to the bottom of the viewport once the content exceeds it in length.

Verify the block and the extension (eg Forms) look good both on desktop and mobile views.

<img width="640" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/c7a39110-123b-43a7-84aa-f1f3a55b993d">
