### PR TITLE
Newsletter settings: update copy for subscription pop-up

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -145,11 +145,11 @@ function SubscriptionsSettings( props ) {
 							disabled={ isDisabled }
 							toggling={ isSavingAnyOption( [ 'sm_enabled' ] ) }
 							onChange={ handleSubscribeModalToggleChange }
-							label={ __( 'Enable subscriber pop-up', 'jetpack' ) }
+							label={ __( 'Enable subscription pop-up', 'jetpack' ) }
 						/>
 						<p className="jp-form-setting-explanation">
 							{ __(
-								'Automatically add a subscribe form pop-up to every post and turn visitors into subscribers. It will appear as readers scroll through your posts.',
+								'Automatically add a subscription form pop-up to every post and turn visitors into subscribers. It will appear as readers scroll through your posts.',
 								'jetpack'
 							) }
 							{ isBlockTheme && subscribeModalEditorUrl && (

--- a/projects/plugins/jetpack/changelog/update-newsletter-setting-popup-copy
+++ b/projects/plugins/jetpack/changelog/update-newsletter-setting-popup-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Newsletter settings: update copy for subscription pop-up toggle


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Copy of Calypso PR https://github.com/Automattic/wp-calypso/pull/86246

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use "subscription pop-up" instead of "subscriber pop-up". (It's not a pop-up for subscribers, it's a pop-up trying to get people to subscribe.)

<img width="1073" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/7a75dee2-114b-4683-a355-3cb1723318e2">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings - > Newsletter
* See toggle copy

