### PR TITLE
CRM: 1817 -Update total value calculation

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 6.3.3-alpha
+ * Version: 6.4.0-alpha
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -287,7 +287,7 @@ function jpcrm_render_company_view_page( $id = -1 ) {
 							if ( $useInvoices == '1' || $useTrans == '1' ) :
 								?>
 							<tr>
-							<td class="zbs-view-vital-label"><strong><?php esc_html_e( 'Total Value', 'zero-bs-crm' ); ?><i class="circle info icon link" data-content="<?php esc_attr_e( 'Total Value is all transaction types and any unpaid invoices (excluding deleted status invoices).', 'zero-bs-crm' ); ?>" data-position="bottom center"></i></strong></td>
+							<td class="zbs-view-vital-label"><strong><?php esc_html_e( 'Total Value', 'zero-bs-crm' ); ?><i class="circle info icon link" data-content="<?php esc_attr_e( "The Total Value can be set to include just transaction values, just invoice values, or both together. You can choose how it's calculated by going to the General Settings page.", 'zero-bs-crm' ); ?>" data-position="bottom center"></i></strong></td>
 							<td><strong><?php echo esc_html( zeroBSCRM_formatCurrency( $company_total_value ) ); ?></strong></td>
 							</tr>
 							<?php endif; ?>

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -377,7 +377,7 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 						<tbody>
 						<?php if ( $useInvoices == '1' || $useTrans == '1' ) : ?>
 						<tr class="zbs-view-vital-totalvalue">
-							<td class="zbs-view-vital-label"><strong><?php esc_html_e( 'Total Value', 'zero-bs-crm' ); ?><i class="circle info icon link" data-content="<?php esc_attr_e( 'Total Value is all transaction types and any unpaid invoices (excluding deleted status invoices).', 'zero-bs-crm' ); ?>" data-position="bottom center"></i></strong></td>
+							<td class="zbs-view-vital-label"><strong><?php esc_html_e( 'Total Value', 'zero-bs-crm' ); ?><i class="circle info icon link" data-content="<?php esc_attr_e( "The Total Value can be set to include just transaction values, just invoice values, or both together. You can choose how it's calculated by going to the General Settings page.", 'zero-bs-crm' ); ?>" data-position="bottom center"></i></strong></td>
 							<td><strong><?php echo esc_html( zeroBSCRM_formatCurrency( $contact_total_value ) ); ?></strong></td>
 						</tr>
 						<?php endif; ?>

--- a/projects/plugins/crm/admin/settings/general.page.php
+++ b/projects/plugins/crm/admin/settings/general.page.php
@@ -189,6 +189,15 @@ if ( isset( $_POST['editwplf'] ) && zeroBSCRM_isZBSAdminOrAdmin() ) {
 		}
 	}
 
+	$total_value_fields = isset( $settings['jpcrm_total_value_fields'] ) ? $settings['jpcrm_total_value_fields'] : array();
+	foreach ( $zbs->acceptable_total_value_fields as $field_name => $field_label ) {
+		$total_value_fields[ $field_name ] = 0;
+		if ( isset( $_POST[ 'wpzbscrm_total_value_field_' . $field_name ] ) && ! empty( $_POST[ 'wpzbscrm_total_value_field_' . $field_name ] ) ) {
+			$total_value_fields[ $field_name ] = 1;
+		}
+	}
+	$updatedSettings['jpcrm_total_value_fields'] = $total_value_fields; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
 	// } Brutal update
 	foreach ( $updatedSettings as $k => $v ) {
 		$zbs->settings->update( $k, $v );
@@ -473,6 +482,25 @@ if ( ! $confirmAct ) {
 						echo ' checked="checked"';}
 					?>
 					/></td>
+				</tr>
+
+				<tr>
+					<td class="wfieldname"><label for="wpzbscrm_useaka"><?php esc_html_e( 'Total Value Field', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Include these values in the Total Value field for contacts and companies.', 'zero-bs-crm' ); ?></td>
+					<td style="width:540px">
+						<?php
+						foreach ( $zbs->acceptable_total_value_fields as $field_name => $field_label ) {
+							?>
+							<input type="checkbox" class="winput form-control" name="<?php echo esc_attr( 'wpzbscrm_total_value_field_' . $field_name ); ?>" id="<?php echo esc_attr( 'wpzbscrm_total_value_field_' . $field_name ); ?>" value="1"
+																								<?php
+																								// For compatibility with previous versions we consider the field selected (checked) if the setting is inexistent.
+																								if ( ! isset( $settings['jpcrm_total_value_fields'] ) || ( isset( $settings['jpcrm_total_value_fields'][ $field_name ] ) && $settings['jpcrm_total_value_fields'][ $field_name ] === 1 ) ) {
+																									echo ' checked="checked"';
+																								}
+																								?>
+							/> <?php echo esc_html_e( $field_label, 'zero-bs-crm' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText ?><br />
+						<?php } ?>
+					</td>
+
 				</tr>
 
 				<tr>

--- a/projects/plugins/crm/admin/settings/transactions.page.php
+++ b/projects/plugins/crm/admin/settings/transactions.page.php
@@ -179,7 +179,7 @@ if ( isset( $sbupdated ) ) {
 			</tr>
 
 			<tr>
-				<td class="wfieldname"><label><?php esc_html_e( 'Include these statuses in total value', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Tick which statuses to include when calculating total transaction value and total overall value of contacts.', 'zero-bs-crm' ); ?>
+				<td class="wfieldname"><label><?php esc_html_e( 'Include these statuses in the transaction total value', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Tick which statuses to include when calculating total transaction value and total overall value of contacts.', 'zero-bs-crm' ); ?>
 					<br /><br /></td>
 				<td style="width:540px" id="jpcrm-transaction-include-status">
 					<?php

--- a/projects/plugins/crm/changelog/update-crm-1817-update-total-value-calculation
+++ b/projects/plugins/crm/changelog/update-crm-1817-update-total-value-calculation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Settings: Add setting to fine tune the Total Value field calculation for contacts and companies.

--- a/projects/plugins/crm/changelog/update-crm-1817-update-total-value-calculation
+++ b/projects/plugins/crm/changelog/update-crm-1817-update-total-value-calculation
@@ -1,4 +1,4 @@
-Significance: patch
-Type: fixed
+Significance: minor
+Type: added
 
 Settings: Add setting to fine tune the Total Value field calculation for contacts and companies.

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -42,7 +42,7 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_3_3_alpha",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_4_0_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -367,6 +367,16 @@ final class ZeroBSCRM {
 	public $acceptable_mime_types;
 
 	/**
+	 * Acceptable fields to be included in the Total Value of contacts and companies
+	 *
+	 * @var Jetpack CRM Acceptable fields to be included in the Total Value
+	 */
+	public $acceptable_total_value_fields = array(
+		'transactions' => 'Transactions',
+		'invoices'     => 'Invoices',
+	);
+
+	/**
 	 * Acceptable html array
 	 *
 	 * @var Jetpack CRM Acceptable html types list

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
@@ -2812,12 +2812,7 @@ class zbsDAL_companies extends zbsDAL_ObjectLayer {
                 // and if have invs + trans totals, add to make total val
                 // This now accounts for "part payments" where trans are part/whole payments against invs
                 if (isset($res['invoices_total']) || isset($res['transactions_total'])){
-                    
-                    $invTotal = 0.0; if (isset($res['invoices_total'])) $invTotal = $res['invoices_total'];
-                    $transTotal = 0.0; if (isset($res['transactions_total'])) $transTotal = $res['transactions_total'];
-
-                    $res['total_value'] = $invTotal + $transTotal;
-                    if (isset($res['transactions_paid_total']) && $res['transactions_paid_total'] > 0) $res['total_value'] -= $res['transactions_paid_total'];
+							$res['total_value'] = jpcrm_get_total_value_from_contact_or_company( $res );
                 }
                 
             // custom fields - tidy any that are present:

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -603,11 +603,6 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 
                 // Calculate total vals etc. with SQL 
                 if ($withValues && !$onlyID){
-
-                    // arguably, if getting $withInvoices etc. may be more performant to calc this in php in AFTER loop, 
-                    // ... for now as a fair guess, this'll be most performant:
-                    // ... we calc total by adding invs + trans below :)
-
                     // only include transactions with statuses which should be included in total value:
 					$transStatusQueryAdd = $this->DAL()->transactions->getTransactionStatusesToIncludeQuery(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					// include invoices without deleted status in the total value for invoices_total_inc_deleted:
@@ -3657,12 +3652,7 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
                 // and if have invs + trans totals, add to make total val
                 // This now accounts for "part payments" where trans are part/whole payments against invs
                 if (isset($res['invoices_total']) || isset($res['transactions_total'])){
-                    
-                    $invTotal = 0.0; if (isset($res['invoices_total'])) $invTotal = $res['invoices_total'];
-                    $transTotal = 0.0; if (isset($res['transactions_total'])) $transTotal = $res['transactions_total'];
-
-                    $res['total_value'] = $invTotal + $transTotal;
-                    if (isset($res['transactions_paid_total']) && $res['transactions_paid_total'] > 0) $res['total_value'] -= $res['transactions_paid_total'];
+							$res['total_value'] = jpcrm_get_total_value_from_contact_or_company( $res );
                 }
                 
             // custom fields - tidy any that are present:

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "6.3.3-alpha",
+	"version": "6.4.0-alpha",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",

--- a/projects/plugins/crm/tests/codeception/acceptance/50_JPCRM_Settings_Cest.php
+++ b/projects/plugins/crm/tests/codeception/acceptance/50_JPCRM_Settings_Cest.php
@@ -280,7 +280,7 @@ class JPCRM_Settings_Cest {
 		$I->see( 'Transactions', 'h1.header' );
 		$I->see( 'Use Shipping' );
 		$I->see( 'Use Paid/Completed Dates' );
-		$I->see( 'Include these statuses in total value' );
+		$I->see( 'Include these statuses in the transaction total value' );
 		$I->see( 'Transaction Status' );
 
 		$I->see( 'Additional settings on transactions' );


### PR DESCRIPTION
Resolves https://github.com/Automattic/zero-bs-crm/issues/1817

## Proposed changes:
* This PR introduces a new setting that allows users to customize the calculation of total values for companies and contacts. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/1817

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the general settings page. `wp-admin/admin.php?page=zerobscrm-plugin-settings`
* You should see a new setting to choose which values will be included in the `Total Value` field for contacts and companies

<img width="1049" alt="image" src="https://github.com/Automattic/jetpack/assets/37049295/6c0dec86-85cd-4f53-a679-e5d9fb86f869">

* Check if the setting works for both companies and contacts in their listing page and their view pages:
   * Contact listing: `wp-admin/admin.php?page=manage-customers`
   * Company listing: `wp-admin/admin.php?page=manage-companies`

Make sure transaction values are only taken into account when their status match the selected statuses in `wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=transactions`.
