### PR TITLE
Boost: Fix not showing all dismissed recommendations at the same time

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state.ts
@@ -125,11 +125,13 @@ export function useSetProviderCssAction() {
  */
 export function useSetProviderErrorDismissedAction() {
 	return useCriticalCssAction(
-		'set-provider-error-dismissed',
-		z.object( {
-			key: z.string(),
-			dismissed: z.boolean(),
-		} )
+		'set-provider-errors-dismissed',
+		z.array(
+			z.object( {
+				key: z.string(),
+				dismissed: z.boolean(),
+			} )
+		)
 	);
 }
 

--- a/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.tsx
@@ -23,8 +23,8 @@ export default function AdvancedCriticalCss() {
 	const activeIssues = issues.filter( issue => issue.error_status !== 'dismissed' );
 	const dismissedIssues = issues.filter( issue => issue.error_status === 'dismissed' );
 
-	function setDismissed( key: string, dismissed: boolean ) {
-		setDismissedAction.mutateAsync( { key, dismissed } );
+	function setDismissed( data: { key: string; dismissed: boolean }[] ) {
+		setDismissedAction.mutate( data );
 	}
 
 	// If there are no issues at all, redirect to the main page.
@@ -44,7 +44,7 @@ export default function AdvancedCriticalCss() {
 			  );
 
 	const showDismissedIssues = () => {
-		dismissedIssues.forEach( issue => setDismissed( issue.key, false ) );
+		setDismissed( dismissedIssues.map( issue => ( { key: issue.key, dismissed: false } ) ) );
 	};
 
 	return (
@@ -77,7 +77,9 @@ export default function AdvancedCriticalCss() {
 			{ activeIssues.map( ( provider: Provider ) => (
 				// Add transition:slide|local to the div below
 				<div className="panel" key={ provider.key }>
-					<CloseButton onClick={ () => setDismissed( provider.key, true ) } />
+					<CloseButton
+						onClick={ () => setDismissed( [ { key: provider.key, dismissed: true } ] ) }
+					/>
 
 					<h4>
 						<InfoIcon />

--- a/projects/plugins/boost/app/lib/critical-css/data-sync-actions/Set_Provider_Error_Dismissed.php
+++ b/projects/plugins/boost/app/lib/critical-css/data-sync-actions/Set_Provider_Error_Dismissed.php
@@ -18,18 +18,21 @@ class Set_Provider_Error_Dismissed implements Data_Sync_Action {
 	public function handle( $data, $_request ) {
 		$state = new Critical_CSS_State();
 
-		if ( empty( $data['key'] ) ) {
-			return array(
-				'success' => false,
-				'state'   => $state->get(),
-				'error'   => 'Invalid data',
-			);
+		foreach ( $data as $item ) {
+			if ( empty( $item['key'] ) ) {
+				return array(
+					'success' => false,
+					'state'   => $state->get(),
+					'error'   => 'Invalid data',
+				);
+			}
+
+			$provider_key = sanitize_key( $item['key'] );
+			$dismissed    = ! empty( $item['dismissed'] );
+
+			$state->set_provider_error_dismissed( $provider_key, $dismissed );
 		}
 
-		$provider_key = sanitize_key( $data['key'] );
-		$dismissed    = ! empty( $data['dismissed'] );
-
-		$state->set_provider_error_dismissed( $provider_key, $dismissed );
 		$state->save();
 
 		return array(

--- a/projects/plugins/boost/changelog/fix-critical-css-advanced-show-all-dismissed
+++ b/projects/plugins/boost/changelog/fix-critical-css-advanced-show-all-dismissed
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix not showing all dismissed recommendations at the same time.
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -192,11 +192,13 @@ jetpack_boost_register_action(
 
 jetpack_boost_register_action(
 	'critical_css_state',
-	'set-provider-error-dismissed',
-	Schema::as_assoc_array(
-		array(
-			'key'       => Schema::as_string(),
-			'dismissed' => Schema::as_boolean(),
+	'set-provider-errors-dismissed',
+	Schema::as_array(
+		Schema::as_assoc_array(
+			array(
+				'key'       => Schema::as_string(),
+				'dismissed' => Schema::as_boolean(),
+			)
 		)
 	),
 	new Set_Provider_Error_Dismissed()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35107

Props to @pyronaur for navigating me to the right place.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update Critical CSS Advanced to show all recommendations after clicking the "Show hidden recommendations" link.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost (free);
* Force Critical CSS generation to show the advanced recommendations page by adding this snippet to your site and regenerating critical CSS:

```php
<?php

add_action( 'template_redirect', function () {
	if ( ! is_front_page() ) {
		noexistentfunction();
	}
} );
```

* Dismiss all recommendations and make sure that clicking the "Show hidden recommendations" link shows them all at the same time. 