### PR TITLE
Subscribe block: disabled email editing when logged in

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-disabled-when-loggedin
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-disabled-when-loggedin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe block: don't allow editing the email for subscribing for logged-in members.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -701,7 +701,7 @@ function render_for_website( $data, $classes, $styles ) {
 							esc_attr( $data['subscribe_email'] ),
 							esc_attr( $subscribe_field_id ),
 							( ! empty( $data['subscribe_email'] )
-								? 'disabled="disabled" title="' . esc_attr__( "You're logged in with this email", 'jetpack' ) . '"'
+								? 'disabled title="' . esc_attr__( "You're logged in with this email", 'jetpack' ) . '"'
 								: ''
 							)
 						);

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -701,7 +701,7 @@ function render_for_website( $data, $classes, $styles ) {
 							esc_attr( $data['subscribe_email'] ),
 							esc_attr( $subscribe_field_id ),
 							( ! empty( $data['subscribe_email'] )
-								? 'disabled="disabled" title="' . esc_attr__( 'Your WordPress.com account email', 'jetpack' ) . '"'
+								? 'disabled="disabled" title="' . esc_attr__( "You're logged in with this email", 'jetpack' ) . '"'
 								: ''
 							)
 						);

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -687,6 +687,7 @@ function render_for_website( $data, $classes, $styles ) {
 								placeholder="%3$s"
 								value="%4$s"
 								id="%5$s"
+								%6$s
 							/>',
 							( ! empty( $classes['email_field'] )
 								? 'class="' . esc_attr( $classes['email_field'] ) . '"'
@@ -698,7 +699,11 @@ function render_for_website( $data, $classes, $styles ) {
 							),
 							esc_attr( $data['subscribe_placeholder'] ),
 							esc_attr( $data['subscribe_email'] ),
-							esc_attr( $subscribe_field_id )
+							esc_attr( $subscribe_field_id ),
+							( ! empty( $data['subscribe_email'] )
+								? 'disabled="disabled" title="' . esc_attr__( 'Your WordPress.com account email', 'jetpack' ) . '"'
+								: ''
+							)
 						);
 						?>
 					</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disabled email editing when logged in. The email they edit wouldn't be used for subscribing anyway when they're logged in at .com with a specific different email.
* Shows a tooltip on hover explaining why they cannot edit the email.

<img width="451" alt="Screenshot 2024-01-12 at 12 06 55" src="https://github.com/Automattic/jetpack/assets/87168/93cee0bf-9ffc-438a-bf31-8e079d145bc1">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have subscribe block on the page
* Have a post with paywall
* Have user who isn't subscribed t othe site
* On frontend of the site, on incognito, login via paywall's "I already have access" link
* Upon returning to the site, see subscribe block now have your email, and you cannot edit it.

