### PR TITLE
Boost: Add animation to critical css show stopper element

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/folding-element/folding-element.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/folding-element/folding-element.tsx
@@ -1,3 +1,5 @@
+import useMeasure from 'react-use-measure';
+import { animated, useSpring } from '@react-spring/web';
 import classNames from 'classnames';
 import { useState } from 'react';
 import styles from './folding-element.module.scss';
@@ -18,6 +20,11 @@ const FoldingElement: React.FC< PropTypes > = ( {
 	const [ expanded, setExpanded ] = useState( isExpanded );
 	const label = expanded ? labelCollapsedText : labelExpandedText;
 
+	const [ ref, { height } ] = useMeasure();
+	const animationStyles = useSpring( {
+		height: expanded ? height : 0,
+	} );
+
 	return (
 		<>
 			<button
@@ -29,7 +36,16 @@ const FoldingElement: React.FC< PropTypes > = ( {
 				{ label }
 			</button>
 
-			{ expanded && <div className={ styles[ 'fade-in' ] }>{ children }</div> }
+			<animated.div
+				style={ {
+					overflow: 'hidden',
+					...animationStyles,
+				} }
+			>
+				<div ref={ ref } className={ styles[ 'fade-in' ] }>
+					{ children }
+				</div>
+			</animated.div>
 		</>
 	);
 };

--- a/projects/plugins/boost/changelog/add-transition-critical-css-show-stopper
+++ b/projects/plugins/boost/changelog/add-transition-critical-css-show-stopper
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add transition for Critical CSS show stopper error UI.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As part of https://github.com/Automattic/jetpack/issues/35015


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the collapse/expand animation back to the Critical CSS show stopper UI.

![CleanShot 2024-01-16 at 16 15 26](https://github.com/Automattic/jetpack/assets/11799079/181816bb-0abc-4565-b96f-6a4f59aec37f)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/issues/35015

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup this version of Boost (free);
* Make sure the UI shows up and the transition is present.
* Break critical CSS generation. I used this script:

```php
<?php

add_action( 'template_redirect', function () {
	if ( ! is_front_page() ) {
		noexistentfunction();
	}
} );
```

* Make the show stopper UI show up. I wasn't sure how to do that, so I edited the source code by removing `!` from [this line](https://github.com/Automattic/jetpack/blob/85350dd07263b2fe20700c4025b0b166eea39dd0/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/critical-css-errors.ts#L37).