### PR TITLE
[Boost] Clean up CSS Meta components

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/critical-css.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/critical-css.scss
@@ -117,9 +117,12 @@
 
 		&.components-button.is-link {
 			margin-left: 8px;
+			font-weight: normal;
 
 			&:hover {
 				color: $gray_90;
+				background: none;
+				text-decoration-thickness: inherit;
 			}
 
 			@include breakpoint(xs) {

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
@@ -13,10 +13,6 @@ export default function CloudCssMetaProps() {
 
 	const progress = calculateCriticalCssProgress( cssState.providers );
 
-	const successCount = cssState.providers.filter(
-		provider => provider.status === 'success'
-	).length;
-
 	return (
 		<Status
 			cssState={ cssState }
@@ -25,7 +21,6 @@ export default function CloudCssMetaProps() {
 			retry={ retry }
 			status={ cssState.status }
 			issues={ getCriticalCssIssues( cssState ) }
-			successCount={ successCount }
 			updated={ cssState.updated }
 			progress={ progress }
 			showRegenerateButton={ false }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
@@ -1,32 +1,28 @@
 import { __ } from '@wordpress/i18n';
-import ShowStopperError from '../show-stopper-error/show-stopper-error';
 import Status from '../status/status';
 import {
 	calculateCriticalCssProgress,
 	useCriticalCssState,
 } from '../lib/stores/critical-css-state';
-import { getCriticalCssIssues, isFatalError } from '../lib/critical-css-errors';
+import { getCriticalCssIssues } from '../lib/critical-css-errors';
 import { useRetryRegenerate } from '../lib/use-retry-regenerate';
 
 export default function CloudCssMetaProps() {
-	const [ hasRetried, retry ] = useRetryRegenerate();
 	const [ cssState ] = useCriticalCssState();
+	const [ hasRetried, retry ] = useRetryRegenerate();
+
 	const progress = calculateCriticalCssProgress( cssState.providers );
 
 	const successCount = cssState.providers.filter(
 		provider => provider.status === 'success'
 	).length;
 
-	return isFatalError( cssState ) ? (
-		<ShowStopperError
-			supportLink="https://jetpackme.wordpress.com/contact-support/"
-			cssState={ cssState }
-			retry={ retry }
-			showRetry={ ! hasRetried }
-		/>
-	) : (
+	return (
 		<Status
-			isCloudCssAvailable={ true }
+			cssState={ cssState }
+			isCloud={ true }
+			hasRetried={ hasRetried }
+			retry={ retry }
 			status={ cssState.status }
 			issues={ getCriticalCssIssues( cssState ) }
 			successCount={ successCount }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
@@ -1,17 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import Status from '../status/status';
-import {
-	calculateCriticalCssProgress,
-	useCriticalCssState,
-} from '../lib/stores/critical-css-state';
-import { getCriticalCssIssues } from '../lib/critical-css-errors';
+import { useCriticalCssState } from '../lib/stores/critical-css-state';
 import { useRetryRegenerate } from '../lib/use-retry-regenerate';
 
 export default function CloudCssMetaProps() {
 	const [ cssState ] = useCriticalCssState();
 	const [ hasRetried, retry ] = useRetryRegenerate();
-
-	const progress = calculateCriticalCssProgress( cssState.providers );
 
 	return (
 		<Status
@@ -19,10 +13,6 @@ export default function CloudCssMetaProps() {
 			isCloud={ true }
 			hasRetried={ hasRetried }
 			retry={ retry }
-			status={ cssState.status }
-			issues={ getCriticalCssIssues( cssState ) }
-			updated={ cssState.updated }
-			progress={ progress }
 			showRegenerateButton={ false }
 			generateText={ __(
 				'Jetpack Boost will generate Critical CSS for you automatically.',

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
@@ -7,17 +7,29 @@ export default function CloudCssMetaProps() {
 	const [ cssState ] = useCriticalCssState();
 	const [ hasRetried, retry ] = useRetryRegenerate();
 
+	const isPending = cssState.status === 'pending';
+	const hasCompletedSome = cssState.providers.some( provider => provider.status !== 'pending' );
+
+	// If CSS generation has made some progress but is not finished indicate that.
+	const extraText =
+		hasCompletedSome &&
+		isPending &&
+		__( 'Jetpack Boost is generating more Critical CSS.', 'jetpack-boost' );
+
+	// If waiting for the back-end generator to begin, provide a blank message.
+	const overrideText =
+		isPending &&
+		! hasCompletedSome &&
+		__( 'Jetpack Boost will generate Critical CSS for you automatically.', 'jetpack-boost' );
+
 	return (
 		<Status
 			cssState={ cssState }
 			isCloud={ true }
 			hasRetried={ hasRetried }
 			retry={ retry }
-			generateText={ __(
-				'Jetpack Boost will generate Critical CSS for you automatically.',
-				'jetpack-boost'
-			) }
-			generateMoreText={ __( 'Jetpack Boost is generating more Critical CSS.', 'jetpack-boost' ) }
+			extraText={ extraText || undefined }
+			overrideText={ overrideText || undefined }
 		/>
 	);
 }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
@@ -13,7 +13,6 @@ export default function CloudCssMetaProps() {
 			isCloud={ true }
 			hasRetried={ hasRetried }
 			retry={ retry }
-			showRegenerateButton={ false }
 			generateText={ __(
 				'Jetpack Boost will generate Critical CSS for you automatically.',
 				'jetpack-boost'

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
@@ -1,32 +1,21 @@
 import { __ } from '@wordpress/i18n';
 import ShowStopperError from '../show-stopper-error/show-stopper-error';
 import Status from '../status/status';
-import { useState } from '@wordpress/element';
 import {
 	calculateCriticalCssProgress,
 	useCriticalCssState,
-	useRegenerateCriticalCssAction,
 } from '../lib/stores/critical-css-state';
 import { getCriticalCssIssues, isFatalError } from '../lib/critical-css-errors';
+import { useRetryRegenerate } from '../lib/use-retry-regenerate';
 
-type CloudCssMetaProps = {
-	isCloudCssAvailable: boolean;
-};
-
-const CloudCssMeta: React.FC< CloudCssMetaProps > = ( { isCloudCssAvailable } ) => {
-	const [ hasRetried, setHasRetried ] = useState( false );
+export default function CloudCssMetaProps() {
+	const [ hasRetried, retry ] = useRetryRegenerate();
 	const [ cssState ] = useCriticalCssState();
-	const regenerateAction = useRegenerateCriticalCssAction();
 	const progress = calculateCriticalCssProgress( cssState.providers );
 
 	const successCount = cssState.providers.filter(
 		provider => provider.status === 'success'
 	).length;
-
-	function retry() {
-		setHasRetried( true );
-		regenerateAction.mutate();
-	}
 
 	return isFatalError( cssState ) ? (
 		<ShowStopperError
@@ -37,7 +26,7 @@ const CloudCssMeta: React.FC< CloudCssMetaProps > = ( { isCloudCssAvailable } ) 
 		/>
 	) : (
 		<Status
-			isCloudCssAvailable={ isCloudCssAvailable }
+			isCloudCssAvailable={ true }
 			status={ cssState.status }
 			issues={ getCriticalCssIssues( cssState ) }
 			successCount={ successCount }
@@ -51,6 +40,4 @@ const CloudCssMeta: React.FC< CloudCssMetaProps > = ( { isCloudCssAvailable } ) 
 			generateMoreText={ __( 'Jetpack Boost is generating more Critical CSS.', 'jetpack-boost' ) }
 		/>
 	);
-};
-
-export default CloudCssMeta;
+}

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
@@ -3,7 +3,6 @@ import Status from '../status/status';
 import ProgressBar from '$features/ui/progress-bar/progress-bar';
 import styles from './critical-css-meta.module.scss';
 import { useCriticalCssState } from '../lib/stores/critical-css-state';
-import { getCriticalCssIssues } from '../lib/critical-css-errors';
 import { RegenerateCriticalCssSuggestion, useRegenerationReason } from '..';
 import { useLocalCriticalCssGenerator } from '../local-generator/local-generator-provider';
 import { useRetryRegenerate } from '../lib/use-retry-regenerate';
@@ -17,10 +16,6 @@ export default function CriticalCssMeta() {
 	const [ hasRetried, retry ] = useRetryRegenerate();
 	const [ regenerateReason ] = useRegenerationReason();
 	const { progress } = useLocalCriticalCssGenerator();
-
-	const successCount = cssState.providers
-		? cssState.providers.filter( provider => provider.status === 'success' ).length
-		: 0;
 
 	if ( cssState.status === 'pending' ) {
 		return (
@@ -43,11 +38,6 @@ export default function CriticalCssMeta() {
 				isCloud={ false }
 				hasRetried={ hasRetried }
 				retry={ retry }
-				status={ cssState.status }
-				issues={ getCriticalCssIssues( cssState ) }
-				successCount={ successCount }
-				updated={ cssState.updated }
-				progress={ progress }
 				showRegenerateButton={ !! regenerateReason }
 			/>
 

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
@@ -1,10 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import Status from '../status/status';
-import ShowStopperError from '../show-stopper-error/show-stopper-error';
 import ProgressBar from '$features/ui/progress-bar/progress-bar';
 import styles from './critical-css-meta.module.scss';
 import { useCriticalCssState } from '../lib/stores/critical-css-state';
-import { getCriticalCssIssues, isFatalError } from '../lib/critical-css-errors';
+import { getCriticalCssIssues } from '../lib/critical-css-errors';
 import { RegenerateCriticalCssSuggestion, useRegenerationReason } from '..';
 import { useLocalCriticalCssGenerator } from '../local-generator/local-generator-provider';
 import { useRetryRegenerate } from '../lib/use-retry-regenerate';
@@ -14,15 +13,14 @@ import { useRetryRegenerate } from '../lib/use-retry-regenerate';
  * Settings page when the feature is enabled.
  */
 export default function CriticalCssMeta() {
-	const [ hasRetried, retry ] = useRetryRegenerate();
 	const [ cssState ] = useCriticalCssState();
+	const [ hasRetried, retry ] = useRetryRegenerate();
 	const [ regenerateReason ] = useRegenerationReason();
+	const { progress } = useLocalCriticalCssGenerator();
 
 	const successCount = cssState.providers
 		? cssState.providers.filter( provider => provider.status === 'success' ).length
 		: 0;
-
-	const { progress } = useLocalCriticalCssGenerator();
 
 	if ( cssState.status === 'pending' ) {
 		return (
@@ -36,14 +34,15 @@ export default function CriticalCssMeta() {
 				<ProgressBar progress={ progress } />
 			</div>
 		);
-	} else if ( isFatalError( cssState ) ) {
-		return <ShowStopperError cssState={ cssState } retry={ retry } showRetry={ ! hasRetried } />;
 	}
 
 	return (
 		<>
 			<Status
-				isCloudCssAvailable={ false }
+				cssState={ cssState }
+				isCloud={ false }
+				hasRetried={ hasRetried }
+				retry={ retry }
 				status={ cssState.status }
 				issues={ getCriticalCssIssues( cssState ) }
 				successCount={ successCount }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
@@ -39,6 +39,10 @@ export default function CriticalCssMeta() {
 				hasRetried={ hasRetried }
 				retry={ retry }
 				highlightRegenerateButton={ !! regenerateReason }
+				extraText={ __(
+					'Remember to regenerate each time you make changes that affect your HTML or CSS structure.',
+					'jetpack-boost'
+				) }
 			/>
 
 			<RegenerateCriticalCssSuggestion regenerateReason={ regenerateReason } />

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
@@ -38,7 +38,7 @@ export default function CriticalCssMeta() {
 				isCloud={ false }
 				hasRetried={ hasRetried }
 				retry={ retry }
-				showRegenerateButton={ !! regenerateReason }
+				highlightRegenerateButton={ !! regenerateReason }
 			/>
 
 			<RegenerateCriticalCssSuggestion regenerateReason={ regenerateReason } />

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
@@ -3,33 +3,24 @@ import Status from '../status/status';
 import ShowStopperError from '../show-stopper-error/show-stopper-error';
 import ProgressBar from '$features/ui/progress-bar/progress-bar';
 import styles from './critical-css-meta.module.scss';
-import { useState } from '@wordpress/element';
-import {
-	useCriticalCssState,
-	useRegenerateCriticalCssAction,
-} from '../lib/stores/critical-css-state';
+import { useCriticalCssState } from '../lib/stores/critical-css-state';
 import { getCriticalCssIssues, isFatalError } from '../lib/critical-css-errors';
 import { RegenerateCriticalCssSuggestion, useRegenerationReason } from '..';
 import { useLocalCriticalCssGenerator } from '../local-generator/local-generator-provider';
+import { useRetryRegenerate } from '../lib/use-retry-regenerate';
 
-type CriticalCssMetaProps = {
-	isCloudCssAvailable: boolean;
-};
-
-const CriticalCssMeta: React.FC< CriticalCssMetaProps > = ( { isCloudCssAvailable } ) => {
-	const [ hasRetried, setHasRetried ] = useState( false );
+/**
+ * Critical CSS Meta - the information and options displayed under the Critical CSS toggle on the
+ * Settings page when the feature is enabled.
+ */
+export default function CriticalCssMeta() {
+	const [ hasRetried, retry ] = useRetryRegenerate();
 	const [ cssState ] = useCriticalCssState();
-	const regenerateAction = useRegenerateCriticalCssAction();
 	const [ regenerateReason ] = useRegenerationReason();
 
 	const successCount = cssState.providers
 		? cssState.providers.filter( provider => provider.status === 'success' ).length
 		: 0;
-
-	function retry() {
-		setHasRetried( true );
-		regenerateAction.mutate();
-	}
 
 	const { progress } = useLocalCriticalCssGenerator();
 
@@ -52,7 +43,7 @@ const CriticalCssMeta: React.FC< CriticalCssMetaProps > = ( { isCloudCssAvailabl
 	return (
 		<>
 			<Status
-				isCloudCssAvailable={ isCloudCssAvailable }
+				isCloudCssAvailable={ false }
 				status={ cssState.status }
 				issues={ getCriticalCssIssues( cssState ) }
 				successCount={ successCount }
@@ -64,6 +55,4 @@ const CriticalCssMeta: React.FC< CriticalCssMetaProps > = ( { isCloudCssAvailabl
 			<RegenerateCriticalCssSuggestion regenerateReason={ regenerateReason } />
 		</>
 	);
-};
-
-export default CriticalCssMeta;
+}

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/use-retry-regenerate.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/use-retry-regenerate.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { useRegenerateCriticalCssAction } from './stores/critical-css-state';
+
+/**
+ * Helper for "Retry" buttons for Critical CSS which need to track whether they have been clicked
+ * before or not in a parent. e.g.: "Retry" buttons in Critical CSS Meta and Cloud CSS Meta.
+ *
+ * Returns a boolean indicating whether retrying has been attempted, and a function to call to retry.
+ */
+export function useRetryRegenerate(): [ boolean, () => void ] {
+	const [ retried, setRetried ] = useState( false );
+	const regenerateAction = useRegenerateCriticalCssAction();
+
+	function retry() {
+		setRetried( true );
+		regenerateAction.mutate();
+	}
+
+	return [ retried, retry ];
+}

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
@@ -19,7 +19,8 @@ type StatusTypes = {
 	hasRetried: boolean;
 	retry: () => void;
 
-	showRegenerateButton: boolean;
+	highlightRegenerateButton?: boolean;
+
 	generateText?: string;
 	generateMoreText?: string;
 };
@@ -30,7 +31,7 @@ const Status: React.FC< StatusTypes > = ( {
 	hasRetried,
 	retry,
 
-	showRegenerateButton = false,
+	highlightRegenerateButton = false,
 	generateText = '',
 	generateMoreText = '',
 } ) => {
@@ -120,12 +121,12 @@ const Status: React.FC< StatusTypes > = ( {
 				<Button
 					type="button"
 					className={ classNames( 'components-button', {
-						'is-link': ! showRegenerateButton || isCloud,
+						'is-link': ! highlightRegenerateButton || isCloud,
 					} ) }
-					isPrimary={ !! showRegenerateButton }
+					isPrimary={ highlightRegenerateButton }
 					onClick={ () => regenerateAction.mutate() }
 				>
-					{ ! showRegenerateButton && <RefreshIcon /> }
+					{ ! highlightRegenerateButton && <RefreshIcon /> }
 					{ __( 'Regenerate', 'jetpack-boost' ) }
 				</Button>
 			) }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom';
 import { useRegenerateCriticalCssAction } from '../lib/stores/critical-css-state';
 import { getCriticalCssIssues, isFatalError } from '../lib/critical-css-errors';
 import ShowStopperError from '../show-stopper-error/show-stopper-error';
+import { Button } from '@automattic/jetpack-components';
 
 type StatusTypes = {
 	cssState: CriticalCssState;
@@ -116,16 +117,17 @@ const Status: React.FC< StatusTypes > = ( {
 				) }
 			</div>
 			{ cssState.status !== 'pending' && (
-				<button
+				<Button
 					type="button"
 					className={ classNames( 'components-button', {
 						'is-link': ! showRegenerateButton || isCloud,
 					} ) }
+					isPrimary={ !! showRegenerateButton }
 					onClick={ () => regenerateAction.mutate() }
 				>
-					<RefreshIcon />
+					{ ! showRegenerateButton && <RefreshIcon /> }
 					{ __( 'Regenerate', 'jetpack-boost' ) }
-				</button>
+				</Button>
 			) }
 		</div>
 	);

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
@@ -23,7 +23,6 @@ type StatusTypes = {
 	progress: number;
 	showRegenerateButton: boolean;
 	issues: Provider[];
-	successCount?: number;
 	generateText?: string;
 	generateMoreText?: string;
 };
@@ -37,11 +36,13 @@ const Status: React.FC< StatusTypes > = ( {
 	showRegenerateButton = false,
 	isCloud = false,
 	issues,
-	successCount = 0,
 	generateText = '',
 	generateMoreText = '',
 } ) => {
 	const regenerateAction = useRegenerateCriticalCssAction();
+	const successCount = cssState.providers
+		? cssState.providers.filter( provider => provider.status === 'success' ).length
+		: 0;
 
 	// If there has been a fatal error, show it.
 	if ( isFatalError( cssState ) ) {

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
@@ -74,7 +74,7 @@ const Status: React.FC< StatusTypes > = ( {
 						</>
 					) }
 
-					{ '.' }
+					{ '. ' }
 
 					{ extraText }
 				</div>

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -23,7 +23,6 @@ const Index = () => {
 	};
 
 	const [ lazyLoadState ] = useSingleModuleState( 'lazy_images' );
-	const [ cloudCssState ] = useSingleModuleState( 'cloud_css' );
 	const [ isaState ] = useSingleModuleState( 'image_size_analysis' );
 	const [ imageCdn ] = useSingleModuleState( 'image_cdn' );
 
@@ -78,7 +77,7 @@ const Index = () => {
 					</>
 				}
 			>
-				<CriticalCssMeta isCloudCssAvailable={ cloudCssState?.available === true } />
+				<CriticalCssMeta />
 
 				<UpgradeCTA
 					description={ __(
@@ -124,7 +123,7 @@ const Index = () => {
 					</>
 				}
 			>
-				<CloudCssMeta isCloudCssAvailable={ cloudCssState?.available === true } />
+				<CloudCssMeta />
 			</Module>
 			<Module
 				slug="render_blocking_js"

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -13,6 +13,7 @@ import styles from './index.module.scss';
 import { RecommendationsMeta } from '$features/image-size-analysis';
 import SuperCacheInfo from '$features/super-cache-info/super-cache-info';
 import { useRegenerateCriticalCssAction } from '$features/critical-css/lib/stores/critical-css-state';
+import PremiumTooltip from '$features/premium-tooltip/premium-tooltip';
 
 const Index = () => {
 	const criticalCssLink = getRedirectUrl( 'jetpack-boost-critical-css' );
@@ -73,6 +74,8 @@ const Index = () => {
 									b: <b />,
 								}
 							) }
+
+							<PremiumTooltip />
 						</p>
 					</>
 				}

--- a/projects/plugins/boost/changelog/boost-cleanup-critical-css-meta
+++ b/projects/plugins/boost/changelog/boost-cleanup-critical-css-meta
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Moved CSS Meta and Status components around for less code reuse
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The Critical CSS Meta and Status components were a mess; different components were responsible for different things. The arguments passed between them were confusing, bespoke and changed shape.

Also fixes https://github.com/Automattic/jetpack/issues/34987

This PR cleans the three of them up so that:
- `Status` shows the Critical CSS status in general; showstopper errors, current generation / final generation status.
- `CloudCssMeta` handles the Cloud-specific stuff and hands it off to `Status`.
- `CriticalCssMeta` handles the extra progress stuff specific to local generation.

It makes the responsibilities of each component clearer, and reduces the amount of redundent code.

## Proposed changes:
* Clean up CSS Meta/Status components.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Make sure Cloud and Local CSS uis work fine.