### PR TITLE
Plans: support creator plans in our plan checks

### DIFF
--- a/projects/packages/plans/changelog/update-plans-creator
+++ b/projects/packages/plans/changelog/update-plans-creator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Support the new creator plan in our plan checks

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.4.0",
+	"version": "0.4.1-alpha",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -80,6 +80,9 @@ class Current_Plan {
 				'value_bundle-monthly',
 				'value_bundle-2y',
 				'value_bundle-3y',
+				'jetpack_creator_yearly',
+				'jetpack_creator_bi_yearly',
+				'jetpack_creator_monthly',
 			),
 			'supports' => array(
 				'simple-payments',


### PR DESCRIPTION
Follow-up to #33893

## Proposed changes:

When one has a creator plan on their site, they should gain access to the features that are currently gated to legacy premium plan users.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

- p1705414284129149-slack-CBG1CP4EN
- 213-gh-jetpack-marketing

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a free site.
* Connect it to WordPress.com.
* Go to Jetpack > Dashboard > Plans
* Purchase a Creator plan
* Go to Jetpack > Dashboard > My Plan and confirm that the Creator plan appears on your site
* Go to Posts > Add New
* Add a new block and search for the Pay with PayPal block
    * It should be available on the site.
