### PR TITLE
Boost: Add back transition for Super Cache notice

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2701,6 +2701,12 @@ importers:
       '@automattic/jetpack-react-data-sync-client':
         specifier: workspace:*
         version: link:../../js-packages/react-data-sync-client
+      '@react-spring/core':
+        specifier: 9.7.3
+        version: 9.7.3(react@18.2.0)
+      '@react-spring/web':
+        specifier: 9.7.3
+        version: 9.7.3(react-dom@18.2.0)(react@18.2.0)
       '@svgr/rollup':
         specifier: 8.1.0
         version: 8.1.0(rollup@2.79.1)(typescript@5.0.4)
@@ -2731,6 +2737,9 @@ importers:
       react-router-dom:
         specifier: 6.21.0
         version: 6.21.0(react-dom@18.2.0)(react@18.2.0)
+      react-use-measure:
+        specifier: 2.1.1
+        version: 2.1.1(react-dom@18.2.0)(react@18.2.0)
       svelte-navigator:
         specifier: 3.2.2
         version: 3.2.2(svelte@3.58.0)(typescript@5.0.4)
@@ -15554,6 +15563,10 @@ packages:
   /date-fns@3.1.0:
     resolution: {integrity: sha512-ZO7yefXV/wCWzd3I9haCHmfzlfA3i1a2HHO7ZXjtJrRjXt8FULKJ2Vl8wji3XYF4dQ0ZJ/tokXDZeYlFvgms9Q==}
 
+  /debounce@1.2.1:
+    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
+    dev: false
+
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -21987,6 +22000,17 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+
+  /react-use-measure@2.1.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    dependencies:
+      debounce: 1.2.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /react@17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}

--- a/projects/plugins/boost/app/assets/src/js/features/super-cache-info/super-cache-info.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/super-cache-info/super-cache-info.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import useMeasure from 'react-use-measure';
+import { animated, useSpring } from '@react-spring/web';
 import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
 import { __, sprintf } from '@wordpress/i18n';
 import { Notice, Button } from '@automattic/jetpack-components';
@@ -22,6 +24,12 @@ const SuperCacheInfo = () => {
 		'super_cache_notice_disabled',
 		z.boolean()
 	);
+
+	const [ ref, { height } ] = useMeasure();
+	const animationStyles = useSpring( {
+		height: isNoticeDismissed ? 0 : height,
+		immediate: ! isNoticeDismissed,
+	} );
 
 	const runTest = async () => {
 		setState( { status: 'testing' } );
@@ -54,24 +62,33 @@ const SuperCacheInfo = () => {
 	}
 
 	if ( ! isSuperCacheEnabled() ) {
-		if ( isNoticeDismissed ) {
-			return null;
-		}
-
 		return (
-			<Notice
-				level="warning"
-				title={ __( 'Super Cache is installed but not enabled', 'jetpack-boost' ) }
-				actions={ [
-					renderActionButton( 'start', __( 'Set up', 'jetpack-boost' ), navToSuperCacheSettings ),
-				] }
-				hideCloseButton={ false }
-				onClose={ () => {
-					setNoticeDismissed( true );
+			<animated.div
+				style={ {
+					overflow: 'hidden',
+					...animationStyles,
 				} }
 			>
-				{ __( 'Enable Super Cache to speed your site up further.', 'jetpack-boost' ) }
-			</Notice>
+				<div ref={ ref }>
+					<Notice
+						level="warning"
+						title={ __( 'Super Cache is installed but not enabled', 'jetpack-boost' ) }
+						actions={ [
+							renderActionButton(
+								'start',
+								__( 'Set up', 'jetpack-boost' ),
+								navToSuperCacheSettings
+							),
+						] }
+						hideCloseButton={ false }
+						onClose={ () => {
+							setNoticeDismissed( true );
+						} }
+					>
+						{ __( 'Enable Super Cache to speed your site up further.', 'jetpack-boost' ) }
+					</Notice>
+				</div>
+			</animated.div>
 		);
 	}
 

--- a/projects/plugins/boost/changelog/add-transition-super-cache-notice
+++ b/projects/plugins/boost/changelog/add-transition-super-cache-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added transition back to Super Cache notice.
+
+

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -10,6 +10,8 @@
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-react-data-sync-client": "workspace:*",
+		"@react-spring/core": "9.7.3",
+		"@react-spring/web": "9.7.3",
 		"@svgr/rollup": "8.1.0",
 		"@types/react": "18.2.33",
 		"@types/react-router-dom": "5.3.3",
@@ -20,6 +22,7 @@
 		"jetpack-boost-critical-css-gen": "github:automattic/jetpack-boost-critical-css-gen#release-0.0.11",
 		"prettier": "npm:wp-prettier@3.0.3",
 		"react-router-dom": "6.21.0",
+		"react-use-measure": "2.1.1",
 		"svelte-navigator": "3.2.2",
 		"zod": "3.22.3"
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the transition for the Super Cache notice just below the Image Guide/ISA section.

Refer to https://github.com/Automattic/jetpack/issues/35015.

Preview:
![CleanShot 2024-01-15 at 16 48 24](https://github.com/Automattic/jetpack/assets/11799079/00ea2418-e6c4-4aff-807a-b5cdcc356faf)

**I wasn't able to figure out a way to remove the element from the dom after the transition ends. If anyone has an idea, feel free to share it!**

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added transition back to the notice.
* Used React spring to test how it works.
* Added react-use-measure package to get access to element dimensions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/issues/35015

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup this version of Boost;
* Setup Super Cache;
* Make sure notice is showing up below the Image Guide section;
* Make sure there's a transition when closing the notice. Please note, that closing it once, will store a value in the database, so you'll have to delete it in order to test again.