### PR TITLE
[Boost] Fix ISA Report error when none found

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/image-size-analysis/lib/stores/types.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/image-size-analysis/lib/stores/types.ts
@@ -67,13 +67,15 @@ export enum ISAStatus {
 export const IsaReport = z.object( {
 	status: z.nativeEnum( ISAStatus ).default( ISAStatus.NotFound ),
 	report_id: z.number().optional(),
-	groups: z.object( {
-		core_front_page: IsaCounts,
-		singular_page: IsaCounts.optional(),
-		singular_post: IsaCounts.optional(),
-		other: IsaCounts.optional(),
-		fixed: IsaCounts.optional(),
-	} ),
+	groups: z
+		.object( {
+			core_front_page: IsaCounts,
+			singular_page: IsaCounts.optional(),
+			singular_post: IsaCounts.optional(),
+			other: IsaCounts.optional(),
+			fixed: IsaCounts.optional(),
+		} )
+		.optional(),
 } );
 
 /**

--- a/projects/plugins/boost/changelog/boost-fix-isa-type-error
+++ b/projects/plugins/boost/changelog/boost-fix-isa-type-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Allow ISA Report object without groups - to account for errors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34965

When there are no ISA reports for a site, an error can appear in the console complaining about a missing groups attribute from the "no reports found" status.

This PR fixes that by allowing the groups prop to be null - which appears to be accounted for elsewhere in the code.

## Proposed changes:
* Fix ISA report zod type.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Set up a premium site
* It will automatically create an ISA report for you
* Delete that ISA report from the wpcom database
* Load the boost dashboard.
* Ensure no zod errors appear in the console.