### PR TITLE
 Jetpack Sync: Fix restoring post global before enqueuing a post action.

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-posts-module-usage-of-global-post
+++ b/projects/packages/sync/changelog/fix-sync-posts-module-usage-of-global-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Fix restoring post global before enqueuing a post action.

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -444,6 +444,10 @@ class Posts extends Module {
 	 */
 	public function filter_post_content_and_add_links( $post_object ) {
 		global $post;
+
+		// Used to restore the post global.
+		$current_post = $post;
+
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$post = $post_object;
 
@@ -456,6 +460,9 @@ class Posts extends Module {
 			$non_existant_post->post_modified_gmt = $post->post_modified_gmt;
 			$non_existant_post->post_status       = 'jetpack_sync_non_registered_post_type';
 			$non_existant_post->post_type         = $post->post_type;
+			// Restore global post.
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$post = $current_post;
 
 			return $non_existant_post;
 		}
@@ -482,6 +489,10 @@ class Posts extends Module {
 			$blocked_post->post_modified_gmt = $post->post_modified_gmt;
 			$blocked_post->post_status       = 'jetpack_sync_blocked';
 			$blocked_post->post_type         = $post->post_type;
+
+			// Restore global post.
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$post = $current_post;
 
 			return $blocked_post;
 		}
@@ -562,7 +573,13 @@ class Posts extends Module {
 			$post->amp_permalink = amp_get_permalink( $post->ID );
 		}
 
-		return $post;
+		$filtered_post = $post;
+
+		// Restore global post.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post = $current_post;
+
+		return $filtered_post;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-sync-posts-module-usage-of-global-post
+++ b/projects/plugins/jetpack/changelog/fix-sync-posts-module-usage-of-global-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Added unit tests for Sync
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -511,6 +511,23 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( '<p>[foo]</p>', trim( $post_on_server->post_content_filtered ) );
 	}
 
+	public function test_sync_post_filter_restores_global_post() {
+		global $post;
+
+		$post_id = self::factory()->post->create();
+		$post    = get_post( $post_id );
+
+		$post_sync_module = Modules::get_module( 'posts' );
+		$post_sync_module->filter_post_content_and_add_links( $this->post );
+
+		$this->assertSame( $post_id, $post->ID );
+
+		// Test with post global not set.
+		$post = null;
+		$post_sync_module->filter_post_content_and_add_links( $this->post );
+		$this->assertNull( $post );
+	}
+
 	public function do_not_expand_shortcode( $shortcodes ) {
 		$shortcodes[] = 'foo';
 		return $shortcodes;

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -910,6 +910,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		wp_update_post( $this->post );
 
+		global $post;
+		$post = $this->post; // Needed to properly apply the shortcode 'the_content' filter.
 		$this->assertStringContainsString( '<form action=', apply_filters( 'the_content', $this->post->post_content ) );
 
 		$this->sender->do_sync();
@@ -937,6 +939,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		wp_update_post( $this->post );
 
+		global $post;
+		$post = $this->post; // Needed to properly apply the shortcode 'the_content' filter.
 		$this->assertStringContainsString( 'div class=\'sharedaddy', apply_filters( 'the_content', $this->post->post_content ) );
 
 		$this->sender->do_sync();
@@ -964,6 +968,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		wp_update_post( $this->post );
 
+		global $post;
+		$post = $this->post; // Needed to properly apply the shortcode 'the_content' filter.
 		$this->assertStringContainsString( 'class="sharedaddy sd-sharing-enabled"', apply_filters( 'the_content', $this->post->post_content ) );
 
 		$this->sender->do_sync();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34979

The Sync package will filter a post before enqueuing a post related Sync action. In https://github.com/Automattic/jetpack/commit/6332534deb6bb177239a3a99f0eb576d37f7f5c0 we started setting the `$post` global while filtering the post content so that it is available in shortcodes and the filter if necessary.
However, at the time  the corresponding method `filter_post_content_and_add_links` was executed on the shutdown hook, before sending a post action to WPCOM.
Now that we modify the post before enqueuing instead, we need to make sure to restore the `$post` global so that other consumers are not affected.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\Posts`: Updates `filter_post_content_and_add_links` in order to restore the `$post` global after setting it.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Ensure the corresponding Sensei bug is now fixed. Test instructions to reproduce can be found here: https://github.com/Automattic/sensei-pro/issues/2517

