### PR TITLE
Boost: Add support for `jb-generate-critical-css` for cloud CSS generator

### DIFF
--- a/projects/plugins/boost/app/data-sync/Critical_CSS_Meta_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Critical_CSS_Meta_Entry.php
@@ -2,7 +2,7 @@
 namespace Automattic\Jetpack_Boost\Data_Sync;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
-use Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Generator;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator;
 
 class Critical_CSS_Meta_Entry implements Entry_Can_Get {
 	public function get() {

--- a/projects/plugins/boost/app/lib/critical-css/Generator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Generator.php
@@ -1,10 +1,36 @@
 <?php
 
-namespace Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS;
+namespace Automattic\Jetpack_Boost\Lib\Critical_CSS;
+
+use Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\CSS_Proxy;
 
 class Generator {
 
 	const GENERATE_QUERY_ACTION = 'jb-generate-critical-css';
+
+	public static function init() {
+		$generator = new static();
+		if ( static::is_generating_critical_css() ) {
+			add_action( 'wp_head', array( $generator, 'display_generate_meta' ), 0 );
+			$generator->force_logged_out_render();
+		}
+	}
+
+	/**
+	 * Force the current page to render as viewed by a logged out user. Useful when generating
+	 * Critical CSS.
+	 */
+	private function force_logged_out_render() {
+		$current_user_id = get_current_user_id();
+
+		if ( 0 !== $current_user_id ) {
+			// Force current user to 0 to ensure page is rendered as a non-logged-in user.
+			wp_set_current_user( 0 );
+
+			// Turn off display of admin bar.
+			add_filter( 'show_admin_bar', '__return_false', PHP_INT_MAX );
+		}
+	}
 
 	/**
 	 * Return true if page is loaded to generate critical CSS
@@ -27,6 +53,15 @@ class Generator {
 		$status['proxy_nonce'] = wp_create_nonce( CSS_Proxy::NONCE_ACTION );
 
 		return $status;
+	}
+
+	/**
+	 * Renders a <meta> tag used to verify this is a valid page to generate Critical CSS with.
+	 */
+	public function display_generate_meta() {
+		?>
+		<meta name="<?php echo esc_attr( self::GENERATE_QUERY_ACTION ); ?>" content="true"/>
+		<?php
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -9,6 +9,7 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Display_Critical_CSS;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
@@ -40,7 +41,9 @@ class Cloud_CSS implements Pluggable, Has_Endpoints {
 		add_action( 'save_post', array( $this, 'handle_save_post' ), 10, 2 );
 		add_filter( 'jetpack_boost_total_problem_count', array( $this, 'update_total_problem_count' ) );
 		add_filter( 'critical_css_invalidated', array( $this, 'handle_critical_css_invalidated' ) );
+		add_filter( 'query_vars', array( '\Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator', 'add_generate_query_action_to_list' ) );
 
+		Generator::init();
 		Critical_CSS_Invalidator::init();
 		Cloud_CSS_Followup::init();
 
@@ -70,6 +73,11 @@ class Cloud_CSS implements Pluggable, Has_Endpoints {
 
 		// Don't show Critical CSS in customizer previews.
 		if ( is_customize_preview() ) {
+			return;
+		}
+
+		// Don't display Critical CSS, if current page load is by the Critical CSS generator.
+		if ( Generator::is_generating_critical_css() ) {
 			return;
 		}
 

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Generator.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Generator.php
@@ -2,18 +2,9 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS;
 
-use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
-
 class Generator {
 
 	const GENERATE_QUERY_ACTION = 'jb-generate-critical-css';
-	const CSS_CALLBACK_ACTION   = 'jb-critical-css-callback';
-
-	private $paths;
-
-	public function __construct() {
-		$this->paths = new Source_Providers();
-	}
 
 	/**
 	 * Return true if page is loaded to generate critical CSS

--- a/projects/plugins/boost/changelog/update-ccss-generator
+++ b/projects/plugins/boost/changelog/update-ccss-generator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Cloud CSS: Added custom query parameter support for more reliable cloud CSS generation

--- a/projects/plugins/boost/compatibility/aioseo.php
+++ b/projects/plugins/boost/compatibility/aioseo.php
@@ -9,4 +9,4 @@ namespace Automattic\Jetpack_Boost\Compatibility\AIOSEO;
 
 // Add the Critical CSS generation query arg to the list of allowed query args of All in One SEO.
 // This prevents All in One SEO from removing the query arg, which breaks Critical CSS generation.
-add_filter( 'aioseo_unrecognized_allowed_query_args', array( '\Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Generator', 'add_generate_query_action_to_list' ) );
+add_filter( 'aioseo_unrecognized_allowed_query_args', array( '\Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator', 'add_generate_query_action_to_list' ) );

--- a/projects/plugins/boost/compatibility/yoast.php
+++ b/projects/plugins/boost/compatibility/yoast.php
@@ -9,4 +9,4 @@ namespace Automattic\Jetpack_Boost\Compatibility\Yoast;
 
 // Add the Critical CSS generation query arg to Yoast's allowed query args list.
 // This prevents Yoast from removing the query arg, which breaks Critical CSS generation.
-add_filter( 'Yoast\WP\SEO\allowlist_permalink_vars', array( '\Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Generator', 'add_generate_query_action_to_list' ) );
+add_filter( 'Yoast\WP\SEO\allowlist_permalink_vars', array( '\Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator', 'add_generate_query_action_to_list' ) );


### PR DESCRIPTION

Fixes #35127 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Share `Generator` between cloud CSS and local C.CSS which was only in local C.CSS before.
* Allow generator view using `jb-generate-critical-css` parameter in the URL

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test generating critical CSS and inspecting front-end for critical CSS with both manual and automated C.CSS

