### PR TITLE
Subscriptions: Fix page scrolling up after the subscription modal is dismissed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-modal-scroll-page-up
+++ b/projects/plugins/jetpack/changelog/fix-subscription-modal-scroll-page-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Fix page scrolling up after the subscription modal is dismissed

--- a/projects/plugins/jetpack/changelog/fix-subscription-modal-scroll-page-up
+++ b/projects/plugins/jetpack/changelog/fix-subscription-modal-scroll-page-up
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: bugfix
 
 Subscriptions: Fix page scrolling up after the subscription modal is dismissed

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -132,7 +132,7 @@ class Jetpack_Subscribe_Modal {
 	public function get_subscribe_template_content() {
 		// translators: %s is the name of the site.
 		$discover_more_from = sprintf( __( 'Discover more from %s', 'jetpack' ), get_bloginfo( 'name' ) );
-		$continue_reading   = __( 'Continue Reading', 'jetpack' );
+		$continue_reading   = __( 'Continue reading', 'jetpack' );
 		$subscribe_text     = __( 'Subscribe now to keep reading and get access to the full archive.', 'jetpack' );
 
 		return <<<HTML

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -28,7 +28,8 @@ domReady( function () {
 
 	// User can edit modal, and could remove close link.
 	if ( close ) {
-		close.onclick = function () {
+		close.onclick = function ( event ) {
+			event.preventDefault();
 			closeModal();
 		};
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/86294

## Proposed changes:

It:
- fixes the page scrolling up after dismissing the subscription modal by clicking the "Continue reading" link
- changes the dismiss link to be sentence cased, not title cased

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have the "Enable subscriber pop-up" enabled from Newsletter settings
* Open a blog post in an incognito window
* Scroll down to open the subscriber pop-up
* Make sure the pop-up dismiss link is sentence cased
* Make sure after clicking the pop-up dismiss link the page is not scrolling up

