### PR TITLE
Fix/my jetpack checkout links

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
@@ -62,6 +62,7 @@ const ProductDetailTableColumn = ( {
 		from: 'my-jetpack',
 		productSlug: wpcomProductSlug,
 		redirectUrl: postActivationUrl.replace( /(^.*\/wp-admin\/)/i, '' ) || myJetpackCheckoutUri,
+		connectAfterCheckout: true,
 		siteSuffix,
 		useBlogIdSuffix: true,
 	} );

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-checkout-links
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-checkout-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Ensure that interstitial tables go straight to checkout just like insterstitial cards

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.6.0",
+	"version": "4.6.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -34,7 +34,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.6.0';
+	const PACKAGE_VERSION = '4.6.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
## Proposed changes:

* Send the product table interstitials straight to checkout
* Before, only product card interstitials were doing that, tables would ask to connect first

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Github: https://github.com/orgs/Automattic/projects/724/views/1?pane=issue&itemId=49348611

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch locally or use the Jetpack Beta plugin on an ephemeral or jurassic ninja site
2. Go to /wp-admin/admin.php?page=my-jetpack
3. Before connecting, go to `/wp-admin/admin.php?page=my-jetpack#/add-boost` and click on the CTA
![image](https://github.com/Automattic/jetpack/assets/65001528/5abe0097-bafb-4ceb-b06c-056086af6e97)
4. Ensure you are sent straight to checkout, and not asked to connect your site until after the purchase has been made
![image](https://github.com/Automattic/jetpack/assets/65001528/b38903bb-8075-4893-a3ff-d66a6b010349)
5. Do the same for `page=my-jetpack#/add-creator`, and `page=my-jetpack#/add-protect`

