### PR TITLE
Subscriptions: Fix subscribtion modal appear right after subscribing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribtion-modal-appear-after-subscribing
+++ b/projects/plugins/jetpack/changelog/fix-subscribtion-modal-appear-after-subscribing
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Subscriptions: Fix subscribtion modal appear after subscribing
+Subscriptions: Fix subscribtion modal appear right after subscribing

--- a/projects/plugins/jetpack/changelog/fix-subscribtion-modal-appear-after-subscribing
+++ b/projects/plugins/jetpack/changelog/fix-subscribtion-modal-appear-after-subscribing
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: bugfix
 
 Subscriptions: Fix subscribtion modal appear after subscribing

--- a/projects/plugins/jetpack/changelog/fix-subscribtion-modal-appear-after-subscribing
+++ b/projects/plugins/jetpack/changelog/fix-subscribtion-modal-appear-after-subscribing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Fix subscribtion modal appear after subscribing

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -38,16 +38,24 @@ domReady( function () {
 		}
 	};
 
+	function closeModalOnEscapeKeypress( event ) {
+		if ( event.key === 'Escape' ) {
+			closeModal();
+		}
+	}
+
 	function openModal() {
 		modal.classList.add( 'open' );
 		document.body.classList.add( 'jetpack-subscribe-modal-open' );
 		hasLoaded = true;
 		setModalDismissedCookie();
+		window.addEventListener( 'keydown', closeModalOnEscapeKeypress );
 	}
 
 	function closeModal() {
 		modal.classList.remove( 'open' );
 		document.body.classList.remove( 'jetpack-subscribe-modal-open' );
+		window.removeEventListener( 'keydown', closeModalOnEscapeKeypress );
 	}
 
 	function setModalDismissedCookie() {

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -2,15 +2,15 @@ const { domReady } = wp;
 
 domReady( function () {
 	const modal = document.getElementsByClassName( 'jetpack-subscribe-modal' )[ 0 ];
+	const modalDismissedCookie = 'jetpack_post_subscribe_modal_dismissed';
+	const hasModalDismissedCookie =
+		document.cookie && document.cookie.indexOf( modalDismissedCookie ) > -1;
 
-	if ( ! modal ) {
+	if ( ! modal || hasModalDismissedCookie ) {
 		return;
 	}
 
 	const close = document.getElementsByClassName( 'jetpack-subscribe-modal__close' )[ 0 ];
-	const modalDismissedCookie = 'jetpack_post_subscribe_modal_dismissed';
-	const hasModalDismissedCookie =
-		document.cookie && document.cookie.indexOf( modalDismissedCookie ) > -1;
 	let hasLoaded = false;
 	let isScrolling;
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -18,7 +18,7 @@ domReady( function () {
 		window.clearTimeout( isScrolling );
 
 		isScrolling = setTimeout( function () {
-			if ( ! hasLoaded && ! hasModalDismissedCookie ) {
+			if ( ! hasLoaded ) {
 				openModal();
 			}
 		}, 300 );

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -38,7 +38,7 @@ domReady( function () {
 		}
 	};
 
-	function closeModalOnEscapeKeypress( event ) {
+	function closeModalOnEscapeKeydown( event ) {
 		if ( event.key === 'Escape' ) {
 			closeModal();
 		}
@@ -49,13 +49,13 @@ domReady( function () {
 		document.body.classList.add( 'jetpack-subscribe-modal-open' );
 		hasLoaded = true;
 		setModalDismissedCookie();
-		window.addEventListener( 'keydown', closeModalOnEscapeKeypress );
+		window.addEventListener( 'keydown', closeModalOnEscapeKeydown );
 	}
 
 	function closeModal() {
 		modal.classList.remove( 'open' );
 		document.body.classList.remove( 'jetpack-subscribe-modal-open' );
-		window.removeEventListener( 'keydown', closeModalOnEscapeKeypress );
+		window.removeEventListener( 'keydown', closeModalOnEscapeKeydown );
 	}
 
 	function setModalDismissedCookie() {

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -19,9 +19,7 @@ domReady( function () {
 
 		isScrolling = setTimeout( function () {
 			if ( ! hasLoaded && ! hasModalDismissedCookie ) {
-				modal.classList.add( 'open' );
-				document.body.classList.add( 'jetpack-subscribe-modal-open' );
-				hasLoaded = true;
+				openModal();
 			}
 		}, 300 );
 	};
@@ -40,10 +38,16 @@ domReady( function () {
 		}
 	};
 
+	function openModal() {
+		modal.classList.add( 'open' );
+		document.body.classList.add( 'jetpack-subscribe-modal-open' );
+		hasLoaded = true;
+		setModalDismissedCookie();
+	}
+
 	function closeModal() {
 		modal.classList.remove( 'open' );
 		document.body.classList.remove( 'jetpack-subscribe-modal-open' );
-		setModalDismissedCookie();
 	}
 
 	function setModalDismissedCookie() {


### PR DESCRIPTION
## Proposed changes:

It:
- fixes a bug where the modal could open again right after the user subscribed, by setting a dismiss cookie when the modal is open to avoid this kind of edge cases
- allows to close the modal by using the Escape key
- improves the modal performance by early exit when the dismiss cookie is present

The bug was reported here p1704738105197219-slack-C02NQ4HMJKV

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have the "Enable subscriber pop-up" enabled from Newsletter settings
* Open a blog post in an incognito window
* Scroll down to open the modal
* Subscribe to the blog and after you are redirected back to the post try to scroll again making sure the popup is not appearing
* Remove the `jetpack_post_subscribe_modal_dismissed` cookie and refresh the page
* Scroll down to open the modal again making sure it can be closed by pressing the Escape key