### PR TITLE
AI Assistant: move usePlanType to shared directory

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-assistant-shared-use-plan-type
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-shared-use-plan-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Assistant: move usePlanType to shared directory

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -9,7 +9,11 @@ import React from 'react';
  * Internal dependencies
  */
 import './style.scss';
-import { PLAN_TYPE_FREE, PLAN_TYPE_TIERED, PLAN_TYPE_UNLIMITED } from './types';
+import {
+	PLAN_TYPE_FREE,
+	PLAN_TYPE_TIERED,
+	PLAN_TYPE_UNLIMITED,
+} from '../../../../shared/use-plan-type';
 /**
  * Types
  */

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
@@ -1,3 +1,5 @@
+import { PlanType } from '../../../../shared/use-plan-type';
+
 export type UsageBarProps = {
 	/**
 	 * The current usage, as a percentage represented by a number between 0 and 1.
@@ -23,9 +25,3 @@ export type UsageControlProps = {
 	daysUntilReset: number;
 	requireUpgrade: boolean;
 };
-
-export const PLAN_TYPE_FREE = 'free';
-export const PLAN_TYPE_TIERED = 'tiered';
-export const PLAN_TYPE_UNLIMITED = 'unlimited';
-
-export type PlanType = typeof PLAN_TYPE_FREE | typeof PLAN_TYPE_TIERED | typeof PLAN_TYPE_UNLIMITED;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -16,33 +16,15 @@ import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import useAnalytics from '../../../../blocks/ai-assistant/hooks/use-analytics';
 import { canUserPurchasePlan } from '../../../../blocks/ai-assistant/lib/connection';
 import useAutosaveAndRedirect from '../../../../shared/use-autosave-and-redirect';
+import {
+	PLAN_TYPE_FREE,
+	PLAN_TYPE_TIERED,
+	usePlanType,
+	PlanType,
+} from '../../../../shared/use-plan-type';
 import UsageControl from '../usage-bar';
 import './style.scss';
-import { PLAN_TYPE_FREE, PLAN_TYPE_TIERED, PLAN_TYPE_UNLIMITED } from '../usage-bar/types';
 import type { UsagePanelProps } from './types';
-import type { PlanType } from '../usage-bar/types';
-
-/**
- * Simple hook to get the plan type from the current tier
- *
- * @param {object} currentTier - the current tier from the AI Feature data
- * @returns {PlanType} the plan type
- */
-const usePlanType = ( currentTier ): PlanType => {
-	if ( ! currentTier ) {
-		return null;
-	}
-
-	if ( currentTier?.value === 0 ) {
-		return PLAN_TYPE_FREE;
-	}
-
-	if ( currentTier?.value === 1 ) {
-		return PLAN_TYPE_UNLIMITED;
-	}
-
-	return PLAN_TYPE_TIERED;
-};
 
 /**
  * Simple hook to get the days until the next reset

--- a/projects/plugins/jetpack/extensions/shared/use-plan-type/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/use-plan-type/index.ts
@@ -1,0 +1,27 @@
+export const PLAN_TYPE_FREE = 'free';
+export const PLAN_TYPE_TIERED = 'tiered';
+export const PLAN_TYPE_UNLIMITED = 'unlimited';
+
+export type PlanType = typeof PLAN_TYPE_FREE | typeof PLAN_TYPE_TIERED | typeof PLAN_TYPE_UNLIMITED;
+
+/**
+ * Simple hook to get the plan type from the current tier
+ *
+ * @param {object} currentTier - the current tier from the AI Feature data
+ * @returns {PlanType} the plan type
+ */
+export const usePlanType = ( currentTier ): PlanType => {
+	if ( ! currentTier ) {
+		return null;
+	}
+
+	if ( currentTier?.value === 0 ) {
+		return PLAN_TYPE_FREE;
+	}
+
+	if ( currentTier?.value === 1 ) {
+		return PLAN_TYPE_UNLIMITED;
+	}
+
+	return PLAN_TYPE_TIERED;
+};


### PR DESCRIPTION
Janitorial: we need usePlanType and its constants available for use outside the UsagePanel / UsageBar

## Proposed changes:
This PR moves a simple usePlanType, its constants and types to a shared location for use on other components.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
As janitorial work there is no actual testing other than building and seeing the UsageBar / UsagePanel working fine.
Go to the editor and insert an AI Assistant block. The UsagePanel should be on the sidebar and should work as usual, the UsageBar should be rendered in the panel and should show usage (tiered/free plans) or "Unlimited" on legacy plans.

<img width="288" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/ed4b3221-40ab-4e57-96d9-c9045e3a1f17">
