### PR TITLE
Launchpad: Cache the domain list request

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-cache-domains-list-request-response
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-cache-domains-list-request-response
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Cache the response of the Domain List request"
+Cache the response of the Domain List request, and harden the code

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-cache-domains-list-request-response
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-cache-domains-list-request-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Cache the response of the Domain List request"

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1100,6 +1100,12 @@ function wpcom_launchpad_verify_domain_email_task_displayed() {
  * @return array|WP_Error Array of domains and their verification status or WP_Error if the request fails.
  */
 function wpcom_request_domains_list() {
+	static $cached_domains = null;
+
+	if ( $cached_domains !== null ) {
+		return $cached_domains;
+	}
+
 	$site_id       = \Jetpack_Options::get_option( 'id' );
 	$request_path  = sprintf( '/sites/%d/domains', $site_id );
 	$wpcom_request = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
@@ -1128,14 +1134,16 @@ function wpcom_request_domains_list() {
 	$body         = wp_remote_retrieve_body( $wpcom_request );
 	$decoded_body = json_decode( $body );
 
-	if ( ! isset( $decoded_body->domains ) ) {
+	if ( ! isset( $decoded_body->domains ) || ! is_array( $decoded_body->domains ) ) {
 		return new \WP_Error(
 			'failed_to_fetch_data',
 			esc_html__( 'Unable to fetch the requested data.', 'jetpack-mu-wpcom' )
 		);
 	}
 
-	return $decoded_body->domains;
+	$cached_domains = $decoded_body->domains;
+
+	return $cached_domains;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1043,7 +1043,7 @@ function wpcom_launchpad_is_verify_domain_email_visible() {
 	// the public API.
 	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
 	if ( $is_atomic_site ) {
-		$domains = wpcom_request_domains_list();
+		$domains = wpcom_launchpad_request_domains_list();
 
 		if ( is_wp_error( $domains ) ) {
 			return false;
@@ -1099,7 +1099,13 @@ function wpcom_launchpad_verify_domain_email_task_displayed() {
  *
  * @return array|WP_Error Array of domains and their verification status or WP_Error if the request fails.
  */
-function wpcom_request_domains_list() {
+function wpcom_launchpad_request_domains_list() {
+	// Use a static variable as a temporary in-memory cache to avoid multiple outbound
+	// HTTP requests within a single incoming request.
+	// We don't expect this to be triggered multiple times, but it's worth adding some
+	// light caching to avoid multiple, possibly slow HTTP requests where the underlying data
+	// is highly unlikely to change.
+	// The "cache" only lasts as long as the current request/memory space, so we don't need to invalidate it.
 	static $cached_domains = null;
 
 	if ( $cached_domains !== null ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1052,7 +1052,7 @@ function wpcom_launchpad_is_verify_domain_email_visible() {
 		$domains_pending_icann_verification = array_filter(
 			$domains,
 			function ( $domain ) {
-				return $domain->is_pending_icann_verification;
+				return isset( $domain->is_pending_icann_verification ) && $domain->is_pending_icann_verification;
 			}
 		);
 	} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a caching mechanism to the `wpcom_request_domains_list` function to prevent the requesting more than once the domain list.
* I also added a check to prevent the execution if the `domains` response is not an array.
* I added a check to prevent warnings in case the `is_pending_icann_verification`  property is undefined.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Visual inspection on the code would be enough, but to test it and ensure we are still showing the task, please follow the steps below:

* Sandbox the public-api
* Add the following filter to your `0-sandbox.php` file
```
add_filter( 'enable_legacy_site_setup_launchpad', '__return_true' );
```
* Create a new site through the `/setup/free` flow and launch your site once you reach the fullscreen Launchpad screen, and then add the Creator plan.
* Add a domain to your site.
* Now, add your site to the WoA Developer list.
* Transfer it to Atomic by navigating to `/hosting-config/:siteSlug` and activating the SSH. You need to upgrade to the Creator plan.
* Edit your `~/htdocs/wp-config.php` to add the `JETPACK__SANDBOX_DOMAIN` constants. This will make the requests from your Atomic site hit your sandbox. You may also need to add `JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN` if you are using the Jetpack Beta Tester plugin to apply this PR to your Atomic site(PCYsg-Osp-p2)
```
// define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true ); // Only if you are using the Jetpack Beta Tester plugin
define( 'JETPACK__SANDBOX_DOMAIN', 'YOU_SANDBOX_HOST' );
```
* Use the Jetpack Beta plugin to apply this PR to your site(You may have to update the files manually, as the plugin doesn't seem to work on my end)
* Go to the Customer Home and click on the `Show site setup` button on the banner.
* Replace the line linked below with the following code:
```
$this->is_pending_icann_verification  = true;
```
fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Snqzva%2Qcyhtvaf%2Sqbznvaf%2Sqbznva%2Qznantrzrag%2Qqbznva.cuc%3Se%3Q9o0577nq%23384-og
* Visit(refresh) the Customer Home page and verify you can see the `Verify the email address for your domains` task.