### PR TITLE
Dotcom patterns release: use wp_block post type patterns in editor

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-use-dotcom-wp-block-patterns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-use-dotcom-wp-block-patterns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dotcom patterns: use wp_block post type patterns in editor

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -160,9 +160,8 @@ class Wpcom_Block_Patterns_From_Api {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
-						'site'         => $override_source_site,
-						'tags'         => 'pattern',
-						'pattern_meta' => 'is_web',
+						'site'      => $override_source_site,
+						'post_type' => 'wp_block',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->utils->get_block_patterns_locale()
 				)
@@ -178,8 +177,7 @@ class Wpcom_Block_Patterns_From_Api {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
-						'tags'            => 'pattern',
-						'pattern_meta'    => 'is_web',
+						'post_type'       => 'wp_block',
 						'patterns_source' => $patterns_source,
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->utils->get_block_patterns_locale()

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -91,7 +91,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
-			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' );
+			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?post_type=wp_block&patterns_source=block_patterns' );
 
 		$utils_mock->expects( $this->once() )
 			->method( 'cache_add' )
@@ -110,7 +110,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?post_type=wp_block&patterns_source=block_patterns' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
@@ -156,7 +156,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
-			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcom&tags=pattern&pattern_meta=is_web' );
+			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcom&post_type=wp_block' );
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/pull/35063

## Proposed changes:

This PR is for releasing v2 patterns in the editor for all themes

<!--- Explain what functional changes your PR includes -->
* Add param `post_type: wp_block` to fetch the new patterns from dotcompatterns.wordpress.com


|BEFORE|AFTER|
|-|-|
|<img width="651" alt="Screenshot 2567-01-16 at 17 48 16" src="https://github.com/Automattic/jetpack/assets/1881481/d1d5c261-0134-4fdc-a2e2-b23ee0b6bc58">|<img width="653" alt="Screenshot 2567-03-26 at 18 53 23" src="https://github.com/Automattic/jetpack/assets/1881481/934a1523-f9ea-4946-a801-4f685c2f0bab">|



### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

### Does this pull request change what data or activity we track or use?
No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a simple site and the public api
* Apply this patch with `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/use-dotcom-wp-block-patterns`
* Access the editor on that site and click the button `[ + ]` on the topbar to explore the patterns from the editor inserter
* Verify you see the new patterns and categories from the source site Dotcompatterns


