### PR TITLE
Fix: isaRequest in purchase success

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/purchase-success.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/purchase-success.tsx
@@ -12,7 +12,7 @@ const PurchaseSuccess: React.FC = () => {
 	const [ imageGuideState ] = useSingleModuleState( 'image_guide' );
 	const [ isaState ] = useSingleModuleState( 'image_size_analysis' );
 	const navigate = useNavigate();
-	const { requestNewReport } = useImageAnalysisRequest();
+	const isaRequest = useImageAnalysisRequest();
 
 	useEffect( () => {
 		setCloudCssState( true );
@@ -23,9 +23,9 @@ const PurchaseSuccess: React.FC = () => {
 			isaState?.active &&
 			false !== Jetpack_Boost.site.canResizeImages
 		) {
-			requestNewReport();
+			isaRequest.requestNewReport();
 		}
-	}, [ imageGuideState?.active, isaState?.active, setCloudCssState, requestNewReport ] );
+	}, [ imageGuideState?.active, isaState?.active, setCloudCssState, isaRequest ] );
 
 	const wpcomPricingUrl = getRedirectUrl( 'wpcom-pricing' );
 

--- a/projects/plugins/boost/changelog/boost-react-fix-isa-request
+++ b/projects/plugins/boost/changelog/boost-react-fix-isa-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a bug in image generation request after purchase


### PR DESCRIPTION
Fix a bug introduced in #34599

## Proposed changes:
Updated the `useImageAnalysisRequest` usage.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Purchase boost premium
* Validate that image scanning begins
