### PR TITLE
JS Packages: Components - Fix build error

### DIFF
--- a/projects/js-packages/components/changelog/fix-build-error
+++ b/projects/js-packages/components/changelog/fix-build-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix import resulting in a build error.
+
+

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.45.10",
+	"version": "0.45.11-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/components/tools/get-site-admin-url/index.ts
+++ b/projects/js-packages/components/tools/get-site-admin-url/index.ts
@@ -1,4 +1,4 @@
-import './types.ts';
+import './types';
 /**
  * Returns the site admin URL.
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When running the Boost watcher/build, I kept getting an error:

![CleanShot 2024-01-10 at 15 37 32](https://github.com/Automattic/jetpack/assets/11799079/dd6e1766-0504-43ca-92bf-d86239bd8201)

This PR fixes it. I'm not sure where this is used, so I couldn't test if everything's okay there, but it's a file extension omission, so things should work as expected.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix build showing an error.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the Boost watcher/build process;
* There error should no longer show up.