### PR TITLE
Subscribe block: add buttons transform

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-buttons-transform
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-buttons-transform
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe block: add buttons transform

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -43,7 +43,7 @@ registerJetpackBlockFromMetadata( metadata, {
 
 					const blocks = [];
 
-					children?.forEach( button => {
+					children.forEach( button => {
 						const text = button?.attributes?.text;
 						blocks.push(
 							createBlock( 'jetpack/subscriptions', {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -32,6 +32,29 @@ registerJetpackBlockFromMetadata( metadata, {
 					} );
 				},
 			},
+			{
+				type: 'block',
+				isMultiBlock: false,
+				blocks: [ 'core/buttons' ],
+				transform: ( props, children ) => {
+					if ( ! children?.length ) {
+						return createBlock( 'jetpack/subscriptions' );
+					}
+
+					const blocks = [];
+
+					children?.forEach( button => {
+						const text = button?.attributes?.text;
+						blocks.push(
+							createBlock( 'jetpack/subscriptions', {
+								...( text ? { submitButtonText: text } : {} ),
+							} )
+						);
+					} );
+
+					return blocks;
+				},
+			},
 		],
 	},
 	deprecated,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add simple transform from core "buttons" block.

Sometimes themes include patterns which include "subscribe" CTAs without actual functionality. This makes it trivial to turn those into Jetpack subscribe block.

E.g. check the "newlsetter" patterin in the new [TwentyTwentyFour](https://wordpress.org/themes/twentytwentyfour/) theme:

<img width="490" alt="Screenshot 2024-01-18 at 17 05 16" src="https://github.com/Automattic/jetpack/assets/87168/31953bf4-9a67-4f54-8447-0c3590c75133">


## Proposed changes:
* New buttons transform for subscribe block

Doesn't include any style or alignment transforms for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Add "buttons" block to page, and use its transforms:

    <img width="546" alt="Screenshot 2024-01-18 at 16 46 46" src="https://github.com/Automattic/jetpack/assets/87168/015efeac-17ee-4c11-b6ec-a3cd7d0e6a73">

2) When you have label, the button label is used as subscribe block's label. Multiple buttons turn into multiple subscribe blocks.

    <img width="669" alt="Screenshot 2024-01-18 at 17 01 11" src="https://github.com/Automattic/jetpack/assets/87168/79cf8b73-a380-4253-83f6-1fb6be846204">
    <img width="682" alt="Screenshot 2024-01-18 at 17 01 19" src="https://github.com/Automattic/jetpack/assets/87168/1eac1120-bd8f-487a-ac2d-1f0a01c2fb96">

3) Single button turns into single subscribe block. When label is empty, default gets used.

    <img width="357" alt="Screenshot 2024-01-18 at 17 01 45" src="https://github.com/Automattic/jetpack/assets/87168/32f2201b-baa5-4179-8554-25fe81c5c5b5">
    <img width="650" alt="Screenshot 2024-01-18 at 17 01 52" src="https://github.com/Automattic/jetpack/assets/87168/f78c0153-af72-4fc9-aa38-12b068cb22c7">

4) When buttons block is empty, it transforms into a single subscribe block. To test, delete the default button from the buttons block.

    <img width="665" alt="Screenshot 2024-01-18 at 17 03 40" src="https://github.com/Automattic/jetpack/assets/87168/0d1ab0c8-12f4-4cf5-8c02-8f981c47db09">

