### PR TITLE
cli: Restore non-interactive use for `jetpack changelog add`

### DIFF
--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -289,6 +289,12 @@ async function getProjectChangeTypes( needChangelog ) {
  * @param {argv} argv - the arguments passed.
  */
 async function changelogAdd( argv ) {
+	// If we already have all the information we need for a potentially-successful changelogger run, skip the prompts and just do it.
+	if ( argv.project && argv.s && argv.t && argv.e ) {
+		await changelogArgs( argv );
+		return;
+	}
+
 	let needChangelog;
 	const defaultProjects = [];
 	const uniqueProjects = [];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Prior to #34216, passing a project and the `-s`, `-t`, and `-e` options to `jetpack changelog add` would skip the prompts and just run changelogger. Restore that behavior.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1704905327683839-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try running `jetpack changelog add plugins/boost -t fixed -s patch -e 'Jetpack Boost: Allow file extensions in TypeScript imports.'`. It should create a changelog entry without prompting.