### PR TITLE
[Boost] Prevent refetch when Critical CSS module is off.

### DIFF
--- a/projects/plugins/boost/changelog/boost-fix-critical-css-refetch
+++ b/projects/plugins/boost/changelog/boost-fix-critical-css-refetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent refetching Critical CSS state when off


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35013

Prevent Critical CSS state from auto-refetching when either module which depends on it is deactivated. Note that React Query will often refetch one more time after you ask it to stop.

## Proposed changes:
* Don't refetch Critical CSS state when neither module is active.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Start regenerating Critical CSS.
* Turn the module off partway through.
* Ensure the requests to `critical-css-state` don't keep going.