### PR TITLE
Add/jetpack search sort by price default

### DIFF
--- a/projects/packages/search/changelog/add-jetpack-search-default-sort-by-price
+++ b/projects/packages/search/changelog/add-jetpack-search-default-sort-by-price
@@ -1,3 +1,4 @@
 Significance: minor
 Type: added
-Comment: Added price and rating to default sort options
+
+Added price and rating to default sort options

--- a/projects/packages/search/changelog/add-jetpack-search-default-sort-by-price
+++ b/projects/packages/search/changelog/add-jetpack-search-default-sort-by-price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added price and rating to default sort options

--- a/projects/packages/search/changelog/add-jetpack-search-default-sort-by-price
+++ b/projects/packages/search/changelog/add-jetpack-search-default-sort-by-price
@@ -1,4 +1,3 @@
 Significance: minor
 Type: added
-
-Added price and rating to default sort options
+Comment: Added price and rating to default sort options

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.41.x-dev"
+			"dev-trunk": "0.42.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.41.2-alpha",
+	"version": "0.42.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.41.2-alpha';
+	const VERSION = '0.42.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import useEntityRecordState from 'hooks/use-entity-record-state';
 import useSiteLoadingState from 'hooks/use-loading-state';
 import useSearchOptions from 'hooks/use-search-options';
-import { SERVER_OBJECT_NAME } from 'instant-search/lib/constants';
+import { RESULT_FORMAT_PRODUCT, SERVER_OBJECT_NAME } from 'instant-search/lib/constants';
 import ColorControl from './color-control';
 import ExcludedPostTypesControl from './excluded-post-types-control';
 import ThemeControl from './theme-control';
@@ -56,6 +56,19 @@ export default function SidebarOptions() {
 	const { isLoading } = useSiteLoadingState();
 	const isDisabled = isSaving || isLoading;
 
+	const sortOptions = [
+		{ label: __( 'Relevance (recommended)', 'jetpack-search-pkg' ), value: 'relevance' },
+		{ label: __( 'Newest first', 'jetpack-search-pkg' ), value: 'newest' },
+		{ label: __( 'Oldest first', 'jetpack-search-pkg' ), value: 'oldest' },
+	];
+	if ( resultFormat === RESULT_FORMAT_PRODUCT ) {
+		sortOptions.push(
+			{ label: __( 'Rating', 'jetpack-search-pkg' ), value: 'rating_desc' },
+			{ label: __( 'Price: low to high', 'jetpack-search-pkg' ), value: 'price_asc' },
+			{ label: __( 'Price: high to low', 'jetpack-search-pkg' ), value: 'price_desc' }
+		);
+	}
+
 	// TODO: ask the user if they attempt to navigate away from the page with pending changes.
 
 	return (
@@ -89,14 +102,7 @@ export default function SidebarOptions() {
 					disabled={ isDisabled }
 					label={ __( 'Default sort', 'jetpack-search-pkg' ) }
 					value={ sort }
-					options={ [
-						{ label: __( 'Relevance (recommended)', 'jetpack-search-pkg' ), value: 'relevance' },
-						{ label: __( 'Newest first', 'jetpack-search-pkg' ), value: 'newest' },
-						{ label: __( 'Oldest first', 'jetpack-search-pkg' ), value: 'oldest' },
-						{ label: __( 'Rating', 'jetpack-search-pkg' ), value: 'rating_desc' },
-						{ label: __( 'Price: low to high', 'jetpack-search-pkg' ), value: 'price_asc' },
-						{ label: __( 'Price: high to low', 'jetpack-search-pkg' ), value: 'price_desc' },
-					] }
+					options={ sortOptions }
 					onChange={ setSort }
 				/>
 				<SelectControl

--- a/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
@@ -93,6 +93,9 @@ export default function SidebarOptions() {
 						{ label: __( 'Relevance (recommended)', 'jetpack-search-pkg' ), value: 'relevance' },
 						{ label: __( 'Newest first', 'jetpack-search-pkg' ), value: 'newest' },
 						{ label: __( 'Oldest first', 'jetpack-search-pkg' ), value: 'oldest' },
+						{ label: __( 'Rating', 'jetpack-search-pkg' ), value: 'rating_desc' },
+						{ label: __( 'Price: low to high', 'jetpack-search-pkg' ), value: 'price_asc' },
+						{ label: __( 'Price: high to low', 'jetpack-search-pkg' ), value: 'price_desc' },
 					] }
 					onChange={ setSort }
 				/>

--- a/projects/packages/search/src/customberg/hooks/use-search-options.js
+++ b/projects/packages/search/src/customberg/hooks/use-search-options.js
@@ -1,4 +1,5 @@
 import { useEntityProp } from '@wordpress/core-data';
+import { PRODUCT_SORT_OPTIONS, RELEVANCE_SORT_KEY } from 'instant-search/lib/constants';
 import { useMemo } from 'react';
 
 /* eslint-disable react/jsx-no-bind */
@@ -11,7 +12,7 @@ const VALID_POST_TYPES = global.JetpackInstantSearchOptions.postTypes;
  */
 export default function useSearchOptions() {
 	const [ theme, setTheme ] = useEntityProp( 'root', 'site', 'jetpack_search_color_theme' );
-	const [ resultFormat, setResultFormat ] = useEntityProp(
+	const [ resultFormat, setResultFormatRaw ] = useEntityProp(
 		'root',
 		'site',
 		'jetpack_search_result_format'
@@ -57,6 +58,18 @@ export default function useSearchOptions() {
 	);
 	const setExcludedPostTypes = postTypesArr =>
 		setExcludedPostTypesCsv( postTypesArr.filter( type => type in VALID_POST_TYPES ).join( ',' ) );
+
+	// Add special handling for product -> non-product result format changes.
+	const setResultFormat = format => {
+		const previousFormat = resultFormat;
+		setResultFormatRaw( format );
+
+		// If switching from product to non-product and the default sort is product-specific,
+		// reset to relevance sort.
+		if ( previousFormat === 'product' && PRODUCT_SORT_OPTIONS.has( sort ) ) {
+			setSort( RELEVANCE_SORT_KEY );
+		}
+	};
 
 	return {
 		color,

--- a/projects/packages/search/src/customizer/class-customizer.php
+++ b/projects/packages/search/src/customizer/class-customizer.php
@@ -107,9 +107,12 @@ class Customizer {
 			$id,
 			array(
 				'choices'     => array(
-					'relevance' => __( 'Relevance (recommended)', 'jetpack-search-pkg' ),
-					'newest'    => __( 'Newest first', 'jetpack-search-pkg' ),
-					'oldest'    => __( 'Oldest first', 'jetpack-search-pkg' ),
+					'relevance'   => __( 'Relevance (recommended)', 'jetpack-search-pkg' ),
+					'newest'      => __( 'Newest first', 'jetpack-search-pkg' ),
+					'oldest'      => __( 'Oldest first', 'jetpack-search-pkg' ),
+					'rating_desc' => __( 'Product rating', 'jetpack-search-pkg' ),
+					'price_asc'   => __( 'Price: low to high', 'jetpack-search-pkg' ),
+					'price_desc'  => __( 'Price: high to low', 'jetpack-search-pkg' ),
 				),
 				'description' => __( 'Pick the initial sort for your search results.', 'jetpack-search-pkg' ),
 				'label'       => __( 'Default Sort', 'jetpack-search-pkg' ),

--- a/projects/plugins/debug-helper/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/debug-helper/changelog/update-changelogger-deduplicate-default
@@ -1,3 +1,3 @@
 Significance: minor
-Type: added
+Type: enhancement
 Comment: Added price as default sorting option for Jetpack Search

--- a/projects/plugins/debug-helper/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/debug-helper/changelog/update-changelogger-deduplicate-default
@@ -1,5 +1,3 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-
+Significance: minor
+Type: added
+Comment: Added price as default sorting option for Jetpack Search

--- a/projects/plugins/debug-helper/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/debug-helper/changelog/update-changelogger-deduplicate-default
@@ -1,3 +1,4 @@
-Significance: minor
-Type: enhancement
+Significance: patch
+Type: changed
+
 Comment: Added price as default sorting option for Jetpack Search

--- a/projects/plugins/jetpack/changelog/add-jetpack-search-default-sort-by-price
+++ b/projects/plugins/jetpack/changelog/add-jetpack-search-default-sort-by-price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack Search: Added price as default sorting option 

--- a/projects/plugins/jetpack/changelog/add-jetpack-search-sort-by-price-default
+++ b/projects/plugins/jetpack/changelog/add-jetpack-search-sort-by-price-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2187,7 +2187,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/search",
-				"reference": "b8e216a03dc91f606b87fab82d6663f2b03dd3c5"
+				"reference": "426240f92e4c83d9d82b815aa64a0ca2b97932e0"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -2215,7 +2215,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.41.x-dev"
+					"dev-trunk": "0.42.x-dev"
 				},
 				"version-constants": {
 					"::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/add-jetpack-search-default-sort-by-price
+++ b/projects/plugins/search/changelog/add-jetpack-search-default-sort-by-price
@@ -1,5 +1,3 @@
 Significance: minor
 Type: added
 Comment: Allow users to select price as default sorting option for search
-
-

--- a/projects/plugins/search/changelog/add-jetpack-search-default-sort-by-price
+++ b/projects/plugins/search/changelog/add-jetpack-search-default-sort-by-price
@@ -1,3 +1,4 @@
 Significance: minor
 Type: added
-Comment: Allow users to select price as default sorting option for search
+
+Allow users to select price as default sorting option for search

--- a/projects/plugins/search/changelog/add-jetpack-search-default-sort-by-price
+++ b/projects/plugins/search/changelog/add-jetpack-search-default-sort-by-price
@@ -1,0 +1,5 @@
+Significance: minor
+Type: New option
+Comment: Allow users to select price as default sorting option for search
+
+

--- a/projects/plugins/search/changelog/add-jetpack-search-default-sort-by-price
+++ b/projects/plugins/search/changelog/add-jetpack-search-default-sort-by-price
@@ -1,5 +1,5 @@
 Significance: minor
-Type: New option
+Type: added
 Comment: Allow users to select price as default sorting option for search
 
 

--- a/projects/plugins/search/changelog/add-jetpack-search-sort-by-price-default
+++ b/projects/plugins/search/changelog/add-jetpack-search-sort-by-price-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1208,7 +1208,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "b8e216a03dc91f606b87fab82d6663f2b03dd3c5"
+                "reference": "426240f92e4c83d9d82b815aa64a0ca2b97932e0"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1236,7 +1236,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.41.x-dev"
+                    "dev-trunk": "0.42.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
moved from https://github.com/Automattic/jetpack/pull/31594

<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
Currently it is only possible to set default sort options to newest, oldest, and relevance. Some WooCommerce users would like to be able to also specify a default sort by price or rating. This adds those options to the UI for the Jetpack Search settings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
To test, spin up a new site with this branch. Look at the Jetpack Search settings. Select "product" as the option for displaying results. You should see the option to set the default sort to price and rating. Choose price, and then perform a search, and check that it is sorted by price by default. If you switch the display back to normal or "expanded", you should no longer see the option to sort by price.

