### PR TITLE
jetpack-mu-wpcom: Prevent get_plugin_data() indirectly calling wptexturize

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-load-coming-soon-get-plugin-data
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-load-coming-soon-get-plugin-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+jetpack-mu-wpcom: Prevent get_plugin_data indirectly calling wptexturize.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -83,7 +83,15 @@ class Jetpack_Mu_Wpcom {
 		if ( ! function_exists( 'is_plugin_active' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
-		$invalid_fse_version_active = is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) && version_compare( get_plugin_data( WP_PLUGIN_DIR . '/full-site-editing/full-site-editing-plugin.php' )['Version'], '3.56084', '<' );
+
+		/**
+		 * Explicitly pass $markup = false in get_plugin_data to avoid indirectly calling wptexturize that could cause unintended side effects.
+		 * See: https://developer.wordpress.org/reference/functions/get_plugin_data/
+		 */
+		$invalid_fse_version_active =
+			is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) &&
+			version_compare( get_plugin_data( WP_PLUGIN_DIR . '/full-site-editing/full-site-editing-plugin.php', false )['Version'], '3.56084', '<' );
+
 		if ( $invalid_fse_version_active ) {
 			return;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


Fixes https://github.com/Automattic/wp-calypso/issues/83404

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR passes the argument $markup = false to `get_plugin_data()` to prevent unintentionally calling wptexturize. Otherwise, issues such as https://github.com/Automattic/wp-calypso/issues/83404 occur.

See https://developer.wordpress.org/reference/functions/get_plugin_data/#comment-2109 and https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/plugin.php#L208


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a WoA site, and ensure that ETK is activated.
* Set your site language to Spanish.
* Add, or edit a post, so that either the title or the post content contains quotation marks ("").
* View the post, and ensure that the quotation marks ("") are converted to angular quotes («»).
