### PR TITLE
Subscriptions: Show subscription numbers more elegantly

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscription-numbers-more-elegantly
+++ b/projects/plugins/jetpack/changelog/update-subscription-numbers-more-elegantly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Show subscription numbers more elegantly

--- a/projects/plugins/jetpack/changelog/update-subscription-numbers-more-elegantly
+++ b/projects/plugins/jetpack/changelog/update-subscription-numbers-more-elegantly
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: update
 
 Subscriptions: Show subscription numbers more elegantly

--- a/projects/plugins/jetpack/changelog/update-subscription-numbers-more-elegantly
+++ b/projects/plugins/jetpack/changelog/update-subscription-numbers-more-elegantly
@@ -1,4 +1,4 @@
 Significance: patch
-Type: update
+Type: other
 
 Subscriptions: Show subscription numbers more elegantly

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -70,7 +70,7 @@ export default function SubscriptionControls( {
 								subscriberCount,
 								'jetpack'
 							),
-							numberFormat( subscriberCount, { notation: 'compact' } )
+							numberFormat( subscriberCount, { notation: 'compact', maximumFractionDigits: 1 } )
 						),
 						{ span: <span style={ { fontWeight: 'bold' } } /> }
 					) }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -1,4 +1,4 @@
-import { ThemeProvider } from '@automattic/jetpack-components';
+import { numberFormat, ThemeProvider } from '@automattic/jetpack-components';
 import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import {
 	BlockControls,
@@ -111,7 +111,7 @@ export function SubscriptionEdit( props ) {
 			subscriberCountString: sprintf(
 				/* translators: Placeholder is a number of subscribers. */
 				_n( 'Join %s other subscriber', 'Join %s other subscribers', count, 'jetpack' ),
-				count
+				numberFormat( count, { notation: 'compact', maximumFractionDigits: 1 } )
 			),
 		};
 	} );

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -180,6 +180,7 @@ export function NewsletterAccessRadioButtons( {
 					{
 						label: `${ accessOptions.subscribers.label } (${ numberFormat( subscribersReach, {
 							notation: 'compact',
+							maximumFractionDigits: 1,
 						} ) })`,
 						value: accessOptions.subscribers.key,
 					},
@@ -188,6 +189,7 @@ export function NewsletterAccessRadioButtons( {
 							paidSubscribersReach,
 							{
 								notation: 'compact',
+								maximumFractionDigits: 1,
 							}
 						) })`,
 						value: accessOptions.paid_subscribers.key,


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/32373

## Proposed changes:

Another iteration of rendering subscription numbers more elegantly. This time for the Subscribe block inside the editor.

It also adds `maximumFractionDigits: 1` in other places to be more precise and unify those numbers.

### Before

<img width="813" alt="Screenshot 2024-01-09 at 17 38 45" src="https://github.com/Automattic/jetpack/assets/4068554/b134d423-089a-473b-b7b7-51a2ea30683e">

### After

<img width="813" alt="Screenshot 2024-01-09 at 17 38 11" src="https://github.com/Automattic/jetpack/assets/4068554/407d1089-3e85-4425-9f42-74a2ddacd283">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Either have a site with 1000+ subscribers, or hardcode the number at https://github.com/Automattic/jetpack/blob/11f795b0491b7df67327cf4c73f3661488004612/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js#L109-L116
* Add a Subscribe block to the post with "Show subscriber count" setting enabled
* Make sure the subscribers number in the editor is displayed as expected

