### PR TITLE
Subscriber Login: Check also the premium content cookie to determine if user is logged in or not

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriber-login-auth-check
+++ b/projects/plugins/jetpack/changelog/fix-subscriber-login-auth-check
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Subscriptions: Check also the premium content cookie to determine if user is logged in or not
+Subscriber Login: Check also the premium content cookie to determine if user is logged in or not

--- a/projects/plugins/jetpack/changelog/fix-subscriber-login-auth-check
+++ b/projects/plugins/jetpack/changelog/fix-subscriber-login-auth-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Check also the premium content cookie to determine if user is logged in or not

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -36,7 +36,7 @@ function register_block() {
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
- * Logout subscriber.
+ * Logs the subscriber out by clearing out the premium content cookie.
  *
  * @return void
  */
@@ -83,6 +83,15 @@ function get_subscriber_login_url() {
 }
 
 /**
+ * Determines whether the current visitor is a logged in user or a subscriber.
+ *
+ * @return bool
+ */
+function is_subscriber_logged_in() {
+	return is_user_logged_in() || Abstract_Token_Subscription_Service::has_token_from_cookie();
+}
+
+/**
  * Renders Subscriber Login block.
  *
  * @param array $attr    Array containing the Subscriber Login block attributes.
@@ -92,7 +101,7 @@ function get_subscriber_login_url() {
 function render_block( $attr ) {
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
-	if ( ! is_user_logged_in() ) {
+	if ( ! is_subscriber_logged_in() ) {
 		return sprintf(
 			'<div class="%1$s"><a href="%2$s">%3$s</a></div>',
 			esc_attr( Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) ),


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/34884

## Proposed changes:

It also checks the premium content cookie to determine if the user is logged in or not.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Add Subscriber Login block to post
* Subscribe to this blog
* Confirm the email address
* Make sure the link now says "Manage subscriptions"
* Unsubscribe
* Make sure the link now says "Log out"
* Click it
* Make sure you are redirected to the same page but now the link says "Log in"

