### PR TITLE
Search: Use Blog ID in links to WPCOM instead of site slug

### DIFF
--- a/projects/packages/search/changelog/update-protect-wpcom-links-blog-id
+++ b/projects/packages/search/changelog/update-protect-wpcom-links-blog-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use blog ID instead of site slug in checkout links.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.41.x-dev"
+			"dev-trunk": "0.42.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.41.0",
+	"version": "0.42.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.41.0';
+	const VERSION = '0.42.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -33,13 +33,14 @@ export default function DashboardPage( { isLoading = false } ) {
 	useSelect( select => select( STORE_ID ).getSearchStats(), [] );
 
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug() );
+	const blogID = useSelect( select => select( STORE_ID ).getBlogId() );
 	const siteAdminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl() );
 	const { hasConnectionError } = useConnectionErrorNotice();
 
 	const sendPaidPlanToCart = () => {
 		const checkoutProductUrl = getProductCheckoutUrl(
 			'jetpack_search',
-			domain,
+			blogID ?? domain,
 			`${ siteAdminUrl }admin.php?page=jetpack-search&just_upgraded=1`,
 			true
 		);

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -41,6 +41,7 @@ export default function UpsellPage( { isLoading = false } ) {
 	const isNewPricing = useSelect( select => select( STORE_ID ).isNewPricing202208(), [] );
 	useSelect( select => select( STORE_ID ).getSearchPricing(), [] );
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
+	const blogID = useSelect( select => select( STORE_ID ).getBlogId(), [] );
 	const adminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl(), [] );
 	const isWpcom = useSelect( select => select( STORE_ID ).isWpcom(), [] );
 
@@ -58,6 +59,7 @@ export default function UpsellPage( { isLoading = false } ) {
 			siteProductAvailabilityHandler: checkSiteHasSearchProduct,
 			from: 'jetpack-search',
 			siteSuffix: domain,
+			blogID,
 			isWpcom,
 		} );
 
@@ -69,6 +71,7 @@ export default function UpsellPage( { isLoading = false } ) {
 			siteProductAvailabilityHandler: checkSiteHasSearchProduct,
 			from: 'jetpack-search',
 			siteSuffix: domain,
+			blogID,
 			isWpcom,
 		} );
 

--- a/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
+++ b/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
@@ -22,6 +22,7 @@ const {
  * @param {string} props.adminUrl     - The base URL of WP-Admin.
  * @param {string} props.redirectUri  - The URI to redirect to after checkout.
  * @param {string} [props.siteSuffix] - The site suffix.
+ * @param {string} [props.blogID]     - The blog ID.
  * @param {Function} props.siteProductAvailabilityHandler - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
  * @param {Function} props.from       - The plugin slug initiated the flow.
  * @param {Function} props.isWpcom    - Whether it's WPCOM site.
@@ -32,6 +33,7 @@ export default function useProductCheckoutWorkflow( {
 	adminUrl,
 	redirectUri,
 	siteSuffix = defaultSiteSuffix,
+	blogID = null,
 	siteProductAvailabilityHandler = null,
 	from,
 	isWpcom = false,
@@ -58,7 +60,7 @@ export default function useProductCheckoutWorkflow( {
 	// Build the checkout URL.
 	const checkoutProductUrl = getProductCheckoutUrl(
 		productSlug,
-		siteSuffix,
+		blogID ?? siteSuffix,
 		adminUrl + redirectUri,
 		isUserConnected || isWpcom
 	);

--- a/projects/plugins/jetpack/changelog/update-protect-wpcom-links-blog-id
+++ b/projects/plugins/jetpack/changelog/update-protect-wpcom-links-blog-id
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2184,7 +2184,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/search",
-				"reference": "b8e216a03dc91f606b87fab82d6663f2b03dd3c5"
+				"reference": "426240f92e4c83d9d82b815aa64a0ca2b97932e0"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -2212,7 +2212,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.41.x-dev"
+					"dev-trunk": "0.42.x-dev"
 				},
 				"version-constants": {
 					"::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/update-protect-wpcom-links-blog-id
+++ b/projects/plugins/search/changelog/update-protect-wpcom-links-blog-id
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1208,7 +1208,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "b8e216a03dc91f606b87fab82d6663f2b03dd3c5"
+                "reference": "426240f92e4c83d9d82b815aa64a0ca2b97932e0"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1236,7 +1236,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.41.x-dev"
+                    "dev-trunk": "0.42.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
## Proposed changes:
Adjust checkout links in Search package to use blog ID instead of slug for multi-URL support.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pf5801-93-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
To test the blog, you'll need two domains pointing to the same site. One way to do that is to setup two proxying tunnels to the same local environment.

**Connect Jetpack with a free plan on URL A, and load it via URL B.**

If your site falls into IDC due to concurrency issues with IDC secret validation (fix pending), remove `jetpack_sync_error_idc` option.

1. Using URL B (not cache site main URL), go to "Jetpack -> Search" and choose the free plan. Confirm you're redirected to the proper checkout with URL A (cache site main URL) in the page URL.
2. After purchasing, you'll end up on the Calypso "My Plan" page instead of being redirected back to the site. That's a bug to be fixed separately on Calypso side.
3. Go back to URL B's "Jetpack -> Search" section, confirm you see the dashboard now.
4. Click on "Upgrade Jetpack Search" and confirm you're taken to the checkout with URL A in page URL.
5. Finish the checkout (you'll probably be redirected to 404) and go back to URL B's "Jetpack -> Search". Confirm the plan got upgraded.