### PR TITLE
Subscribe modal: Hide in Elementor editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-modal-with-elementor
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-modal-with-elementor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribe modal: Don't show in Elementor editor

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -169,6 +169,12 @@ HTML;
 			return false;
 		}
 
+		// Needed because Elementor editor makes is_admin() return false
+		// See https://coreysalzano.com/wordpress/why-elementor-disobeys-is_admin/
+		if ( isset( $_GET['elementor-preview'] ) ) {
+			return false;
+		}
+
 		// Don't show when previewing blog posts or site's theme
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['preview'] ) || isset( $_GET['theme_preview'] ) || isset( $_GET['customize_preview'] ) || isset( $_GET['hide_banners'] ) ) {

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -171,6 +171,8 @@ HTML;
 
 		// Needed because Elementor editor makes is_admin() return false
 		// See https://coreysalzano.com/wordpress/why-elementor-disobeys-is_admin/
+		// Ignore nonce warning as just checking if is set
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['elementor-preview'] ) ) {
 			return false;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34899

## Proposed changes:

When creating or editing a post with Elementor, the Elementor editor makes is_admin() return false. As a result, our subscribe popup will show. I've added an extra check for when we're in the Elementor editor. 

<img width="1419" alt="elementor-modal" src="https://github.com/Automattic/jetpack/assets/21228350/df29e573-c18e-4e09-828c-f2fbd0769da7">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/34899

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Check out this branch and load in a jurassic enabled site.
2) Ensure the Settings > Discussion > 'Enable Subscribe Modal' option is turned on. 
3) Install the Elementor plugin. 
4) Create a new post, and click the button to load Elementor. Scroll and confirm no modal shows. 
5) As an extra check, you might load Jetpack trunk, run the same test in #4, and confirm you can duplicate the issue.
