### PR TITLE
Gardening: ensure board triage works regardless of capitalization

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-auto-assignment-capitalization
+++ b/projects/github-actions/repo-gardening/changelog/fix-auto-assignment-capitalization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Board triage: ensure the task works when the organization name is capitalized

--- a/projects/github-actions/repo-gardening/src/tasks/update-board/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/update-board/index.js
@@ -424,7 +424,7 @@ async function setTeamField( octokit, projectInfo, projectItemId, team ) {
  */
 async function loadTeamAssignments( ownerLogin ) {
 	// If we're in an Automattic repo, we can use the team assignments file that ships with this action.
-	if ( 'automattic' === ownerLogin ) {
+	if ( 'automattic' === ownerLogin.toLowerCase() ) {
 		return automatticAssignments;
 	}
 


### PR DESCRIPTION
## Proposed changes:

This is a follow-up to #34313.

The automattic org is capitalized in many places, e.g. https://github.com/Automattic/

Let's ensure it's set to lowercase so it can be properly detected by our auto-triage task.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This cannot be tested in this repo, it can only be tested in a fork. The instructions are similar to #34313.
