### PR TITLE
[Boost] Prevent Critical CSS status flashes

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/data-sync-actions/Regenerate_CSS.php
+++ b/projects/plugins/boost/app/lib/critical-css/data-sync-actions/Regenerate_CSS.php
@@ -24,7 +24,7 @@ class Regenerate_CSS implements Data_Sync_Action {
 
 		return array(
 			'success' => ! $state->has_errors(),
-			'state'   => $state,
+			'state'   => $state->get(),
 			'errors'  => $state->get_error_message(),
 		);
 	}

--- a/projects/plugins/boost/changelog/boost-fix-regen-repeat
+++ b/projects/plugins/boost/changelog/boost-fix-regen-repeat
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix the CCSS regen button kicking off the process twice
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35014

When you click to regenerate Critical CSS, there is a moment where it flashed into a weird state before beginning. It turned out that invalid data was being returned by the Regenerate_CSS handler, causing the flashing UI.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Return the correct data from the regenerate_css handler, preventing ui flashing when starting the process

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Click to regenerate local critical css, see taht you don't get a weird status flash.
* Note that this does NOT address the old status being shown before a new regeneration run begins when turning on CCSS.