### PR TITLE
Make edit_url nullable, not optional

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/image-size-analysis/lib/stores/types.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/image-size-analysis/lib/stores/types.ts
@@ -40,7 +40,7 @@ export const IsaImage = z.object( {
 		id: z.coerce.number(),
 		url: z.string().url(),
 		title: z.string(),
-		edit_url: z.string().url().optional(),
+		edit_url: z.string().url().nullable(),
 	} ),
 	device_type: z.enum( [ 'phone', 'desktop' ] ),
 	instructions: z.string(),

--- a/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Entry.php
+++ b/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Entry.php
@@ -69,7 +69,7 @@ class Image_Size_Analysis_Entry implements Lazy_Entry, Entry_Can_Get {
 		return array(
 			'id'       => $issue->page_id,
 			'url'      => $issue->page_url,
-			'edit_url' => $edit_url,
+			'edit_url' => $edit_url ? $edit_url : null,
 			'title'    => $title,
 		);
 	}

--- a/projects/plugins/boost/changelog/boost-react-hotfix-edit-url-null
+++ b/projects/plugins/boost/changelog/boost-react-hotfix-edit-url-null
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Hotfix
+
+


### PR DESCRIPTION
## Proposed changes:
This fixes a Zod URL caused by an unexpected null

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
🌈
