### PR TITLE
cli: Use args for prompt defaults in `jetpack changelog add`

### DIFF
--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -65,6 +65,11 @@ export function changelogDefine( yargs ) {
 								alias: 'e',
 								describe: 'Changelog entry',
 								type: 'string',
+							} )
+							.option( 'comment', {
+								alias: 'c',
+								describe: 'Changelog comment',
+								type: 'string',
 							} );
 					},
 					async argv => {
@@ -732,7 +737,7 @@ async function promptChangelog( argv, needChangelog, types ) {
 		type: 'input',
 		name: 'changelogName',
 		message: 'Name your changelog file:',
-		default: gitBranch,
+		default: argv.f ?? gitBranch,
 		validate: input => {
 			const fileExists = doesFilenameExist( input, needChangelog );
 			if ( fileExists ) {
@@ -748,6 +753,9 @@ async function promptChangelog( argv, needChangelog, types ) {
 		name: 'significance',
 		message: 'Significance of the change, in the style of semantic versioning.',
 		suggest: ( input, choices ) => choices.filter( choice => choice.value.startsWith( input ) ),
+		initial() {
+			return this.choices.findIndex( v => v.value === argv.s );
+		},
 		highlight: v => v,
 		choices: [
 			{
@@ -770,13 +778,13 @@ async function promptChangelog( argv, needChangelog, types ) {
 		name: 'userFacing',
 		message:
 			'Is this change something an end user or site administrator of a standalone Jetpack site would like to know about?',
-		initial: true,
+		initial: argv.t !== 'other',
 		skip: ! needChangelog.includes( 'plugins/jetpack' ),
 	} );
 
 	// Get the type, set it to other if this isn't a user facing change.
 	let typeResponse;
-	if ( ! userFacingResponse.userFacing ) {
+	if ( ! userFacingResponse.userFacing && typeChoices.findIndex( v => v.value === 'other' ) >= 0 ) {
 		typeResponse = { type: 'other' };
 	} else {
 		// Get the type of change.
@@ -787,6 +795,7 @@ async function promptChangelog( argv, needChangelog, types ) {
 			suggest: ( input, choices ) => choices.filter( choice => choice.value.startsWith( input ) ),
 			highlight: v => v,
 			choices: typeChoices,
+			initial: typeChoices.findIndex( v => v.value === argv.t ),
 		} );
 	}
 	const { type } = typeResponse;
@@ -806,6 +815,7 @@ async function promptChangelog( argv, needChangelog, types ) {
 			type: 'input',
 			name: 'entry',
 			message: 'Changelog entry. May not be empty.',
+			initial: argv.e,
 			validate: input => {
 				if ( ! input || ! input.trim() ) {
 					return `Changelog entry can't be blank`;
@@ -818,6 +828,7 @@ async function promptChangelog( argv, needChangelog, types ) {
 			type: 'input',
 			name: 'entry',
 			message: 'Changelog entry. May be left empty if this change is particularly insignificant.',
+			initial: argv.e,
 		} );
 	}
 	const { entry } = entryResponse;
@@ -830,6 +841,7 @@ async function promptChangelog( argv, needChangelog, types ) {
 			name: 'comment',
 			message:
 				'You omitted the changelog entry, which is fine. But please comment as to why no entry is needed.',
+			initial: argv.c,
 		} );
 	}
 	const { comment } = commentResponse || {};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If someone supplies arguments `-f`, `-t`, `-s`, `-e`, and/or `-c` (without triggering non-interactive mode), use the values supplied as the defaults for the respective prompts.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
none

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack changelog add`. The defaults for all prompts should be as before.
* Run `jetpack changelog add -f foobar`. The filename prompt should default to "foobar" rather than the branch name.
* Run `jetpack changelog add -s major`. The significance prompt should have "major" highlighted to start with rather than "patch".
* Run `jetpack changelog add plugins/boost -t fixed`. The type-of-change prompt should have "fixed" highlighted to start with rather than "security".
* Run `jetpack changelog add plugins/jetpack -t other`. The "Is this user-facing?" prompt should default to false rather than true. Answering "yes" should have "other" highlighted to start with.
* Run `jetpack changelog add plugins/jetpack -t enhancement`. The "Is this user-facing?" prompt should default to true. Answering "yes" should have "enhancement" highlighted to start with.
* Run `jetpack changelog add plugins/boost -t other`. The type-of-change prompt should appear and have the top item ("security") highlighted to start with, since "other" is not a valid type for plugins/boost.
* Run `jetpack changelog add -e foobar`. The default for the changelog entry prompt should be "foobar".
* Run `jetpack changelog add -c foobar`, and specify a patch-level change with no entry. The default for the comment prompt should be "foobar".
