### PR TITLE
JurassicNinja : use direct betadownload.jetpack.me url i tampermonkey script

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -112,7 +112,9 @@
 		} else {
 			if ( ! pluginsList ) {
 				pluginsList = dofetch(
-					`https://betadownload.jetpack.me/query-branch.php?repo=${ repo }&branch=${ currentBranch }`
+					`https://betadownload.jetpack.me/query-branch.php?repo=${ encodeURIComponent(
+						repo
+					) }&branch=${ encodeURIComponent( currentBranch ) }`
 				);
 			}
 			pluginsList
@@ -148,13 +150,7 @@
 							return;
 						}
 					} else {
-						plugins.push( {
-							name: 'branch',
-							value: currentBranch,
-							label: 'Jetpack',
-							checked: true,
-							disabled: true,
-						} );
+						throw new Error( 'Invalid response from server' );
 					}
 
 					const contents = `

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -112,9 +112,8 @@
 		} else {
 			if ( ! pluginsList ) {
 				pluginsList = dofetch(
-					`https://betadownload.jetpack.me/query-branch.php?repo=${ encodeURIComponent(
-						repo
-					) }&branch=${ encodeURIComponent( currentBranch ) }`
+					// prettier-ignore
+					`https://betadownload.jetpack.me/query-branch.php?repo=${ encodeURIComponent( repo ) }&branch=${ encodeURIComponent( currentBranch ) }`
 				);
 			}
 			pluginsList

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,10 +1,10 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.32
+// @version      1.31
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
-// @connect      jurassic.ninja
+// @connect      betadownload.jetpack.me
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*
 // ==/UserScript==
@@ -99,7 +99,7 @@
 				<p><a target="_blank" rel="nofollow noopener" href="${ getLink( host )[ 0 ] }">
 					Test with <code>trunk</code> branch instead.
 				</a><br/>
-				<a target="_blank" rel="nofollow noopener" href="${ getLink( host2 )[ 0 ] }">
+                <a target="_blank" rel="nofollow noopener" href="${ getLink( host2 )[ 0 ] }">
 					Test with <code>trunk</code> branch instead on Atomic.
 				</a></p>
 			`;
@@ -112,19 +112,19 @@
 		} else {
 			if ( ! pluginsList ) {
 				pluginsList = dofetch(
-					`${ host }/wp-json/jurassic.ninja/jetpack-beta/branches/${ repo }/${ currentBranch }`
+					`https://betadownload.jetpack.me/query-branch.php?repo=${ repo }&branch=${ currentBranch }`
 				);
 			}
 			pluginsList
 				.then( body => {
 					const plugins = [];
 
-					if ( body.status === 'ok' ) {
+					if ( body.hasOwnProperty( 'plugins' ) ) {
 						const labels = new Set(
 							$.map( $( '.js-issue-labels a.IssueLabel' ), e => $( e ).data( 'name' ) )
 						);
-						Object.keys( body.data.plugins ).forEach( k => {
-							const data = body.data.plugins[ k ];
+						Object.keys( body.plugins ).forEach( k => {
+							const data = body.plugins[ k ];
 							plugins.push( {
 								name: `branches.${ k }`,
 								value: currentBranch,
@@ -147,7 +147,7 @@
 							);
 							return;
 						}
-					} else if ( body.code === 'rest_no_route' ) {
+					} else {
 						plugins.push( {
 							name: 'branch',
 							value: currentBranch,
@@ -155,8 +155,6 @@
 							checked: true,
 							disabled: true,
 						} );
-					} else {
-						throw new Error( 'Invalid response from server' );
 					}
 
 					const contents = `
@@ -282,8 +280,8 @@
 					<p>
 						<a id="jetpack-beta-branch-link" target="_blank" rel="nofollow noopener" href="#">…</a>
 					</p>
-					<p><h3>JurassicNinja on Atomic</h3></p>
-					<p>
+                    <p><h3>JurassicNinja on Atomic</h3></p>
+                    <p>
 						<a id="jetpack-beta-branch-link2" target="_blank" rel="nofollow noopener" href="#">…</a>
 					</p>
 					`;

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.31
+// @version      1.33
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      betadownload.jetpack.me
@@ -99,7 +99,7 @@
 				<p><a target="_blank" rel="nofollow noopener" href="${ getLink( host )[ 0 ] }">
 					Test with <code>trunk</code> branch instead.
 				</a><br/>
-                <a target="_blank" rel="nofollow noopener" href="${ getLink( host2 )[ 0 ] }">
+				<a target="_blank" rel="nofollow noopener" href="${ getLink( host2 )[ 0 ] }">
 					Test with <code>trunk</code> branch instead on Atomic.
 				</a></p>
 			`;
@@ -280,8 +280,8 @@
 					<p>
 						<a id="jetpack-beta-branch-link" target="_blank" rel="nofollow noopener" href="#">…</a>
 					</p>
-                    <p><h3>JurassicNinja on Atomic</h3></p>
-                    <p>
+					<p><h3>JurassicNinja on Atomic</h3></p>
+					<p>
 						<a id="jetpack-beta-branch-link2" target="_blank" rel="nofollow noopener" href="#">…</a>
 					</p>
 					`;


### PR DESCRIPTION
Jurassic.Ninja is migrating to WP.com. Tampermonkey has a dependency on the jetpack-beta/branches endpoint that was a pass through for betadownload.jetpack.me. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update Tampermonkey script to use betadownload.jetpack.me endpoint

### Other information:

- [N/A] Have you written new tests for your changes, if applicable?
- [N/A] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [N/A] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://wp.me/p9o2xV-3Fc

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Modify your local tampermonkey script to use the version in this PR
* Access a Jetpack pull request
* Verify the tampermonkey script executes and when creating the new site it set the beta branch correctly.

