### PR TITLE
Memberships: Add translations to newsletter modal

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-modal-translations
+++ b/projects/plugins/jetpack/changelog/add-newsletter-modal-translations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Memberships: Adds translation to paid content modal.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -626,6 +626,7 @@ function get_post_access_level_for_current_post() {
  * @return string
  */
 function render_for_website( $data, $classes, $styles ) {
+	$lang              = get_locale();
 	$blog_id           = \Jetpack_Options::get_option( 'id' );
 	$widget_id_suffix  = Jetpack_Subscriptions_Widget::$instance_count > 1 ? '-' . Jetpack_Subscriptions_Widget::$instance_count : '';
 	$form_id           = 'subscribe-blog' . $widget_id_suffix;
@@ -718,6 +719,7 @@ function render_for_website( $data, $classes, $styles ) {
 						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
 						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
 						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
+						<input type="hidden" name="lang" value="<?php echo esc_attr( $lang ); ?>"/>
 						<?php
 						wp_nonce_field( 'blogsub_subscribe_' . $blog_id );
 

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -41,10 +41,12 @@ export function showModal( url ) {
 	dialog.setAttribute( 'id', 'memberships-modal-window' );
 
 	const iframe = document.createElement( 'iframe' );
+	const siteLanguage = document.querySelector( 'input[name="lang"]' ).value;
 	iframe.setAttribute( 'id', 'memberships-modal-iframe' );
 	iframe.innerText =
 		'This feature requires inline frames. You have iframes disabled or your browser does not support them.';
-	iframe.src = url + '&display=alternate&jwt_token=' + getTokenFromCookie();
+	iframe.src =
+		url + '&display=alternate&lang=' + siteLanguage + '&jwt_token=' + getTokenFromCookie();
 	iframe.setAttribute( 'frameborder', '0' );
 	iframe.setAttribute( 'allowtransparency', 'true' );
 	iframe.setAttribute( 'allowfullscreen', 'true' );

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -40,17 +40,17 @@ export function showModal( url ) {
 	const dialog = document.createElement( 'dialog' );
 	dialog.setAttribute( 'id', 'memberships-modal-window' );
 
-	const iframe = document.createElement( 'iframe' );
-	const siteLanguage = document.documentElement.lang;
-	iframe.setAttribute( 'id', 'memberships-modal-iframe' );
-	iframe.innerText =
-		'This feature requires inline frames. You have iframes disabled or your browser does not support them.';
-	iframe.src =
-		url + '&display=alternate&language=' + siteLanguage + '&jwt_token=' + getTokenFromCookie();
-	iframe.setAttribute( 'frameborder', '0' );
-	iframe.setAttribute( 'allowtransparency', 'true' );
-	iframe.setAttribute( 'allowfullscreen', 'true' );
-	dialog.classList.add( 'jetpack-memberships-modal' );
+		const iframe = document.createElement( 'iframe' );
+		const siteLanguage = document.documentElement.lang;
+		iframe.setAttribute( 'id', 'memberships-modal-iframe' );
+		iframe.innerText =
+			'This feature requires inline frames. You have iframes disabled or your browser does not support them.';
+		iframe.src =
+			url + '&display=alternate&lang=' + siteLanguage + '&jwt_token=' + getTokenFromCookie();
+		iframe.setAttribute( 'frameborder', '0' );
+		iframe.setAttribute( 'allowtransparency', 'true' );
+		iframe.setAttribute( 'allowfullscreen', 'true' );
+		dialog.classList.add( 'jetpack-memberships-modal' );
 
 	document.body.appendChild( dialog );
 	dialog.appendChild( iframe );

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -41,7 +41,7 @@ export function showModal( url ) {
 	dialog.setAttribute( 'id', 'memberships-modal-window' );
 
 	const iframe = document.createElement( 'iframe' );
-	const siteLanguage = document.documentElement.lang.split( '-' )[ 0 ];
+	const siteLanguage = document.documentElement.lang.toLowerCase();
 	iframe.setAttribute( 'id', 'memberships-modal-iframe' );
 	iframe.innerText =
 		'This feature requires inline frames. You have iframes disabled or your browser does not support them.';

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -41,7 +41,7 @@ export function showModal( url ) {
 	dialog.setAttribute( 'id', 'memberships-modal-window' );
 
 	const iframe = document.createElement( 'iframe' );
-	const siteLanguage = document.documentElement.lang;
+	const siteLanguage = document.documentElement.lang.split( '-' )[ 0 ];
 	iframe.setAttribute( 'id', 'memberships-modal-iframe' );
 	iframe.innerText =
 		'This feature requires inline frames. You have iframes disabled or your browser does not support them.';

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -41,7 +41,9 @@ export function showModal( url ) {
 	dialog.setAttribute( 'id', 'memberships-modal-window' );
 
 	const iframe = document.createElement( 'iframe' );
-	const siteLanguage = document.documentElement.lang.toLowerCase();
+	const fullLang = document.documentElement.lang.toLowerCase();
+	const parts = fullLang.split( '-' );
+	const siteLanguage = parts[ 0 ] === parts[ 1 ] ? parts[ 0 ] : fullLang;
 	iframe.setAttribute( 'id', 'memberships-modal-iframe' );
 	iframe.innerText =
 		'This feature requires inline frames. You have iframes disabled or your browser does not support them.';

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -41,13 +41,10 @@ export function showModal( url ) {
 	dialog.setAttribute( 'id', 'memberships-modal-window' );
 
 	const iframe = document.createElement( 'iframe' );
-	const fullLang = document.documentElement.lang.toLowerCase();
-	const parts = fullLang.split( '-' );
-	const siteLanguage = parts[ 0 ] === parts[ 1 ] ? parts[ 0 ] : fullLang;
 	iframe.setAttribute( 'id', 'memberships-modal-iframe' );
 	iframe.innerText =
 		'This feature requires inline frames. You have iframes disabled or your browser does not support them.';
-	iframe.src = url + '&lang=' + siteLanguage + '&jwt_token=' + getTokenFromCookie();
+	iframe.src = url + '&display=alternate&jwt_token=' + getTokenFromCookie();
 	iframe.setAttribute( 'frameborder', '0' );
 	iframe.setAttribute( 'allowtransparency', 'true' );
 	iframe.setAttribute( 'allowfullscreen', 'true' );

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -45,8 +45,7 @@ export function showModal( url ) {
 	iframe.setAttribute( 'id', 'memberships-modal-iframe' );
 	iframe.innerText =
 		'This feature requires inline frames. You have iframes disabled or your browser does not support them.';
-	iframe.src =
-		url + '&display=alternate&lang=' + siteLanguage + '&jwt_token=' + getTokenFromCookie();
+	iframe.src = url + '&lang=' + siteLanguage + '&jwt_token=' + getTokenFromCookie();
 	iframe.setAttribute( 'frameborder', '0' );
 	iframe.setAttribute( 'allowtransparency', 'true' );
 	iframe.setAttribute( 'allowfullscreen', 'true' );

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -41,10 +41,12 @@ export function showModal( url ) {
 	dialog.setAttribute( 'id', 'memberships-modal-window' );
 
 	const iframe = document.createElement( 'iframe' );
+	const siteLanguage = document.documentElement.lang;
 	iframe.setAttribute( 'id', 'memberships-modal-iframe' );
 	iframe.innerText =
 		'This feature requires inline frames. You have iframes disabled or your browser does not support them.';
-	iframe.src = url + '&display=alternate&jwt_token=' + getTokenFromCookie();
+	iframe.src =
+		url + '&display=alternate&language=' + siteLanguage + '&jwt_token=' + getTokenFromCookie();
 	iframe.setAttribute( 'frameborder', '0' );
 	iframe.setAttribute( 'allowtransparency', 'true' );
 	iframe.setAttribute( 'allowfullscreen', 'true' );

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -40,17 +40,17 @@ export function showModal( url ) {
 	const dialog = document.createElement( 'dialog' );
 	dialog.setAttribute( 'id', 'memberships-modal-window' );
 
-		const iframe = document.createElement( 'iframe' );
-		const siteLanguage = document.documentElement.lang;
-		iframe.setAttribute( 'id', 'memberships-modal-iframe' );
-		iframe.innerText =
-			'This feature requires inline frames. You have iframes disabled or your browser does not support them.';
-		iframe.src =
-			url + '&display=alternate&lang=' + siteLanguage + '&jwt_token=' + getTokenFromCookie();
-		iframe.setAttribute( 'frameborder', '0' );
-		iframe.setAttribute( 'allowtransparency', 'true' );
-		iframe.setAttribute( 'allowfullscreen', 'true' );
-		dialog.classList.add( 'jetpack-memberships-modal' );
+	const iframe = document.createElement( 'iframe' );
+	const siteLanguage = document.documentElement.lang;
+	iframe.setAttribute( 'id', 'memberships-modal-iframe' );
+	iframe.innerText =
+		'This feature requires inline frames. You have iframes disabled or your browser does not support them.';
+	iframe.src =
+		url + '&display=alternate&lang=' + siteLanguage + '&jwt_token=' + getTokenFromCookie();
+	iframe.setAttribute( 'frameborder', '0' );
+	iframe.setAttribute( 'allowtransparency', 'true' );
+	iframe.setAttribute( 'allowfullscreen', 'true' );
+	dialog.classList.add( 'jetpack-memberships-modal' );
 
 	document.body.appendChild( dialog );
 	dialog.appendChild( iframe );

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -202,7 +202,6 @@ class Jetpack_Memberships {
 	public function init_hook_action() {
 		add_filter( 'rest_api_allowed_post_types', array( $this, 'allow_rest_api_types' ) );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'allow_sync_post_meta' ) );
-		\switch_to_locale( get_locale() );
 		$this->setup_cpts();
 	}
 

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -202,6 +202,7 @@ class Jetpack_Memberships {
 	public function init_hook_action() {
 		add_filter( 'rest_api_allowed_post_types', array( $this, 'allow_rest_api_types' ) );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'allow_sync_post_meta' ) );
+		\switch_to_locale( get_locale() );
 		$this->setup_cpts();
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/281

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This adds a query parameter to the newsletter modal iframe link, in order to easily pass the site's language through to the modal. Currently, the modal will use the logged-in WPCOM user's language, or default to EN if not logged in. Because the modal is appearing as if it's part of the site, we want to utilize the site's language for this.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Testing instructions will be in D134629-code