### PR TITLE
Boost: Replace react transition group with react spring for speed score popout

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2885,9 +2885,6 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
-      react-transition-group:
-        specifier: ^4.4.5
-        version: 4.4.5(react-dom@18.2.0)(react@18.2.0)
       sass:
         specifier: 1.64.1
         version: 1.64.1
@@ -15720,6 +15717,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.5
       csstype: 3.1.3
+    dev: false
 
   /dom-scroll-into-view@1.2.1:
     resolution: {integrity: sha512-LwNVg3GJOprWDO+QhLL1Z9MMgWe/KAFLxVWKzjRTxNSPn8/LLDIfmuG71YHznXCqaqTjvHJDYO1MEAgX6XCNbQ==}
@@ -21842,6 +21840,7 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /react-use-measure@2.1.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==}

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.module.scss
@@ -12,21 +12,12 @@
 .card {
 	box-shadow: 0 0 20px 0 rgb(170 170 170 / 28%);
 
-	transition: right 0.5s ease-in-out;
-
 	position: relative;
 	right: -100%;
 	padding: 24px;
 
 	background-color: white;
 	pointer-events: all;
-}
-
-/**
- * Styles applied by CSSTransition when the component is fully visible.
- */
-.appearDone, .enterDone {
-	right: 0%;
 }
 
 .dismiss-button {

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
@@ -1,4 +1,4 @@
-import { CSSTransition } from 'react-transition-group';
+import { animated, useSpring } from '@react-spring/web';
 import CloseButton from '$features/ui/close-button/close-button';
 import styles from './pop-out.module.scss';
 import { __ } from '@wordpress/i18n';
@@ -70,40 +70,48 @@ function PopOut( { scoreChange }: Props ) {
 
 	const hideAlert = () => setClose( true );
 
+	const animationStyles = useSpring( {
+		from: {
+			right: '-100%',
+		},
+		to: {
+			right: hasScoreChanged && ! isDismissed && ! isClosed ? '0%' : '-100%',
+		},
+	} );
+
 	return (
 		<div id="parent" className={ styles.wrapper }>
-			<CSSTransition
-				in={ hasScoreChanged && ! isDismissed && ! isClosed }
-				appear={ true }
-				classNames={ { ...styles } }
+			<animated.div
+				className={ styles.card }
+				style={ {
+					...animationStyles,
+				} }
 			>
-				<div className={ styles.card }>
-					<CloseButton onClick={ hideAlert } />
+				<CloseButton onClick={ hideAlert } />
 
-					<h3 className={ styles.headline }>{ message.title }</h3>
+				<h3 className={ styles.headline }>{ message.title }</h3>
 
-					<>{ message.body }</>
+				<>{ message.body }</>
 
-					<a
-						className="jb-button--primary"
-						href={ message?.ctaLink }
-						target="_blank"
-						rel="noreferrer"
-						onClick={ dismissAlert }
-					>
-						{ message.cta }
-					</a>
+				<a
+					className="jb-button--primary"
+					href={ message?.ctaLink }
+					target="_blank"
+					rel="noreferrer"
+					onClick={ dismissAlert }
+				>
+					{ message.cta }
+				</a>
 
-					<Button
-						variant="link"
-						size="small"
-						className={ styles[ 'dismiss-button' ] }
-						onClick={ dismissAlert }
-					>
-						{ __( 'Do not show me again', 'jetpack-boost' ) }
-					</Button>
-				</div>
-			</CSSTransition>
+				<Button
+					variant="link"
+					size="small"
+					className={ styles[ 'dismiss-button' ] }
+					onClick={ dismissAlert }
+				>
+					{ __( 'Do not show me again', 'jetpack-boost' ) }
+				</Button>
+			</animated.div>
 		</div>
 	);
 }

--- a/projects/plugins/boost/changelog/use-react-spring-for-speed-score-popout
+++ b/projects/plugins/boost/changelog/use-react-spring-for-speed-score-popout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update speed score popout to use react spring for animation instead of react-transition-group.
+
+

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -42,7 +42,6 @@
 		"preset": "link:@automattic/jetpack-webpack-config/babel/preset",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
-		"react-transition-group": "^4.4.5",
 		"sass": "1.64.1",
 		"sass-loader": "12.4.0",
 		"tslib": "2.5.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace react transition group with [react spring](https://react-spring.dev/). We'll be using react spring for transitions throughout Boost.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost;
* Make sure the Speed Score popout shows up and closes properly when interacting with it.