### PR TITLE
Launchpad: Add the completion and visibility logic for the 'Install the mobile app' task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-mobile-app-installed-completion-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-mobile-app-installed-completion-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the completion logic for the 'Install the mobile app' task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -978,10 +978,6 @@ function wpcom_launchpad_is_mobile_app_installed_visible() {
  * @return bool True if the Mobile App is installed for the current user.
  */
 function wpcom_launchpad_is_mobile_app_installed() {
-	if ( wpcom_is_checklist_task_complete( 'mobile_app_installed' ) ) {
-		return true;
-	}
-
 	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
 	if ( $is_atomic_site ) {
 		return false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -978,6 +978,10 @@ function wpcom_launchpad_is_mobile_app_installed_visible() {
  * @return bool True if the Mobile App is installed for the current user.
  */
 function wpcom_launchpad_is_mobile_app_installed() {
+	if ( wpcom_is_checklist_task_complete( 'mobile_app_installed' ) ) {
+		return true;
+	}
+
 	$user_id          = get_current_user_id();
 	$mobile_last_seen = get_user_attribute( $user_id, 'jp_mobile_app_last_seen' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -579,7 +579,8 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Install the mobile app', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_mobile_app_installed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_mobile_app_installed_visible',
 			'get_calypso_path'     => function () {
 				return '/me/get-apps';
 			},
@@ -954,6 +955,37 @@ function wpcom_launchpad_is_domain_upsell_task_visible() {
 	);
 
 	return empty( $bundle_purchases );
+}
+
+/**
+ * Determines whether or not the Install the mobile app task should be visible.
+ *
+ * @return bool True if the Install the mobile app task should be visible.
+ */
+function wpcom_launchpad_is_mobile_app_installed_visible() {
+	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
+	// If the site is not an Atomic site, we should not show the task.
+	if ( $is_atomic_site ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Verifies if the Mobile App is installed for the current user.
+ *
+ * @return bool True if the Mobile App is installed for the current user.
+ */
+function wpcom_launchpad_is_mobile_app_installed() {
+	$user_id          = get_current_user_id();
+	$mobile_last_seen = get_user_attribute( $user_id, 'jp_mobile_app_last_seen' );
+
+	if ( empty( $mobile_last_seen ) ) {
+		return false;
+	}
+
+	return true;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -964,7 +964,7 @@ function wpcom_launchpad_is_domain_upsell_task_visible() {
  */
 function wpcom_launchpad_is_mobile_app_installed_visible() {
 	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
-	// If the site is not an Atomic site, we should not show the task.
+	// If the site is an Atomic site, we should not show the task.
 	if ( $is_atomic_site ) {
 		return false;
 	}
@@ -980,6 +980,15 @@ function wpcom_launchpad_is_mobile_app_installed_visible() {
 function wpcom_launchpad_is_mobile_app_installed() {
 	if ( wpcom_is_checklist_task_complete( 'mobile_app_installed' ) ) {
 		return true;
+	}
+
+	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
+	if ( $is_atomic_site ) {
+		return false;
+	}
+
+	if ( ! function_exists( 'get_user_attribute' ) ) {
+		return false;
 	}
 
 	$user_id          = get_current_user_id();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* This PR is part of the Site Setup checklist migration to the Launchpad.
* We decided to display the "Install the mobile app" task only to Simple sites to simplify the completion logic for now until we find a way to make it available on Atomic as well.
* I followed @antonis suggestion of using the `jp_mobile_app_last_seen` user attribute to determine whether the user has ever seen the app.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox the public-api
* Add the following filter to your `0-sandbox.php` file
```
add_filter( 'enable_legacy_site_setup_launchpad', '__return_true' );
```
* Apply this patch to your sandbox with the following command:
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/mobile-app-installed-completion-logic
```
* Create a new site through the `/setup/free` flow.
* Launch your site without completing any task on the Fullscreen Launchpad.
* When you reach the Customer Home, click on the `Show site setup` button on the main banner.
* You should see the `Install the mobile app` task. 
* Clicking on the task should take you to `/me/get-apps`
* If you have the app installed, the task should be marked as complete.
* If you don't have the App installed, installing the app is expected to update the `jp_mobile_app_last_seen` and complete the task.
* To also simulate the task completion if you already have the App installed or already have the `jp_mobile_app_last_seen` attribute, I deleted the attribute through `wpsh` as follows:
```
$my_user_id = <YOUR USER ID>;
// Make sure you have the attribute
return get_user_attribute($my_user_id, 'jp_mobile_app_last_seen');
// Delete the attribute
return delete_user_attribute($my_user_id, 'jp_mobile_app_last_seen');
```
Now, this is a little fuzzy, as my first attempts at accessing the App did not update the `jp_mobile_app_last_seen` again. I also uninstalled and reinstalled the App without success. However, the attribute was set a few minutes after I did all of this. I believe there's some sort of caching that prevents it from updating right away.



