### PR TITLE
Backport mu-wpcom-plugin 2.0.13, jetpack 13.1-a.1 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2024-01-15
+### Added
+- AI Client: introduce bannerComponent prop, React.Element, to render on top of the AI Control [#34918]
+
+### Fixed
+- Jetpack AI: Check for post id type and only include numbers [#34974]
+
 ## [0.3.1] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]
@@ -180,6 +187,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.4.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.2.0...v0.2.1

--- a/projects/js-packages/ai-client/changelog/fix-ai-assistant-upgrade-nudge-positioning
+++ b/projects/js-packages/ai-client/changelog/fix-ai-assistant-upgrade-nudge-positioning
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-AI Client: introduce bannerComponent prop, React.Element, to render on top of the AI Control

--- a/projects/js-packages/ai-client/changelog/fix-jetpack-ai-post-id
+++ b/projects/js-packages/ai-client/changelog/fix-jetpack-ai-post-id
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack AI: Check for post id type and only include numbers

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.4.0-alpha",
+	"version": "0.4.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2024-01-15
+### Changed
+- Changes the Blaze Dashboard paths to use the new format [#34896]
+
 ## [0.14.3] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]
@@ -261,6 +265,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.15.0]: https://github.com/automattic/jetpack-blaze/compare/v0.14.3...v0.15.0
 [0.14.3]: https://github.com/automattic/jetpack-blaze/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/automattic/jetpack-blaze/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/automattic/jetpack-blaze/compare/v0.14.0...v0.14.1

--- a/projects/packages/blaze/changelog/update-blaze-dashboard-urls
+++ b/projects/packages/blaze/changelog/update-blaze-dashboard-urls
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Changes the Blaze Dashboard paths to use the new format

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.15.0-alpha",
+	"version": "0.15.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.15.0-alpha';
+	const PACKAGE_VERSION = '0.15.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/boost-speed-score/CHANGELOG.md
+++ b/projects/packages/boost-speed-score/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2024-01-15
+### Changed
+- Internal updates.
+
 ## [0.3.1] - 2023-12-14
 ### Changed
 - Internal updates.
@@ -35,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new package for Boost Speed Score [#30914]
 - Add a new argument to `Speed_Score` to identify where the request was made from (e.g. 'boost-plugin', 'jetpack-dashboard', etc). [#31012]
 
+[0.3.2]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.2.1...v0.2.2

--- a/projects/packages/boost-speed-score/changelog/change-visibility
+++ b/projects/packages/boost-speed-score/changelog/change-visibility
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Made a private method public
-
-

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -23,7 +23,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.3.2-alpha';
+	const PACKAGE_VERSION = '0.3.2';
 
 	/**
 	 * An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup passed to the constructor

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.8.2] - 2024-01-15
+### Added
+- Add the completion logic for the `front_page_updated` task [#34837]
+- Add the Verify Domain Email task [#34893]
+
+### Removed
+- Removes the `Set up your Professional Email` task [#34865]
+
 ## [5.8.1] - 2024-01-08
 ### Added
 - Adds the is_dismissible prop to the Launchpad task list definition. [#34839]
@@ -515,6 +523,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.8.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.1...v5.8.2
 [5.8.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.0...v5.8.1
 [5.8.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.7.0...v5.8.0
 [5.7.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.6.0...v5.7.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-update-front-page-task-completion-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-update-front-page-task-completion-logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add the completion logic for the `front_page_updated` task

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-verify_domain_email-task-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-verify_domain_email-task-logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add the Verify Domain Email task

--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-professional-email-setup-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-professional-email-setup-task
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Removes the `Set up your Professional Email` task

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.8.2-alpha",
+	"version": "5.8.2",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '5.8.2-alpha';
+	const PACKAGE_VERSION = '5.8.2';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.0] - 2024-01-15
+### Changed
+- add plan check to My Jetpack Akismet product card [#34905]
+- Prevent new users from seeing JITMs [#34927]
+- To avoid displaying the Welcome banner to every user, now we only display it to new users. [#34883]
+
 ## [4.3.0] - 2024-01-08
 ### Added
 - Add a check to determine if a user is "new" to Jetpack. [#34821]
@@ -1183,6 +1189,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.4.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.3.0...4.4.0
 [4.3.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.2.1...4.3.0
 [4.2.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.2.0...4.2.1
 [4.2.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.1.4...4.2.0

--- a/projects/packages/my-jetpack/changelog/add-welcome-banner-for-new-users
+++ b/projects/packages/my-jetpack/changelog/add-welcome-banner-for-new-users
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-To avoid displaying the Welcome banner to every user, now we only display it to new users.

--- a/projects/packages/my-jetpack/changelog/fix-social-cta-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/fix-social-cta-my-jetpack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: This commit fixes a small bug that is mostly visual, where it was always rendering the "Activate" button for Social on My Jetpack.
-
-

--- a/projects/packages/my-jetpack/changelog/hide-jitms-for-new-users
+++ b/projects/packages/my-jetpack/changelog/hide-jitms-for-new-users
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Prevent new users from seeing JITMs

--- a/projects/packages/my-jetpack/changelog/update-anti-spam-plan-check
+++ b/projects/packages/my-jetpack/changelog/update-anti-spam-plan-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-add plan check to My Jetpack Akismet product card

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.4.0-alpha",
+	"version": "4.4.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -33,7 +33,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.4.0-alpha';
+	const PACKAGE_VERSION = '4.4.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2024-01-15
+### Added
+- Options: synchronize block status option. [#34989]
+
+### Changed
+- Sync: Dedicated sync now disabled for high queue lags only if test request fails. [#34888]
+
+### Fixed
+- Added `is_array` check to `get_items_to_send` to make sure no fatals are thrown on non-array values. [#31552]
+- Jetpack Sync: Fixed buffer sanitization in Sync close endpoint [#34961]
+- Jetpack Sync: Fix restoring post global before enqueuing a post action. [#34990]
+
 ## [2.4.0] - 2024-01-04
 ### Removed
 - Social: Removed sync option for tweetstorm. [#34330]
@@ -1014,6 +1026,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.4.1]: https://github.com/Automattic/jetpack-sync/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/Automattic/jetpack-sync/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/Automattic/jetpack-sync/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/Automattic/jetpack-sync/compare/v2.2.0...v2.2.1

--- a/projects/packages/sync/changelog/add-blocks-option-sync
+++ b/projects/packages/sync/changelog/add-blocks-option-sync
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Options: synchronize block status option.

--- a/projects/packages/sync/changelog/fix-buffer-sanitization-in-sync-close-endpoint
+++ b/projects/packages/sync/changelog/fix-buffer-sanitization-in-sync-close-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack Sync: Fixed buffer sanitization in Sync close endpoint

--- a/projects/packages/sync/changelog/fix-dedicated-sync-fall-back-to-default-only-after-unsuccesful-spawn-aync-test
+++ b/projects/packages/sync/changelog/fix-dedicated-sync-fall-back-to-default-only-after-unsuccesful-spawn-aync-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Sync: Dedicated sync now disabled for high queue lags only if test request fails.

--- a/projects/packages/sync/changelog/fix-jetpack-sync-fix-non-array-input-in-sender
+++ b/projects/packages/sync/changelog/fix-jetpack-sync-fix-non-array-input-in-sender
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Added `is_array` check to `get_items_to_send` to make sure no fatals are thrown on non-array values.

--- a/projects/packages/sync/changelog/fix-sync-posts-module-usage-of-global-post
+++ b/projects/packages/sync/changelog/fix-sync-posts-module-usage-of-global-post
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack Sync: Fix restoring post global before enqueuing a post action.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.4.1-alpha';
+	const PACKAGE_VERSION = '2.4.1';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,21 +2,63 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 13.0-beta - 2024-01-08
+## 13.1-a.1 - 2024-01-15
+### Enhancements
+- GIF Block: Accept Giphy shortlinks as a valid embed. [#34786]
+- GIF Block: fix styling of the search bar input. [#34779]
+- Subscribe block: don't allow editing the email for subscribing for logged-in members. [#34982]
+
+### Improved compatibility
+- Post Images: avoid PHP warnings on sites using PHP 8.1+, when a post image has a malformed URL. [#34926]
+
+### Bug fixes
+- AI Assistant: avoid deprecation notices when using a development version of WordPress. [#34921]
+- AI Assistant: do not attempt to display the AI Excerpt assistant in the site editor and the widget editor. [#34970]
+- Fixes recurring payments buttons multiple plan support. [#34928]
+- Subscribe modal: Don't show in Elementor editor [#34955]
+- Subscriptions: do not display subscription checkboxes in comment forms displayed on Custom Post Type pages. [#34912]
+- Subscriptions: Fix broken subscribe button in email [#34966]
+- Subscriptions: Fix page scrolling up after the subscription modal is dismissed [#34963]
+- Theme Tools: Ensure that Content Options does not override the Featured Images options set within blocks. [#34805]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Action Bar: remove experimental module. [#34939]
+- add label to prompt blog for bloganuary [#34913]
+- AI Assistant: compose ConnectPrompt and UpgradePrompt and pass it as bannerComponent prop to AI Client [#34918]
+- cast_and_filter_item: Do not cast an array to a string [#34942]
+- Extensions: auto-generate public path [#34923]
+- Extensions: Don't auto-generate public path after all. But improve the way the manual path is being set. [#34969]
+- External media: provide default numerical post id for uploads. [#34795]
+- Jetpack AI: include feature name as a parameter on the content feedback tool. [#34972]
+- Like block: Set index.html version based on the current Jetpack version [#34920]
+- Newsletter settings: update copy for subscription pop-up toggle [#34959]
+- Recommendations: update link in summary upsell [#34898]
+- Sharing: be more defensive when fetching sharing service to avoid errors. [#34991]
+- Spotify shortcode: Prevent a fatal error in PHP 8.1 if no attributes are passed. [#34891]
+- Subscriptions: Fix subscriber pop-up button text color [#34915]
+- Subscriptions: Fix subscriber popup background scrolling [#34933]
+- Subscriptions: Format subscribers reach numbers [#34887]
+- Subscriptions: Show subscription numbers more elegantly [#34919]
+- Sync: synchronize block status option. [#34989]
+- Track store managers actions in WooCommerce analytics. [#34827]
+
+## [13.0] - 2024-01-10
 ### Enhancements
 - Subscription Modal: Display thesubscription modal when a user makes a comment. [#34659]
 
 ### Bug fixes
 - Likes Widget: Fix accessibility on likes popover. [#34800]
 - Likes Widget: Make likes widget accessibility compatible across themes. [#34857]
+- Payments: Fix recurring payments buttons not working with multiple plans.
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
-- Use useModuleStatus hook instead of direct call of store selectors. [#34856]
+- AI Assistant: compose ConnectPrompt and UpgradePrompt and pass it as bannerComponent prop to AI Client [#34918]
 - AI Excerpt: remove GPT model selector since it's not possible to change models anymore. [#34855]
 - Backup: Add namespace versioning to Helper_Script_Manager and other classes. [#34739]
 - Fix the sidebar toggle on mobile displays. [#34807]
 - Like Widget: Fix caching issue. [#34860]
 - Updated package dependencies. [#34882]
+- Use useModuleStatus hook instead of direct call of store selectors. [#34856]
 
 ## 13.0-a.13 - 2024-01-04
 ### Bug fixes
@@ -160,7 +202,7 @@
 ### Bug fixes
 - Carousel: fix unresponsive navigation on Chrome browsers. [#34678]
 
-## 12.9 - 2023-12-05
+## [12.9] - 2023-12-05
 ### Enhancements
 - Likes: Updated the likes popover design and added RTL support. [#34396]
 - My Jetpack: Added Creator to My Jetpack overview. [#34307]
@@ -377,7 +419,7 @@
 - Removed scssc 0.0.12 and replaced it with with ScssPhp 1.1.11. [#33928]
 - Rollback change. [#33973]
 
-## 12.8 - 2023-11-06
+## [12.8] - 2023-11-06
 ### Enhancements
 - Added a notice for wp-admin settings pages when the wpcom_admin_interface option is set to wp-admin. [#33933]
 - Added nextdoor block to production blocks. [#33950]
@@ -9533,6 +9575,9 @@ Other bugfixes and enhancements at https://github.com/Automattic/jetpack/commits
 
 - Initial release
 
+[13.0]: https://wp.me/p1moTy-10Xp
+[12.9]: https://wp.me/p1moTy-YJA
+[12.8]: https://wp.me/p1moTy-Xdz
 [12.7]: https://wp.me/p1moTy-Wfx
 [12.6]: https://wp.me/p1moTy-VLL
 [12.5]: https://wp.me/p1moTy-Vab

--- a/projects/plugins/jetpack/changelog/add-blocks-option-sync
+++ b/projects/plugins/jetpack/changelog/add-blocks-option-sync
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Sync: synchronize block status option.

--- a/projects/plugins/jetpack/changelog/add-bloganuary-label-update
+++ b/projects/plugins/jetpack/changelog/add-bloganuary-label-update
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-add label to prompt blog for bloganuary

--- a/projects/plugins/jetpack/changelog/add-giphy-shortlink-support
+++ b/projects/plugins/jetpack/changelog/add-giphy-shortlink-support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-GIF Block: Accept Giphy shortlinks as a valid embed.

--- a/projects/plugins/jetpack/changelog/add-like-block-update-styles-script
+++ b/projects/plugins/jetpack/changelog/add-like-block-update-styles-script
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: This is only for developers of this block.
-
-

--- a/projects/plugins/jetpack/changelog/add-welcome-banner-for-new-users
+++ b/projects/plugins/jetpack/changelog/add-welcome-banner-for-new-users
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/cast-and-filter-string-skip-array
+++ b/projects/plugins/jetpack/changelog/cast-and-filter-string-skip-array
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-cast_and_filter_item: Do not cast an array to a string

--- a/projects/plugins/jetpack/changelog/fix-34921-take-2
+++ b/projects/plugins/jetpack/changelog/fix-34921-take-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Assistant: do not attempt to display the AI Excerpt assistant in the site editor and the widget editor.

--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-upgrade-nudge-positioning
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-upgrade-nudge-positioning
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-AI Assistant: compose ConnectPrompt and UpgradePrompt and pass it as bannerComponent prop to AI Client

--- a/projects/plugins/jetpack/changelog/fix-ai-excerpt-deprecation-notices
+++ b/projects/plugins/jetpack/changelog/fix-ai-excerpt-deprecation-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Assistant: avoid deprecation notices when using a development version of WordPress.

--- a/projects/plugins/jetpack/changelog/fix-broken-subscribe-email-button
+++ b/projects/plugins/jetpack/changelog/fix-broken-subscribe-email-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscriptions: Fix broken subscribe button in email

--- a/projects/plugins/jetpack/changelog/fix-content-options-featured-images
+++ b/projects/plugins/jetpack/changelog/fix-content-options-featured-images
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Theme Tools: Ensure that Content Options does not override the Featured Images options set within blocks.

--- a/projects/plugins/jetpack/changelog/fix-gif-block-input
+++ b/projects/plugins/jetpack/changelog/fix-gif-block-input
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-GIF Block: fix styling of the search bar input.

--- a/projects/plugins/jetpack/changelog/fix-like-block-editor-styles
+++ b/projects/plugins/jetpack/changelog/fix-like-block-editor-styles
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Just an update to the editor styles
-
-

--- a/projects/plugins/jetpack/changelog/fix-like-block-styles-script-enhacements
+++ b/projects/plugins/jetpack/changelog/fix-like-block-styles-script-enhacements
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Just changes semicolons & tabs
-
-

--- a/projects/plugins/jetpack/changelog/fix-recommendation-summary-upsell-link
+++ b/projects/plugins/jetpack/changelog/fix-recommendation-summary-upsell-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Recommendations: update link in summary upsell

--- a/projects/plugins/jetpack/changelog/fix-sharing-block-services
+++ b/projects/plugins/jetpack/changelog/fix-sharing-block-services
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Sharing: be more defensive when fetching sharing service to avoid errors.

--- a/projects/plugins/jetpack/changelog/fix-subscribe-modal-with-elementor
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-modal-with-elementor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscribe modal: Don't show in Elementor editor

--- a/projects/plugins/jetpack/changelog/fix-subscriber-popup-background-scrolling
+++ b/projects/plugins/jetpack/changelog/fix-subscriber-popup-background-scrolling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Fix subscriber popup background scrolling

--- a/projects/plugins/jetpack/changelog/fix-subscriber-popup-button-text-color
+++ b/projects/plugins/jetpack/changelog/fix-subscriber-popup-button-text-color
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Fix subscriber pop-up button text color

--- a/projects/plugins/jetpack/changelog/fix-subscription-modal-scroll-page-up
+++ b/projects/plugins/jetpack/changelog/fix-subscription-modal-scroll-page-up
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscriptions: Fix page scrolling up after the subscription modal is dismissed

--- a/projects/plugins/jetpack/changelog/fix-subscriptions-checkboxes-cpt
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-checkboxes-cpt
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscriptions: do not display subscription checkboxes in comment forms displayed on Custom Post Type pages.

--- a/projects/plugins/jetpack/changelog/fix-sync-posts-module-usage-of-global-post
+++ b/projects/plugins/jetpack/changelog/fix-sync-posts-module-usage-of-global-post
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Added unit tests for Sync
-
-

--- a/projects/plugins/jetpack/changelog/fix-webpack-public-path-js-concatenation
+++ b/projects/plugins/jetpack/changelog/fix-webpack-public-path-js-concatenation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Extensions: Don't auto-generate public path after all. But improve the way the manual path is being set.

--- a/projects/plugins/jetpack/changelog/gold-fix-recurring-payments-plan-ids
+++ b/projects/plugins/jetpack/changelog/gold-fix-recurring-payments-plan-ids
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fixes recurring payments buttons multiple plan support.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.1-a.0
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.1-a.2
+
+

--- a/projects/plugins/jetpack/changelog/test-with-media-send-numerical-post-id
+++ b/projects/plugins/jetpack/changelog/test-with-media-send-numerical-post-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-External media: provide default numerical post id for uploads.

--- a/projects/plugins/jetpack/changelog/update-action-bar-module
+++ b/projects/plugins/jetpack/changelog/update-action-bar-module
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Action Bar: remove experimental module.

--- a/projects/plugins/jetpack/changelog/update-blaze-dashboard-urls
+++ b/projects/plugins/jetpack/changelog/update-blaze-dashboard-urls
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-extensions-auto-public-path
+++ b/projects/plugins/jetpack/changelog/update-extensions-auto-public-path
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Extensions: auto-generate public path

--- a/projects/plugins/jetpack/changelog/update-format-subscribers-reach-numbers
+++ b/projects/plugins/jetpack/changelog/update-format-subscribers-reach-numbers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Format subscribers reach numbers

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-include-feature-name-on-proofread-request
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-include-feature-name-on-proofread-request
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: include feature name as a parameter on the content feedback tool.

--- a/projects/plugins/jetpack/changelog/update-like-block-index-version
+++ b/projects/plugins/jetpack/changelog/update-like-block-index-version
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Like block: Set index.html version based on the current Jetpack version

--- a/projects/plugins/jetpack/changelog/update-newsletter-setting-popup-copy
+++ b/projects/plugins/jetpack/changelog/update-newsletter-setting-popup-copy
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Newsletter settings: update copy for subscription pop-up toggle

--- a/projects/plugins/jetpack/changelog/update-post-images
+++ b/projects/plugins/jetpack/changelog/update-post-images
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Post Images: avoid PHP warnings on sites using PHP 8.1+, when a post image has a malformed URL.

--- a/projects/plugins/jetpack/changelog/update-spotify-shortcode
+++ b/projects/plugins/jetpack/changelog/update-spotify-shortcode
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Spotify shortcode: Prevent a fatal error in PHP 8.1 if no attributes are passed.

--- a/projects/plugins/jetpack/changelog/update-store-admin-property
+++ b/projects/plugins/jetpack/changelog/update-store-admin-property
@@ -1,6 +1,0 @@
-Significance: minor
-Type: other
-
-Track store managers actions in WooCommerce analytics.
-
-

--- a/projects/plugins/jetpack/changelog/update-subscribe-block-disabled-when-loggedin
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-disabled-when-loggedin
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscribe block: don't allow editing the email for subscribing for logged-in members.

--- a/projects/plugins/jetpack/changelog/update-subscription-numbers-more-elegantly
+++ b/projects/plugins/jetpack/changelog/update-subscription-numbers-more-elegantly
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Show subscription numbers more elegantly

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_0",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-a.0
+ * Version: 13.1-a.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-a.0' );
+define( 'JETPACK__VERSION', '13.1-a.1' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-a.1
+ * Version: 13.1-a.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-a.1' );
+define( 'JETPACK__VERSION', '13.1-a.2' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-a.0",
+	"version": "13.1.0-a.1",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-a.1",
+	"version": "13.1.0-a.2",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack - WP Security, Backup, Speed, & Growth ===
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, barry, batmoo, beaulebens, bindlegirl, biskobe, bjorsch, blobaugh, brbrr, cainm, cena, cfinke, cgastrell, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, daniloercoli, davoraltman, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jasmussen, jblz, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lhkowalski, lschuyler, macmanx, martinremy, matt, mattwiebe, matveb, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, nunyvega, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, renatoagds, retrofox, richardmtl, richardmuscat, robertbpugh, roccotripaldi, ryancowles, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, thehenridev, tmoorewp, tyxla, Viper007Bond, westi, williamvianas, wpkaren, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, spam, CDN, search, social
-Stable tag: 12.9.1
+Stable tag: 13.0
 Requires at least: 6.3
 Requires PHP: 7.0
 Tested up to: 6.4
@@ -293,42 +293,24 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.0-beta - 2024-01-08
+### 13.1-a.1 - 2024-01-15
 #### Enhancements
-- Added description and link inviting to disable legacy sharing module if block is available
-- AI Usage panel: Added yellow color to indicate going over the soft limit.
-- Gutenberg: Added Top Posts & Pages block.
-- Sharing Buttons Block: update the admin's setting screen when the sharing block is available.
-- Social Menu & Social Media Icons: Add support for the Bluesky service.
-- Subscription Modal: Display thesubscription modal when a user makes a comment.
-- Subscriptions: adds toggle to disable email sending.
+- GIF Block: Accept Giphy shortlinks as a valid embed.
+- GIF Block: fix styling of the search bar input.
+- Subscribe block: don't allow editing the email for subscribing for logged-in members.
 
 #### Improved compatibility
-- Contact Form: avoid PHP warnings in the WordPress dashboard when used alongside other plugins making changes to admin pages.
-- Patreon: Updated Patreon icon to match the updated Patreon branding guidelines.
-- Sharing Buttons: add the official X button to the list of supported services.
-- Sharing Buttons Block: Improved consistency for how the button icons are rendered on different pages.
+- Post Images: avoid PHP warnings on sites using PHP 8.1+, when a post image has a malformed URL.
 
 #### Bug fixes
-- Calendly Block: Fixed custom colours being stripped.
-- Dashboard: Disabled VideoPress card in offline mode.
-- Editor: Fixed missing fonts issue inside the block editor.
-- Jetpack footer links are now consistent within different pages.
-- Launchpad: Fixed the save modal not showing after saving changes in the editor.
-- Likes: Fixed popover closing area.
-- Likes Widget: Fix accessibility on likes popover.
-- Likes Widget: Make likes widget accessibility compatible across themes.
-- My Plan: Fix JS errors due to nested anchor tags.
-- Newsletter: Updated post-publish panel text for scheduled posts.
-- Notification Accessibility: THe notification icon is not a link.
-- Payments Block: show an error message when unable to render payment button.
-- Paywall: Fix stuck pending subscription state when email isn't verified.
-- Subscribe Modal: Fix fatal under exceptional conditions
-- Subscribers: fix the subscriber count display if above 1000 subscribers.
-- Subscribers: pre/post-publish panel, show correct subscription count when using paywall.
-- Subscriptions Block: Added compatibility for the latest Gutenberg.
-- Widgets: Fix console JS error in EU Cookie Widget.
-- WoA: Updated SEO Tools on Atomic sites to show only for Business plan and higher.
+- AI Assistant: avoid deprecation notices when using a development version of WordPress.
+- AI Assistant: do not attempt to display the AI Excerpt assistant in the site editor and the widget editor.
+- Fixes recurring payments buttons multiple plan support.
+- Subscribe modal: Don't show in Elementor editor
+- Subscriptions: do not display subscription checkboxes in comment forms displayed on Custom Post Type pages.
+- Subscriptions: Fix broken subscribe button in email
+- Subscriptions: Fix page scrolling up after the subscription modal is dismissed
+- Theme Tools: Ensure that Content Options does not override the Featured Images options set within blocks.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.13 - 2024-01-15
+### Changed
+- Internal updates.
+
 ## 2.0.12 - 2024-01-08
 ### Changed
 - Updated package dependencies. [#34882]

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_12"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_13"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.12
+ * Version: 2.0.13
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.12",
+	"version": "2.0.13",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.13, jetpack 13.1-a.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.