### PR TITLE
blogroll: $attr['is_non_wpcom_site'] is not always set

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blogrollitemblock
+++ b/projects/plugins/jetpack/changelog/fix-blogrollitemblock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blogroll block: avoid PHP notices on specific sites.

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -118,7 +118,7 @@ HTML;
 
 	$subscribe_button_html = '';
 	$fieldset              = '';
-	$has_subscription_form = defined( 'IS_WPCOM' ) && IS_WPCOM && ! $attr['is_non_wpcom_site'];
+	$has_subscription_form = defined( 'IS_WPCOM' ) && IS_WPCOM && isset( $attr['is_non_wpcom_site'] ) && ! $attr['is_non_wpcom_site'];
 	$classes               = Blocks::classes( FEATURE_NAME, $attr );
 
 	if ( $has_subscription_form ) {


### PR DESCRIPTION
`$attr['is_non_wpcom_site']` is not always set, so add a check for that in the comparison before trying to use it directly.