### PR TITLE
Boost: Fix react warnings for critical css tooltip

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.module.scss
@@ -12,3 +12,11 @@
 	transform: translateY( -4.5px );
 	display: inline-block;
 }
+
+.tooltip-wrapper {
+	margin: 1em 0;
+}
+
+.tooltip-wrapper p {
+	display: inline;
+}

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -64,19 +64,20 @@ const Index = () => {
 								}
 							) }
 						</p>
-						<p>
-							{ createInterpolateElement(
-								__(
-									`<b>You should regenerate your Critical CSS</b> whenever you make changes to the HTML or CSS structure of your site.`,
-									'jetpack-boost'
-								),
-								{
-									b: <b />,
-								}
-							) }
-
+						<div className={ styles[ 'tooltip-wrapper' ] }>
+							<p>
+								{ createInterpolateElement(
+									__(
+										`<b>You should regenerate your Critical CSS</b> whenever you make changes to the HTML or CSS structure of your site.`,
+										'jetpack-boost'
+									),
+									{
+										b: <b />,
+									}
+								) }
+							</p>
 							<PremiumTooltip />
-						</p>
+						</div>
 					</>
 				}
 			>

--- a/projects/plugins/boost/changelog/fix-react-tooltip-warnings
+++ b/projects/plugins/boost/changelog/fix-react-tooltip-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed react warnings caused by element nesting.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35026

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes react warnings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup this version of Boost, free;
* Make sure the tooltip after "You should regenerate your Critical CSS whenever you make changes to the HTML or CSS structure of your site." is working correctly and there are no JS warnings/errors.