### PR TITLE
Boost: Send boost version with API requests

### DIFF
--- a/projects/packages/boost-core/changelog/update-send-boost-version
+++ b/projects/packages/boost-core/changelog/update-send-boost-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Send current boost version with API requests to handle requests accordingly

--- a/projects/packages/boost-core/src/contracts/boost-api-client.php
+++ b/projects/packages/boost-core/src/contracts/boost-api-client.php
@@ -19,15 +19,18 @@ interface Boost_API_Client {
 	 *
 	 * @param string  $path - Request path.
 	 * @param mixed[] $payload - Request arguments.
+	 * @param mixed[] $args - Request arguments.
 	 * @return mixed
 	 */
-	public function post( $path, $payload = array() );
+	public function post( $path, $payload = array(), $args = null );
 
 	/**
 	 * Make a get request to boost API and return response.
 	 *
 	 * @param string  $path - Request path.
 	 * @param mixed[] $query - Query parameters.
+	 * @param mixed[] $args - Request arguments.
+	 * @return mixed
 	 */
-	public function get( $path, $query = array() );
+	public function get( $path, $query = array(), $args = null );
 }

--- a/projects/packages/boost-core/src/contracts/boost-api-client.php
+++ b/projects/packages/boost-core/src/contracts/boost-api-client.php
@@ -19,18 +19,16 @@ interface Boost_API_Client {
 	 *
 	 * @param string  $path - Request path.
 	 * @param mixed[] $payload - Request arguments.
-	 * @param mixed[] $args - Request arguments.
 	 * @return mixed
 	 */
-	public function post( $path, $payload = array(), $args = null );
+	public function post( $path, $payload = array() );
 
 	/**
 	 * Make a get request to boost API and return response.
 	 *
 	 * @param string  $path - Request path.
 	 * @param mixed[] $query - Query parameters.
-	 * @param mixed[] $args - Request arguments.
 	 * @return mixed
 	 */
-	public function get( $path, $query = array(), $args = null );
+	public function get( $path, $query = array() );
 }

--- a/projects/packages/boost-core/src/lib/class-boost-api.php
+++ b/projects/packages/boost-core/src/lib/class-boost-api.php
@@ -87,7 +87,9 @@ class Boost_API {
 	 * @return string[]
 	 */
 	public static function default_headers() {
-		$headers = array();
+		$headers = array(
+			'Content-Type' => 'application/json; charset=utf-8',
+		);
 
 		if ( defined( 'JETPACK_BOOST_VERSION' ) ) {
 			$headers['X-Jetpack-Boost-Version'] = JETPACK_BOOST_VERSION;

--- a/projects/packages/boost-core/src/lib/class-boost-api.php
+++ b/projects/packages/boost-core/src/lib/class-boost-api.php
@@ -28,7 +28,7 @@ class Boost_API {
 	 *
 	 * @return Boost_API_Client
 	 */
-	public static function get_client() {
+	private static function get_client() {
 		if ( ! self::$api_client ) {
 			$class            = apply_filters( 'jetpack_boost_api_client_class', WPCOM_Boost_API_Client::class );
 			self::$api_client = new $class();
@@ -45,7 +45,7 @@ class Boost_API {
 	 * @return array|\WP_Error
 	 */
 	public static function get( $path, $query = array(), $args = null ) {
-		return self::get_client()->get( $path, $query, $args );
+		return self::get_client()->get( $path, $query, self::merge_args( $args ) );
 	}
 
 	/**
@@ -57,6 +57,42 @@ class Boost_API {
 	 * @return mixed
 	 */
 	public static function post( $path, $payload = array(), $args = null ) {
-		return self::get_client()->post( $path, $payload, $args );
+		return self::get_client()->post( $path, $payload, self::merge_args( $args ) );
+	}
+
+	/**
+	 * Merge the arguments with the defaults.
+	 *
+	 * @param mixed[] $args - Provided arguments.
+	 * @return mixed[]
+	 */
+	private static function merge_args( $args ) {
+		if ( ! is_array( $args ) ) {
+			$args = wp_parse_args(
+				$args,
+				array(
+					'headers' => self::default_headers(),
+				)
+			);
+		} else {
+			$args['headers'] = wp_parse_args( $args['headers'] ?? array(), self::default_headers() );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Get the default headers to include with each request.
+	 *
+	 * @return string[]
+	 */
+	public static function default_headers() {
+		$headers = array();
+
+		if ( defined( 'JETPACK_BOOST_VERSION' ) ) {
+			$headers['X-Jetpack-Boost-Version'] = JETPACK_BOOST_VERSION;
+		}
+
+		return $headers;
 	}
 }

--- a/projects/packages/boost-core/src/lib/class-boost-api.php
+++ b/projects/packages/boost-core/src/lib/class-boost-api.php
@@ -40,11 +40,12 @@ class Boost_API {
 	 * Make a get request to boost API and return response.
 	 *
 	 * @param string  $path - Request path.
-	 * @param mixed[] $args - Query parameters.
+	 * @param mixed[] $query - Query parameters.
+	 * @param mixed[] $args - Request arguments.
 	 * @return array|\WP_Error
 	 */
-	public static function get( $path, $args = array() ) {
-		return self::get_client()->get( $path, $args );
+	public static function get( $path, $query = array(), $args = null ) {
+		return self::get_client()->get( $path, $query, $args );
 	}
 
 	/**
@@ -52,9 +53,10 @@ class Boost_API {
 	 *
 	 * @param string  $path - Request path.
 	 * @param mixed[] $payload - Request arguments.
+	 * @param mixed[] $args - Request arguments.
 	 * @return mixed
 	 */
-	public static function post( $path, $payload = array() ) {
-		return self::get_client()->post( $path, $payload );
+	public static function post( $path, $payload = array(), $args = null ) {
+		return self::get_client()->post( $path, $payload, $args );
 	}
 }

--- a/projects/packages/boost-core/src/lib/class-wpcom-boost-api-client.php
+++ b/projects/packages/boost-core/src/lib/class-wpcom-boost-api-client.php
@@ -20,14 +20,15 @@ class WPCOM_Boost_API_Client implements Boost_API_Client {
 	 * Submit a POST request to boost API and return response.
 	 *
 	 * @param string  $path - Request path.
-	 * @param mixed[] $payload - Request arguments.
+	 * @param mixed[] $payload - Request payload.
+	 * @param mixed[] $args - Request arguments.
 	 * @return mixed
 	 */
-	public function post( $path, $payload = array() ) {
+	public function post( $path, $payload = array(), $args = null ) {
 		return Utils::send_wpcom_request(
 			'POST',
 			$this->get_api_path( $path ),
-			null,
+			$args,
 			$payload
 		);
 	}
@@ -37,11 +38,14 @@ class WPCOM_Boost_API_Client implements Boost_API_Client {
 	 *
 	 * @param string  $path - Request path.
 	 * @param mixed[] $query - Query parameters.
+	 * @param mixed[] $args - Request arguments.
+	 * @return mixed
 	 */
-	public function get( $path, $query = array() ) {
+	public function get( $path, $query = array(), $args = null ) {
 		return Utils::send_wpcom_request(
 			'GET',
-			add_query_arg( $query, $this->get_api_path( $path ) )
+			add_query_arg( $query, $this->get_api_path( $path ) ),
+			$args
 		);
 	}
 

--- a/projects/packages/boost-speed-score/changelog/update-send-boost-version
+++ b/projects/packages/boost-speed-score/changelog/update-send-boost-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Send current boost version with API requests to handle requests accordingly

--- a/projects/packages/boost-speed-score/src/class-speed-score-graph-history-request.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score-graph-history-request.php
@@ -117,7 +117,7 @@ class Speed_Score_Graph_History_Request extends Cacheable {
 	 * @return true|\WP_Error True on success, WP_Error on failure.
 	 */
 	public function execute() {
-		$response = $this->get_client()->get(
+		$response = Boost_API::get(
 			'speed-scores-history',
 			array(
 				'start' => $this->start,
@@ -134,14 +134,5 @@ class Speed_Score_Graph_History_Request extends Cacheable {
 		}
 
 		return $response;
-	}
-
-	/**
-	 * Instantiate the API client.
-	 *
-	 * @return Boost_API_Client
-	 */
-	private function get_client() {
-		return Boost_API::get_client();
 	}
 }

--- a/projects/packages/boost-speed-score/src/class-speed-score-request.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score-request.php
@@ -162,7 +162,7 @@ class Speed_Score_Request extends Cacheable {
 	 * @return true|\WP_Error True on success, WP_Error on failure.
 	 */
 	public function execute() {
-		$response = $this->get_client()->post(
+		$response = Boost_API::post(
 			'speed-scores',
 			array(
 				'request_id'     => $this->get_cache_id(),
@@ -210,7 +210,7 @@ class Speed_Score_Request extends Cacheable {
 	 * @return true|\WP_Error True on success, WP_Error on failure.
 	 */
 	public function poll_update() {
-		$response = $this->get_client()->get(
+		$response = Boost_API::get(
 			sprintf(
 				'speed-scores/%s',
 				$this->get_cache_id()
@@ -311,14 +311,5 @@ class Speed_Score_Request extends Cacheable {
 				)
 			);
 		}
-	}
-
-	/**
-	 * Instantiate the API client.
-	 *
-	 * @return Boost_API_Client
-	 */
-	private function get_client() {
-		return Boost_API::get_client();
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -111,10 +111,9 @@ class Cloud_CSS implements Pluggable, Has_Endpoints {
 		}
 
 		// Send the request to the Cloud.
-		$client               = Boost_API::get_client();
 		$payload              = array( 'providers' => $grouped_urls );
 		$payload['requestId'] = md5( wp_json_encode( $payload ) . time() );
-		return $client->post( 'cloud-css', $payload );
+		return Boost_API::post( 'cloud-css', $payload );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/update-send-boost-version
+++ b/projects/plugins/boost/changelog/update-send-boost-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Send current boost version with API requests to handle requests accordingly


### PR DESCRIPTION
Related to #35129 

## Proposed changes:
* It would be useful for hydras to know the boost version the request is coming from. This just does that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Make sure API requests still work
* Make sure the header `X-Jetpack-Boost-Version` is present when wpcom receives the response.

