### PR TITLE
Like block: Hide the block markup if it tries to load in the block editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-like-block-editor-loading
+++ b/projects/plugins/jetpack/changelog/fix-like-block-editor-loading
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix Like block (beta) view in the editor when loaded inside the Query Loop block
+
+

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -5,6 +5,11 @@
     }
 }
 
+// Hide the Like block if it tries to load in the editor (e.g. as a part of the Query Loop block).
+.wp-block-jetpack-like .sharedaddy {
+	display: none;
+}
+
 /* Fetched below from https://widgets.wp.com/likes/style.css at 2024-01-15T08:02:21.397Z */
 .wpl-likebox,.wpl-follow a,.wpl-count a {
 	font-size:11px!important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/86578.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* introduce CSS that targets the Like block when it tries to load in block editor

| Before | After |
|--------|--------|
| ![Markup on 2024-01-18 at 12:00:15](https://github.com/Automattic/jetpack/assets/25105483/d9b3b3e1-0729-4a35-a879-c9a648129b02) | ![Markup on 2024-01-18 at 12:02:39](https://github.com/Automattic/jetpack/assets/25105483/f94eb6d9-12e3-4f8d-ae68-c59824ee7e99) | 

ℹ️ Please note the the outer Like block `div` is not being hidden:

![Markup on 2024-01-18 at 12:13:40](https://github.com/Automattic/jetpack/assets/25105483/3c362c93-aa7b-4048-830e-5b2f05db8fd7)

This does not have any visible effect to how the block loads in the editor, but allows us not to rely on `:has` - that may not be compatible with the user's browser. Otherwise, we could use the following instead:

```css
.wp-block-jetpack-like {
    &:has(> .sharedaddy) {
        display: none;
    }
}
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1705569948981259-slack-C02TCEHP3HA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create at least one post with the Like block in its content.
2. Create a page with the Query Loop block and make the above post load in it.
3. The Like block from the post content shouldn't be visible.
4. If you add Like blocks to the page itself (even to the body of the Query Loop block), these blocks should load correctly - displaying the block placeholder.