### PR TITLE
Untangle: Themes to core & add Theme Showcase submenu

### DIFF
--- a/projects/plugins/jetpack/changelog/update-untangle-themes
+++ b/projects/plugins/jetpack/changelog/update-untangle-themes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Untangle Calypso from Themes & new sub-menu to Marketplace

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -31,7 +31,11 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->add_testimonials_menu();
 		$this->add_portfolio_menu();
 		$this->add_comments_menu();
-		$this->add_appearance_menu();
+		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+			add_submenu_page( 'themes.php', esc_attr__( 'Add new theme', 'jetpack' ), __( 'Add new theme', 'jetpack' ), 'read', 'https://wordpress.com/themes/' . $this->domain );
+		} else {
+			$this->add_appearance_menu();
+		}
 		$this->add_plugins_menu();
 		$this->add_users_menu();
 		$this->add_tools_menu();

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -30,12 +30,7 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->add_page_menu();
 		$this->add_testimonials_menu();
 		$this->add_portfolio_menu();
-		$this->add_comments_menu();
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
-			add_submenu_page( 'themes.php', esc_attr__( 'Add new theme', 'jetpack' ), __( 'Add new theme', 'jetpack' ), 'read', 'https://wordpress.com/themes/' . $this->domain );
-		} else {
-			$this->add_appearance_menu();
-		}
+		$this->add_appearance_menu();
 		$this->add_plugins_menu();
 		$this->add_users_menu();
 		$this->add_tools_menu();

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -30,6 +30,7 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->add_page_menu();
 		$this->add_testimonials_menu();
 		$this->add_portfolio_menu();
+		$this->add_comments_menu();
 		$this->add_appearance_menu();
 		$this->add_plugins_menu();
 		$this->add_users_menu();

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -523,4 +523,15 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		add_action( 'admin_notices', $admin_notices );
 	}
+
+	/**
+	 * Adds Appearance menu.
+	 */
+	public function add_appearance_menu() {
+		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+			add_submenu_page( 'themes.php', esc_attr__( 'Add new theme', 'jetpack' ), __( 'Add new theme', 'jetpack' ), 'read', 'https://wordpress.com/themes/' . $this->domain );
+		} else {
+			parent::add_appearance_menu();
+		}
+	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -530,7 +530,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_appearance_menu() {
 		// When the interface is set to wp-admin, we need to add a link to the Marketplace and rest of the menu keeps like core.
 		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
-			add_submenu_page( 'themes.php', esc_attr__( 'Add New Theme', 'jetpack' ), __( 'Add New Theme', 'jetpack' ), 'read', 'https://wordpress.com/themes/' . $this->domain );
+			add_submenu_page( 'themes.php', esc_attr__( 'Theme Showcase', 'jetpack' ), __( 'Theme Showcase', 'jetpack' ), 'read', 'https://wordpress.com/themes/' . $this->domain );
 		} else {
 			parent::add_appearance_menu();
 		}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -530,7 +530,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_appearance_menu() {
 		// When the interface is set to wp-admin, we need to add a link to the Marketplace and rest of the menu keeps like core.
 		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
-			add_submenu_page( 'themes.php', esc_attr__( 'Add new theme', 'jetpack' ), __( 'Add new theme', 'jetpack' ), 'read', 'https://wordpress.com/themes/' . $this->domain );
+			add_submenu_page( 'themes.php', esc_attr__( 'Add New Theme', 'jetpack' ), __( 'Add New Theme', 'jetpack' ), 'read', 'https://wordpress.com/themes/' . $this->domain );
 		} else {
 			parent::add_appearance_menu();
 		}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -528,6 +528,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds Appearance menu.
 	 */
 	public function add_appearance_menu() {
+		// When the interface is set to wp-admin, we need to add a link to the Marketplace and rest of the menu keeps like core.
 		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
 			add_submenu_page( 'themes.php', esc_attr__( 'Add new theme', 'jetpack' ), __( 'Add new theme', 'jetpack' ), 'read', 'https://wordpress.com/themes/' . $this->domain );
 		} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5263, https://github.com/Automattic/dotcom-forge/issues/5264

## Proposed changes:
Remove Calypso links in favor of core links inside `Appearance` menu, and add `Theme Showcase` linked to `wordpress.com/themes/:site_slug`


## Jetpack product discussion
paYJgx-4uN-p2#comment-4524

## Does this pull request change what data or activity we track or use?
NO

## Testing instructions:
* Set your `Admin interface style` to `Classic (wp-admin)` in `wordpress.com/hosting-config/site_slug`
* Go to `wp-admin`
* The `Appareance` sub-menu should link to `/wp-admin` (except 👇 )
* The `Add new link` sub-menu should link to Themes marketplace on Calypso
