### PR TITLE
Boost: Fix image guide style

### DIFF
--- a/projects/plugins/boost/changelog/fix-image-guide-style
+++ b/projects/plugins/boost/changelog/fix-image-guide-style
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed image guide styles
+
+

--- a/projects/plugins/boost/webpack.config.js
+++ b/projects/plugins/boost/webpack.config.js
@@ -24,6 +24,15 @@ if ( ! isProduction ) {
 	} );
 }
 
+const imageGuideCopyPatterns = [
+	{
+		from: path.join(
+			path.dirname( require.resolve( '@automattic/jetpack-image-guide' ) ),
+			'guide.css'
+		),
+	},
+];
+
 module.exports = [
 	/**
 	 * The Boost plugin
@@ -123,6 +132,7 @@ module.exports = [
 			...jetpackWebpackConfig.StandardPlugins( {
 				DependencyExtractionPlugin: { injectPolyfill: true },
 			} ),
+			new CopyPlugin( { patterns: imageGuideCopyPatterns } ),
 		],
 		module: {
 			strictExportPresence: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35152

## Proposed changes:
* Image guide CSS file was missing. This PR copies the CSS file from the image guide package and uses it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pedxs5-mg-p2#comment-176

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Install boost and activate image guide module.
* Visit the front-end of the site and make sure image guide elements are styled, i.e. `guide.css` is loading.