### PR TITLE
Newsletter launchpad: move email verify task above subscriber task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-launchpad-subscriber-task-order
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-launchpad-subscriber-task-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Newsletter launchpad: move email verify task above subscriber task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -87,11 +87,11 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'task_ids'            => array(
 				'setup_newsletter',
 				'plan_selected',
-				'subscribers_added',
 				'verify_email',
+				'subscribers_added',
+				'migrate_content',
 				'set_up_payments',
 				'newsletter_plan_created',
-				'migrate_content',
 				'first_post_published_newsletter',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Goes with https://github.com/Automattic/wp-calypso/pull/86525

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves email verification task above add subscribers task, since email verification is required for the latter.

**Before**
<img width="334" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/46b66fbc-48b1-424e-b693-e3113dc78187">

**After**
<img width="340" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/61e0d5b9-14bc-424b-bf77-137cd8d34299">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply diff to simple site (see how in https://github.com/Automattic/jetpack/pull/35084#issuecomment-1895503356)
* Sandbox the public API and the simple site URL
* Create new site via /setup/newsletter
* Note that verify task is above subscriber task
