### PR TITLE
Sync: synchronize block status option

### DIFF
--- a/projects/packages/sync/changelog/add-blocks-option-sync
+++ b/projects/packages/sync/changelog/add-blocks-option-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Options: synchronize block status option.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -192,6 +192,7 @@ class Defaults {
 		'wpcom_site_setup',
 		'wpcom_subscription_emails_use_excerpt',
 		'jetpack_verbum_subscription_modal',
+		'jetpack_blocks_disabled',
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-blocks-option-sync
+++ b/projects/plugins/jetpack/changelog/add-blocks-option-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync: synchronize block status option.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -243,6 +243,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_reader_views_enabled'                   => true,
 			'wpcom_site_setup'                             => '',
 			'jetpack_verbum_subscription_modal'            => true,
+			'jetpack_blocks_disabled'                      => false,
 			'wpcom_ai_site_prompt'                         => '',
 		);
 


### PR DESCRIPTION
See 8766-gh-jpop-issues

## Proposed changes:

In #23630, we introduced an option to control whether the blocks should be displayed in the editor or not. Let's synchronize that option with WordPress.com.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 8766-gh-jpop-issues

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test so far on this one. Once this (and the counterpart D134534-code) is merged, we'll be able to see updates to that option on the site be reflected on the cache site.
