### PR TITLE
Boost: Concat JS: Don't lose before/after scripts when src is false

### DIFF
--- a/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
@@ -82,9 +82,17 @@ class Concatenate_JS extends WP_Scripts {
 			}
 
 			if ( ! $this->registered[ $handle ]->src ) { // Defines a group.
-				// if there are localized items, echo them
-				$this->print_extra_script( $handle );
-				$this->done[] = $handle;
+				if ( $this->has_inline_content( $handle ) ) {
+					++$level;
+					$javascripts[ $level ]['type']   = 'do_item';
+					$javascripts[ $level ]['handle'] = $handle;
+					++$level;
+					unset( $this->to_do[ $key ] );
+				} else {
+					// if there are localized items, echo them
+					$this->print_extra_script( $handle );
+					$this->done[] = $handle;
+				}
 				continue;
 			}
 

--- a/projects/plugins/boost/changelog/fix-boost-concatenate-js-src-false-inline-scripts
+++ b/projects/plugins/boost/changelog/fix-boost-concatenate-js-src-false-inline-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Concatenate JS: Output inline before/after scripts for handles with `src` false.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When a handle is registered with no `src`, any inline scripts associated with the handle were being skipped.

Instead, we need to handle them in the same way that scripts with a `src` are handled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/page-optimize/pull/77#issuecomment-1898687675
Fixes #35118

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site with Jetpack and Boost. Connect both plugins.
* Enable Boost's JS concatenation.
* Create a post with a slideshow block. You make also have to add some other block (e.g. business hours) that has scripts to trigger concatenation to actually happen.
* View the post.
