### PR TITLE
Jetpack Live Branches: Revert additional test link

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -98,6 +98,7 @@
 				<p><a target="_blank" rel="nofollow noopener" href="${ getLink()[ 0 ] }">
 					Test with <code>trunk</code> branch instead.
 				</a></p>
+				<p>Note: You need to be Logged in to WordPress.com to create a test site.</p>
 			`;
 			appendHtml( markdownBody, contents );
 		} else if ( ! repo ) {
@@ -271,6 +272,7 @@
 					<p>
 						<a id="jetpack-beta-branch-link" target="_blank" rel="nofollow noopener" href="#">…</a>
 					</p>
+					<p>Note: You need to be Logged in to WordPress.com to create a test site.</p>
 					`;
 					appendHtml( markdownBody, contents );
 					updateLink();

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.33
+// @version      1.34
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      betadownload.jetpack.me
@@ -88,7 +88,6 @@
 		}
 
 		const host = 'https://jurassic.ninja';
-		const host2 = 'https://jurassicninja1.wordpress.com';
 		const currentBranch = jQuery( '.head-ref:first' ).text();
 		const branchStatus = $( '.gh-header-meta .State' ).text().trim();
 		const repo = determineRepo();
@@ -96,11 +95,8 @@
 		if ( branchStatus === 'Merged' ) {
 			const contents = `
 				<p><strong>This branch is already merged.</strong></p>
-				<p><a target="_blank" rel="nofollow noopener" href="${ getLink( host )[ 0 ] }">
+				<p><a target="_blank" rel="nofollow noopener" href="${ getLink()[ 0 ] }">
 					Test with <code>trunk</code> branch instead.
-				</a><br/>
-				<a target="_blank" rel="nofollow noopener" href="${ getLink( host2 )[ 0 ] }">
-					Test with <code>trunk</code> branch instead on Atomic.
 				</a></p>
 			`;
 			appendHtml( markdownBody, contents );
@@ -275,14 +271,9 @@
 					<p>
 						<a id="jetpack-beta-branch-link" target="_blank" rel="nofollow noopener" href="#">…</a>
 					</p>
-					<p><h3>JurassicNinja on Atomic</h3></p>
-					<p>
-						<a id="jetpack-beta-branch-link2" target="_blank" rel="nofollow noopener" href="#">…</a>
-					</p>
 					`;
 					appendHtml( markdownBody, contents );
 					updateLink();
-					updateLink2();
 				} )
 				.catch( e => {
 					pluginsList = null;
@@ -340,10 +331,9 @@
 		/**
 		 * Build the JN create URI.
 		 *
-		 * @param {string} which_host - Host/domain to use for link.
 		 * @returns {string} URI.
 		 */
-		function getLink( which_host ) {
+		function getLink() {
 			const query = [ 'jetpack-beta' ];
 			$(
 				'#jetpack-live-branches input[type=checkbox]:checked:not([data-invert]), #jetpack-live-branches input[type=checkbox][data-invert]:not(:checked)'
@@ -361,7 +351,7 @@
 				}
 			} );
 			// prettier-ignore
-			return [ `${ which_host }/create?${ query.join( '&' ).replace( /%(2F|5[BD])/g, m => decodeURIComponent( m ) ) }`, query ];
+			return [ `${ host }/create?${ query.join( '&' ).replace( /%(2F|5[BD])/g, m => decodeURIComponent( m ) ) }`, query ];
 		}
 
 		/**
@@ -442,7 +432,6 @@
 				e.target.removeAttribute( 'checked' );
 			}
 			updateLink();
-			updateLink2();
 		}
 
 		/**
@@ -465,38 +454,7 @@
 		 */
 		function updateLink() {
 			const $link = $( '#jetpack-beta-branch-link' );
-			const [ url, query ] = getLink( host );
-
-			if ( url.match( /[?&]branch(es\.[^&=]*)?=/ ) ) {
-				if (
-					query.includes( 'jpcrm-populate-crm-data' ) &&
-					! url.match( /[?&]branches\.zero-bs-crm/ )
-				) {
-					// /jpcrm-populate-crm-data/
-					$link
-						.attr( 'href', null )
-						.text( 'Select the Jetpack CRM plugin in order to populate with CRM data' );
-				} else if (
-					query.includes( 'jpcrm-populate-woo-data' ) &&
-					! query.includes( 'woocommerce' )
-				) {
-					$link
-						.attr( 'href', null )
-						.text( 'Select the WooCommerce plugin in order to populate with CRM Woo data' );
-				} else {
-					$link.attr( 'href', url ).text( url );
-				}
-			} else {
-				$link.attr( 'href', null ).text( 'Select at least one plugin to test' );
-			}
-		}
-
-		/**
-		 * Update the link.
-		 */
-		function updateLink2() {
-			const $link = $( '#jetpack-beta-branch-link2' );
-			const [ url, query ] = getLink( host2 );
+			const [ url, query ] = getLink();
 
 			if ( url.match( /[?&]branch(es\.[^&=]*)?=/ ) ) {
 				if (


### PR DESCRIPTION
Remove jurassicninja1.wordpress.com link from Jetpack Live Branches

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove testing link from Jetpack Live Branches as service has been migrated. (reverts #35067)

### Other information:

- [ NA ] Have you written new tests for your changes, if applicable?
- [ NA ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://wp.me/p1HpG7-qFw

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Update your copy of Jetpack LIve Branches in Tampermonkey
* Verify Jetpack Live branches link to create site is functional and adheres to selected options.

- 
I've tested the "test against trun" (pr has been merged) and open prs are both functional.

