### PR TITLE
Subscriptions: simplify access panel css

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriptions-acccess-simplify-css
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-acccess-simplify-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscribe block: simplify access panel CSS

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -155,8 +155,8 @@ export function NewsletterAccessRadioButtons( {
 	} );
 
 	return (
-		<fieldset className="editor-post-visibility__fieldset jetpack-newsletter-access-radio-buttons">
-			<VisuallyHidden as="legend">{ __( 'Audience', 'jetpack' ) } </VisuallyHidden>
+		<fieldset className="jetpack-newsletter-access-radio-buttons">
+			<VisuallyHidden as="legend">{ __( 'Access', 'jetpack' ) } </VisuallyHidden>
 			<RadioControl
 				onChange={ value => {
 					if (
@@ -276,20 +276,18 @@ export function NewsletterAccessDocumentSettings( { accessLevel } ) {
 							</div>
 						</>
 					) }
-					<PanelRow className="edit-post-post-visibility">
+					<PanelRow>
 						<Flex direction="column">
 							{ showMisconfigurationWarning && <MisconfigurationWarning /> }
 							<FlexBlock direction="row" justify="flex-start">
 								{ canEdit && (
-									<div className="editor-post-visibility">
-										<NewsletterAccessRadioButtons
-											isEditorPanel={ true }
-											accessLevel={ _accessLevel }
-											stripeConnectUrl={ stripeConnectUrl }
-											hasTierPlans={ hasTierPlans }
-											postHasPaywallBlock={ foundPaywallBlock }
-										/>
-									</div>
+									<NewsletterAccessRadioButtons
+										isEditorPanel={ true }
+										accessLevel={ _accessLevel }
+										stripeConnectUrl={ stripeConnectUrl }
+										hasTierPlans={ hasTierPlans }
+										postHasPaywallBlock={ foundPaywallBlock }
+									/>
 								) }
 
 								{ /* Display the uneditable access level when the user doesn't have edit privileges*/ }

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
@@ -29,28 +29,6 @@
 			}
 		}
 	}
-
-	.edit-post-post-visibility {
-		display: block;
-		* {
-			text-wrap: pretty;
-		}
-
-		&__notice {
-			&.is-info {
-				background: #e9f0f5;
-				border-left-color: #e9f0f5;
-			}
-		}
-
-		.components-notice__content {
-			margin-right: 0;
-		}
-
-		.components-button {
-			margin-top: 10px;
-		}
-	}
 }
 
 .jetpack-editor-post-tiers {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/wp-calypso/issues/86700

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove core CSS selectors used for the access panel, and related CSS.

I'm not sure why these selectors were placed here originally, they're meant to provide styles for the core panel which has some similarities but we shouldn't rely core styles like this. They can change/get removed entirely under us.

If we find any CSS removal affecting UI, we should add the CSS back without using core selectors.

Some of the issues caused by this CSS were also fixed already earlier in https://github.com/Automattic/jetpack/pull/31544

Core UI
<img width="336" alt="Screenshot 2024-01-22 at 15 27 57" src="https://github.com/Automattic/jetpack/assets/87168/c8d87154-89d5-4c2d-b45a-d158dfbd623d">

Access panel
<img width="297" alt="Screenshot 2024-01-22 at 15 32 37" src="https://github.com/Automattic/jetpack/assets/87168/8d61151d-1390-4eb8-9aeb-b65ada827fe4">

Access panel should continue work also —

1) Inside pre-publish panel:
<img width="191" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/07a5896a-206e-46b4-b879-7b6fd9e7a074">

2) With paywall block in post content

<img width="570" alt="Screenshot 2024-01-22 at 15 32 18" src="https://github.com/Automattic/jetpack/assets/87168/543fb08d-5228-4b5b-bd5b-0c45e22a7721">

3) With Tiers
<img width="193" alt="Screenshot 2024-01-22 at 15 32 41" src="https://github.com/Automattic/jetpack/assets/87168/c6a92586-bd73-4816-9a8c-a9815b5bdf50">

4) Inside paywall block's sidepanel:

<img width="215" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/dba6e8e9-600a-4bdb-b53b-ed535504f3d2">


Looks like this doesn't have any effect on the access panel UI.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

