### PR TITLE
Avoid a warning under PHP 8.1 when wp_parse_url() returns false

### DIFF
--- a/projects/plugins/jetpack/changelog/update-post-images
+++ b/projects/plugins/jetpack/changelog/update-post-images
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: compat
 
-post images: Prevent a warning in PHP 8.1 if wp_parse_url() returns false.
+Post Images: avoid PHP warnings on sites using PHP 8.1+, when a post image has a malformed URL.

--- a/projects/plugins/jetpack/changelog/update-post-images
+++ b/projects/plugins/jetpack/changelog/update-post-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+post images: Prevent a warning in PHP 8.1 if wp_parse_url() returns false.

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -266,6 +266,10 @@ class Jetpack_PostImages {
 
 		foreach ( $html_images as $html_image ) {
 			$src = wp_parse_url( $html_image['src'] );
+			if ( ! $src ) {
+				continue;
+			}
+
 			// strip off any query strings from src.
 			if ( ! empty( $src['scheme'] ) && ! empty( $src['host'] ) ) {
 				$inserted_images[] = $src['scheme'] . '://' . $src['host'] . $src['path'];


### PR DESCRIPTION
## Proposed changes: Check `wp_parse_url()` response for false

When the current code provides `$html_image['src']` that has a value that `wp_parse_url()` returns false on, warnings are logged under PHP 8.1.  Since the looped code does not work under that condition currently, this patch looks for the condition and skips to the next entry in the loop.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

