### PR TITLE
Launchpad: Add completion logic for the Verify Domain Email task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-verify_domain_email-completion-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-verify_domain_email-completion-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds the completion logic for the Verify Domain Email task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1037,7 +1037,10 @@ function wpcom_launchpad_is_verify_domain_email_visible() {
 	}
 
 	if ( $has_domains_pending_icann_verification ) {
-		wpcom_set_launchpad_config_option( 'verify_domain_email_task_displayed', true );
+		if ( ! wpcom_launchpad_verify_domain_email_task_displayed() ) {
+			wpcom_set_launchpad_config_option( 'verify_domain_email_task_displayed', true );
+		}
+		return true;
 	}
 
 	return false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1005,7 +1005,6 @@ function wpcom_launchpad_is_verify_domain_email_visible() {
 		$domains = wpcom_request_domains_list();
 
 		if ( is_wp_error( $domains ) ) {
-			// logs the erro
 			return false;
 		}
 
@@ -1015,8 +1014,6 @@ function wpcom_launchpad_is_verify_domain_email_visible() {
 				return $domain->is_pending_icann_verification;
 			}
 		);
-
-		return ! empty( $domains_pending_icann_verification );
 	} else {
 		if ( ! class_exists( 'Domain_Management' ) ) {
 			return false;
@@ -1032,7 +1029,25 @@ function wpcom_launchpad_is_verify_domain_email_visible() {
 		);
 	}
 
-	return ! empty( $domains_pending_icann_verification );
+	$has_domains_pending_icann_verification = ! empty( $domains_pending_icann_verification );
+
+	if ( ! $has_domains_pending_icann_verification && wpcom_launchpad_verify_domain_email_task_displayed() ) {
+		wpcom_mark_launchpad_task_complete( 'verify_domain_email' );
+		return true;
+	}
+
+	if ( $has_domains_pending_icann_verification ) {
+		wpcom_set_launchpad_config_option( 'verify_domain_email_task_displayed', true );
+	}
+
+	return false;
+}
+
+/**
+ * Checks if the Verify Email Domain task was displayed to the user.
+ */
+function wpcom_launchpad_verify_domain_email_task_displayed() {
+	return wpcom_get_launchpad_config_option( 'verify_domain_email_task_displayed', false );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -1088,7 +1088,7 @@ function wpcom_get_launchpad_checklist_title_by_checklist_slug( $checklist_slug 
 function wpcom_get_launchpad_config_option( $option, $default = null ) {
 	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config', array() );
 
-	if ( ! isset( $wpcom_launchpad_config[ $option ] ) ) {
+	if ( ! is_array( $wpcom_launchpad_config ) || ! isset( $wpcom_launchpad_config[ $option ] ) ) {
 		return $default;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -1078,3 +1078,33 @@ function wpcom_get_launchpad_checklist_title_by_checklist_slug( $checklist_slug 
 
 	return wpcom_launchpad_checklists()->get_task_list_title( $checklist_slug );
 }
+
+/**
+ * Gets a launchpad config option.
+ *
+ * @param string $option The option to get.
+ * @param mixed  $default The default value to return if the option is not set.
+ */
+function wpcom_get_launchpad_config_option( $option, $default = null ) {
+	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config', array() );
+
+	if ( ! isset( $wpcom_launchpad_config[ $option ] ) ) {
+		return $default;
+	}
+
+	return $wpcom_launchpad_config[ $option ];
+}
+
+/**
+ * Sets a launchpad config option.
+ *
+ * @param string $option The option to set.
+ * @param mixed  $value The value to set.
+ */
+function wpcom_set_launchpad_config_option( $option, $value ) {
+	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config', array() );
+
+	$wpcom_launchpad_config[ $option ] = $value;
+
+	return update_option( 'wpcom_launchpad_config', $wpcom_launchpad_config );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the completion logic for the `Verify the email address for your domains` task.
* There were no hooks that we could use to get the completion status for this task, so I had to replicate the logic the same way we had previously. 
* The problem was that we only know the verification status for a domain when we fetch the domain information, as it makes a request to the provider to verify the ICANN status. 
* As the manipulation of the Launchpad config options is growing, I decided to create a few helper functions to help us manipulate the option instead of always doing it directly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To simulate the behavior of a site with a domain that requires ICANN verification, I came up with the solution of manually setting the properties responsible for storing the status. Atomic and Simple sites require us to alter different files because the Atomic Site uses an endpoint to get the domain list, and for simple sites, we directly invoke a method to get the list.

When we set the `is_pending_icann_verification` properties as true, it means that the site has a domain with a pending ICANN verification, and we should show the `Verify the email address for your domains` task. 

Since the `is_pending_icann_verification` is all we have to know whether the site has a pending ICANN verification, once the domain is verified, we don't have a way to know if the verification happened. That's why I created a flag and added it to the Launchpad Config options; this flag will be set to `true` when the task is shown at least once. This way, if the list of domains requiring the ICANN verification becomes empty, we will know we should mark the task as complete.

For Atomic, we need to edit the method used to load the domain information on the `/sites/:siteId/domains` endpoint, as we use this endpoint to get Atomic's domain status. For Simple Sites, we need to update the `get_paid_domains_with_icann_verification_status` method.

### Testing Atomic Site

* Make sure the public-api is sandboxed
* Add the following filter to your `0-sandbox.php` file
```
add_filter( 'enable_legacy_site_setup_launchpad', '__return_true' );
```
* Create a new site through the `/setup/free` flow.
* On the fullscreen Launchpad, launch your site without completing any other tasks.
* Once you reach the Customer Home, click on the `Show site setup` button on the main banner.
* Add a domain to the site
* Now, add your site to the WoA Developer list.
* Transfer it to Atomic by navigating to `/hosting-config/:siteSlug` and activating the SSH. You'll need to add the Creator plan to your site.
* Once your site is Atomic, use the credentials on `/hosting-config/:siteSlug` to access the SSH
* Edit your `~/htdocs/wp-config.php` to add the constants listed below:
```
// define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true ); // Only add this line if you are using the Jetpack Beta Tester plugin
define( 'JETPACK__SANDBOX_DOMAIN', 'YOU_SANDBOX_HOST' );
```
* Use the Jetpack Beta plugin to apply this PR to your site(You may have to update the files manually, as the plugin doesn't seem to work on my end)
* Replace the line linked below with the following code:
```
$this->is_pending_icann_verification = true;
```
fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Snqzva%2Qcyhtvaf%2Sqbznvaf%2Sqbznva%2Qznantrzrag%2Qqbznva.cuc%3Se%3Qp7n2prrs%23382-og
* Go to the Customer Home page. You should see the `Verify the email address for your domains` task.
* Now undo the changes to the `domain-management-domain.php` file mentioned above and refresh the Customer Home page. Then, check that the `Verify the email address for your domains` task is marked as complete.

### Testing Simple Site

* Make sure the public-api is sandboxed
* Apply this PR to your sandbox using the following command:
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/verify_domain_email-completion-logic
```
* Create a new site through the `/setup/free` flow.
* On the fullscreen Launchpad, launch your site without completing any other tasks.
* Once you reach the Customer Home, click on the `Show site setup` button on the main banner.
* Add a domain to the site
* Add the following filter to your `0-sandbox.php` file
```
add_filter( 'enable_legacy_site_setup_launchpad', '__return_true' );
```
* For testing Simple sites, edit the following line to always return true:
fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Snqzva%2Qcyhtvaf%2Sqbznvaf%2Sznantrzrag.cuc%3Se%3Q2q5nns96%23308-og
* Reload the Customer Home page so you can see the Launchpad and the `Verify the email address for your domains` task in it.
* Now undo the changes to the files mentioned above and refresh the Customer Home page. The `Verify the email address for your domains` task should be marked as complete.