### PR TITLE
AI Assistant: avoid deprecation notice in AI Excerpt

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-excerpt-deprecation-notices
+++ b/projects/plugins/jetpack/changelog/fix-ai-excerpt-deprecation-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: avoid deprecation notices when using a development version of WordPress.

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
@@ -3,6 +3,7 @@
  */
 import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
 import { dispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
@@ -42,7 +43,7 @@ function extendAiContentLensFeatures( settings, name ) {
 	registerJetpackPlugin( aiExcerptPluginName, aiExcerptPluginSettings );
 
 	// Remove the excerpt panel by dispatching an action.
-	dispatch( 'core/edit-post' )?.removeEditorPanel( 'post-excerpt' );
+	dispatch( editorStore )?.removeEditorPanel( 'post-excerpt' );
 
 	return settings;
 }


### PR DESCRIPTION
## Proposed changes:

This should avoid warnings like this one:

```
dispatch( 'core/edit-post' ).removeEditorPanel is deprecated since version 6.5. Please use dispatch( 'core/editor').removeEditorPanel instead.
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Open the JavaScript console.
* Install the latest version of the Gutenberg plugin.
* Go to Posts > Add New
    * You should no longer see the warning above.
    * You should still only see the AI Excerpt panel and the core one gets removed.
    * Confirm you never see both panels at the same time.
