### PR TITLE
Fix missing likers in likers popup 

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-likes-popup-missing-likers
+++ b/projects/plugins/jetpack/changelog/fix-likes-popup-missing-likers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+There was a problem with likers without avatar images not appearing in the likers popup. Now they appear with their default avatar images.

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -236,40 +236,12 @@ function JetpackLikesMessageListener( event ) {
 				}
 
 				const element = document.createElement( 'li' );
-				// Appending element before fetching avatar_URL to avoid racing conditions on the list order
 				list.append( element );
-
-				try {
-					const response = await fetch( liker.avatar_URL, { method: 'HEAD' } );
-					if ( ! response.ok ) {
-						// Image doesn't exist, remove the element
-						element.remove();
-						return;
-					}
-				} catch ( error ) {
-					// Error occurred, but we check if there is a default image to be used in case the error were CORS
-					const url = new URL( liker.avatar_URL );
-					const defaultImageUrl = decodeURI( url.searchParams.get( 'd' ) );
-					if ( defaultImageUrl ) {
-						const defaultImageResponse = await fetch( defaultImageUrl, { method: 'HEAD' } );
-						if ( defaultImageResponse.ok ) {
-							liker.avatar_URL = defaultImageUrl;
-						} else {
-							// Default image doesn't exist, remove the element
-							element.remove();
-							return;
-						}
-					} else {
-						// Error occurred while checking image existence, remove the element
-						element.remove();
-						return;
-					}
-				}
 
 				if ( newLayout ) {
 					element.innerHTML = `
 					<a href="${ encodeURI( liker.profile_URL ) }" rel="nofollow" target="_parent" class="wpl-liker">
-						<img src="${ encodeURI( liker.avatar_URL ) }"
+						<img src="${ liker.avatar_URL }"
 							alt=""
 							style="width: 28px; height: 28px;" />
 						<span></span>
@@ -278,7 +250,7 @@ function JetpackLikesMessageListener( event ) {
 				} else {
 					element.innerHTML = `
 					<a href="${ encodeURI( liker.profile_URL ) }" rel="nofollow" target="_parent" class="wpl-liker">
-						<img src="${ encodeURI( liker.avatar_URL ) }"
+						<img src="${ liker.avatar_URL }"
 							alt=""
 							style="width: 30px; height: 30px; padding-right: 3px;" />
 					</a>

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -247,9 +247,23 @@ function JetpackLikesMessageListener( event ) {
 						return;
 					}
 				} catch ( error ) {
-					// Error occurred while checking image existence, remove the element
-					element.remove();
-					return;
+					// Error occurred, but we check if there is a default image to be used in case the error were CORS
+					const url = new URL( liker.avatar_URL );
+					const defaultImageUrl = decodeURI( url.searchParams.get( 'd' ) );
+					if ( defaultImageUrl ) {
+						const defaultImageResponse = await fetch( defaultImageUrl, { method: 'HEAD' } );
+						if ( defaultImageResponse.ok ) {
+							liker.avatar_URL = defaultImageUrl;
+						} else {
+							// Default image doesn't exist, remove the element
+							element.remove();
+							return;
+						}
+					} else {
+						// Error occurred while checking image existence, remove the element
+						element.remove();
+						return;
+					}
 				}
 
 				if ( newLayout ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/86471

## Proposed changes:

When the user clicks in the "x likes" label in the likes block, a popup appears with the likers list:
<img width="459" alt="Screenshot 2024-01-18 at 15 23 59" src="https://github.com/Automattic/jetpack/assets/3832570/269b2d86-af40-49aa-bc80-a81d1f7da7d0">

The problem was this: users without Gravatar profiles were missing from the list. This was happening because the avatar URL had this format:

`https://[url-of-the-gravatar-image]?d=[url-of-the-default-avatar-in-case-the-previous-url-fails]`

That redirection was because the redirection from the `d` parameter gave CORS problems from sites not hosted on WordPress.com. If there is any problem retrieving the avatar image (like this CORS problem), that liker was removed from the list. 

This PR checks manually for the URL in the `d` param after the CORS error happens, so the likers don't disappear from the list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply this PR to your local repository and spin your JT site.
- Open a post with a like block on the site.
- You need to have at least 2 likers and at least 1 liker without Gravatar profile on that post. You can get one by opening the post in incognito and pressing the "like" button. In the login popup, create an account instead. That account won't have a Gravatar profile created yet.
- Click on the "x likes" label and see all of the likers appear in the popup, regardless of whether they have a profile picture or not.