### PR TITLE
Like block: Update the `index.html` version based on the current Jetpack version

### DIFF
--- a/projects/plugins/jetpack/changelog/update-like-block-index-version
+++ b/projects/plugins/jetpack/changelog/update-like-block-index-version
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Like block: Set index.html version based on thecurrent Jetpack version
+Like block: Set index.html version based on the current Jetpack version

--- a/projects/plugins/jetpack/changelog/update-like-block-index-version
+++ b/projects/plugins/jetpack/changelog/update-like-block-index-version
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Like block: Set index.html version based on thecurrent Jetpack version

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -87,9 +87,8 @@ function render_block( $attr, $content, $block ) {
 		$blog_id      = get_current_blog_id();
 		$bloginfo     = get_blog_details( (int) $blog_id );
 		$domain       = $bloginfo->domain;
-		$version      = '20231201';
 		$reblog_param = $show_reblog_button ? '&amp;reblog=1' : '';
-		$src          = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$d#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', $version, $blog_id, $post_id, $domain, $uniqid, $new_layout, $reblog_param );
+		$src          = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', JETPACK__VERSION, $blog_id, $post_id, $domain, $uniqid, $new_layout, $reblog_param );
 		$headline     = '';
 
 		// provide the mapped domain when needed

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -88,7 +88,7 @@ function render_block( $attr, $content, $block ) {
 		$bloginfo     = get_blog_details( (int) $blog_id );
 		$domain       = $bloginfo->domain;
 		$reblog_param = $show_reblog_button ? '&amp;reblog=1' : '';
-		$src          = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', JETPACK__VERSION, $blog_id, $post_id, $domain, $uniqid, $new_layout, $reblog_param );
+		$src          = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout, $reblog_param );
 		$headline     = '';
 
 		// provide the mapped domain when needed
@@ -101,7 +101,7 @@ function render_block( $attr, $content, $block ) {
 		$url       = home_url();
 		$url_parts = wp_parse_url( $url );
 		$domain    = $url_parts['host'];
-		$src       = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1', JETPACK__VERSION, $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src       = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$headline  = sprintf(
 			/** This filter is already documented in modules/sharedaddy/sharing-service.php */
 			apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>', esc_html__( 'Like this:', 'jetpack' ), 'likes' ),

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -444,7 +444,7 @@ class Jetpack_Likes {
 		 */
 		$new_layout = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
 
-		$src      = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s', JETPACK__VERSION, $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src      = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout );
 		$name     = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$wrapper  = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$headline = sprintf(
@@ -521,7 +521,7 @@ class Jetpack_Likes {
 		// Make sure to include the scripts before the iframe otherwise weird things happen.
 		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
 
-		$src = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%3$d&amp;post_id=%4$d&amp;origin=%2$s://%5$s', JETPACK__VERSION, $protocol, $blog_id, $post_id, $domain );
+		$src = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%3$d&amp;post_id=%4$d&amp;origin=%2$s://%5$s', rawurlencode( JETPACK__VERSION ), $protocol, $blog_id, $post_id, $domain );
 
 		$html = "<iframe class='admin-bar-likes-widget jetpack-likes-widget' scrolling='no' frameBorder='0' name='admin-bar-likes-widget' src='$src'></iframe>";
 


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the Like widget's `index.html` version based on the current Jetpack version (applies similar changes as were already merged in https://github.com/Automattic/jetpack/pull/34860; this time we are targeting Simple sites)
* Run `JETPACK_VERSION` through `rawurlencode()` - in case there are unexpected changes to the way the constant is created in the future

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1704812459917019/1704420940.584919-slack-C02TCEHP3HA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Sync the PR changes to your WPCOM sandbox: you can use the script from the comment below: https://github.com/Automattic/jetpack/pull/34920#issuecomment-1883417855
2. Add a Like block to your test site (to one of the posts).
3. Review the post in the front-end using Inspector.
4. Search for `widgets.wp.com/likes` in the page source code: the version should match with the current Jetpack version (instead of the previous date stamp). The Like block should still work as expected.