### PR TITLE
Like block: Update editor styles and add script to automatically update them.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-like-block-update-styles-script
+++ b/projects/plugins/jetpack/changelog/add-like-block-update-styles-script
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This is only for developers of this block.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -5,16 +5,15 @@
     }
 }
 
-/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-01-10T14:03:26.649Z */
-
-.wpl-likebox,.wpl-follow a,.wpl-count a{
+/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-01-10T14:20:09.727Z */
+.wpl-likebox,.wpl-follow a,.wpl-count a {
   font-size:11px!important;
   font-family:"Open Sans",sans-serif!important
 }
-.wpl-button{
+.wpl-button {
   min-width:73px
 }
-.wpl-button a{
+.wpl-button a {
   text-decoration:none;
   display:flex;
   margin:1px 7px 8px 1px;
@@ -29,13 +28,13 @@
   line-height:23px;
   padding:4px 10px 3px
 }
-.wpl-button a:hover{
+.wpl-button a:hover {
   box-shadow:0 1px 2px rgba(0,0,0,.22),0 0 0 1px rgba(0,0,0,.22)
 }
-.wpl-button a:active{
+.wpl-button a:active {
   box-shadow:0 1px 2px rgba(0,0,0,.22),0 0 0 1px rgba(0,0,0,.22)
 }
-.wpl-button a:before{
+.wpl-button a:before {
   display:inline-block;
   position:relative;
   width:16px;
@@ -47,74 +46,74 @@
   content:"";
   background-size:16px 16px
 }
-.wpl-button.like a:before{
+.wpl-button.like a:before {
   background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m9.00081 2 1.95699 4.26814h4.3763l-3.6666 3.39117 1.2473 4.34069-3.91399-2.25-3.914 2.25 1.24734-4.34069-3.66667-3.39117h2.18817 2.18816z' stroke='%232c3338' stroke-linecap='round' stroke-width='1.5'/%3E%3C/svg%3E")
 }
-.wpl-button.like a:hover:before{
+.wpl-button.like a:hover:before {
   background-image:url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 18 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.00081 2L10.9578 6.26814H15.3341L11.6675 9.65931L12.9148 14L9.00081 11.75L5.08681 14L6.33415 9.65931L2.66748 6.26814H4.85565H7.04381L9.00081 2Z' stroke='%230675C4' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")
 }
-.wpl-button.liked a:before{
+.wpl-button.liked a:before {
   background-image:url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 18 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.00081 2L10.9578 6.26814H15.3341L11.6675 9.65931L12.9148 14L9.00081 11.75L5.08681 14L6.33415 9.65931L2.66748 6.26814H4.85565H7.04381L9.00081 2Z' fill='%230675C4' stroke='%230675C4' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")
 }
-.wpl-button.reblog a:before{
+.wpl-button.reblog a:before {
   background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m1 0h16v16h-16z' fill='%23fff'/%3E%3Cpath d='m16.0163 5.56587-1.4511-1.43412v8.99325c0 .7597-.6226 1.375-1.3913 1.375h-4.86955v-1.375h4.86955v-8.99325l-1.4511 1.43412-.9837-.97212 3.1305-3.09375 3.1304 3.09375zm-11.19021 6.30243v-8.9933h4.86956v-1.375h-4.86956c-.7687 0-1.39131.61531-1.39131 1.375v8.9933l-1.45113-1.4342-.98365.9721 3.13043 3.0938 3.13044-3.0938-.98365-.9721z' fill='%232c3338' stroke='%232c3338' stroke-width='.14'/%3E%3C/svg%3E")
 }
-.wpl-button.reblog a.reblogged:before{
+.wpl-button.reblog a.reblogged:before {
   background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m1 0h16v16h-16z' fill='%23fff'/%3E%3Cpath d='m16.0163 5.56587-1.4511-1.43412v8.99325c0 .7597-.6226 1.375-1.3913 1.375h-4.86955v-1.375h4.86955v-8.99325l-1.4511 1.43412-.9837-.97212 3.1305-3.09375 3.1304 3.09375zm-11.19021 6.30243v-8.9933h4.86956v-1.375h-4.86956c-.7687 0-1.39131.61531-1.39131 1.375v8.9933l-1.45113-1.4342-.98365.9721 3.13043 3.0938 3.13044-3.0938-.98365-.9721z' fill='%230675c4' stroke='%230675c4' stroke-width='.14'/%3E%3C/svg%3E")
 }
-.rtl .wpl-button.like a:before,.rtl .wpl-button.liked a:before{
+.rtl .wpl-button.like a:before,.rtl .wpl-button.liked a:before {
   margin-left:1px;
   margin-right:-1px
 }
-.wpl-button.like a span,.wpl-button.liked a span,.wpl-button.reblog a span{
+.wpl-button.like a span,.wpl-button.liked a span,.wpl-button.reblog a span {
   margin-left:3px
 }
-.wpl-count{
+.wpl-count {
   clear:both
 }
-.wpl-count-text{
+.wpl-count-text {
   line-height:1.6
 }
-.wpl-likebox.wpl-new-layout .wpl-count,.wpl-likebox.wpl-new-layout .wpl-count a,.wpl-likebox.wpl-new-layout .wpl-count-text,.wpl-likebox.wpl-new-layout .wpl-count-text a{
+.wpl-likebox.wpl-new-layout .wpl-count,.wpl-likebox.wpl-new-layout .wpl-count a,.wpl-likebox.wpl-new-layout .wpl-count-text,.wpl-likebox.wpl-new-layout .wpl-count-text a {
   font-size:12px!important
 }
-.wpl-button{
+.wpl-button {
   float:left
 }
-.rtl .wpl-button{
+.rtl .wpl-button {
   float:right
 }
-.wpl-avatars{
+.wpl-avatars {
   margin:0;
   padding:0;
   list-style:none;
   overflow:hidden;
   height:34px
 }
-.wpl-avatars li{
+.wpl-avatars li {
   margin:0;
   display:inline
 }
-.wpl-avatars li a{
+.wpl-avatars li a {
   display:block;
   float:left;
   margin:1px 5px 3px 0;
   border:0
 }
-.rtl .wpl-avatars li a{
+.rtl .wpl-avatars li a {
   float:right;
   margin:0 0 3px 5px
 }
-.wpl-avatars li a img{
+.wpl-avatars li a img {
   width:30px;
   height:30px;
   padding:0!important;
   border:0
 }
-span.wpl-follow,span.wpl-comment{
+span.wpl-follow,span.wpl-comment {
   margin-left:5px
 }
-a.comment-like-link:before{
+a.comment-like-link:before {
   color:#2ea2cc;
   width:16px;
   height:16px;
@@ -127,79 +126,79 @@ a.comment-like-link:before{
   background-size:16px 16px;
   background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%232EA2CC' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E")
 }
-a.comment-like-link:hover:before,a.comment-liked:before,div.comment-liked a.comment-like-link:before{
+a.comment-like-link:hover:before,a.comment-liked:before,div.comment-liked a.comment-like-link:before {
   background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%23f1831e' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E")
 }
-a.comment-liked:hover:before,div.comment-liked a.comment-like-link:hover:before{
+a.comment-liked:hover:before,div.comment-liked a.comment-like-link:hover:before {
   background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%23ff9a00' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E")
 }
-a.comment-like-link{
+a.comment-like-link {
   color:#222;
   font-size:12px;
   opacity:.8;
   text-decoration:none
 }
-a.comment-like-link.loading:before{
+a.comment-like-link.loading:before {
   transition:opacity 2s;
   opacity:0
 }
-.wpl-likebox.wpl-new-layout{
+.wpl-likebox.wpl-new-layout {
   display:flex;
   align-items:center
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars{
+.wpl-likebox.wpl-new-layout .wpl-avatars {
   display:inline-flex;
   flex-direction:row-reverse;
   align-items:center;
   justify-content:flex-end;
   margin-bottom:4px
 }
-.rtl .wpl-likebox.wpl-new-layout .wpl-avatars{
+.rtl .wpl-likebox.wpl-new-layout .wpl-avatars {
   justify-content:flex-start;
   margin-right:8px;
   overflow:initial
 }
-@media screen and (max-width:147px){
-  .wpl-likebox.wpl-new-layout .wpl-avatars{
+@media screen and (max-width:147px) {
+  .wpl-likebox.wpl-new-layout .wpl-avatars {
   display:none
 }
 }
-@media screen and (max-width:782px){
-  .wpl-likebox.wpl-new-layout .wpl-avatars{
+@media screen and (max-width:782px) {
+  .wpl-likebox.wpl-new-layout .wpl-avatars {
   justify-content:center
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars,.rtl .wpl-likebox.wpl-new-layout .wpl-avatars{
+.wpl-likebox.wpl-new-layout .wpl-avatars,.rtl .wpl-likebox.wpl-new-layout .wpl-avatars {
   flex-wrap:wrap
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li,.rtl .wpl-likebox.wpl-new-layout .wpl-avatars li{
+.wpl-likebox.wpl-new-layout .wpl-avatars li,.rtl .wpl-likebox.wpl-new-layout .wpl-avatars li {
   margin-bottom:10px
 }
-.wpl-likebox.wpl-new-layout .wpl-count,.rtl .wpl-likebox.wpl-new-layout .wpl-count{
+.wpl-likebox.wpl-new-layout .wpl-count,.rtl .wpl-likebox.wpl-new-layout .wpl-count {
   white-space:nowrap
 }
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li a{
+.wpl-likebox.wpl-new-layout .wpl-avatars li a {
   position:relative;
   margin:0
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li:not(:first-child) a{
+.wpl-likebox.wpl-new-layout .wpl-avatars li:not(:first-child) a {
   margin-right:-4px
 }
-.rtl .wpl-likebox.wpl-new-layout .wpl-avatars li:not(:first-child) a{
+.rtl .wpl-likebox.wpl-new-layout .wpl-avatars li:not(:first-child) a {
   margin-left:-4px
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li a img{
+.wpl-likebox.wpl-new-layout .wpl-avatars li a img {
   border:solid 1.5px rgba(255,255,255,.5);
   border-radius:50%;
   width:26px;
   height:26px
 }
-.wpl-likebox.wpl-new-layout .wpl-count{
+.wpl-likebox.wpl-new-layout .wpl-count {
   margin-left:8px;
   margin-bottom:4px;
   clear:none
 }
-.rtl .wpl-likebox.wpl-new-layout .wpl-count{
+.rtl .wpl-likebox.wpl-new-layout .wpl-count {
   margin-left:0;
   margin-right:12px
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -43,7 +43,7 @@
   text-align:center;
   top:3px;
   margin-left:-1px;
-  margin-right:1px
+  margin-right:1px;
   content:"";
   background-size:16px 16px
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -1,220 +1,205 @@
-/**
- * Editor styles for Like
- */
-
 .wp-block-jetpack-like {
-	&__learn-more {
-		padding: 0 16px 16px 52px;
-		margin-top: -12px;
-	}
+    &__learn-more {
+        padding: 0 16px 16px 52px;
+        margin-top: -12px;
+    }
 }
 
-/*
- * These are directly taken from widgets.wp.com/likes/style.css
- * without html & body selectors.
- */
+/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-01-10T14:03:26.649Z */
 
-.wpl-likebox, .wpl-follow a, .wpl-count a {
-	/* Webfonts aren't copied into the iframe, so fall back to sans-serifs
-	!important to override inline styles. Eventually this text should disappear. */
-	font-size: 11px !important;
-	font-family: "Open Sans", sans-serif !important;
+.wpl-likebox,.wpl-follow a,.wpl-count a{
+  font-size:11px!important;
+  font-family:"Open Sans",sans-serif!important
 }
-.wpl-button {
-	min-width: 73px; /* Prevent avatars from jumping around when Like becomes Liked */
+.wpl-button{
+  min-width:73px
 }
-/* Like button, make sure it matches mu-plugins/post-flair/sharing/sharing.css, based on http://wordpress.com/i/buttons/ */
-.wpl-button a {
-	text-decoration: none;
-	display: flex;
-	margin: 1px 7px 8px 1px;
-	font-size: 13px;
-	font-family: "Open Sans", sans-serif;
-	font-weight: 500;
-	border-radius: 4px;
-	color: #2C3338;
-	background: #fff;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.12);
-	text-shadow: none;
-	line-height: 23px;
-	padding: 4px 10px 3px;
+.wpl-button a{
+  text-decoration:none;
+  display:flex;
+  margin:1px 7px 8px 1px;
+  font-size:13px;
+  font-family:"Open Sans",sans-serif;
+  font-weight:500;
+  border-radius:4px;
+  color:#2c3338;
+  background:#fff;
+  box-shadow:0 1px 2px rgba(0,0,0,.12),0 0 0 1px rgba(0,0,0,.12);
+  text-shadow:none;
+  line-height:23px;
+  padding:4px 10px 3px
 }
-.wpl-button a:hover {
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22), 0 0 0 1px rgba(0, 0, 0, 0.22);
+.wpl-button a:hover{
+  box-shadow:0 1px 2px rgba(0,0,0,.22),0 0 0 1px rgba(0,0,0,.22)
 }
-.wpl-button a:active {
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22), 0 0 0 1px rgba(0, 0, 0, 0.22);
+.wpl-button a:active{
+  box-shadow:0 1px 2px rgba(0,0,0,.22),0 0 0 1px rgba(0,0,0,.22)
 }
-.wpl-button a:before {
-	display: inline-block;
-	position: relative;
-	width: 16px;
-	height: 16px;
-	text-align: center;
-	top: 3px;
-	margin-left: -1px;
-	margin-right: 1px;
-	content: '';
-	background-size: 16px 16px;
+.wpl-button a:before{
+  display:inline-block;
+  position:relative;
+  width:16px;
+  height:16px;
+  text-align:center;
+  top:3px;
+  margin-left:-1px;
+  margin-right:1px
+  content:"";
+  background-size:16px 16px
 }
-.wpl-button.like a:before {
-	background-image: url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m9.00081 2 1.95699 4.26814h4.3763l-3.6666 3.39117 1.2473 4.34069-3.91399-2.25-3.914 2.25 1.24734-4.34069-3.66667-3.39117h2.18817 2.18816z' stroke='%232c3338' stroke-linecap='round' stroke-width='1.5'/%3E%3C/svg%3E");
+.wpl-button.like a:before{
+  background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m9.00081 2 1.95699 4.26814h4.3763l-3.6666 3.39117 1.2473 4.34069-3.91399-2.25-3.914 2.25 1.24734-4.34069-3.66667-3.39117h2.18817 2.18816z' stroke='%232c3338' stroke-linecap='round' stroke-width='1.5'/%3E%3C/svg%3E")
 }
-.wpl-button.like a:hover:before {
-	background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 18 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.00081 2L10.9578 6.26814H15.3341L11.6675 9.65931L12.9148 14L9.00081 11.75L5.08681 14L6.33415 9.65931L2.66748 6.26814H4.85565H7.04381L9.00081 2Z' stroke='%230675C4' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+.wpl-button.like a:hover:before{
+  background-image:url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 18 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.00081 2L10.9578 6.26814H15.3341L11.6675 9.65931L12.9148 14L9.00081 11.75L5.08681 14L6.33415 9.65931L2.66748 6.26814H4.85565H7.04381L9.00081 2Z' stroke='%230675C4' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")
 }
-.wpl-button.liked a:before {
-	background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 18 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.00081 2L10.9578 6.26814H15.3341L11.6675 9.65931L12.9148 14L9.00081 11.75L5.08681 14L6.33415 9.65931L2.66748 6.26814H4.85565H7.04381L9.00081 2Z' fill='%230675C4' stroke='%230675C4' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+.wpl-button.liked a:before{
+  background-image:url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 18 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.00081 2L10.9578 6.26814H15.3341L11.6675 9.65931L12.9148 14L9.00081 11.75L5.08681 14L6.33415 9.65931L2.66748 6.26814H4.85565H7.04381L9.00081 2Z' fill='%230675C4' stroke='%230675C4' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")
 }
-.wpl-button.reblog a:before {
-	background-image: url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m1 0h16v16h-16z' fill='%23fff'/%3E%3Cpath d='m16.0163 5.56587-1.4511-1.43412v8.99325c0 .7597-.6226 1.375-1.3913 1.375h-4.86955v-1.375h4.86955v-8.99325l-1.4511 1.43412-.9837-.97212 3.1305-3.09375 3.1304 3.09375zm-11.19021 6.30243v-8.9933h4.86956v-1.375h-4.86956c-.7687 0-1.39131.61531-1.39131 1.375v8.9933l-1.45113-1.4342-.98365.9721 3.13043 3.0938 3.13044-3.0938-.98365-.9721z' fill='%232c3338' stroke='%232c3338' stroke-width='.14'/%3E%3C/svg%3E");
+.wpl-button.reblog a:before{
+  background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m1 0h16v16h-16z' fill='%23fff'/%3E%3Cpath d='m16.0163 5.56587-1.4511-1.43412v8.99325c0 .7597-.6226 1.375-1.3913 1.375h-4.86955v-1.375h4.86955v-8.99325l-1.4511 1.43412-.9837-.97212 3.1305-3.09375 3.1304 3.09375zm-11.19021 6.30243v-8.9933h4.86956v-1.375h-4.86956c-.7687 0-1.39131.61531-1.39131 1.375v8.9933l-1.45113-1.4342-.98365.9721 3.13043 3.0938 3.13044-3.0938-.98365-.9721z' fill='%232c3338' stroke='%232c3338' stroke-width='.14'/%3E%3C/svg%3E")
 }
-.wpl-button.reblog a.reblogged:before {
-	background-image: url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m1 0h16v16h-16z' fill='%23fff'/%3E%3Cpath d='m16.0163 5.56587-1.4511-1.43412v8.99325c0 .7597-.6226 1.375-1.3913 1.375h-4.86955v-1.375h4.86955v-8.99325l-1.4511 1.43412-.9837-.97212 3.1305-3.09375 3.1304 3.09375zm-11.19021 6.30243v-8.9933h4.86956v-1.375h-4.86956c-.7687 0-1.39131.61531-1.39131 1.375v8.9933l-1.45113-1.4342-.98365.9721 3.13043 3.0938 3.13044-3.0938-.98365-.9721z' fill='%230675c4' stroke='%230675c4' stroke-width='.14'/%3E%3C/svg%3E");
+.wpl-button.reblog a.reblogged:before{
+  background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m1 0h16v16h-16z' fill='%23fff'/%3E%3Cpath d='m16.0163 5.56587-1.4511-1.43412v8.99325c0 .7597-.6226 1.375-1.3913 1.375h-4.86955v-1.375h4.86955v-8.99325l-1.4511 1.43412-.9837-.97212 3.1305-3.09375 3.1304 3.09375zm-11.19021 6.30243v-8.9933h4.86956v-1.375h-4.86956c-.7687 0-1.39131.61531-1.39131 1.375v8.9933l-1.45113-1.4342-.98365.9721 3.13043 3.0938 3.13044-3.0938-.98365-.9721z' fill='%230675c4' stroke='%230675c4' stroke-width='.14'/%3E%3C/svg%3E")
 }
-.rtl .wpl-button.like a:before,
-.rtl .wpl-button.liked a:before {
-	margin-left: 1px;
-	margin-right: -1px;
+.rtl .wpl-button.like a:before,.rtl .wpl-button.liked a:before{
+  margin-left:1px;
+  margin-right:-1px
 }
-.wpl-button.like a span,
-.wpl-button.liked a span,
-.wpl-button.reblog a span {
-	margin-left: 3px;
+.wpl-button.like a span,.wpl-button.liked a span,.wpl-button.reblog a span{
+  margin-left:3px
 }
-.wpl-count {
-	clear: both;
+.wpl-count{
+  clear:both
 }
-.wpl-count-text {
-	line-height: 1.6;
+.wpl-count-text{
+  line-height:1.6
 }
-.wpl-likebox.wpl-new-layout .wpl-count, .wpl-likebox.wpl-new-layout .wpl-count a, .wpl-likebox.wpl-new-layout .wpl-count-text, .wpl-likebox.wpl-new-layout .wpl-count-text a  {
-	font-size: 12px !important;
+.wpl-likebox.wpl-new-layout .wpl-count,.wpl-likebox.wpl-new-layout .wpl-count a,.wpl-likebox.wpl-new-layout .wpl-count-text,.wpl-likebox.wpl-new-layout .wpl-count-text a{
+  font-size:12px!important
 }
-.wpl-button {
-	float: left;
+.wpl-button{
+  float:left
 }
-.rtl .wpl-button {
-	float: right;
+.rtl .wpl-button{
+  float:right
 }
-.wpl-avatars {
-	margin: 0;
-	padding: 0;
-	list-style: none;
-	overflow: hidden;
-	height: 34px;
+.wpl-avatars{
+  margin:0;
+  padding:0;
+  list-style:none;
+  overflow:hidden;
+  height:34px
 }
-.wpl-avatars li {
-	margin: 0;
-	display: inline;
+.wpl-avatars li{
+  margin:0;
+  display:inline
 }
-.wpl-avatars li a {
-	display: block;
-	float: left;
-	margin: 1px 5px 3px 0;
-	border: none;
+.wpl-avatars li a{
+  display:block;
+  float:left;
+  margin:1px 5px 3px 0;
+  border:0
 }
-.rtl .wpl-avatars li a {
-	float: right;
-	margin: 0 0 3px 5px;
+.rtl .wpl-avatars li a{
+  float:right;
+  margin:0 0 3px 5px
 }
-.wpl-avatars li a img {
-	width: 30px;
-	height: 30px;
-	padding: 0 !important;
-	border: none;
+.wpl-avatars li a img{
+  width:30px;
+  height:30px;
+  padding:0!important;
+  border:0
 }
-span.wpl-follow, span.wpl-comment {
-	margin-left: 5px;
+span.wpl-follow,span.wpl-comment{
+  margin-left:5px
 }
-a.comment-like-link:before {
-	color: #2EA2CC;
-	width: 16px;
-	height: 16px;
-	content: '';
-	display: inline-block;
-	position: relative;
-	top: 3px;
-	padding-right: 5px;
-	background-repeat: no-repeat;
-	background-size: 16px 16px;
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%232EA2CC' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E");
+a.comment-like-link:before{
+  color:#2ea2cc;
+  width:16px;
+  height:16px;
+  content:"";
+  display:inline-block;
+  position:relative;
+  top:3px;
+  padding-right:5px;
+  background-repeat:no-repeat;
+  background-size:16px 16px;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%232EA2CC' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E")
 }
-a.comment-like-link:hover:before,
-a.comment-liked:before,
-div.comment-liked a.comment-like-link:before {
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%23f1831e' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E");
+a.comment-like-link:hover:before,a.comment-liked:before,div.comment-liked a.comment-like-link:before{
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%23f1831e' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E")
 }
-a.comment-liked:hover:before,
-div.comment-liked a.comment-like-link:hover:before {
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%23ff9a00' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E");
+a.comment-liked:hover:before,div.comment-liked a.comment-like-link:hover:before{
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%23ff9a00' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E")
 }
-a.comment-like-link {
-	color: #222;
-	font-size: 12px;
-	opacity: .8;
-	text-decoration: none;
+a.comment-like-link{
+  color:#222;
+  font-size:12px;
+  opacity:.8;
+  text-decoration:none
 }
-a.comment-like-link.loading:before {
-	transition: opacity 2s;
-	opacity: 0;
+a.comment-like-link.loading:before{
+  transition:opacity 2s;
+  opacity:0
 }
-.wpl-likebox.wpl-new-layout {
-	display: flex;
-	align-items: center;
+.wpl-likebox.wpl-new-layout{
+  display:flex;
+  align-items:center
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars {
-	display: inline-flex;
-    flex-direction: row-reverse; /* Reverse to overlap avatars on the right */
-    align-items: center;
-    justify-content: flex-end; /* Push avatars to the left */
-	margin-bottom: 4px;
+.wpl-likebox.wpl-new-layout .wpl-avatars{
+  display:inline-flex;
+  flex-direction:row-reverse;
+  align-items:center;
+  justify-content:flex-end;
+  margin-bottom:4px
 }
-.rtl .wpl-likebox.wpl-new-layout .wpl-avatars {
-	flex-direction: row; /* Reverse to overlap avatars on the right */
-	justify-content: flex-start; /* Push avatars to the left */
-	margin-right: 8px;
-	overflow: initial;
+.rtl .wpl-likebox.wpl-new-layout .wpl-avatars{
+  justify-content:flex-start;
+  margin-right:8px;
+  overflow:initial
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li a {
-	position: relative; /* For z-index */
-	margin: 0;
+@media screen and (max-width:147px){
+  .wpl-likebox.wpl-new-layout .wpl-avatars{
+  display:none
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li:not(:first-child) a {
-	margin-right: -4px;
 }
-.rtl .wpl-likebox.wpl-new-layout .wpl-avatars li:not(:first-child) a {
-	margin-left: -4px;
+@media screen and (max-width:782px){
+  .wpl-likebox.wpl-new-layout .wpl-avatars{
+  justify-content:center
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li a img {
-	border: solid 1.5px #fff;
-	border-radius: 50%;
-	width: 26px;
-	height: 26px;
+.wpl-likebox.wpl-new-layout .wpl-avatars,.rtl .wpl-likebox.wpl-new-layout .wpl-avatars{
+  flex-wrap:wrap
 }
-.wpl-likebox.wpl-new-layout .wpl-count {
-	margin-left: 8px;
-	margin-bottom: 4px;
-	clear: none;
+.wpl-likebox.wpl-new-layout .wpl-avatars li,.rtl .wpl-likebox.wpl-new-layout .wpl-avatars li{
+  margin-bottom:10px
 }
-.rtl .wpl-likebox.wpl-new-layout .wpl-count {
-	margin-left: 0;
-	margin-right: 12px;
+.wpl-likebox.wpl-new-layout .wpl-count,.rtl .wpl-likebox.wpl-new-layout .wpl-count{
+  white-space:nowrap
 }
-
-/* Overrides to fix CSS conflicts within editor. */
-.wpl-likebox {
-
-	// Prevents color conflict by
-	// .wp-block-post-content a:where(:not(.wp-element-button)) 
-	a {
-		color: #2C3338 !important;
-		text-decoration: none !important;
-	}
-
-	// Prevents focus state conflict by
-	// a:where(:not(.wp-element-button)):focus
-	a:focus {
-		text-decoration: none !important;
-	}
+}
+.wpl-likebox.wpl-new-layout .wpl-avatars li a{
+  position:relative;
+  margin:0
+}
+.wpl-likebox.wpl-new-layout .wpl-avatars li:not(:first-child) a{
+  margin-right:-4px
+}
+.rtl .wpl-likebox.wpl-new-layout .wpl-avatars li:not(:first-child) a{
+  margin-left:-4px
+}
+.wpl-likebox.wpl-new-layout .wpl-avatars li a img{
+  border:solid 1.5px rgba(255,255,255,.5);
+  border-radius:50%;
+  width:26px;
+  height:26px
+}
+.wpl-likebox.wpl-new-layout .wpl-count{
+  margin-left:8px;
+  margin-bottom:4px;
+  clear:none
+}
+.rtl .wpl-likebox.wpl-new-layout .wpl-count{
+  margin-left:0;
+  margin-right:12px
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -5,7 +5,7 @@
     }
 }
 
-/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-01-10T14:20:09.727Z */
+/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-01-10T14:37:12.523Z */
 .wpl-likebox,.wpl-follow a,.wpl-count a {
   font-size:11px!important;
   font-family:"Open Sans",sans-serif!important
@@ -201,4 +201,21 @@ a.comment-like-link.loading:before {
 .rtl .wpl-likebox.wpl-new-layout .wpl-count {
   margin-left:0;
   margin-right:12px
+}
+
+
+/* Overrides to fix CSS conflicts within editor. */
+.wpl-likebox {
+	// Prevents color conflict by
+	// .wp-block-post-content a:where(:not(.wp-element-button))
+	a {
+		color: #2C3338 !important;
+		text-decoration: none !important;
+	}
+
+	// Prevents focus state conflict by
+	// a:where(:not(.wp-element-button)):focus
+	a:focus {
+		text-decoration: none !important;
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/tools/README.md
+++ b/projects/plugins/jetpack/extensions/blocks/like/tools/README.md
@@ -1,0 +1,10 @@
+# Update editor styles for the Like block
+
+## Requirements
+NodeJS 
+
+## Runnning it
+`node update-editor-styles.js`
+
+## Description
+This script fetches the latest styles from https://widgets.wp.com/likes/style.css, strips the HTML and body tags, and updates the editor styles for the Like block.

--- a/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
@@ -36,12 +36,30 @@ function processCSS( css ) {
     }
 }`;
 
+	const customRule2 = `
+	/* Overrides to fix CSS conflicts within editor. */
+.wpl-likebox {
+	// Prevents color conflict by
+	// .wp-block-post-content a:where(:not(.wp-element-button))
+	a {
+		color: #2C3338 !important;
+		text-decoration: none !important;
+	}
+
+	// Prevents focus state conflict by
+	// a:where(:not(.wp-element-button)):focus
+	a:focus {
+		text-decoration: none !important;
+	}
+}
+`;
+
 	// Get current date and time
 	const now = new Date();
 	const dateAndTime = now.toISOString();
 
 	// Combine and format with a comment
-	const finalCSS = `${ customRule.trim() }\n\n/* Fetched below from ${ url } at ${ dateAndTime } */\n${ processedCSS }`;
+	const finalCSS = `${ customRule.trim() }\n\n/* Fetched below from ${ url } at ${ dateAndTime } */\n${ processedCSS }\n\n${ customRule2.trim() }\n`;
 
 	// Path for the output file in the same directory as the script
 	const outputPath = path.join( __dirname, '..', 'editor.scss' );

--- a/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
@@ -6,11 +6,16 @@ const url = 'https://widgets.wp.com/likes/style.css';
 
 // Function to pretty print CSS
 function prettyPrintCSS( css ) {
-	return css
-		.replace( /\{/g, '{\n  ' )
-		.replace( /\}/g, '\n}\n' )
-		.replace( /;\s*/g, ';\n  ' )
-		.replace( /\n\s*\n/g, '\n' );
+	// Adding a line break after each semicolon and opening brace
+	css = css.replace( /;/g, ';\n  ' ).replace( /\{/g, ' {\n  ' );
+
+	// Adding a line break before/after each closing brace
+	css = css.replace( /\}/g, '\n}\n' );
+
+	// Removing extra spaces and line breaks for correct indentation
+	css = css.replace( /\n\s*\n/g, '\n' );
+
+	return css;
 }
 
 // Function to process CSS
@@ -36,7 +41,7 @@ function processCSS( css ) {
 	const dateAndTime = now.toISOString();
 
 	// Combine and format with a comment
-	const finalCSS = `${ customRule.trim() }\n\n/* Fetched below from ${ url } at ${ dateAndTime } */\n\n${ processedCSS }`;
+	const finalCSS = `${ customRule.trim() }\n\n/* Fetched below from ${ url } at ${ dateAndTime } */\n${ processedCSS }`;
 
 	// Path for the output file in the same directory as the script
 	const outputPath = path.join( __dirname, '..', 'editor.scss' );

--- a/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
@@ -59,7 +59,7 @@ function processCSS( css ) {
 	const dateAndTime = now.toISOString();
 
 	// Combine and format with a comment
-	const finalCSS = `${ customRule.trim() }\n\n/* Fetched below from ${ url } at ${ dateAndTime } */\n${ processedCSS }\n\n${ customRule2.trim() }\n`;
+	const finalCSS = `${ customRule.trim() }\n\n/* Fetched below from ${ url } at ${ dateAndTime } */\n${ processedCSS }\n${ customRule2.trim() }\n`;
 
 	// Path for the output file in the same directory as the script
 	const outputPath = path.join( __dirname, '..', 'editor.scss' );

--- a/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
@@ -1,0 +1,55 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+// URL to fetch CSS from
+const url = 'https://widgets.wp.com/likes/style.css';
+
+// Function to pretty print CSS
+function prettyPrintCSS( css ) {
+	return css
+		.replace( /\{/g, '{\n  ' )
+		.replace( /\}/g, '\n}\n' )
+		.replace( /;\s*/g, ';\n  ' )
+		.replace( /\n\s*\n/g, '\n' );
+}
+
+// Function to process CSS
+function processCSS( css ) {
+	// Remove body and HTML styles
+	let processedCSS = css.replace( /body[^{]*\{[^}]*\}/g, '' );
+	processedCSS = processedCSS.replace( /html[^{]*\{[^}]*\}/g, '' );
+
+	// Pretty print the CSS
+	processedCSS = prettyPrintCSS( processedCSS );
+
+	// Custom rule to add
+	const customRule = `
+.wp-block-jetpack-like {
+    &__learn-more {
+        padding: 0 16px 16px 52px;
+        margin-top: -12px;
+    }
+}`;
+
+	// Get current date and time
+	const now = new Date();
+	const dateAndTime = now.toISOString();
+
+	// Combine and format with a comment
+	const finalCSS = `${ customRule.trim() }\n\n/* Fetched below from ${ url } at ${ dateAndTime } */\n\n${ processedCSS }`;
+
+	// Path for the output file in the same directory as the script
+	const outputPath = path.join( __dirname, '..', 'editor.scss' );
+
+	// Write to editor.scss in the same directory as the script
+	fs.writeFileSync( outputPath, finalCSS );
+	// eslint-disable-next-line no-console
+	console.log( `CSS processed and saved to ${ outputPath }` );
+}
+
+// Fetch and process the CSS
+fetch( url )
+	.then( response => response.text() )
+	.then( processCSS )
+	// eslint-disable-next-line no-console
+	.catch( err => console.error( 'Error fetching CSS:', err ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/85934

## Proposed changes:
- Updates the editor styles for the Like block
- Adds a script to update these styles automatically (fetches them from widget.wp.com and updates editor.scss.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this PR
2. On your JT site add a Like block
3. Ensure the styling is correct
4. Try running the script to see that it does what it needs to do. 