### PR TITLE
Subscriber Login: Allow to transform it to/from core Login/out block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriber-login-transforms
+++ b/projects/plugins/jetpack/changelog/update-subscriber-login-transforms
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriber Login: Allow to transform it to/from core Login/out block

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/block.json
@@ -31,5 +31,10 @@
 			"gradients": true
 		}
 	},
-	"attributes": {}
+	"attributes": {
+		"redirectToCurrent": {
+			"type": "boolean",
+			"default": true
+		}
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
@@ -1,10 +1,25 @@
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function SubscriberLoginEdit( { className } ) {
+function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
+	const { redirectToCurrent } = attributes;
+
 	return (
-		<div className={ className }>
-			<a href="#logout-pseudo-link">{ __( 'Log out', 'jetpack' ) }</a>
-		</div>
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
+					<ToggleControl
+						label={ __( 'Redirect to current URL', 'jetpack' ) }
+						checked={ redirectToCurrent }
+						onChange={ () => setAttributes( { redirectToCurrent: ! redirectToCurrent } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div className={ className }>
+				<a href="#logout-pseudo-link">{ __( 'Log out', 'jetpack' ) }</a>
+			</div>
+		</>
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/editor.js
@@ -10,8 +10,8 @@ registerJetpackBlockFromMetadata( metadata, {
 			{
 				type: 'block',
 				blocks: [ 'core/loginout' ],
-				transform: () => {
-					return createBlock( 'jetpack/subscriber-login' );
+				transform: ( { fontSize, redirectToCurrent } ) => {
+					return createBlock( 'jetpack/subscriber-login', { fontSize, redirectToCurrent } );
 				},
 			},
 		],
@@ -19,8 +19,8 @@ registerJetpackBlockFromMetadata( metadata, {
 			{
 				type: 'block',
 				blocks: [ 'core/loginout' ],
-				transform: () => {
-					return createBlock( 'core/loginout' );
+				transform: ( { fontSize, redirectToCurrent } ) => {
+					return createBlock( 'core/loginout', { fontSize, redirectToCurrent } );
 				},
 			},
 		],

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/editor.js
@@ -1,8 +1,28 @@
+import { createBlock } from '@wordpress/blocks';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
 import edit from './edit';
 
 registerJetpackBlockFromMetadata( metadata, {
 	edit,
-	save: () => null,
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/loginout' ],
+				transform: () => {
+					return createBlock( 'jetpack/subscriber-login' );
+				},
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/loginout' ],
+				transform: () => {
+					return createBlock( 'core/loginout' );
+				},
+			},
+		],
+	},
 } );


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/34884

## Proposed changes:

It:
- allows to transform the Subscriber Login block to/from core Login/out block
- introduces the "Redirect to current URL" setting to the Subscriber Login block bo be consistent with the core Login/out block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* transform the Subscriber Login block to/from the core Login/out block and make sure the `fontSize` and `redirectToCurrent` settings are preserved
* test if the Subscriber Login with disabled "Redirect to current URL" toggle works as expected

