### PR TITLE
Revert "AI Assistant: avoid deprecation notice in AI Excerpt (#34921)"

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-excerpt-deprecation-notices
+++ b/projects/plugins/jetpack/changelog/fix-ai-excerpt-deprecation-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Assistant: avoid deprecation notices when using a development version of WordPress.

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
@@ -3,7 +3,6 @@
  */
 import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
 import { dispatch } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
@@ -43,7 +42,7 @@ function extendAiContentLensFeatures( settings, name ) {
 	registerJetpackPlugin( aiExcerptPluginName, aiExcerptPluginSettings );
 
 	// Remove the excerpt panel by dispatching an action.
-	dispatch( editorStore )?.removeEditorPanel( 'post-excerpt' );
+	dispatch( 'core/edit-post' )?.removeEditorPanel( 'post-excerpt' );
 
 	return settings;
 }


### PR DESCRIPTION
## Proposed changes:

Follow-up to #34921.

This reverts commit 05e4a870152f2f378d6b0487e178a9732bc9dcd4.

See p1704992823025689-slack-CBG1CP4EN

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Start with a site without the Gutenberg plugin, and with a classic theme like Twenty Ten.

* After connecting Jetpack to WordPress.com, go to
    * Posts > Add New
    * Appearance > Widgets

Both editors should continue to work.
