### PR TITLE
Update how Cart/Checkout is tracked to be realtime.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-move-woo-event-tracking-frontend
+++ b/projects/plugins/jetpack/changelog/add-move-woo-event-tracking-frontend
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: We updated how we track Cart/Checkout
+
+

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
@@ -73,6 +73,18 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 
 		$order = wc_get_order( $order_id );
 
+		$order_source = $order->get_created_via();
+		if ( 'store-api' === $order_source ) {
+			$checkout_page_contains_checkout_block     = '1';
+			$checkout_page_contains_checkout_shortcode = '0';
+		} elseif ( 'checkout' === $order_source ) {
+			$checkout_page_contains_checkout_block     = '0';
+			$checkout_page_contains_checkout_shortcode = '1';
+		} else {
+			$checkout_page_contains_checkout_block     = '0';
+			$checkout_page_contains_checkout_shortcode = '0';
+		}
+
 		$coupons     = $order->get_coupons();
 		$coupon_used = 0;
 		if ( is_countable( $coupons ) ) {
@@ -88,17 +100,19 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 		$this->record_event(
 			'woocommerceanalytics_order_confirmation_view',
 			array(
-				'coupon_used'      => $coupon_used,
-				'create_account'   => $create_account,
-				'express_checkout' => 'null', // TODO: not solved yet.
-				'guest_checkout'   => $order->get_customer_id() ? 'No' : 'Yes',
-				'oi'               => $order->get_id(),
-				'order_value'      => $order->get_total(),
-				'payment_option'   => $order->get_payment_method(),
-				'products_count'   => $order->get_item_count(),
-				'products'         => $this->format_items_to_json( $order->get_items() ),
-				'order_note'       => $order->get_customer_note(),
-				'shipping_option'  => $order->get_shipping_method(),
+				'coupon_used'                           => $coupon_used,
+				'create_account'                        => $create_account,
+				'express_checkout'                      => 'null', // TODO: not solved yet.
+				'guest_checkout'                        => $order->get_customer_id() ? 'No' : 'Yes',
+				'oi'                                    => $order->get_id(),
+				'order_value'                           => $order->get_total(),
+				'payment_option'                        => $order->get_payment_method(),
+				'products_count'                        => $order->get_item_count(),
+				'products'                              => $this->format_items_to_json( $order->get_items() ),
+				'order_note'                            => $order->get_customer_note(),
+				'shipping_option'                       => $order->get_shipping_method(),
+				'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
+				'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
 			)
 		);
 	}

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -113,14 +113,14 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		);
 
 		$enabled_payment_options = array_keys( $enabled_payment_options );
-
-		$shared_data = array(
+		$cart_total              = wc_prices_include_tax() ? $cart->get_cart_contents_total() + $cart->get_cart_contents_tax() : $cart->get_cart_contents_total();
+		$shared_data             = array(
 			'products'               => $this->format_items_to_json( $cart->get_cart() ),
 			'create_account'         => $create_account,
 			'guest_checkout'         => $guest_checkout,
 			'express_checkout'       => 'null', // TODO: not solved yet.
 			'products_count'         => $cart->get_cart_contents_count(),
-			'order_value'            => $cart->get_cart_total(),
+			'order_value'            => $cart_total,
 			'shipping_options_count' => 'null', // TODO: not solved yet.
 			'coupon_used'            => $coupon_used,
 			'payment_options'        => $enabled_payment_options,
@@ -387,8 +387,8 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		$all_props = apply_filters(
 			'jetpack_woocommerce_analytics_event_props',
 			array_merge(
-				$properties,
-				$this->get_common_properties()
+				$this->get_common_properties(), // We put this here to allow override of common props.
+				$properties
 			)
 		);
 

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -244,9 +244,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				// Check if jQuery is available
 				if ( typeof jQuery !== 'undefined' ) {
 					// This is only triggered on the checkout shortcode.
-					console.log('running here');
 					jQuery( document.body ).on( 'init_checkout', function () {
-						console.log('but not here');
 						if ( true === cartItem_{$cart_item_key}_logged ) {
 							return;
 						}
@@ -274,7 +272,10 @@ class Jetpack_WooCommerce_Analytics_Universal {
 
 						const checkoutDataStore = wp.data.select( 'wc/store/checkout' );
 						// Ensures we're not in Cart, but in Checkout page.
-						if ( checkoutDataStore.getOrderId() !== 0 ) {
+						if (
+							typeof checkoutDataStore !== 'undefined' &&
+							checkoutDataStore.getOrderId() !== 0
+						) {
 							properties.express_checkout = Object.keys( wc.wcBlocksRegistry.getExpressPaymentMethods() );
 							properties.checkout_page_contains_checkout_block = '1';
 							properties.checkout_page_contains_checkout_shortcode = '0';
@@ -282,7 +283,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 							_wca.push( properties );
 							cartItem_{$cart_item_key}_logged = true;
 						}
-					}, 'wc/store/checkout' );
+					} );
 				}
 			"
 			);
@@ -330,6 +331,9 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			}
 		}
 
+		$checkout_page_contains_checkout_block         = '0';
+			$checkout_page_contains_checkout_shortcode = '0';
+
 		$order_source = $order->get_created_via();
 		if ( 'store-api' === $order_source ) {
 			$checkout_page_contains_checkout_block     = '1';
@@ -337,9 +341,6 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		} elseif ( 'checkout' === $order_source ) {
 			$checkout_page_contains_checkout_block     = '0';
 			$checkout_page_contains_checkout_shortcode = '1';
-		} else {
-			$checkout_page_contains_checkout_block     = '0';
-			$checkout_page_contains_checkout_shortcode = '0';
 		}
 
 		// loop through products in the order and queue a purchase event.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR changes how we're tracking Checkout block events. Instead of firing the event when Checkout loads, and assuming whatever is in the Checkout page is that, we now only react to Checkout events (shortcode and Block), and dynamically edit the `checkout_page_contains_checkout_block` and `checkout_page_contains_checkout_shortcode` values.

This is done by hooking into Checkout events.

This PR also adds a `from_checkout` prop to indicate if the event came from Checkout page or not.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Setup a new website That's running Checkout Block on the Checkout page. Install One Page Checkout, and mark a product a single page product.
- Create a new page called Checkout Shortcode and add Shortcode Checkout to it.
- Add a product to your cart, open track vigilante, and go to Checkout page (with Block), make sure the `checkout_page_contains_checkout_block` value is `1` and `checkout_page_contains_checkout_shortcode` is `0` on `product_checkout` event, make sure that `from_checkout` is `1`.
- Place the order, make sure the values are still correct in the `product_purshase` event.
- Do the same from the one page checkout product page, make sure the values are reversed, so `shortcode` is 1 and `block` is 0, and that `from_checkout` is `0`.
- Do the same from the extra page you create and make sure the values are still correct.
- Now change your default Checkout to shortcode, run the flow again the Checkout page and make sure the values are correct in both events.

