### PR TITLE
Like block: Change the way the "other likers" list is built

### DIFF
--- a/projects/plugins/jetpack/changelog/update-likes-queuehandler
+++ b/projects/plugins/jetpack/changelog/update-likes-queuehandler
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Just applying changes already made on the WPCOM side
+
+

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -236,6 +236,22 @@ function JetpackLikesMessageListener( event ) {
 				}
 
 				const element = document.createElement( 'li' );
+				// Appending element before fetching avatar_URL to avoid racing conditions on the list order
+				list.append( element );
+
+				try {
+					const response = await fetch( liker.avatar_URL, { method: 'HEAD' } );
+					if ( ! response.ok ) {
+						// Image doesn't exist, remove the element
+						element.remove();
+						return;
+					}
+				} catch ( error ) {
+					// Error occurred while checking image existence, remove the element
+					element.remove();
+					return;
+				}
+
 				if ( newLayout ) {
 					element.innerHTML = `
 					<a href="${ encodeURI( liker.profile_URL ) }" rel="nofollow" target="_parent" class="wpl-liker">
@@ -254,8 +270,6 @@ function JetpackLikesMessageListener( event ) {
 					</a>
 				`;
 				}
-
-				list.append( element );
 
 				// Add some extra attributes through native methods, to ensure strings are sanitized.
 				element.classList.add( liker.css_class );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* ports the same change as was introduce in D133753-code to Jetpack
* add a missing image availability check (that is already available to Simple sites)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pdDOJh-2JP-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:

1. Test with self-hosted JP and WoA sites to check whether the Like block is working as expected.