### PR TITLE
Subscriptions: Fix Newsletter column width

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-column-width
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-column-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Fix Newsletter column width

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -147,9 +147,12 @@ function register_block() {
 	add_filter( 'get_the_excerpt', __NAMESPACE__ . '\jetpack_filter_excerpt_for_newsletter', 10, 2 );
 
 	// Add a 'Newsletter access' column to the Edit posts page
-	add_action( 'manage_post_posts_columns', __NAMESPACE__ . '\register_newsletter_access_column' );
-	add_action( 'manage_post_posts_custom_column', __NAMESPACE__ . '\render_newsletter_access_rows', 10, 2 );
-	add_action( 'admin_head', __NAMESPACE__ . '\newsletter_access_column_styles' );
+	// We only display the "NL access" column if we have published one paid-newsletter
+	if ( Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' ) ) {
+		add_action( 'manage_post_posts_columns', __NAMESPACE__ . '\register_newsletter_access_column' );
+		add_action( 'manage_post_posts_custom_column', __NAMESPACE__ . '\render_newsletter_access_rows', 10, 2 );
+		add_action( 'admin_head', __NAMESPACE__ . '\newsletter_access_column_styles' );
+	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
 
@@ -169,11 +172,6 @@ function is_wpcom() {
  * @return array An array of column names.
  */
 function register_newsletter_access_column( $columns ) {
-	if ( ! Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' ) ) {
-		// We only display the "NL access" column if we have published one paid-newsletter
-		return $columns;
-	}
-
 	$position   = array_search( 'title', array_keys( $columns ), true );
 	$new_column = array( NEWSLETTER_COLUMN_ID => __( 'Newsletter', 'jetpack' ) );
 	return array_merge(

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -149,6 +149,7 @@ function register_block() {
 	// Add a 'Newsletter access' column to the Edit posts page
 	add_action( 'manage_post_posts_columns', __NAMESPACE__ . '\register_newsletter_access_column' );
 	add_action( 'manage_post_posts_custom_column', __NAMESPACE__ . '\render_newsletter_access_rows', 10, 2 );
+	add_action( 'admin_head', __NAMESPACE__ . '\newsletter_access_column_styles' );
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
 
@@ -174,7 +175,7 @@ function register_newsletter_access_column( $columns ) {
 	}
 
 	$position   = array_search( 'title', array_keys( $columns ), true );
-	$new_column = array( NEWSLETTER_COLUMN_ID => '<span>' . __( 'Newsletter', 'jetpack' ) . '</span>' );
+	$new_column = array( NEWSLETTER_COLUMN_ID => __( 'Newsletter', 'jetpack' ) );
 	return array_merge(
 		array_slice( $columns, 0, $position + 1, true ),
 		$new_column,
@@ -211,6 +212,13 @@ function render_newsletter_access_rows( $column_id, $post_id ) {
 		default:
 			echo '';
 	}
+}
+
+/**
+ * Adds the Newsletter column styles
+ */
+function newsletter_access_column_styles() {
+	echo '<style id="jetpack-newsletter-newsletter-access-column"> table.fixed .column-newsletter_access { width: 10%; } </style>';
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -147,7 +147,7 @@ function register_block() {
 	add_filter( 'get_the_excerpt', __NAMESPACE__ . '\jetpack_filter_excerpt_for_newsletter', 10, 2 );
 
 	// Add a 'Newsletter access' column to the Edit posts page
-	// We only display the "NL access" column if we have published one paid-newsletter
+	// We only display the "Newsletter" column if we have configured the paid newsletter plan
 	if ( Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' ) ) {
 		add_action( 'manage_post_posts_columns', __NAMESPACE__ . '\register_newsletter_access_column' );
 		add_action( 'manage_post_posts_custom_column', __NAMESPACE__ . '\render_newsletter_access_rows', 10, 2 );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -146,7 +146,7 @@ function register_block() {
 	// Gate the excerpt for a post
 	add_filter( 'get_the_excerpt', __NAMESPACE__ . '\jetpack_filter_excerpt_for_newsletter', 10, 2 );
 
-	// Add a 'Newsletter access' column to the Edit posts page
+	// Add a 'Newsletter' column to the Edit posts page
 	// We only display the "Newsletter" column if we have configured the paid newsletter plan
 	if ( Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' ) ) {
 		add_action( 'manage_post_posts_columns', __NAMESPACE__ . '\register_newsletter_access_column' );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/86161

## Proposed changes:

It:
- sets the Newsletter column width to 10% (the same width as the Author column)
- improves the performance a bit by not executing the Newsletter column-related code if it's not really needed

### Before

<img width="857" alt="Screenshot 2024-01-18 at 10 58 18" src="https://github.com/Automattic/jetpack/assets/4068554/a6046f2f-0cb8-44de-965e-4e3f08193a14">

### After

<img width="857" alt="Screenshot 2024-01-18 at 10 57 57" src="https://github.com/Automattic/jetpack/assets/4068554/cb9a89d5-befa-41a6-a3b4-c05c8ccec92f">

<br>
<br>

The issue with the Title column is a Core thing and it's already reported:
https://core.trac.wordpress.org/ticket/52151

cc @crisbusquets 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Enable the Newsletter module
* Enable the Newsletter column for Posts by commenting out this check
https://github.com/Automattic/jetpack/blob/3a8e6a72096f80eb1cae425f6e483708bcfe0f66/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php#L151
* Shrink the window width making sure the Newsletter column is still readable
