### PR TITLE
In the user link tracking url, the parent iframe only listen one redirection post message from its child

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-parent-iframe-only-listen-one-message
+++ b/projects/plugins/jetpack/changelog/fix-parent-iframe-only-listen-one-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+In the tracking user link url, the parent of the iframe only listens one redirection post message from its child 

--- a/projects/plugins/jetpack/modules/subscriptions/jetpack-user-content-link-redirection.php
+++ b/projects/plugins/jetpack/modules/subscriptions/jetpack-user-content-link-redirection.php
@@ -25,11 +25,13 @@ function jetpack_user_content_link_redirection() {
 <html>
 <head>
 <script>
+	var messageReceived = false;
 	window.addEventListener( 'message', function(event) {
-		if ( event.origin !== 'https://subscribe.wordpress.com' ) {
+		if ( event.origin !== 'https://subscribe.wordpress.com' || messageReceived ) {
 			return;
 		}
 		if ( event.data.redirectUrl ) {
+			messageReceived = true;
 			window.location.href = event.data.redirectUrl;
 		}
 	} );

--- a/projects/plugins/jetpack/modules/subscriptions/jetpack-user-content-link-redirection.php
+++ b/projects/plugins/jetpack/modules/subscriptions/jetpack-user-content-link-redirection.php
@@ -25,7 +25,7 @@ function jetpack_user_content_link_redirection() {
 <html>
 <head>
 <script>
-	var messageReceived = false;
+	let messageReceived = false;
 	window.addEventListener( 'message', function(event) {
 		if ( event.origin !== 'https://subscribe.wordpress.com' || messageReceived ) {
 			return;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/86535

## Proposed changes:

When a custom link is clicked on the body of the post in an email, it goes to a site with only an iframe to subscribe.wordpress.com URL. That subscribe site will track the link and then send a post message to the iframe's parent to redirect to the original link. This is done in a loop, as we don't know if the listening script is ready on the parent when the iframe sends the message.

This PR makes the parent stop listening to these messages once it receives one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Sync this change to your sandbox.
- Sandbox your site.
- Make a new post with a link outside WordPress.com (to `youtube.com` for example). Note: you should be subscribed to the blog to receive an email.
- Go to the email and copy the link.
- Open a new tab in the browser and open the network tab in the developer tools.
- Check `disable cache` and `persist logs`.
- Go to the URL of the link in that tab.
- The redirection should work, and inspecting the raw response in the first link with a query param "action=user_content_redirect" on the network tab should show the new `messageReceived` var.

