### PR TITLE
Launchpad: Remove the "Install the mobile app" task from the Legacy Site Setup Launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-mobile-app-install-task-legacy-site-setup
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-mobile-app-install-task-legacy-site-setup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removes the 'Install the mobile app' task from the Legacy Site Setup launchpad

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -278,7 +278,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'front_page_updated',
 				'verify_domain_email',
 				'verify_email',
-				'mobile_app_installed',
 				'post_sharing_enabled',
 				'site_launched',
 			),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Removes the "Install the mobile app" task from the Legacy Site Setup Launchpad.
* Since I couldn't reach a decision yet on how we should make it work, I decided to remove it and focus on the launch.

More context: paYKcK-3Hy-p2#comment-2773

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visual inspection is enough