### PR TITLE
Super Cache: If rebuild is enabled it should be applied to sub-directory files too

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-rebuild_cache_subdirectory
+++ b/projects/plugins/super-cache/changelog/fix-rebuild_cache_subdirectory
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Super Cache: with rebuild enabled, apply that to subdirectories instead of deleting them.

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -1313,7 +1313,7 @@ function wpsc_delete_url_cache( $url ) {
 	$dir = str_replace( get_option( 'home' ), '', $url );
 	if ( $dir != '' ) {
 		$supercachedir = get_supercache_dir();
-		wpsc_delete_files( $supercachedir . $dir );
+		wpsc_rebuild_files( $supercachedir . $dir );
 		prune_super_cache( $supercachedir . $dir . '/page', true );
 		return true;
 	} else {


### PR DESCRIPTION
WP Super Cache can make backups of cache files and rename them back to their proper names , while recreating the original cache file. This feature always worked on blog posts, but did not apply to archive files. This PR fixes that by doing a "rebuild" rather than deleting the archive files immediately.

Fixes #33590 


## Proposed changes:
* Instead of calling wpsc_delete_files(), it calls wpsc_rebuild_files().

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Install the plugin on a test site and enable the "Cache Rebuild" feature.
* Load the "Hello world" post in an anonymous browser. Also visit the Uncategorized category to create another cache file.
* In your shell, navigate to wp-content/cache/supercache/ and into the directory for your hostname. `ls -lR` will show the cached files called index-https.html or similar in the hello-world and uncategorized directories.
* Edit that post and save it. Check those directories and you'll see there's nothing in the uncategorized directory.
* Apply this patch and repeat the above.
* Check the uncategorized directory and you'll see a file that looks like index-https.html.needs-rebuild but it has a ".needs-rebuild" extension.

