### PR TITLE
AI Assistant: change event names, provide placement prop

### DIFF
--- a/projects/plugins/jetpack/changelog/change-ai-usage-panel-event-names
+++ b/projects/plugins/jetpack/changelog/change-ai-usage-panel-event-names
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Assistant: rename upgrade event name, provide placement prop for metrics

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -412,7 +412,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 
 	const banner = (
 		<>
-			{ isOverLimit && isSelected && <UpgradePrompt /> }
+			{ isOverLimit && isSelected && <UpgradePrompt placement="ai-assistant-block" /> }
 			{ ! connected && <ConnectPrompt /> }
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -250,7 +250,7 @@ export default function AiAssistantBar( {
 					} ) }
 					tabIndex={ -1 }
 				>
-					{ siteRequireUpgrade && <UpgradePrompt /> }
+					{ siteRequireUpgrade && <UpgradePrompt placement="jetpack-form-block" /> }
 					{ ! connected && <ConnectPrompt /> }
 					<AIControl
 						ref={ inputRef }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -12,9 +12,7 @@ import React from 'react';
  * Internal dependencies
  */
 import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
-import useAiFeature, {
-	UpgradeTypeProp,
-} from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
+import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
 import Proofread from '../proofread';
 import UsagePanel from '../usage-panel';
@@ -31,7 +29,7 @@ const Upgrade = ( {
 }: {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	onClick: ( event: any ) => void;
-	type: UpgradeTypeProp;
+	type: string;
 } ) => {
 	const { tracks } = useAnalytics();
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -130,7 +130,7 @@ export default function UsagePanel( { placement = null }: UsagePanelProps ) {
 	const trackUpgradeClick = useCallback(
 		( event: React.MouseEvent< HTMLElement > ) => {
 			event.preventDefault();
-			tracks.recordEvent( 'jetpack_ai_usage_panel_upgrade_button_click', {
+			tracks.recordEvent( 'jetpack_ai_upgrade_button', {
 				current_tier_slug: currentTier?.slug,
 				requests_count: requestsCount,
 				...( placement ? { placement } : {} ),
@@ -143,7 +143,7 @@ export default function UsagePanel( { placement = null }: UsagePanelProps ) {
 	const trackContactUsClick = useCallback(
 		( event: React.MouseEvent< HTMLElement > ) => {
 			event.preventDefault();
-			tracks.recordEvent( 'jetpack_ai_usage_panel_upgrade_button_click', {
+			tracks.recordEvent( 'jetpack_ai_upgrade_button', {
 				current_tier_slug: currentTier?.slug,
 				requests_count: requestsCount,
 				...( placement ? { placement } : {} ),

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -219,7 +219,7 @@ ${ postContent }
 					</Notice>
 				) }
 
-				{ isOverLimit && <UpgradePrompt /> }
+				{ isOverLimit && <UpgradePrompt placement="excerpt-panel" /> }
 
 				<AiExcerptControl
 					words={ excerptWordsNumber }


### PR DESCRIPTION
Refactor event name on UpgradePrompt add prop where it's being rendered

## Proposed changes:
This PR renames the event `jetpack_ai_usage_panel_upgrade_button_click` to `jetpack_ai_upgrade_button`. The event is now provisioned with a `placement` prop to pinpoint where it was rendered.

IN PROGRESS

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
All these instructions will get you to the interstitial, you don't need to actually perform the upgrade. Once you've clicked on the upgrade button you'll need to wait 5-10 minutes before the events show up. All events should be called `jetpack_ai_upgrade_button` and carry a `placement` prop to let you know which is which.

### UsagePanel
This can be tested without forcing the requests, UsagePanel should show on
- [ ] the AI Assistant block's settings (sidebar)
- [ ] the Jetpack sidebar's AI panel

### UpgradePrompt:

Force an upgrade case (either invoke `wp.data.dispatch( 'wordpress-com/plans' ).increaseAiAssistantRequestsCount( X )` or use a filter on backend for `jetpack_ai_current_period_requests_count`), see the UpgradePrompt and test in 3 places:
- [ ] AI Assistant block
- [ ] Excerpt panel (Post settings sidebar)
- [ ] Jetpack Form block


