### PR TITLE
Contact Form: fix source for concatenated stylesheet

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-contact-form-concatenated-styles
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-concatenated-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Contact Form: fix source for concatenated stylesheet

--- a/projects/plugins/jetpack/tools/webpack.config.css.js
+++ b/projects/plugins/jetpack/tools/webpack.config.css.js
@@ -123,7 +123,7 @@ const weirdRtlEntries = {
 		// When making changes to that list, you must also update $concatenated_style_handles in class.jetpack.php.
 		'modules/carousel/swiper-bundle.css',
 		'modules/carousel/jetpack-carousel.css',
-		'modules/contact-form/css/grunion.css',
+		'jetpack_vendor/automattic/jetpack-forms/src/contact-form/css/grunion.css',
 		'modules/infinite-scroll/infinity.css',
 		'modules/likes/style.css',
 		'modules/related-posts/related-posts.css',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When multiple Jetpack modules are activated, styles are concatenated in a single `jetpack.css` stylesheet. The source used for the Contact Form styles was out of date. This PR fixes it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Connect Jetpack
- Visit the modules page at `/wp-admin/admin.php?page=jetpack_modules`
- Activate several block related modules, such as VideoPress, Markdown, Likes, or Carousel
- If you're testing locally, make sure `SCRIPT_DEBUG` is set to `false` in your `wp-config.php` file
- Create a new post
- Add the Contact Form block
- Save the draft and open the preview
- In the Network panel, you should see the `jetpack.css` file
- Make sure it contains the `.contact-form__input-error` selector

