### PR TITLE
Boost: Fix cachePageSecret error

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/super-cache-info/lib/hooks.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/super-cache-info/lib/hooks.ts
@@ -23,14 +23,13 @@ export function useMeasureSuperCacheSaving() {
 		site: { url },
 	} = Jetpack_Boost;
 
-	if ( ! cachePageSecret ) {
-		// eslint-disable-next-line no-console
-		console.error( "Cache Page Secret is missing in `jetpack_boost_ds['super_cache']` " );
-
-		return () => Promise.resolve( 0 );
-	}
-
 	return useCallback( async () => {
+		if ( ! cachePageSecret ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Cache Page Secret is missing.' );
+			return 0;
+		}
+
 		recordBoostEvent( 'super_cache_test_started', {} );
 
 		const uncachedUrl = addGetParameter( url, 'donotcachepage', cachePageSecret as string );

--- a/projects/plugins/boost/changelog/fix-cache-page-secret-error
+++ b/projects/plugins/boost/changelog/fix-cache-page-secret-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed a recently introduced error
+
+


### PR DESCRIPTION
Fixes #35103

## Proposed changes:
* Don't show cachePageSecret missing error unless measuring.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to Boost dashboard
* Check console and make sure there is no error
* Install super cache
* Visit boost error and make sure everything still works including the supercache measurement tool