### PR TITLE
add new entries for meteorite team for WPJM and Crowdsignal gardening tasks

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gardening-actions-meteorite
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-actions-meteorite
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: It is just a change to a repo automation
+
+

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -152,8 +152,11 @@ function formatSlackMessage( payload, channel, message ) {
 			break;
 		case 'Automattic/zero-bs-crm':
 		case 'Automattic/sensei':
-		case 'Automattic/WP-Job-Manager':
 			dris = '@heysatellite';
+			break;
+		case 'Automattic/WP-Job-Manager':
+		case 'Automattic/Crowdsignal':
+			dris = '@meteorite-team';
 			break;
 	}
 

--- a/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
@@ -41,8 +41,11 @@ function formatSlackMessage( payload, channel, message ) {
 			break;
 		case 'Automattic/zero-bs-crm':
 		case 'Automattic/sensei':
-		case 'Automattic/WP-Job-Manager':
 			dris = '@heysatellite';
+			break;
+		case 'Automattic/WP-Job-Manager':
+		case 'Automattic/Crowdsignal':
+			dris = '@meteorite-team';
 			break;
 	}
 


### PR DESCRIPTION
From p9JkDc-Jj-p2#comment-1145

In order to get the ball rolling on the updates for meteorite, I believe this change as well as updates to `SLACK_HE_TRIAGE_CHANNEL` (or `SLACK_QUALITY_CHANNEL` or both?) in the respective repos to `#meteorite` is needed.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
- From other PRs it seems like forking the repo is necessary to test these, but I'm hoping this simple change is OK as is 😅