### PR TITLE
Fix: Import types error message

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-import-types
+++ b/projects/plugins/boost/changelog/fix-boost-import-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Boost: Allow file extensions in TypeScript imports

--- a/projects/plugins/boost/tsconfig.json
+++ b/projects/plugins/boost/tsconfig.json
@@ -10,6 +10,7 @@
 	"compilerOptions": {
 		"target": "es6",
 		"types": [ "svelte" ],
+		"allowImportingTsExtensions": true,
 		"typeRoots": [ "./node_modules/@types/", "./app/assets/src/js" ],
 		"paths": {
 			"$lib/*": [ "./app/assets/src/js/lib/*" ],


### PR DESCRIPTION
## Proposed changes:

#34787 introduced an error in our part of the repo:

```
../../js-packages/components/tools/get-site-admin-url/index.ts:1:8 - error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.

1 import './types.ts';
         ~~~~~~~~~~~~
```

This PR fixes that error.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
-

## Does this pull request change what data or activity we track or use?
-

## Testing instructions:
Run `npm run dev-validate-ts`

