### PR TITLE
Updating the doc parser to give best results in exporting docs.

### DIFF
--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -75,6 +75,11 @@ function get_html_from_markdown( $file_path ) {
 	$headers = $document->getElementsByTagName( 'h1' );
 	if ( count( $headers ) ) {
 		$doc_title = $headers[0]->textContent;
+
+		$parent = $headers[0]->parentNode;
+		if ( null !== $parent ) {
+			$parent->removeChild( $headers[0] );
+		}
 	}
 
 	return array(

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -81,10 +81,7 @@ function get_html_from_markdown( $file_path ) {
 	if ( count( $headers ) ) {
 		$doc_title = $headers[0]->textContent;
 
-		$parent = $headers[0]->parentNode;
-		if ( null !== $parent ) {
-			$parent->removeChild( $headers[0] );
-		}
+		$headers[0]->remove();
 	}
 
 	return array(

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -61,6 +61,8 @@ function get_html_from_markdown( $file_path ) {
 		dirname( __DIR__, 4 ) . DIRECTORY_SEPARATOR . $file_path
 	);
 
+	$markdown = mb_convert_encoding( $markdown, 'UTF-8' );
+
 	if ( false === $markdown ) {
 		throw new Exception( 'Could not read Markdown from ' . $file_path );
 	}
@@ -68,7 +70,7 @@ function get_html_from_markdown( $file_path ) {
 	$contents = $parser->defaultTransform( $markdown );
 
 	$document = new DOMDocument();
-	$document->loadHTML( $contents );
+	$document->loadHTML( '<?xml encoding="UTF-8">' . $contents );
 
 	$doc_title = $file_path;
 

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -61,8 +61,6 @@ function get_html_from_markdown( $file_path ) {
 		dirname( __DIR__, 4 ) . DIRECTORY_SEPARATOR . $file_path
 	);
 
-	$markdown = mb_convert_encoding( $markdown, 'UTF-8' );
-
 	if ( false === $markdown ) {
 		throw new Exception( 'Could not read Markdown from ' . $file_path );
 	}

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -70,7 +70,10 @@ function get_html_from_markdown( $file_path ) {
 	$contents = $parser->defaultTransform( $markdown );
 
 	$document = new DOMDocument();
-	$document->loadHTML( '<?xml encoding="UTF-8">' . $contents );
+	$document->loadHTML(
+		'<!DOCTYPE html><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>'
+		. $contents
+	);
 
 	$doc_title = $file_path;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes several problems in parsing Markdown documents in the Monorepo.

## Proposed changes:
* Removing the title from the document to avoid duplication.
* Preserving multibyte characters as is for best importing results.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
*

