### PR TITLE
Paid/Premium blocks: Fix cover block alignments on free sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-paid-blocks-upgrade-nudge-break-cover-block-free
+++ b/projects/plugins/jetpack/changelog/fix-paid-blocks-upgrade-nudge-break-cover-block-free
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Payment blocks: Fix cover block alignments on free sites  

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -79,13 +79,15 @@ const withUpgradeBanner = createHigherOrderComponent(
 		}, [ setAttributes, hasParentBanner ] );
 
 		const blockProps = useBlockProps();
+		// Fix for alignfull cover block because otherwise the div defaults to content-size as max width
+		const cssFixForCoverBlock = { 'max-width': 'none' };
 
 		return (
 			<PaidBlockProvider
 				onBannerVisibilityChange={ setIsVisible }
 				hasParentBanner={ isBannerVisible }
 			>
-				<div ref={ blockProps.ref }>
+				<div ref={ blockProps.ref } style={ cssFixForCoverBlock }>
 					<UpgradePlanBanner
 						className={ `is-${ name.replace( /\//, '-' ) }-paid-block` }
 						title={ null }

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -79,8 +79,8 @@ const withUpgradeBanner = createHigherOrderComponent(
 		}, [ setAttributes, hasParentBanner ] );
 
 		const blockProps = useBlockProps();
-		// Fix for alignfull cover block because otherwise the div defaults to content-size as max width
-		const cssFixForCoverBlock = { 'max-width': 'none' };
+		// Fix for width of cover block because otherwise the div defaults to content-size as max width
+		const cssFixForCoverBlock = { 'max-width': 'unset' };
 
 		return (
 			<PaidBlockProvider


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/71882 https://github.com/Automattic/wp-calypso/issues/79025
Related https://github.com/Automattic/jetpack/pull/27909

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable `max-width` on the `div` wrapper introduced on free sites to show the upgrade nudge. 

The `div` was added in https://github.com/Automattic/jetpack/pull/27909. This fix doesn't allow the editor to apply the content size `max-width` on it because it's not content

See the CSS that is overwritten:

<img width="421" alt="Screenshot 2567-01-15 at 15 45 44" src="https://github.com/Automattic/jetpack/assets/1881481/1f0c9c0a-8f55-4bfc-92fb-c88ae471914f">



>[!NOTE]
> Other options to solve this issue can be:
> - Any option better than `unset` for `max-width`?
> - Add a classname and put the CSS fix in the editor [stylesheet](https://github.com/Automattic/jetpack/blob/719694efecac86717808467b597d79172c5df8dd/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss#L107) for Paid blocks. 
> - Can we show the upgrade nudge without adding that `div` element?


|BEFORE|AFTER|
|-|-|
|<img width="1728" alt="Screenshot 2567-01-15 at 15 34 15" src="https://github.com/Automattic/jetpack/assets/1881481/e63b8765-64fd-4bca-b938-c3776d89f4e4">|<img width="1728" alt="Screenshot 2567-01-15 at 15 35 14" src="https://github.com/Automattic/jetpack/assets/1881481/8d2f8ec7-4a98-47c0-a926-27b7d534da31">|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a free site
* Apply these changes on your sandbox
* Go to `/themes`, search for "Blockstar", open the theme detail, and click "Preview & Customize"
* Verify the width of the cover image on the header is the canvas full-width



