### PR TITLE
Memberships & Subscriptions: add logout API

### DIFF
--- a/projects/plugins/jetpack/changelog/update-memberships-add-logout-api
+++ b/projects/plugins/jetpack/changelog/update-memberships-add-logout-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Memberships & Subscriptions: add logout API


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a way to "logout" as a member from the site; basically just clearing out the membership cookie.
* Accepts both get/post requests; allows flexibility to not leave trace in browser history by using `post`, but also flexibility we need with simple `get` when calling it from Calypso.

Next step is to add a simple "logout" link in Calypso to subscription management page: 

<img width="977" alt="Screenshot 2024-01-12 at 14 29 40" src="https://github.com/Automattic/jetpack/assets/87168/7787c391-e78a-4efc-858b-f6086d5681f7">

In future potentially "logout" functionality in ["Subscriber login" block](https://github.com/Automattic/jetpack/issues/34884) as well. cc @pkuliga 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On any page at blog where you're subscribed to, append `?jp-memberships-logout` to the URL and note how cookie gets cleared and you get logged out from subscriber-only content.


