### PR TITLE
cli: Pass only needed dirs to chokidar for rsync --watch

### DIFF
--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -1,4 +1,4 @@
-import { createWriteStream } from 'fs';
+import { createWriteStream, existsSync } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
 import process from 'process';
@@ -95,12 +95,16 @@ export async function rsyncInit( argv ) {
 
 				// Watch `.gitignore` and `.gitattributes` in parent dirs, as they too may change which files are synced.
 				// Here we assume sourcePluginPath is always `projects/plugins/whatever`
-				watcher.add( '../.gitignore' );
-				watcher.add( '../.gitattributes' );
-				watcher.add( '../../.gitignore' );
-				watcher.add( '../../.gitattributes' );
-				watcher.add( '../../../.gitignore' );
-				watcher.add( '../../../.gitattributes' );
+				for ( const dir of [ '.', 'projects', 'projects/plugins' ] ) {
+					const ignorepath = path.join( process.cwd(), dir, '.gitignore' );
+					if ( existsSync( ignorepath ) ) {
+						watcher.add( ignorepath );
+					}
+					const attributespath = path.join( process.cwd(), dir, '.gitattributes' );
+					if ( existsSync( attributespath ) ) {
+						watcher.add( attributespath );
+					}
+				}
 
 				watcher.once( 'ready', () => {
 					console.log( 'jetpack rsync --watch is now watching for changes to:', sourcePluginPath );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This builds on top of #34909.

At least on Linux just telling chokidar to watch the plugin dir causes it to try to watch hundreds of thousands of paths, digging deep inside `node_modules/` and recursively through `vendor/` and such.

Instead, let's configure chokidar with `depth: 0` and manually tell it each directory we want it to watch.

That also means refactoring the code that builds the rsync filter into separate code to collect the list of paths and then code to turn that into rsync's syntax.

Then we'll also want to skip the prompting for saving the destination after each rsync, as ideally there should be no user interaction needed with --watch. Unfortunately I couldn't figure out a method to have ssh not prompt for a password; if you're trying to rsync-watch to JN you'll first have to set up a public key manually.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try it out?
