### PR TITLE
cast_and_filter_item: Do not cast an array to a string

### DIFF
--- a/projects/plugins/jetpack/changelog/cast-and-filter-string-skip-array
+++ b/projects/plugins/jetpack/changelog/cast-and-filter-string-skip-array
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+cast_and_filter_item: Do not cast an array to a string

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -608,6 +608,10 @@ abstract class WPCOM_JSON_API_Endpoint {
 						$next_type = array_shift( $types );
 						return $this->cast_and_filter_item( $return, $next_type, $key, $value, $types, $for_output );
 					}
+					if ( is_array( $value ) ) {
+						// Give up rather than setting the value to the string 'Array'.
+						break;
+					}
 				}
 				$return[ $key ] = (string) $value;
 				break;


### PR DESCRIPTION
## Proposed changes:

* `cast_and_filter_item()`: Do not cast an array to a string

This fixes a large number of warnings I see when searching a P2 using PHP 8.1, but I don't really understand what's going on here. I feel like I'm a bit in over my head. Perhaps a deeper problem needs to be fixed, or there's another approach necessary. Any help is appreciated.

Essentially, the P2 search makes a request to `/wp-json/wpcom-origin/v1.3/sites/<SITE_ID>/search?...` and `cast_and_filter_item()` is called with the parameters including `$type='string'`,
`$key='fields'` and
```
$value= Array
        (
            [0] => date
            [1] => permalink.url.raw
            [2] => tag.name.default
            [3] => category.name.default
            [4] => post_type
            [5] => shortcode_types
            [6] => forum.topic_resolved
            [7] => has.image
            [8] => image.url.raw
            [9] => image.alt_text
        )
```

It ends up setting `$return[ $key ] = (string) $value;`, and `(string) $value` just becomes the string 'Array'`. Stopping this from happening fixes the warnings and does not impact the search results.  I have more information and testing instructions in D134239-code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* I have detailed testing instructions and a description of the problem in D134239-code.