### PR TITLE
Jetpack Sync: Fix buffer_id sanitization in sync close endpoint

### DIFF
--- a/projects/packages/sync/changelog/fix-buffer-sanitization-in-sync-close-endpoint
+++ b/projects/packages/sync/changelog/fix-buffer-sanitization-in-sync-close-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Fixed buffer sanitization in Sync close endpoint

--- a/projects/packages/sync/src/class-rest-endpoints.php
+++ b/projects/packages/sync/src/class-rest-endpoints.php
@@ -679,7 +679,7 @@ class REST_Endpoints {
 		}
 
 		// Limit to A-Z,a-z,0-9,_,- .
-		$request_body['buffer_id'] = preg_replace( '/[^A-Za-z0-9]/', '', $request_body['buffer_id'] );
+		$request_body['buffer_id'] = preg_replace( '/[^A-Za-z0-9\-_\.]/', '', $request_body['buffer_id'] );
 		$request_body['item_ids']  = array_filter( array_map( array( 'Automattic\Jetpack\Sync\REST_Endpoints', 'sanitize_item_ids' ), $request_body['item_ids'] ) );
 
 		$queue = new Queue( $queue_name );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The `jetpack/v4/sync/close` endpoint accepts the `buffer_id` parameter in the request body, which was sanitized using: `preg_replace( '/[^A-Za-z0-9]/', '', $request_body['buffer_id'] );`.
However, this results in removing the following allowed chars (as per the corresponding comment above `preg_replace`) from the `buffer_id`: `_`, `-`, `.` which leads to `buffer_mismatch` errors.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\REST_Endpoints`: Updates `close` method by allowing `_`, `-`, `.` in `buffer_id` request body param

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
- Disable sending via the sync queue by returning a dummy error in `do_sync_and_set_delays`
- From your sandbox pull some items from the queue and note the `buffer_id` (it should contain a `.`)
- From your sandbox checkin the buffer using the above `buffer_id`
- Confirm the `buffer_mismatch` error without the PR applied
- Confirm no errors with the PR applied