### PR TITLE
[Boost] Fix Modules e2e test

### DIFF
--- a/projects/js-packages/react-data-sync-client/changelog/boost-fix-e2e-tests
+++ b/projects/js-packages/react-data-sync-client/changelog/boost-fix-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix e2e tests
+
+

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -92,6 +92,7 @@ export function useDataSync<
 	 * - `queryKey` is the key of the value that's being synced.
 	 * - `queryFn` is wired up to DataSync `GET` method.
 	 * - `initialData` gets the value from the global window object.
+	 * - `staleTime` is set to 1 second by default; to prevent immediate re-fetching after setting a value.
 	 *
 	 * If your property is lazy-loaded, you should populate `initialData` with a value manually.
 	 * ```js
@@ -104,7 +105,7 @@ export function useDataSync<
 		queryKey,
 		queryFn: ( { signal } ) => datasync.GET( params, signal ),
 		initialData: () => datasync.getInitialValue(),
-		staleTime: Infinity,
+		staleTime: 1 * 1000,
 	};
 
 	/**

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -104,6 +104,7 @@ export function useDataSync<
 		queryKey,
 		queryFn: ( { signal } ) => datasync.GET( params, signal ),
 		initialData: () => datasync.getInitialValue(),
+		staleTime: Infinity,
 	};
 
 	/**
@@ -138,8 +139,8 @@ export function useDataSync<
 		onError: ( _, __, context ) => {
 			queryClient.setQueryData( queryKey, context.previousValue );
 		},
-		onSettled: () => {
-			queryClient.invalidateQueries( { queryKey } );
+		onSuccess: ( data: Schema ) => {
+			queryClient.setQueryData( queryKey, data );
 		},
 	};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We've had Modules E2E tests fail a lot lately on random PRs. There is a timing bug in there.

I traced it down to a problem with how we set data when writing (e.g.: module state) to the server. React Query was immediately calling a getter after setting the data because its local data was invalidated by our onSettled handler.

Instead, this update uses onSuccess to store the new value returned by the server from the setter.

Additionally, the default stale time for data in React Query appears to be 0 seconds - that is, it's considered stale immediately upon storage and can be randomly refetched any time. This update also sets the stale timer to Infinity - so we can refetch it whenever we believe there is a reason to do so.

## Proposed changes:
* Save the data returned by datasync setters, instead of throwing it away and refetching
* Don't mark freshly cached data as stale.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Turn modules on and off
* Look at the network tab, and observe that the ui is working nicely but data is not immediately refetched after setting it.

