### PR TITLE
Jetpack: Backport never-Fusioned content-options changes from wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-content-options-never-fusioned-changes-from-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-content-options-never-fusioned-changes-from-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Content Options: Allow themes to hide the default avatar (when author has no custom Gravatar) via `'avatar-default' => false`.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-content-options-never-fusioned-changes-from-wpcom#2
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-content-options-never-fusioned-changes-from-wpcom#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+ Content Options: Add new class to post when using the featured images fallback.

--- a/projects/plugins/jetpack/modules/theme-tools/content-options.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options.php
@@ -17,6 +17,7 @@
 		'blog-display'       => 'content', // the default setting of the theme: 'content', 'excerpt' or array( 'content', 'excerpt' ) for themes mixing both display.
 		'author-bio'         => true, // display or not the author bio: true or false.
 		'author-bio-default' => false, // the default setting of the author bio, if it's being displayed or not: true or false (only required if false).
+		'avatar-default'     => true, // display or not the default avatar for the author bio: true or false.
 		'masonry'            => '.site-main', // a CSS selector matching the elements that triggers a masonry refresh if the theme is using a masonry layout.
 		'post-details'       => array(
 			'stylesheet'        => 'themeslug-style', // name of the theme's stylesheet.

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/author-bio.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/author-bio.php
@@ -17,6 +17,7 @@ function jetpack_author_bio() {
 	$options            = get_theme_support( 'jetpack-content-options' );
 	$author_bio         = ( ! empty( $options[0]['author-bio'] ) ) ? $options[0]['author-bio'] : null;
 	$author_bio_default = ( isset( $options[0]['author-bio-default'] ) && false === $options[0]['author-bio-default'] ) ? '' : 1;
+	$avatar_default     = ( isset( $options[0]['avatar-default'] ) && false === $options[0]['avatar-default'] ) ? '' : 1;
 
 	// If the theme doesn't support 'jetpack-content-options[ 'author-bio' ]', don't continue.
 	if ( true !== $author_bio ) {
@@ -32,8 +33,16 @@ function jetpack_author_bio() {
 	if ( ! is_single() ) {
 		return;
 	}
+
+	// Define class for entry-author.
+	if ( ! $avatar_default && ! jetpack_has_gravatar( get_the_author_meta( 'user_email' ) ) ) {
+		$class = 'author-avatar-hide';
+	} else {
+		$class = 'author-avatar-show';
+	}
 	?>
-	<div class="entry-author">
+	<div class="entry-author <?php echo esc_attr( $class ); ?>">
+		<?php if ( 'author-avatar-show' === $class ) : ?>
 		<div class="author-avatar">
 			<?php
 			/**
@@ -50,6 +59,7 @@ function jetpack_author_bio() {
 			echo get_avatar( get_the_author_meta( 'user_email' ), $author_bio_avatar_size );
 			?>
 		</div><!-- .author-avatar -->
+		<?php endif; ?>
 
 		<div class="author-heading">
 			<h2 class="author-title">
@@ -71,4 +81,19 @@ function jetpack_author_bio() {
 		</p><!-- .author-bio -->
 	</div><!-- .entry-auhtor -->
 	<?php
+}
+
+/**
+ * Checks to see if the specified email address has a Gravatar image.
+ *
+ * @param string $email The email of the address of the user to check.
+ * @return bool Whether or not the user has a gravatar
+ */
+function jetpack_has_gravatar( $email ) {
+
+	$url     = get_avatar_url( $email, array( 'default' => '404' ) );
+	$headers = get_headers( $url );
+
+	// If 200 is found, the user has a Gravatar; otherwise, they don't.
+	return preg_match( '|200|', $headers[0] ) ? true : false;
 }

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images-fallback.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images-fallback.php
@@ -218,6 +218,7 @@ function jetpack_featured_images_post_class( $classes, $class, $post_id ) {
 
 	if ( jetpack_has_featured_image( $post_id ) && (bool) 1 === (bool) $opts['fallback-option'] && ! is_attachment() && ! $post_password_required && 'post' === get_post_type() ) {
 		$classes[] = 'has-post-thumbnail';
+		$classes[] = 'fallback-thumbnail';
 	}
 
 	return $classes;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allow themes to hide the default avatar (when author has no custom Gravatar) via `'avatar-default' => false` (r161782-wpcom)
* Content Options: Add new class to post when using the featured images fallback (r168293-wpcom)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a test site.
* Create a post. Include an Image block, but do not set a featured image.
* Create a second user with the Author role and a dummy email such as `dummy@example.com`. Create another post and set the author to that user.
* Download, install, and activate the theme from https://wordpress.com/theme/radcliffe-2/
* Go to Customize → Content Options, and enable the "Automatically use first image in post" checkbox.
* View the posts.
  * The first should show your gravatar in the "author bio" at the bottom. Also the element with class `has-post-thumbnail` should also have class `fallback-thumbnail`.
  * The second should not show a default gravatar.
