### PR TITLE
Subscriptions: Fix broken subscribe button in email

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-broken-subscribe-email-button
+++ b/projects/plugins/jetpack/changelog/fix-broken-subscribe-email-button
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Subscriptions: Fix broken subscribe button in newsletter
+Subscriptions: Fix broken subscribe button in email

--- a/projects/plugins/jetpack/changelog/fix-broken-subscribe-email-button
+++ b/projects/plugins/jetpack/changelog/fix-broken-subscribe-email-button
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: bugfix
 
 Subscriptions: Fix broken subscribe button in newsletter

--- a/projects/plugins/jetpack/changelog/fix-broken-subscribe-email-button
+++ b/projects/plugins/jetpack/changelog/fix-broken-subscribe-email-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Fix broken subscribe button in newsletter

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -768,7 +768,7 @@ function render_for_email( $data, $styles ) {
 			<div>
 				<div>
 					<p ' . $submit_button_wrapper_style . '>
-						<a href="' . esc_url( get_post_permalink() ) . '" style="text-decoration: none; display: inline-block; ' . esc_attr( $styles['submit_button'] ) . '">' . sanitize_submit_text( $button_text ) . '</a>
+						<a href="' . esc_url( get_post_permalink() ) . '" style="' . esc_attr( $styles['submit_button'] ) . ' text-decoration: none; white-space: nowrap; margin-left: 0">' . sanitize_submit_text( $button_text ) . '</a>
 					</p>
 				</div>
 			</div>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -768,7 +768,7 @@ function render_for_email( $data, $styles ) {
 			<div>
 				<div>
 					<p ' . $submit_button_wrapper_style . '>
-						<a href="' . esc_url( get_post_permalink() ) . '" style="text-decoration: none; ' . esc_attr( $styles['submit_button'] ) . '">' . sanitize_submit_text( $button_text ) . '</a>
+						<a href="' . esc_url( get_post_permalink() ) . '" style="text-decoration: none; display: inline-block; ' . esc_attr( $styles['submit_button'] ) . '">' . sanitize_submit_text( $button_text ) . '</a>
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34748

## Proposed changes:

It:
* prevents subscribe button text from wrapping by applying `white-space: nowrap`
* removes subscribe button left margin by applying `margin-left: 0`
* moves the custom styles after the `$styles['submit_button']` to make sure they won't be overwritten

I noticed more issues with it, e.g. on the page this button is horizontally centered while in email is aligned to the left but I think we can tackle it in a follow-up PRs if needed. For now the most important is fixing the broken look of it.

#### Before

<img width="339" alt="Screenshot 2024-01-11 at 21 54 09" src="https://github.com/Automattic/jetpack/assets/4068554/9ffeca04-9eb5-40b1-8f60-a4a5520458ec">

#### After

<img width="339" alt="Screenshot 2024-01-11 at 22 02 11" src="https://github.com/Automattic/jetpack/assets/4068554/93380f74-966c-45fe-8d17-e152e6f2e801">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Be a subscriber to your blog
* Add subscribe block to post
* Set the font size of this block in the "Typography" section to "Extra Extra Large"
* Receive an email
* Make sure the button looks good even when you shrink the window width

