### PR TITLE
Dotcom patterns: allow testing assembler v2 patterns in editor when Assembler theme is active

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-register-dotcom-v2-patterns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-register-dotcom-v2-patterns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dotcom patterns: use assembler v2 patterns in editor 

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -173,11 +173,20 @@ class Wpcom_Block_Patterns_From_Api {
 
 		$block_patterns = $this->utils->cache_get( $patterns_cache_key, 'ptk_patterns' );
 
+		// Enable testing v2 patterns on sites with Assembler theme active
+		$enable_testing_v2_patterns = in_array( get_stylesheet(), array( 'pub/assembler', 'assembler' ), true );
+
 		// Load fresh data if we don't have any patterns.
-		if ( false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
+		if ( $enable_testing_v2_patterns || false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
+			if ( $enable_testing_v2_patterns ) {
+				$request_params = array(
+					'site'      => 'assemblerv2patterns.wordpress.com',
+					'post_type' => 'wp_block',
+				);
+			}
 			$request_url = esc_url_raw(
 				add_query_arg(
-					array(
+					$request_params ?? array(
 						'tags'            => 'pattern',
 						'pattern_meta'    => 'is_web',
 						'patterns_source' => $patterns_source,
@@ -188,7 +197,9 @@ class Wpcom_Block_Patterns_From_Api {
 
 			$block_patterns = $this->utils->remote_get( $request_url );
 
-			$this->utils->cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
+			if ( ! $enable_testing_v2_patterns ) {
+				$this->utils->cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
+			}
 		}
 
 		return $block_patterns;

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -86,12 +86,8 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$block_patterns_from_api = new Wpcom_Block_Patterns_From_Api( $utils_mock );
 
 		$utils_mock->expects( $this->once() )
-			->method( 'cache_get' )
-			->willReturn( false );
-
-		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
-			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' );
+			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=assemblerv2patterns.wordpress.com&post_type=wp_block' );
 
 		$utils_mock->expects( $this->once() )
 			->method( 'cache_add' )
@@ -110,7 +106,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=assemblerv2patterns.wordpress.com&post_type=wp_block' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
@@ -126,9 +122,6 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'cache_get' )
 			->with( $this->stringContains( 'key-largo' ), 'ptk_patterns' );
-
-		$utils_mock->expects( $this->never() )
-			->method( 'remote_get' );
 
 		$utils_mock->expects( $this->never() )
 			->method( 'cache_add' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -86,10 +86,6 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$block_patterns_from_api = new Wpcom_Block_Patterns_From_Api( $utils_mock );
 
 		$utils_mock->expects( $this->once() )
-			->method( 'remote_get' )
-			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=assemblerv2patterns.wordpress.com&post_type=wp_block' );
-
-		$utils_mock->expects( $this->once() )
 			->method( 'cache_add' )
 			->with( $this->stringContains( 'key-largo' ), array( $this->pattern_mock_object ), 'ptk_patterns', DAY_IN_SECONDS );
 
@@ -106,7 +102,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=assemblerv2patterns.wordpress.com&post_type=wp_block' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fetch assembler v2 patterns in the editor and disable the cache when the Assembler theme is active
* Disable patterns cache for that case

>[!WARNING]
>This is following what we are also doing for the Editor "Add a page" Modal in https://github.com/Automattic/wp-calypso/pull/86292
>
>This is only for the internal CfT, to help test v2 patterns on any site without needing a sandbox.
>
>For the public CfT, the plan is to show v2 patterns on the editor for all Automatticians, again to help testing without needing a sandbox. See https://github.com/Automattic/jetpack/pull/35063


>[!NOTE]
>All patterns are fetched, including pages.  
>Some page patterns show errors because they contain reusable patterns that must be detached.


|BEFORE|AFTER|
|-|-|
|<img width="651" alt="Screenshot 2567-01-16 at 17 48 16" src="https://github.com/Automattic/jetpack/assets/1881481/d1d5c261-0134-4fdc-a2e2-b23ee0b6bc58">|<img width="652" alt="Screenshot 2567-01-16 at 17 47 02" src="https://github.com/Automattic/jetpack/assets/1881481/9dd2f65f-768f-427d-8c7a-86a934eaf603">|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Setup your sandbox
* Sandbox a simple site, and the public API
* Run in your sandbox `bin/jetpack-downloader test jetpack-mu-wpcom-plugin test/use-dotcom-v2-patterns-in-editor`

### Test patterns
* Access the editor on that site
  * click "Patterns" on the sidebar  to explore the patterns
  * click to edit a template and then click the button `[ + ]` on the topbar to explore the patterns from the editor inserter
* Verify you see the new patterns and categories from the source site assemblerv2patterns

