### PR TITLE
Dotcom patterns: allow testing assembler v2 patterns in editor for all Automatticians

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-register-dotcom-v2-patterns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-register-dotcom-v2-patterns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dotcom patterns: use assembler v2 patterns in editor 

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -55,7 +55,7 @@ class Wpcom_Block_Patterns_From_Api {
 			$patterns_cache_key = $this->utils->get_patterns_cache_key( $patterns_source );
 
 			$pattern_categories = array();
-			$block_patterns     = $this->get_patterns( $patterns_cache_key, $patterns_source );
+			$block_patterns     = $this->get_patterns( $patterns_cache_key );
 
 			foreach ( (array) $block_patterns as $pattern ) {
 				foreach ( (array) $pattern['categories'] as $slug => $category ) {
@@ -151,10 +151,9 @@ class Wpcom_Block_Patterns_From_Api {
 	 * Returns a list of patterns.
 	 *
 	 * @param string $patterns_cache_key Key to store responses to and fetch responses from cache.
-	 * @param string $patterns_source    Slug for valid patterns source site, e.g., `block_patterns`.
 	 * @return array                      The list of translated patterns.
 	 */
-	private function get_patterns( $patterns_cache_key, $patterns_source ) {
+	private function get_patterns( $patterns_cache_key ) {
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
 		if ( $override_source_site ) {
 			// Skip caching and request all patterns from a specified source site.
@@ -186,8 +185,8 @@ class Wpcom_Block_Patterns_From_Api {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
-						'post_type'       => 'wp_block',
-						'patterns_source' => $patterns_source,
+						'site'      => 'assemblerv2patterns.wordpress.com',
+						'post_type' => 'wp_block',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->utils->get_block_patterns_locale()
 				)

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -55,7 +55,7 @@ class Wpcom_Block_Patterns_From_Api {
 			$patterns_cache_key = $this->utils->get_patterns_cache_key( $patterns_source );
 
 			$pattern_categories = array();
-			$block_patterns     = $this->get_patterns( $patterns_cache_key, $patterns_source );
+			$block_patterns     = $this->get_patterns( $patterns_cache_key );
 
 			foreach ( (array) $block_patterns as $pattern ) {
 				foreach ( (array) $pattern['categories'] as $slug => $category ) {
@@ -151,10 +151,9 @@ class Wpcom_Block_Patterns_From_Api {
 	 * Returns a list of patterns.
 	 *
 	 * @param string $patterns_cache_key Key to store responses to and fetch responses from cache.
-	 * @param string $patterns_source    Slug for valid patterns source site, e.g., `block_patterns`.
 	 * @return array                      The list of translated patterns.
 	 */
-	private function get_patterns( $patterns_cache_key, $patterns_source ) {
+	private function get_patterns( $patterns_cache_key ) {
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
 		if ( $override_source_site ) {
 			// Skip caching and request all patterns from a specified source site.

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -175,7 +175,7 @@ class Wpcom_Block_Patterns_From_Api {
 		}
 
 		$block_patterns = $this->utils->cache_get( $patterns_cache_key, 'ptk_patterns' );
-		$disable_cache  = function_exists( 'is_automattician' ) ? is_automattician() : false;
+		$disable_cache  = true;
 
 		// Enable testing v2 patterns on sites with Assembler theme active
 		$enable_testing_v2_patterns = in_array( get_stylesheet(), array( 'pub/assembler', 'assembler' ), true );

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -55,7 +55,7 @@ class Wpcom_Block_Patterns_From_Api {
 			$patterns_cache_key = $this->utils->get_patterns_cache_key( $patterns_source );
 
 			$pattern_categories = array();
-			$block_patterns     = $this->get_patterns( $patterns_cache_key );
+			$block_patterns     = $this->get_patterns( $patterns_cache_key, $patterns_source );
 
 			foreach ( (array) $block_patterns as $pattern ) {
 				foreach ( (array) $pattern['categories'] as $slug => $category ) {
@@ -151,9 +151,10 @@ class Wpcom_Block_Patterns_From_Api {
 	 * Returns a list of patterns.
 	 *
 	 * @param string $patterns_cache_key Key to store responses to and fetch responses from cache.
+	 * @param string $patterns_source    Slug for valid patterns source site, e.g., `block_patterns`.
 	 * @return array                      The list of translated patterns.
 	 */
-	private function get_patterns( $patterns_cache_key ) {
+	private function get_patterns( $patterns_cache_key, $patterns_source ) {
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
 		if ( $override_source_site ) {
 			// Skip caching and request all patterns from a specified source site.
@@ -180,18 +181,11 @@ class Wpcom_Block_Patterns_From_Api {
 		$enable_testing_v2_patterns = in_array( get_stylesheet(), array( 'pub/assembler', 'assembler' ), true );
 
 		// Load fresh data if we don't have any patterns.
-		if ( $enable_testing_v2_patterns || false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
-			if ( $enable_testing_v2_patterns ) {
-				$request_params = array(
-					'site'      => 'dotcompatterns.wordpress.com',
-					'post_type' => 'wp_block',
-				);
-			}
+		if ( is_automattician() && false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
 			$request_url = esc_url_raw(
 				add_query_arg(
-					$request_params ?? array(
-						'tags'            => 'pattern',
-						'pattern_meta'    => 'is_web',
+					array(
+						'post_type'       => 'wp_block',
 						'patterns_source' => $patterns_source,
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->utils->get_block_patterns_locale()
@@ -200,7 +194,7 @@ class Wpcom_Block_Patterns_From_Api {
 
 			$block_patterns = $this->utils->remote_get( $request_url );
 
-			if ( ! $enable_testing_v2_patterns ) {
+			if ( ! is_automattician() ) {
 				$this->utils->cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
 			}
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -176,12 +176,13 @@ class Wpcom_Block_Patterns_From_Api {
 		}
 
 		$block_patterns = $this->utils->cache_get( $patterns_cache_key, 'ptk_patterns' );
+		$disable_cache  = function_exists( 'is_automattician' ) ? is_automattician() : false;
 
 		// Enable testing v2 patterns on sites with Assembler theme active
 		$enable_testing_v2_patterns = in_array( get_stylesheet(), array( 'pub/assembler', 'assembler' ), true );
 
 		// Load fresh data if we don't have any patterns.
-		if ( is_automattician() && false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
+		if ( $disable_cache && false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
@@ -194,7 +195,7 @@ class Wpcom_Block_Patterns_From_Api {
 
 			$block_patterns = $this->utils->remote_get( $request_url );
 
-			if ( ! is_automattician() ) {
+			if ( ! $disable_cache ) {
 				$this->utils->cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
 			}
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -177,11 +177,8 @@ class Wpcom_Block_Patterns_From_Api {
 
 		$block_patterns = $this->utils->cache_get( $patterns_cache_key, 'ptk_patterns' );
 
-		// Enable testing v2 patterns for Automatticians and Jurassic sites
-		$enable_testing_v2_patterns = function_exists( 'is_automattician' ) ? is_automattician() : ! defined( 'IS_WPCOM' );
-
-		// Enable testing v2 patterns on sites with Assembler theme active
-		$enable_testing_v2_patterns = in_array( get_stylesheet(), array( 'pub/assembler', 'assembler' ), true );
+		// Enable testing v2 patterns for Automatticians
+		$enable_testing_v2_patterns = function_exists( 'is_automattician' ) ? is_automattician() : false;
 
 		// Load fresh data if we don't have any patterns.
 		if ( $enable_testing_v2_patterns || false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -184,7 +184,7 @@ class Wpcom_Block_Patterns_From_Api {
 		if ( $enable_testing_v2_patterns || false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
 			if ( $enable_testing_v2_patterns ) {
 				$request_params = array(
-					'site'      => 'assemblerv2patterns.wordpress.com',
+					'site'      => 'dotcompatterns.wordpress.com',
 					'post_type' => 'wp_block',
 				);
 			}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -102,7 +102,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcompatterns.wordpress.com&post_type=wp_block' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -102,7 +102,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=assemblerv2patterns.wordpress.com&post_type=wp_block' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcompatterns.wordpress.com&post_type=wp_block' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -102,7 +102,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=assemblerv2patterns.wordpress.com&post_type=wp_block' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR enables the CfT for v2 patterns in the editor for all Automatticians. There is another only for the release https://github.com/Automattic/jetpack/pull/35064

* Fetch assembler v2 patterns in the editor for Automatticians
* Disable patterns cache for Automatticians

|BEFORE|AFTER|
|-|-|
|<img width="651" alt="Screenshot 2567-01-16 at 17 48 16" src="https://github.com/Automattic/jetpack/assets/1881481/d1d5c261-0134-4fdc-a2e2-b23ee0b6bc58">|<img width="653" alt="Screenshot 2567-01-26 at 19 48 39" src="https://github.com/Automattic/jetpack/assets/1881481/9608799b-2f34-43eb-b774-80a748925c22">|

### Does this pull request change what data or activity we track or use?
No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->


### Other information:
- [x] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### A sandbox is required
* Sandbox a simple site, and the public API
* Run in your sandbox `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/register-dotcom-v2-patterns`

### Testing patterns
* Access the editor on that site
  * click "Patterns" on the sidebar  to explore the patterns
  * click to edit a template and then click the button `[ + ]` on the topbar to explore the patterns from the editor inserter
* Verify you see the new patterns and categories from the source site Dotcompatterns