### PR TITLE
Update Subscription modal on comment to use subscribe block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscription-modal-to-subscribe-block
+++ b/projects/plugins/jetpack/changelog/update-subscription-modal-to-subscribe-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update Subscription Modal on comment to use Subscribe Block

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/block.json
@@ -108,6 +108,9 @@
 		"successMessage": {
 			"type": "string",
 			"default": "Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing."
+		},
+		"appSource": {
+			"type": "string"
 		}
 	},
 	"example": {}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -593,6 +593,7 @@ function render_block( $attributes ) {
 			( isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '' )
 		),
 		'source'                        => 'subscribe-block',
+		'app_source'                    => get_attribute( $attributes, 'appSource', null ),
 	);
 
 	if ( ! jetpack_is_frontend() ) {
@@ -717,6 +718,7 @@ function render_for_website( $data, $classes, $styles ) {
 						<input type="hidden" name="blog_id" value="<?php echo (int) $blog_id; ?>"/>
 						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
 						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
+						<input type="hidden" name="app_source" value="<?php echo esc_attr( $data['app_source'] ); ?>"/>
 						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 						<?php
 						wp_nonce_field( 'blogsub_subscribe_' . $blog_id );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -68,6 +68,7 @@ domReady( function () {
 
 					const post_id = form.querySelector( 'input[name=post_id]' )?.value ?? '';
 					const tier_id = form.querySelector( 'input[name=tier_id]' )?.value ?? '';
+					const app_source = form.querySelector( 'input[name=app_source]' )?.value ?? '';
 
 					show_iframe( {
 						email,
@@ -76,6 +77,7 @@ domReady( function () {
 						blog: form.dataset.blog,
 						plan: 'newsletter',
 						source: 'jetpack_subscribe',
+						app_source,
 						post_access_level: form.dataset.post_access_level,
 						display: 'alternate',
 					} );

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -15,7 +15,8 @@ export function handleIframeResult( eventFromIframe ) {
 		}
 		if ( data && data.action === 'close' && premiumContentJWTTokenForCookie ) {
 			// The token was set during the purchase flow, we want to reload the whole page so the content is displayed
-			window.location.reload();
+			// For avoiding Firefox reload, we need to force reload bypassing the cache.
+			window.location.reload( true );
 		} else if ( data && data.action === 'close' ) {
 			// User just aborted.
 			window.removeEventListener( 'message', handleIframeResult );

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
@@ -133,9 +133,10 @@ class Jetpack_Subscription_Modal_On_Comment {
 	 * @return string
 	 */
 	public function get_subscribe_template_content() {
-		$discover_more_from = __( 'Never miss a beat!', 'default' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
-		$subscribe_text     = __( 'Interested in getting blog post updates? Simply click the button below to stay in the loop!', 'default' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
-		$subscribe_button   = __( 'Subscribe', 'default' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+		// translators: %s is the name of the site.
+		$discover_more_from = sprintf( __( 'Discover more from %s', 'jetpack' ), get_bloginfo( 'name' ) );
+		$subscribe_text     = __( 'Subscribe now to keep reading and get access to the full archive.', 'jetpack' );
+		$continue_reading   = __( 'Continue reading', 'jetpack' );
 
 		return <<<HTML
 	<!-- wp:group -->
@@ -150,11 +151,7 @@ class Jetpack_Subscription_Modal_On_Comment {
 	</div>
 	<!-- /wp:group -->
 	<!-- wp:group {"style":{"spacing":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
-	<div class="wp-block-group has-border-color jetpack-subscription-modal__modal-content-form" style="border-color:#dddddd;border-width:1px;margin-top:0;margin-bottom:0;padding-top:0;padding-right:32px;padding-bottom:32px;padding-left:32px">
-
-		<!-- wp:paragraph {"align":"right","style":{"spacing":{"margin":{"top":"0"}},"typography":{"fontSize":"14px"}},"className":"jetpack-subscription-modal__close"} -->
-		<p class="has-text-align-center jetpack-subscription-modal__close" style="margin-top:20px;font-size:14px;text-align:right"><a href="#"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="24" height="24" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg></a></p>
-		<!-- /wp:paragraph -->
+	<div class="wp-block-group has-border-color jetpack-subscription-modal__modal-content-form" style="border-color:#dddddd;border-width:1px;margin-top:0;margin-bottom:0;padding:32px">
 
 		<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"600","fontSize":"26px"},"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"4px","bottom":"10px"}}}} -->
 		<h2 class="wp-block-heading has-text-align-center" style="margin-top:4px;margin-bottom:10px;font-size:26px;font-style:normal;font-weight:600">$discover_more_from</h2>
@@ -164,21 +161,9 @@ class Jetpack_Subscription_Modal_On_Comment {
 		<p class='has-text-align-center' style='margin-top:4px;margin-bottom:0px;font-size:15px'>$subscribe_text</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:group {"style":{"spacing":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
-		<form class="jetpack-subscription-modal__form">
-			<input
-				class="jetpack-subscription-modal__form-email"
-				required="required"
-				type="email"
-				name="email"
-				style="border-width: 1px !important;"
-				/>
-			<button
-				class="jetpack-subscription-modal__form-submit"
-				type="submit"
-				name="jetpack_subscriptions_widget" >$subscribe_button</button>
-		</form>
-		<!-- /wp:group -->
+		<!-- wp:jetpack/subscriptions {"borderRadius":50,"className":"is-style-compact","appSource":"atomic-subscription-modal-lo"} /-->
+
+		<p class="has-text-align-center jetpack-subscription-modal__close" style="margin-top:20px;font-size:14px"><a href="#">$continue_reading</a></p>
 	</div>
 	<!-- /wp:group -->
 HTML;

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
@@ -139,17 +139,6 @@ class Jetpack_Subscription_Modal_On_Comment {
 		$continue_reading   = __( 'Continue reading', 'jetpack' );
 
 		return <<<HTML
-	<!-- wp:group -->
-	<div class="jetpack-subscription-modal__iframe-container">
-		<iframe
-			class="jetpack-subscription-modal__iframe"
-			frameBorder="0"
-			allowTransparency="1"
-			src="about:blank"
-			id="jetpack-subscription-modal__iframe"
-		></iframe>
-	</div>
-	<!-- /wp:group -->
 	<!-- wp:group {"style":{"spacing":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
 	<div class="wp-block-group has-border-color jetpack-subscription-modal__modal-content-form" style="border-color:#dddddd;border-width:1px;margin-top:0;margin-bottom:0;padding:32px">
 
@@ -163,7 +152,9 @@ class Jetpack_Subscription_Modal_On_Comment {
 
 		<!-- wp:jetpack/subscriptions {"borderRadius":50,"className":"is-style-compact","appSource":"atomic-subscription-modal-lo"} /-->
 
+		<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"20px"}},"typography":{"fontSize":"14px"}},"className":"jetpack-subscription-modal__close"} -->
 		<p class="has-text-align-center jetpack-subscription-modal__close" style="margin-top:20px;font-size:14px"><a href="#">$continue_reading</a></p>
+		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
 HTML;

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.css
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.css
@@ -51,44 +51,6 @@
     opacity: 0;
 }
 
-.jetpack-subscription-modal__modal-content .jetpack-subscription-modal__iframe-container {
-    visibility: hidden;
-    opacity: 0;
-    background-image: url( 'https://s0.wp.com/i/loading/dark-200.gif' );
-    background-size: 50px;
-    background-repeat: no-repeat;
-    background-position: center 150px;
-    margin: 0 !important;
-    box-shadow: none;
-    -webkit-box-shadow: none;
-    -moz-box-shadow: none;
-    border: none;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    top: 0;
-    width: 100% !important;
-    height: 100%;
-    position: absolute;
-}
-
-.jetpack-subscription-modal.has-iframe .jetpack-subscription-modal__iframe-container {
-    opacity: 1;
-    visibility: visible;
-
-}
-
-.jetpack-subscription-modal__iframe {
-    margin: 0 !important;
-    height: 100% !important;
-    width: 100% !important;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-}
-
 /*
  * These text-wrap properties still have limited browser
  * support, but based on feedback still adding them for when
@@ -97,53 +59,6 @@
 .jetpack-subscription-modal__modal-content p {
     text-wrap: pretty;
     text-wrap: pretty;
-}
-
-.jetpack-subscription-modal__form {
-    margin-top: 20px;
-    align-items: flex-start;
-    display: flex;
-}
-
-.jetpack-subscription-modal__form-email {
-    flex: 1;
-    font-size: 16px;
-    line-height: 28px;
-    padding: 15px 23px 15px 23px !important;
-    border-radius: 50px !important;
-    border-width: 1px !important;
-    border-color: #113AF5 !important;
-    border-end-end-radius: 0 !important;
-    border-start-end-radius: 0 !important;
-    border-style: solid !important;
-    outline: none;
-}
-.jetpack-subscription-modal__form-email:focus {
-    outline: none !important;
-}
-.jetpack-subscription-modal__form-submit {
-    font-size: 16px;
-    line-height: 28px;
-    padding: 15px 23px 15px 23px;
-    margin: 0px;
-    margin-left: 10px;
-    border-radius: 50px;
-    border-width: 1px;
-    border-end-start-radius: 0;
-    border-start-start-radius: 0;
-    margin-inline-start: 0;
-    background-color: #113AF5;
-    border-color: #113AF5;
-    border-style: solid;
-    color: #FFFFFF;
-}
-.jetpack-subscription-modal__form-submit:hover {
-    opacity: .9;
-    cursor: pointer;
-}
-.jetpack-subscription-modal__form-submit:disabled {
-    opacity: .7 !important;
-    cursor: not-allowed;
 }
 
 @media screen and (max-width: 640px) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/5058

## Proposed changes:
Update Subscription modal on Comment to use Subscribe Block instead of custom subscription core.
We also added the `app_source` parameter to the Subscribe Block for tracking purpose.
We also removed the X icon in favor of `Continue reading`

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/jetpack/assets/402286/f609a1c5-159f-4868-991c-fdc528ca8c6c) | ![image](https://github.com/Automattic/jetpack/assets/402286/72e9367d-3426-42d0-93e6-a614a3f31bae) |


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* You can test it with this site: https://explorersatomicsub2.wpcomstaging.com/2023/12/26/unveiling-the-future-a-comprehensive-review-of-the-quantumx-pro-vr-headset/
* Try to break it

OR

* Go to Atomic site with Subscription Modal on comment enabled in `/settings/newsletter/`
* Comment in a post while logged out
* You should see the Subscription modal with the continue reading button.
* Do the same but logged-in (not admin user)
* You should see the subscription modal with the email already completed.
* Check the copy & design
* Try to break it
