### PR TITLE
Sharing Block: be more defensive when fetching services

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-block-services
+++ b/projects/plugins/jetpack/changelog/fix-sharing-block-services
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sharing: be more defensive when fetching sharing service to avoid errors.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -111,12 +111,11 @@ function sharing_process_requests() {
 
 	// Only process if: single post and share={service} defined
 	if ( ( is_page() || is_single() ) && isset( $_GET['share'] ) && is_string( $_GET['share'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$services                = get_services();
-		$available_service_names = array_keys( $services );
-		$service_name            = sanitize_text_field( wp_unslash( $_GET['share'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$services     = get_services();
+		$service_name = sanitize_text_field( wp_unslash( $_GET['share'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// Only allow services that have been defined in get_services().
-		if ( ! in_array( $service_name, $available_service_names, true ) ) {
+		if ( ! array_key_exists( $service_name, $services ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -65,7 +65,7 @@ function render_block( $attr, $content, $block ) {
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
 	$component  = '<li class="jetpack-sharing-button__list-item">';
-	$component .= '<a rel="nofollow noopener noreferrer" class="' . esc_attr( $sharing_link_class ) . '" href="' . esc_attr( $link_url ) . '" target="_blank" ';
+	$component .= '<a rel="nofollow noopener noreferrer" class="' . esc_attr( $sharing_link_class ) . '" href="' . esc_url( $link_url ) . '" target="_blank" ';
 	$component .= 'data-service="' . esc_attr( $attr['service'] ) . '" data-shared="' . esc_attr( $data_shared ) . '" aria-label="' . esc_attr( $link_aria_label ) . '" primary>';
 	$component .= $icon;
 	$component .= '<span class="jetpack-sharing-button__service-label" aria-hidden="true">' . esc_html( $title ) . '</span>';
@@ -111,9 +111,16 @@ function sharing_process_requests() {
 
 	// Only process if: single post and share={service} defined
 	if ( ( is_page() || is_single() ) && isset( $_GET['share'] ) && is_string( $_GET['share'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$services     = get_services();
-		$service_name = sanitize_text_field( wp_unslash( $_GET['share'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$service      = new $services[ ( $service_name ) ]( $service_name, array() ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$services                = get_services();
+		$available_service_names = array_keys( $services );
+		$service_name            = sanitize_text_field( wp_unslash( $_GET['share'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		// Only allow services that have been defined in get_services().
+		if ( ! in_array( $service_name, $available_service_names, true ) ) {
+			return;
+		}
+
+		$service = new $services[ ( $service_name ) ]( $service_name, array() ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( $service ) {
 			$service->process_request( $post, $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		}


### PR DESCRIPTION
## Proposed changes:

Follow-up to #34414

This should avoid errors like:

```
Fatal error: Uncaught Error: Class name must be a valid object or a string in wp-content/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php:116
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1705072777000969-slack-C4N88L95W

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Enable Beta blocks on your site: `add_filter( 'jetpack_blocks_variation', function () { return 'beta'; } );`
* Go to Appearance > Editor > Templates > Single Post
* Add a Sharing Block with a few services to your template and save your changes.
* On the frontend of your site, try sharing a few posts.
