### PR TITLE
tools: Commit version bumps in release-plugin.sh

### DIFF
--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -286,6 +286,9 @@ fi
 git fetch
 git merge origin/trunk
 tools/fixup-project-versions.sh
+if [[ -n "$(git status --porcelain)" ]]; then
+	git commit -am 'Version bumps'
+fi
 git push
 PLUGINS_CHANGED=
 for PLUGIN in "${!PROJECTS[@]}"; do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The `release-plugin.sh` script runs `tools/fixup-project-versions.sh` after a `git merge` to bump versions when necessary, but it wasn't actually committing them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1705619632413309/1705612362.687589-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unsure how to test without making an actual release.