### PR TITLE
Fixed doc parser producing duplicate entries.

### DIFF
--- a/tools/cli/helpers/doc-parser/docs.json
+++ b/tools/cli/helpers/doc-parser/docs.json
@@ -1,6 +1,20 @@
 {
 	"parents": {
 		"readme.md": [ "docs/quick-start.md", "docs/CONTRIBUTING.md" ],
-		"docs/CONTRIBUTING.md": [ "CODE-OF-CONDUCT.md", "docs/monorepo.md", "docs/quick-start.md" ]
+		"docs/CONTRIBUTING.md": [
+			"CODE-OF-CONDUCT.md",
+			"docs/coding-guidelines.md",
+			"docs/development-environment.md",
+			"docs/git-workflow.md",
+			"docs/monorepo.md",
+			"docs/quick-start.md",
+			"docs/writing-a-good-changelog-entry.md",
+			"docs/unison-wordpress-com.md",
+			"docs/rest-api.md",
+			"docs/code-reviews.md",
+			"docs/release-management.md",
+			"docs/translations.md",
+			"docs/automated-testing.md"
+		]
 	}
 }

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -18,16 +18,26 @@ $parser->generate( array( $args, 'phpdoc.json' ) );
 
 $docs_json = json_decode( file_get_contents( __DIR__ . '/docs.json' ), true );
 
-$result = array();
+$processed_docs = array();
+$result         = array();
+
 // Each parent file has to be present in the import.
 foreach ( $docs_json['parents'] as $parent => $child_docs ) {
-	printf( 'Extracting Markdown from %1$s.' . PHP_EOL, $parent );
-	$result[] = get_html_from_markdown( $parent );
+	if ( ! in_array( $parent, $processed_docs, true ) ) {
+		printf( 'Extracting Markdown from %1$s.' . PHP_EOL, $parent );
+		$result[]         = get_html_from_markdown( $parent );
+		$processed_docs[] = $parent;
+	}
 
 	foreach ( $child_docs as $doc ) {
+		if ( in_array( $doc, $processed_docs, true ) ) {
+			continue;
+		}
+
 		printf( 'Extracting Markdown from %1$s.' . PHP_EOL, $doc );
-		$data           = get_html_from_markdown( $doc );
-		$data['parent'] = $parent;
+		$data             = get_html_from_markdown( $doc );
+		$data['parent']   = $parent;
+		$processed_docs[] = $doc;
 
 		$result[] = $data;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes the markdown parser producing duplicate entries in the result of `jetpack docs` CLI command.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix duplicate doc entries.
* Add more docs to the parser.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

