### PR TITLE
Jetpack: Add a link to 5-star reviews on plugins page.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-5-star-link-plugins-page
+++ b/projects/plugins/jetpack/changelog/add-jetpack-5-star-link-plugins-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack plugin: Add 5-star review link in the Jetpack Plugin meta, in the plugins list table (on the plugins page).

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -867,6 +867,9 @@ class Jetpack {
 
 		// Actions for conditional recommendations.
 		add_action( 'plugins_loaded', array( 'Jetpack_Recommendations', 'init_conditional_recommendation_actions' ) );
+
+		// Add 5-star
+		add_filter( 'plugin_row_meta', array( $this, 'add_5_star_review_link' ), 10, 2 );
 	}
 
 	/**
@@ -6898,5 +6901,25 @@ endif;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Add 5-star review link on the Jetpack Plugin meta, in the plugins list table (on the plugins page).
+	 *
+	 * @param array  $plugin_meta An array of the plugin's metadata.
+	 * @param string $plugin_file Path to the plugin file.
+	 *
+	 * @return array $plugin_meta An array of the plugin's metadata.
+	 */
+	public function add_5_star_review_link( $plugin_meta, $plugin_file ) {
+		if ( $plugin_file !== 'jetpack/jetpack.php' ) {
+			return $plugin_meta;
+		}
+
+		$plugin_meta[] = '<a href="https://wordpress.org/support/plugin/jetpack/reviews/?filter=5" target="_blank" title="' . esc_html__( 'Rate Jetpack on WordPress.org', 'jetpack' ) . '" style="color: #ffb900">'
+			. str_repeat( '<span class="dashicons dashicons-star-filled" style="font-size: 16px; width:16px; height: 16px"></span>', 5 )
+			. '</a>';
+
+		return $plugin_meta;
 	}
 }

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6916,7 +6916,7 @@ endif;
 			return $plugin_meta;
 		}
 
-		$plugin_meta[] = '<a href="https://wordpress.org/support/plugin/jetpack/reviews/?filter=5" target="_blank" title="' . esc_html__( 'Rate Jetpack on WordPress.org', 'jetpack' ) . '" style="color: #ffb900">'
+		$plugin_meta[] = '<a href="https://wordpress.org/support/plugin/jetpack/reviews/?filter=5" target="_blank" rel="noopener noreferrer" title="' . esc_attr__( 'Rate Jetpack on WordPress.org', 'jetpack' ) . '" style="color: #ffb900">'
 			. str_repeat( '<span class="dashicons dashicons-star-filled" style="font-size: 16px; width:16px; height: 16px"></span>', 5 )
 			. '</a>';
 


### PR DESCRIPTION
This PR adds a 5-star review link on the Jetpack Plugin meta, in the plugins list table (on the plugins page).

Related to:  pbNhbs-89s-p2

Screenshot:

![Markup 2024-01-12 at 14 39 08](https://github.com/Automattic/jetpack/assets/11078128/c406b273-3f54-4460-8a8b-17599c2731a0)


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hook into the `plugin_row_meta` filter to add 5 star dashicons and link them to the Jetpack 5-star review page on wordpress.org.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pbNhbs-89s-p2
https://github.com/orgs/Automattic/projects/724/views/1?pane=issue&itemId=37716381

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, but ideally we would like to track clicks to the 5-star review link. I'm wondering how I would go about doing that? Attaching a Tracks event on-click of the link?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch locally with a local Jetpack dev environment or create a Jurassic Ninja site with Jetpack Beta pointing to this branch.
    * If you're using a JN site with Beta plugin, You'll need to SSH into the site and edit file `wp-content/plugins/jetpack-dev/class.jetpack.php`, line 6915
    * Change `if ( $plugin_file !== 'jetpack/jetpack.php' ) {` to --> `if ( $plugin_file !== 'jetpack-dev/jetpack.php' ) {`
* Open your site and go to the Plugins page (`/wp-admin/plugins.php`).
* In the plugins list table, inspect the Jetpack plugin item and verify you see the 5-star review link (See image above).
* Hover and pause your mouse cursor over the link (the stars) and verify you see the title, "Rate Jetpack on WordPress.org".
* Verify the link points to: https://wordpress.org/support/plugin/jetpack/reviews/?filter=5, and it opens in a new tab.

