### PR TITLE
Content Options: Respect Block Settings for Featured Images [Attempt 2]

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-content-options-take-2
+++ b/projects/plugins/jetpack/changelog/fix-content-options-take-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Theme Tools: Ensure that Content Options does not override the Featured Images options set within blocks. [Attempt two] 

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images.php
@@ -69,13 +69,9 @@ function jetpack_featured_images_remove_post_thumbnail( $metadata, $object_id, $
 			&& in_the_loop()
 		)
 	) {
-
 		// Do not override thumbnail settings within blocks (eg. Latest Posts block).
-		$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
-		foreach ( $trace as $frame ) {
-			if ( ! empty( $frame['class'] ) && class_exists( $frame['class'], false ) && is_a( $frame['class'], WP_Block::class, true ) ) {
-					return $metadata;
-			}
+		if ( doing_filter( 'the_content' ) ) {
+			return $metadata;
 		}
 
 		return false;


### PR DESCRIPTION
Follow up to #34805 - fixes 15 issues listed there

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensures that the Content Options' Featured Images selection doesn't override the user's selection for blocks such as Latest Posts, Homepage Articles, Post Carousel and Query Loop.

The last fix in #34805 works fine for Atomic and Jetpack sites, but it doesn't seem to have fixed the issue on Simple sites. I can't debug Simple sites, but I wonder if this is an issue with `debug_backtrace` and the way that blocks are rendered on Simple sites. 

This is a different approach; the Featured Images that we actually want to hide are inserted by the theme in the header area. I tested several themes in the Automattic/themes directory with Content Options, and couldn't find an example of where you'd actively want a Featured Image within the content to be hidden. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See https://github.com/Automattic/jetpack/issues/29286#issuecomment-1876043341.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to the WordPress.com theme directory and install any theme which uses Content Options (any child theme of Varia, such as Stow, will work - but you can also use others like Canard) - https://wordpress.com/theme/stow
- Under the "Content Options" settings in the Customizer, hide Featured Images for posts or pages
- Create a post or a page with a Latest Posts block, the a8c Blog Posts block or the Query Loop block, and ensure that thumbnails are set to be displayed
- Set a Featured Image for that post or page
- Confirm that the Featured Image is hidden, but that the thumbnails within the blocks aren't

Please test this on a Simple site if possible, since I haven't been able to do so! #34805 worked for Atomic/Jetpack, but not WP.com Simple 