### PR TITLE
Boost: ISA - fix incorrect date for report status

### DIFF
--- a/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Entry.php
+++ b/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Entry.php
@@ -45,7 +45,7 @@ class Image_Size_Analysis_Entry implements Lazy_Entry, Entry_Can_Get {
 		}
 
 		return array(
-			'last_updated' => strtotime( $data->last_updated ) * 1000,
+			'last_updated' => strtotime( $data['last_updated'] ) * 1000,
 			'total_pages'  => $data['pagination']['total_pages'],
 			'images'       => $issues,
 		);

--- a/projects/plugins/boost/changelog/boost-react-fix-isa-report-time
+++ b/projects/plugins/boost/changelog/boost-react-fix-isa-report-time
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect date for report status.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35157

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix referencing an object property instead of an array item.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost (premium);
* Request an Image Size Analysis report;
* Check the report date to make sure it's the correct one.

![CleanShot 2024-01-22 at 13 23 22](https://github.com/Automattic/jetpack/assets/11799079/1bda8c50-a29b-446e-9467-85e1b6d36988)
