### PR TITLE
Jetpack Google Fonts: Filters out deprecated font provider when reading the theme's theme.json.

### DIFF
--- a/projects/plugins/jetpack/changelog/google-fonts-filter-out-dirty-data-from-theme-json
+++ b/projects/plugins/jetpack/changelog/google-fonts-filter-out-dirty-data-from-theme-json
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Filters out deprecated jetpack-google-fonts provider when reading the theme's theme.json.

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -186,12 +186,13 @@ function jetpack_google_fonts_filter_out_deprecated_font_data( $font_families ) 
 }
 
 /**
- * Unregister the google fonts data from user's theme json data that were stored by accident.
+ * Unregister the deprecated jetpack-google-fonts provider from theme json data that were stored
+ * before we moved to the Font Library.
  *
- * @param WP_Theme_JSON_Data $theme_json The theme json data of user.
+ * @param WP_Theme_JSON_Data $theme_json The theme json data.
  * @return WP_Theme_JSON_Data The filtered theme json data.
  */
-function jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user( $theme_json ) {
+function jetpack_unregister_deprecated_google_fonts_from_theme_json_data( $theme_json ) {
 	$raw_data = $theme_json->get_data();
 	$origin   = 'theme';
 	if ( empty( $raw_data['settings']['typography']['fontFamilies'][ $origin ] ) ) {
@@ -207,7 +208,8 @@ function jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user( $
 	return new $theme_json_class( $raw_data, 'custom' );
 }
 
-add_filter( 'wp_theme_json_data_user', 'jetpack_unregister_deprecated_google_fonts_from_theme_json_data_user' );
+add_filter( 'wp_theme_json_data_theme', 'jetpack_unregister_deprecated_google_fonts_from_theme_json_data' );
+add_filter( 'wp_theme_json_data_user', 'jetpack_unregister_deprecated_google_fonts_from_theme_json_data' );
 
 // Initialize Jetpack Google Font Face to avoid printing **ALL** google fonts provided by this module.
 // See p1700040028362329-slack-C4GAQ900P and p7DVsv-jib-p2


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/85036

## Proposed changes:

This is a continuation to https://github.com/Automattic/jetpack/pull/34306. Here, the deprecated font provider might have been still present in the site's global styles. When a user exported the theme from such sites, the resulting `theme.json` in the zip file will contain the deprecated font provider. This PR filters out such provider when reading the theme's `theme.json` as well.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare a WoA site.
2. Install this theme: [test-theme.zip](https://github.com/Automattic/jetpack/files/13945523/test-theme.zip), which contains the deprecated font provider.
3. Go to the frontend; verify that the text body shows a broken serif font (instead of Jost).
4. Apply this PR to the site via instructions below provided by the bot.
5. Go to the frontend again; verify that the text body now correctly uses Jost.
