### PR TITLE
AI Assistant: conditionally remove the core excerpt box.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-34921-take-2
+++ b/projects/plugins/jetpack/changelog/fix-34921-take-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: do not attempt to display the AI Excerpt assistant in the site editor and the widget editor.

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
@@ -1,21 +1,19 @@
-/**
- * External dependencies
- */
 import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
 import { dispatch } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 import { addFilter } from '@wordpress/hooks';
-/**
- * Internal dependencies
- */
 import metadata from '../../blocks/ai-assistant/block.json';
 import { isPossibleToExtendBlock } from '../../blocks/ai-assistant/extensions/ai-assistant';
+import { getEditorType, POST_EDITOR } from '../../shared/get-editor-type';
 import { aiExcerptPluginName, aiExcerptPluginSettings } from '.';
 
 export const AI_CONTENT_LENS = 'ai-content-lens';
 
 const isAiAssistantSupportExtensionEnabled =
 	window?.Jetpack_Editor_Initial_State?.available_blocks[ 'ai-content-lens' ];
+
+const isPostEditor = getEditorType() === POST_EDITOR;
 
 /**
  * Extend the editor with AI Content Lens features,
@@ -42,14 +40,22 @@ function extendAiContentLensFeatures( settings, name ) {
 	// Register AI Excerpt plugin.
 	registerJetpackPlugin( aiExcerptPluginName, aiExcerptPluginSettings );
 
+	// check if the removeEditorPanel function exists in the editorStore.
+	// íf not, look for it in the editPostStore.
+	// @to-do: remove this once Jetpack requires WordPres 6.5,
+	// where the removeEditorPanel function will be available in the editorStore.
+	const removeEditorPanel = dispatch( editorStore )?.removeEditorPanel
+		? dispatch( editorStore )?.removeEditorPanel
+		: dispatch( editPostStore )?.removeEditorPanel;
+
 	// Remove the excerpt panel by dispatching an action.
-	dispatch( editorStore )?.removeEditorPanel( 'post-excerpt' );
+	removeEditorPanel( 'post-excerpt' );
 
 	return settings;
 }
 
 // Filter only if the extension is enabled.
-if ( isAiAssistantSupportExtensionEnabled?.available ) {
+if ( isAiAssistantSupportExtensionEnabled?.available && isPostEditor ) {
 	addFilter(
 		'blocks.registerBlockType',
 		'jetpack/ai-content-lens-features',

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
@@ -42,7 +42,7 @@ function extendAiContentLensFeatures( settings, name ) {
 
 	// check if the removeEditorPanel function exists in the editorStore.
 	// íf not, look for it in the editPostStore.
-	// @to-do: remove this once Jetpack requires WordPres 6.5,
+	// @todo: remove this once Jetpack requires WordPres 6.5,
 	// where the removeEditorPanel function will be available in the editorStore.
 	const removeEditorPanel = dispatch( editorStore )?.removeEditorPanel
 		? dispatch( editorStore )?.removeEditorPanel


### PR DESCRIPTION
## Proposed changes:

Fixes the warnings mentioned in #34921, in a different way:

1. Do not even attempt to do anything where we are not in the post editor, the only place where the post excerpt box lives.
2. Since the removeEditorPanel function is not yet available in `@wordpress/editor` in current versions of WordPress, let's still load it from `@wordpress/edit-post` when necessary.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Start with a site without the Gutenberg plugin, and with a classic theme like Twenty Ten.

* After connecting Jetpack to WordPress.com, go to
    * Posts > Add New
    * Appearance > Widgets
* Both editors should continue to work.
* Now install the Gutenberg plugin, and go to Posts > Add New again
    * You should not see any warnings about removeEditorPanel in your browser console.
    * You should still only see the AI Excerpt panel and the core one gets removed.
