### PR TITLE
AI Assistant: add panel sidebar events

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-panel-sidebar-events
+++ b/projects/plugins/jetpack/changelog/add-ai-panel-sidebar-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: trigger event on panel uncollapse

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -7,6 +7,7 @@ import { Button, PanelBody, PanelRow, BaseControl } from '@wordpress/components'
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import debugFactory from 'debug';
 import React from 'react';
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ import Proofread from '../proofread';
 import UsagePanel from '../usage-panel';
 import { USAGE_PANEL_PLACEMENT_JETPACK_SIDEBAR } from '../usage-panel/types';
 
+const debug = debugFactory( 'jetpack-ai-assistant-plugin:sidebar' );
 // Determine if the usage panel is enabled or not
 const isUsagePanelAvailable =
 	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'ai-assistant-usage-panel' ]
@@ -26,19 +28,21 @@ const isUsagePanelAvailable =
 const Upgrade = ( {
 	onClick,
 	type,
+	placement = '',
 }: {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	onClick: ( event: any ) => void;
 	type: string;
+	placement?: string;
 } ) => {
 	const { tracks } = useAnalytics();
 
 	const handleClick = useCallback(
 		evt => {
-			tracks.recordEvent( 'jetpack_ai_get_feedback_upgrade_click' );
+			tracks.recordEvent( 'jetpack_ai_upgrade_button', { placement } );
 			onClick?.( evt );
 		},
-		[ onClick, tracks ]
+		[ onClick, tracks, placement ]
 	);
 
 	const messageForVip = createInterpolateElement(
@@ -68,12 +72,24 @@ export default function AiAssistantPluginSidebar() {
 	const { requireUpgrade, upgradeType } = useAiFeature();
 	const { autosaveAndRedirect, isRedirecting } = useAICheckout();
 
+	const { tracks } = useAnalytics();
 	const title = __( 'AI Assistant', 'jetpack' );
+
+	const panelToggleTracker = placement => {
+		debug( placement );
+		tracks.recordEvent( 'jetpack_ai_panel_open', { placement } );
+	};
 
 	return (
 		<>
 			<JetpackPluginSidebar>
-				<PanelBody title={ title } initialOpen={ false }>
+				<PanelBody
+					title={ title }
+					initialOpen={ false }
+					onToggle={ isOpen => {
+						isOpen && panelToggleTracker( 'jetpack-sidebar' );
+					} }
+				>
 					<PanelRow>
 						<BaseControl
 							className="jetpack-ai-proofread-control__header"
@@ -84,7 +100,11 @@ export default function AiAssistantPluginSidebar() {
 					</PanelRow>
 					{ requireUpgrade && ! isUsagePanelAvailable && (
 						<PanelRow>
-							<Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } />
+							<Upgrade
+								placement="jetpack-sidebar"
+								onClick={ autosaveAndRedirect }
+								type={ upgradeType }
+							/>
 						</PanelRow>
 					) }
 					{ isUsagePanelAvailable && (
@@ -102,7 +122,9 @@ export default function AiAssistantPluginSidebar() {
 			>
 				<>
 					<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
-					{ requireUpgrade && <Upgrade onClick={ autosaveAndRedirect } type={ upgradeType } /> }
+					{ requireUpgrade && (
+						<Upgrade placement="pre-publish" onClick={ autosaveAndRedirect } type={ upgradeType } />
+					) }
 				</>
 			</PluginPrePublishPanel>
 		</>


### PR DESCRIPTION
We need to know when users are reaching out our AI panel

## Proposed changes:
- add event on panel un-collapse
- update upgrade event name (remnant of #35116 )

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
On the editor, open the Jetpack sidebar panel, then un-collapse the AI panel.