### PR TITLE
Changelogger: Default `--deduplicate` to 0

### DIFF
--- a/projects/packages/changelogger/changelog/update-changelogger-deduplicate-default
+++ b/projects/packages/changelogger/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Default for `--deduplicate` is now 0, as 1 caused unexpected behavior for some cases and so should be opted in to.

--- a/projects/packages/changelogger/composer.json
+++ b/projects/packages/changelogger/composer.json
@@ -57,7 +57,7 @@
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "4.0.x-dev"
+			"dev-trunk": "4.1.x-dev"
 		},
 		"mirror-repo": "Automattic/jetpack-changelogger",
 		"version-constants": {

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.0.5';
+	const VERSION = '4.1.0-alpha';
 
 	/**
 	 * Constructor.

--- a/projects/packages/changelogger/src/WriteCommand.php
+++ b/projects/packages/changelogger/src/WriteCommand.php
@@ -70,7 +70,7 @@ class WriteCommand extends Command {
 			->addOption( 'buildinfo', 'b', InputOption::VALUE_REQUIRED, 'When fetching the next version, include this buildinfo suffix' )
 			->addOption( 'release-date', null, InputOption::VALUE_REQUIRED, 'Release date, as a valid PHP date or "unreleased"', 'now' )
 			->addOption( 'default-first-version', null, InputOption::VALUE_NONE, 'If the changelog is currently empty, guess a "first" version instead of erroring' )
-			->addOption( 'deduplicate', null, InputOption::VALUE_REQUIRED, 'Deduplicate new changes against the last N versions. Set -1 to disable deduplication entirely.', 1 )
+			->addOption( 'deduplicate', null, InputOption::VALUE_REQUIRED, 'Deduplicate new changes against the last N versions. Set -1 to disable deduplication entirely.', 0 )
 			->addOption( 'prologue', null, InputOption::VALUE_REQUIRED, 'Prologue text for the new changelog entry' )
 			->addOption( 'epilogue', null, InputOption::VALUE_REQUIRED, 'Epilogue text for the new changelog entry' )
 			->addOption( 'link', null, InputOption::VALUE_REQUIRED, 'Link for the new changelog entry' )

--- a/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
@@ -45,7 +45,7 @@ class ApplicationTest extends TestCase {
 
 		$app->setAutoExit( false );
 		$tester = new ApplicationTester( $app );
-		$tester->run( array( 'command' => 'list' ) );
+		$tester->run( array( 'command' => 'list' ), array( 'decorated' => false ) );
 		$output = $tester->getDisplay();
 		$this->assertMatchesRegularExpression( '/Available commands:/', $output );
 		$this->assertMatchesRegularExpression( '/add\s*Adds a change file/', $output );
@@ -85,7 +85,7 @@ class ApplicationTest extends TestCase {
 			unset( $options['inputs'] );
 		}
 
-		$options[] = 'decorated';
+		$options['decorated'] = false;
 		$tester->run( array( 'command' => 'testDoRun' ), $options );
 		return $tester;
 	}

--- a/projects/packages/changelogger/tests/php/tests/src/WriteCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/WriteCommandTest.php
@@ -471,7 +471,7 @@ class WriteCommandTest extends CommandTestCase {
 				true,
 				"# Changelog\n\n## 1.0.2 - $date\n### Added\n- Initial release.\n- Stuff. And more stuff.\n\n## 1.0.1 - 2021-02-23\n\nPrologue for v1.0.1\n\n### Added\n- Stuff.\n\n### Removed\n- Other stuff.\n\nEpilogue for v1.0.1\n\n## 1.0.0 - 2021-02-23\n\n- Initial release.\n",
 			),
-			'Deduplication, --dedupliacte default 0'       => array(
+			'Deduplication, --deduplicate default 0'       => array(
 				array(),
 				array(
 					'changes' => array(

--- a/projects/packages/changelogger/tests/php/tests/src/WriteCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/WriteCommandTest.php
@@ -132,7 +132,7 @@ class WriteCommandTest extends CommandTestCase {
 				array(
 					'{^Reading changelog from /.*/CHANGELOG.md\\.\\.\\.$}m',
 					'{^Reading changes from /.*/changelog\\.\\.\\.$}m',
-					'{^Deduplicating changes from the last 1 version\\(s\\)\\.\\.\\.$}m',
+					'{^Deduplicating changes in the current version\\.\\.\\.$}m',
 					'{^Checking if any changes have content\\.\\.\\.$}m',
 					'{^Yes, a-change has content\\.$}m',
 					'{^Latest version from changelog is 1\\.0\\.1\\.$}m',
@@ -455,8 +455,8 @@ class WriteCommandTest extends CommandTestCase {
 				"# Changelog\n\n## 1.0.2 - $date\n\n## 1.0.1 - 2021-02-23\n\nPrologue for v1.0.1\n\n### Added\n- Stuff.\n\n### Removed\n- Other stuff.\n\nEpilogue for v1.0.1\n\n## 1.0.0 - 2021-02-23\n\n- Initial release.\n",
 			),
 
-			'Deduplication'                                => array(
-				array(),
+			'Deduplication, --deduplicate=1'               => array(
+				array( '--deduplicate' => '1' ),
 				array(
 					'changes' => array(
 						'initial-release' => "Significance: patch\nType: added\n\nInitial release.\n",
@@ -471,8 +471,8 @@ class WriteCommandTest extends CommandTestCase {
 				true,
 				"# Changelog\n\n## 1.0.2 - $date\n### Added\n- Initial release.\n- Stuff. And more stuff.\n\n## 1.0.1 - 2021-02-23\n\nPrologue for v1.0.1\n\n### Added\n- Stuff.\n\n### Removed\n- Other stuff.\n\nEpilogue for v1.0.1\n\n## 1.0.0 - 2021-02-23\n\n- Initial release.\n",
 			),
-			'Deduplication, --dedupliacte=0'               => array(
-				array( '--deduplicate' => '0' ),
+			'Deduplication, --dedupliacte default 0'       => array(
+				array(),
 				array(
 					'changes' => array(
 						'initial-release' => "Significance: patch\nType: added\n\nInitial release.\n",
@@ -520,7 +520,7 @@ class WriteCommandTest extends CommandTestCase {
 			),
 
 			'Deduplication removes all changes'            => array(
-				array(),
+				array( '--deduplicate' => '1' ),
 				array(
 					'changes' => array(
 						'added-stuff' => "Significance: patch\nType: added\n\nStuff.\n",
@@ -531,7 +531,7 @@ class WriteCommandTest extends CommandTestCase {
 				array( '{^All changes were duplicates\. Proceed\? \[y/N\]}m' ),
 			),
 			'Deduplication removes all changes (2)'        => array(
-				array(),
+				array( '--deduplicate' => '1' ),
 				array(
 					'changes' => array(
 						'added-stuff' => "Significance: patch\nType: added\n\nStuff.\n",
@@ -544,7 +544,7 @@ class WriteCommandTest extends CommandTestCase {
 				"# Changelog\n\n## 1.0.2 - $date\n\n## 1.0.1 - 2021-02-23\n\nPrologue for v1.0.1\n\n### Added\n- Stuff.\n\n### Removed\n- Other stuff.\n\nEpilogue for v1.0.1\n\n## 1.0.0 - 2021-02-23\n\n- Initial release.\n",
 			),
 			'Deduplication removes all changes, non-interactive' => array(
-				array(),
+				array( '--deduplicate' => '1' ),
 				array(
 					'interactive' => false,
 					'changes'     => array(
@@ -556,7 +556,10 @@ class WriteCommandTest extends CommandTestCase {
 				array( '{^All changes were duplicates\.$}m' ),
 			),
 			'Deduplication removes all changes, non-interactive, --yes' => array(
-				array( '--yes' => true ),
+				array(
+					'--deduplicate' => '1',
+					'--yes'         => true,
+				),
 				array(
 					'interactive' => false,
 					'changes'     => array(
@@ -571,7 +574,7 @@ class WriteCommandTest extends CommandTestCase {
 			),
 
 			'All changes are empty'                        => array(
-				array(),
+				array( '--deduplicate' => '1' ),
 				array(
 					'changes' => array(
 						'duplicate' => "Significance: patch\nType: added\n\nStuff.\n",
@@ -584,7 +587,7 @@ class WriteCommandTest extends CommandTestCase {
 				array( '{There are no changes with content for this write\. Proceed\? \[y/N\]}m' ),
 			),
 			'All changes are empty (2)'                    => array(
-				array(),
+				array( '--deduplicate' => '1' ),
 				array(
 					'changes' => array(
 						'duplicate' => "Significance: patch\nType: added\n\nStuff.\n",
@@ -599,7 +602,7 @@ class WriteCommandTest extends CommandTestCase {
 				"# Changelog\n\n## 1.0.2 - $date\n\n## 1.0.1 - 2021-02-23\n\nPrologue for v1.0.1\n\n### Added\n- Stuff.\n\n### Removed\n- Other stuff.\n\nEpilogue for v1.0.1\n\n## 1.0.0 - 2021-02-23\n\n- Initial release.\n",
 			),
 			'All changes are empty, non-interactive'       => array(
-				array(),
+				array( '--deduplicate' => '1' ),
 				array(
 					'interactive' => false,
 					'changes'     => array(
@@ -612,7 +615,10 @@ class WriteCommandTest extends CommandTestCase {
 				array( '{^There are no changes with content for this write\.$}m' ),
 			),
 			'All changes are empty, non-interactive, --yes' => array(
-				array( '--yes' => true ),
+				array(
+					'--deduplicate' => '1',
+					'--yes'         => true,
+				),
 				array(
 					'interactive' => false,
 					'changes'     => array(

--- a/projects/plugins/backup/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/backup/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1475,7 +1475,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -1493,7 +1493,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/beta/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/beta/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -270,7 +270,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -288,7 +288,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/boost/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/boost/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1830,7 +1830,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -1848,7 +1848,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/crm/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/crm/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -576,7 +576,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -594,7 +594,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/debug-helper/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/debug-helper/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -31,7 +31,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/inspect/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/inspect/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -637,7 +637,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -655,7 +655,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/jetpack/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/jetpack/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2931,7 +2931,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/changelogger",
-				"reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+				"reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
 			},
 			"require": {
 				"php": ">=7.0",
@@ -2949,7 +2949,7 @@
 			"extra": {
 				"autotagger": true,
 				"branch-alias": {
-					"dev-trunk": "4.0.x-dev"
+					"dev-trunk": "4.1.x-dev"
 				},
 				"mirror-repo": "Automattic/jetpack-changelogger",
 				"version-constants": {

--- a/projects/plugins/migration/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/migration/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1475,7 +1475,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -1493,7 +1493,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -81,7 +81,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -99,7 +99,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/protect/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/protect/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -79,6 +79,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ2_0_0"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ2_0_1_alpha"
 	}
 }

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1582,7 +1582,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -1600,7 +1600,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/protect/jetpack-protect.php
+++ b/projects/plugins/protect/jetpack-protect.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Protect
  * Plugin URI: https://wordpress.org/plugins/jetpack-protect
  * Description: Security tools that keep your site safe and sound, from posts to plugins.
- * Version: 2.0.0
+ * Version: 2.0.1-alpha
  * Author: Automattic - Jetpack Security team
  * Author URI: https://jetpack.com/protect/
  * License: GPLv2 or later
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'JETPACK_PROTECT_VERSION', '2.0.0' );
+define( 'JETPACK_PROTECT_VERSION', '2.0.1-alpha' );
 define( 'JETPACK_PROTECT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_PROTECT_ROOT_FILE', __FILE__ );
 define( 'JETPACK_PROTECT_ROOT_FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );

--- a/projects/plugins/search/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/search/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1477,7 +1477,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -1495,7 +1495,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/social/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/social/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1456,7 +1456,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/changelogger",
-				"reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+				"reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
 			},
 			"require": {
 				"php": ">=7.0",
@@ -1474,7 +1474,7 @@
 			"extra": {
 				"autotagger": true,
 				"branch-alias": {
-					"dev-trunk": "4.0.x-dev"
+					"dev-trunk": "4.1.x-dev"
 				},
 				"mirror-repo": "Automattic/jetpack-changelogger",
 				"version-constants": {

--- a/projects/plugins/starter-plugin/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/starter-plugin/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1379,7 +1379,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -1397,7 +1397,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/super-cache/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/super-cache/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/super-cache/composer.lock
+++ b/projects/plugins/super-cache/composer.lock
@@ -64,7 +64,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -82,7 +82,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/vaultpress/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/vaultpress/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/vaultpress/composer.lock
+++ b/projects/plugins/vaultpress/composer.lock
@@ -127,7 +127,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -145,7 +145,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/videopress/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/videopress/changelog/update-changelogger-deduplicate-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1410,7 +1410,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "a3fe745d83642d741dffe5e1884cc53c65fd056b"
+                "reference": "24b6e97347346c7c06f03a53d9c50c8b9d111d8b"
             },
             "require": {
                 "php": ">=7.0",
@@ -1428,7 +1428,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.0.x-dev"
+                    "dev-trunk": "4.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When set to 1, it looks at the previous changelog entry and removes any from the current entry that already show there. While that makes sense in the case of "normal" changes that might have been backported, it makes much less sense for perennial things like "Updated dependencies". So probably better if people have to opt in to that behavior.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes https://github.com/Automattic/garage-backlog/issues/56

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI tests happy?
