### PR TITLE
iCalendarReader: Support BYDAY recurrence rules for last, second-to-last, or third-to-last weekdays

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/icalendar-reader.php
+++ b/projects/plugins/jetpack/_inc/lib/icalendar-reader.php
@@ -341,17 +341,23 @@ class iCalendarReader {
 							$recurring_event_date_start = date( 'Ymd\THis', strtotime( $event['DTSTART'] ) );
 						} else {
 							// Describe the date in the month.
-							if ( isset( $rrule_array['BYDAY'] ) ) {
-								$day_number      = substr( $rrule_array['BYDAY'], 0, 1 );
-								$week_day        = substr( $rrule_array['BYDAY'], 1 );
-								$day_cardinals   = array(
-									1 => 'first',
-									2 => 'second',
-									3 => 'third',
-									4 => 'fourth',
-									5 => 'fifth',
+							if ( isset( $rrule_array['BYDAY'] )
+								&& preg_match( '/^(-?\d)([A-Z]{2})/', $rrule_array['BYDAY'], $matches )
+							) {
+								$day_number = $matches[1];
+								$week_day   = $matches[2];
+
+								$day_cardinals = array(
+									-3 => 'third to last',
+									-2 => 'second to last',
+									-1 => 'last',
+									1  => 'first',
+									2  => 'second',
+									3  => 'third',
+									4  => 'fourth',
+									5  => 'fifth',
 								);
-								$weekdays        = array(
+								$weekdays      = array(
 									'SU' => 'Sunday',
 									'MO' => 'Monday',
 									'TU' => 'Tuesday',
@@ -360,7 +366,10 @@ class iCalendarReader {
 									'FR' => 'Friday',
 									'SA' => 'Saturday',
 								);
-								$event_date_desc = "{$day_cardinals[$day_number]} {$weekdays[$week_day]} of ";
+
+								$day_cardinal    = $day_cardinals[ $day_number ] ?? '';
+								$weekday         = $weekdays[ $week_day ] ?? '';
+								$event_date_desc = "$day_cardinal $weekday of ";
 							} else {
 								$event_date_desc = date( 'd ', strtotime( $event['DTSTART'] ) );
 							}

--- a/projects/plugins/jetpack/changelog/update-ical-negative-recurrence-rules
+++ b/projects/plugins/jetpack/changelog/update-ical-negative-recurrence-rules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+iCalendarReader: Support BYDAY recurrence rules for last, second-to-last, or third-to-last weekdays


### PR DESCRIPTION
Jetpack's iCalendarReader supports simple BYDAY values like `4WE`, `3MO` or `1TH`, but fails on ones with negative numbers like: `-1WE` (the last Wednesday of every month).

## Proposed changes:

* Use a regex to pull out the number + weekday abbreviation, and allow negative numbers to be detected
* Add -1 -2 -3 to the day cardinals array
* Use `??` to prevent warnings if someone specifies an invalid string, like "9ZZ".

There are some examples here: https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html
There is a feed that uses -1WE in the wild here, found on a customer site:  332ca-pb

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* WPCOM Testing helper and instructions in D134762-code