### PR TITLE
Jetpack_Upcoming_Events_Widget: Return early if no feed url set

### DIFF
--- a/projects/plugins/jetpack/changelog/upcoming-events-widget-return-early
+++ b/projects/plugins/jetpack/changelog/upcoming-events-widget-return-early
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack_Upcoming_Events_Widget: Return early if no feed url set

--- a/projects/plugins/jetpack/modules/widgets/upcoming-events.php
+++ b/projects/plugins/jetpack/modules/widgets/upcoming-events.php
@@ -120,6 +120,10 @@ class Jetpack_Upcoming_Events_Widget extends WP_Widget {
 	public function widget( $args, $instance ) {
 		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/icalendar-reader.php';
 
+		if ( empty( $instance['feed-url'] ) ) {
+			return;
+		}
+
 		$ical           = new iCalendarReader();
 		$events         = $ical->get_events( $instance['feed-url'], $instance['count'] );
 		$events         = $this->apply_timezone_offset( $events );

--- a/projects/plugins/jetpack/modules/widgets/upcoming-events.php
+++ b/projects/plugins/jetpack/modules/widgets/upcoming-events.php
@@ -120,13 +120,12 @@ class Jetpack_Upcoming_Events_Widget extends WP_Widget {
 	public function widget( $args, $instance ) {
 		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/icalendar-reader.php';
 
-		if ( empty( $instance['feed-url'] ) ) {
-			return;
+		$ical   = new iCalendarReader();
+		$events = array();
+		if ( ! empty( $instance['feed-url'] ) ) {
+			$events = $ical->get_events( $instance['feed-url'], $instance['count'] );
+			$events = $this->apply_timezone_offset( $events );
 		}
-
-		$ical           = new iCalendarReader();
-		$events         = $ical->get_events( $instance['feed-url'], $instance['count'] );
-		$events         = $this->apply_timezone_offset( $events );
 		$ical->timezone = null;
 
 		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -136,11 +135,17 @@ class Jetpack_Upcoming_Events_Widget extends WP_Widget {
 			echo $args['after_title']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
-		if ( ! $events ) : // nothing to display?
-			?>
-			<p><?php esc_html_e( 'No upcoming events', 'jetpack' ); ?></p>
-			<?php
-		else :
+		if ( empty( $instance['feed-url'] ) ) {
+			if ( current_user_can( 'manage_options' ) ) {
+				echo '<div class="error-message">';
+				esc_html_e( 'The events feed URL is not properly set up in this widget.', 'jetpack' );
+				echo '</div>';
+			}
+		} elseif ( ! $events ) {
+			echo '<p>';
+			esc_html_e( 'No upcoming events', 'jetpack' );
+			echo '</p>';
+		} else {
 			?>
 			<ul class="upcoming-events">
 				<?php foreach ( $events as $event ) : ?>
@@ -169,7 +174,7 @@ class Jetpack_Upcoming_Events_Widget extends WP_Widget {
 				<?php endforeach; ?>
 			</ul>
 			<?php
-		endif;
+		}
 
 		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 


### PR DESCRIPTION
## Proposed changes:

* When rendering the `Jetpack_Upcoming_Events_Widget`, return early if no feed url is set.

This fixes some warnings on PHP 8.1 sites that have the widget installed with no parameters set on it.

```
Warning: Undefined array key "feed-url" in (...)/widgets/upcoming-events.php on line 126 
Warning: Undefined array key "count" in (...)/widgets/upcoming-events.php on line 126
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Check D134697-code 

