### PR TITLE
Boost: Fix critical CSS auto activation

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/getting-started.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/getting-started.tsx
@@ -11,6 +11,7 @@ import { useConfig } from '$lib/stores/config-ds';
 import { useGettingStarted } from '$lib/stores/getting-started';
 import { useNavigate } from 'react-router-dom';
 import { __ } from '@wordpress/i18n';
+import { useSingleModuleState } from '$features/module/lib/stores';
 
 const GettingStarted: React.FC = () => {
 	const [ selectedPlan, setSelectedPlan ] = useState< 'free' | 'premium' | false >( false );
@@ -24,6 +25,7 @@ const GettingStarted: React.FC = () => {
 	} = useConfig();
 
 	const { shouldGetStarted, markGettingStartedComplete } = useGettingStarted();
+	const [ , setCriticalCssState ] = useSingleModuleState( 'critical_css' );
 
 	const {
 		connection: { userConnected },
@@ -36,10 +38,19 @@ const GettingStarted: React.FC = () => {
 			if ( ! isPremium && selectedPlan === 'premium' ) {
 				window.location.href = getUpgradeURL( domain, userConnected );
 			} else {
+				setCriticalCssState( true );
 				navigate( '/', { replace: true } );
 			}
 		}
-	}, [ domain, isPremium, navigate, selectedPlan, shouldGetStarted, userConnected ] );
+	}, [
+		domain,
+		isPremium,
+		navigate,
+		selectedPlan,
+		setCriticalCssState,
+		shouldGetStarted,
+		userConnected,
+	] );
 
 	async function initialize( plan: 'free' | 'premium' ) {
 		setSelectedPlan( plan );
@@ -54,7 +65,7 @@ const GettingStarted: React.FC = () => {
 			// * premium_cta_from_getting_started_page_in_plugin
 			await recordBoostEvent( `${ plan }_cta_from_getting_started_page_in_plugin`, {} );
 
-			markGettingStartedComplete();
+			await markGettingStartedComplete();
 		} catch ( e ) {
 			// Display the error in a snackbar message
 			setSnackbarMessage(

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -28,7 +28,6 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Site_Health;
-use Automattic\Jetpack_Boost\Lib\Status;
 use Automattic\Jetpack_Boost\Modules\Modules_Setup;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Config_State;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\List_Site_Urls;
@@ -111,7 +110,6 @@ class Jetpack_Boost {
 		add_action( 'init', array( $this, 'init_textdomain' ) );
 
 		add_action( 'handle_environment_change', array( $this, 'handle_environment_change' ), 10, 2 );
-		add_action( 'jetpack_boost_connection_established', array( $this, 'handle_jetpack_connection' ) );
 
 		// Fired when plugin ready.
 		do_action( 'jetpack_boost_loaded', $this );
@@ -142,20 +140,6 @@ class Jetpack_Boost {
 		// Make sure user sees the "Get Started" when first time opening.
 		( new Getting_Started_Entry() )->set( true );
 		Analytics::record_user_event( 'activate_plugin' );
-	}
-
-	/**
-	 * Plugin connected to Jetpack handler.
-	 */
-	public function handle_jetpack_connection() {
-		$getting_started = new Getting_Started_Entry();
-		if ( $getting_started->get() === true ) {
-			// Special case: when getting started, ensure that the Critical CSS module is enabled.
-			$status = new Status( 'critical_css' );
-			$status->update( true );
-		}
-
-		$getting_started->set( false );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/fix-module-auto-activation
+++ b/projects/plugins/boost/changelog/fix-module-auto-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix regrassion: Critical CSS stopped being auto-enabled on getting started
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34988

## Proposed changes:
* Toggle critical CSS on, when user chooses the free plan

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* From getting started page on boost, choose the free plan
* Make sure critical CSS is enabled