### PR TITLE
Backport mu-wpcom-plugin 2.0.14, jetpack 13.1-a.3 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2024-01-22
+### Changed
+- Update dependencies. [#35117]
+
 ## [0.4.0] - 2024-01-15
 ### Added
 - AI Client: introduce bannerComponent prop, React.Element, to render on top of the AI Control [#34918]
@@ -187,6 +191,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.4.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.2.1...v0.3.0

--- a/projects/js-packages/ai-client/changelog/force-a-release
+++ b/projects/js-packages/ai-client/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.4.1-alpha",
+	"version": "0.4.1",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.66 - 2024-01-22
+### Changed
+- Update dependencies. [#35117]
+
 ## 0.2.65 - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815] [#34816]

--- a/projects/js-packages/partner-coupon/changelog/force-a-release
+++ b/projects/js-packages/partner-coupon/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.66-alpha",
+	"version": "0.2.66",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.1] - 2024-01-22
+### Changed
+- Update dependencies. [#35126]
+
+### Fixed
+- Fixed a bug where the post body images weren't used for social previews [#35111]
+
 ## [0.45.0] - 2024-01-18
 ### Changed
 - Changed dismissed notices endpoint to be a core endpoint [#34544]
@@ -564,6 +571,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.45.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.45.0...v0.45.1
 [0.45.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.44.2...v0.45.0
 [0.44.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.44.1...v0.44.2
 [0.44.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.44.0...v0.44.1

--- a/projects/js-packages/publicize-components/changelog/fix-social-previews-post-image-usage
+++ b/projects/js-packages/publicize-components/changelog/fix-social-previews-post-image-usage
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a bug where the post body images weren't used for social previews

--- a/projects/js-packages/publicize-components/changelog/force-a-release
+++ b/projects/js-packages/publicize-components/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.45.1-alpha",
+	"version": "0.45.1",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2024-01-22
+### Changed
+- Use blog ID instead site slug for checkout and WPCOM links. [#35020]
+
 ## [3.0.0] - 2024-01-04
 ### Fixed
 - Backup: Add namespace versioning to Helper_Script_Manager and other classes [#34739]
@@ -538,6 +542,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.1.0]: https://github.com/Automattic/jetpack-backup/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/Automattic/jetpack-backup/compare/v2.0.5...v3.0.0
 [2.0.5]: https://github.com/Automattic/jetpack-backup/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/Automattic/jetpack-backup/compare/v2.0.3...v2.0.4

--- a/projects/packages/backup/changelog/update-backup-wpcom-links-blog-id
+++ b/projects/packages/backup/changelog/update-backup-wpcom-links-blog-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Use blog ID instead site slug for checkout and WPCOM links.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup\V0001;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.1.0-alpha';
+	const PACKAGE_VERSION = '3.1.0';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2024-01-22
+### Changed
+- Update dependencies. [#35117]
+
 ## [0.15.0] - 2024-01-15
 ### Changed
 - Changes the Blaze Dashboard paths to use the new format [#34896]
@@ -265,6 +269,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.15.1]: https://github.com/automattic/jetpack-blaze/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/automattic/jetpack-blaze/compare/v0.14.3...v0.15.0
 [0.14.3]: https://github.com/automattic/jetpack-blaze/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/automattic/jetpack-blaze/compare/v0.14.1...v0.14.2

--- a/projects/packages/blaze/changelog/force-a-release
+++ b/projects/packages/blaze/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.15.1-alpha",
+	"version": "0.15.1",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.15.1-alpha';
+	const PACKAGE_VERSION = '0.15.1';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2024-01-22
+### Changed
+- Default for `--deduplicate` is now 0, as 1 caused unexpected behavior for some cases and so should be opted in to. [#35138]
+
 ## [4.0.5] - 2023-12-11
 ### Changed
 - Updated package dependencies. [#34492]
@@ -204,6 +208,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[4.1.0]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.5...4.1.0
 [4.0.5]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.4...4.0.5
 [4.0.4]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.3...4.0.4
 [4.0.3]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.2...4.0.3

--- a/projects/packages/changelogger/changelog/update-changelogger-deduplicate-default
+++ b/projects/packages/changelogger/changelog/update-changelogger-deduplicate-default
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Default for `--deduplicate` is now 0, as 1 caused unexpected behavior for some cases and so should be opted in to.

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.1.0-alpha';
+	const VERSION = '4.1.0';
 
 	/**
 	 * Constructor.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.1] - 2024-01-22
+### Added
+- Contact Form: test setup for front end script [#35074]
+
 ## [0.30.0] - 2024-01-08
 ### Changed
 - Updated useModuleStatus hook to use module_status redux store. [#34845]
@@ -465,6 +469,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.1]: https://github.com/automattic/jetpack-forms/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/automattic/jetpack-forms/compare/v0.29.2...v0.30.0
 [0.29.2]: https://github.com/automattic/jetpack-forms/compare/v0.29.1...v0.29.2
 [0.29.1]: https://github.com/automattic/jetpack-forms/compare/v0.29.0...v0.29.1

--- a/projects/packages/forms/changelog/add-contact-form-tests
+++ b/projects/packages/forms/changelog/add-contact-form-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Contact Form: test setup for front end script

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.1-alpha",
+	"version": "0.30.1",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.1-alpha';
+	const PACKAGE_VERSION = '0.30.1';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.9.0] - 2024-01-22
+### Added
+- Added the completion logic for the 'Install the mobile app' task [#35110]
+- Adds the completion logic for the Verify Domain Email task [#35068]
+- Block theme previews: show an education modal when previewing a theme. [#34935]
+- Launchpad: Enabled to temporary dismiss a dismissible launchpad [#34889]
+
+### Changed
+- Dotcom patterns: use assembler v2 patterns in editor [#35081]
+- Newsletter launchpad: move email verify task above subscriber task [#35084]
+
+### Fixed
+- jetpack-mu-wpcom: Prevent get_plugin_data indirectly calling wptexturize. [#35087]
+
 ## [5.8.2] - 2024-01-15
 ### Added
 - Add the completion logic for the `front_page_updated` task [#34837]
@@ -523,6 +537,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.9.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.2...v5.9.0
 [5.8.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.1...v5.8.2
 [5.8.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.0...v5.8.1
 [5.8.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.7.0...v5.8.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/Enable to temporary dismiss an launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/Enable to temporary dismiss an launchpad
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Launchpad: Enabled to temporary dismiss a dismissible launchpad

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-mobile-app-installed-completion-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-mobile-app-installed-completion-logic
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added the completion logic for the 'Install the mobile app' task

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-register-dotcom-v2-patterns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-register-dotcom-v2-patterns
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Dotcom patterns: use assembler v2 patterns in editor 

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-verify_domain_email-completion-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-verify_domain_email-completion-logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Adds the completion logic for the Verify Domain Email task

--- a/projects/packages/jetpack-mu-wpcom/changelog/block-theme-previews-modal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/block-theme-previews-modal
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Block theme previews: show an education modal when previewing a theme.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-load-coming-soon-get-plugin-data
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-load-coming-soon-get-plugin-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-jetpack-mu-wpcom: Prevent get_plugin_data indirectly calling wptexturize.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-launchpad-subscriber-task-order
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-launchpad-subscriber-task-order
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Newsletter launchpad: move email verify task above subscriber task

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.9.0-alpha",
+	"version": "5.9.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.9.0-alpha';
+	const PACKAGE_VERSION = '5.9.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.6.2] - 2024-01-22
+### Added
+- My Jetpack: add contact us event for Jetpack AI [#35136]
+
 ## [4.6.1] - 2024-01-22
 ### Changed
 - Display Jetpack Protect product card for all users. [#35142]
@@ -1203,6 +1207,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.6.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.6.1...4.6.2
 [4.6.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.6.0...4.6.1
 [4.6.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.5.0...4.6.0
 [4.5.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.4.0...4.5.0

--- a/projects/packages/my-jetpack/changelog/add-ai-checkout-events
+++ b/projects/packages/my-jetpack/changelog/add-ai-checkout-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-My Jetpack: add contact us event for Jetpack AI

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.6.2-alpha",
+	"version": "4.6.2",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -34,7 +34,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.6.2-alpha';
+	const PACKAGE_VERSION = '4.6.2';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.1] - 2024-01-22
+### Changed
+- Update dependencies. [#35117]
+
 ## [0.41.0] - 2024-01-04
 ### Added
 - Search: Add a filter to prevent tracking cookie reset. [#34803]
@@ -872,6 +876,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.41.1]: https://github.com/Automattic/jetpack-search/compare/v0.41.0...v0.41.1
 [0.41.0]: https://github.com/Automattic/jetpack-search/compare/v0.40.4...v0.41.0
 [0.40.4]: https://github.com/Automattic/jetpack-search/compare/v0.40.3...v0.40.4
 [0.40.3]: https://github.com/Automattic/jetpack-search/compare/v0.40.2...v0.40.3

--- a/projects/packages/search/changelog/force-a-release
+++ b/projects/packages/search/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.41.1-alpha",
+	"version": "0.41.1",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.41.1-alpha';
+	const VERSION = '0.41.1';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2024-01-22
+### Changed
+- Update dependencies. [#35117]
+
 ## [0.3.4] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]
@@ -291,6 +295,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.5]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.1...v0.3.2

--- a/projects/packages/wordads/changelog/force-a-release
+++ b/projects/packages/wordads/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.5-alpha",
+	"version": "0.3.5",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.5-alpha';
+	const VERSION = '0.3.5';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.1-a.3 - 2024-01-22
+### Enhancements
+- Add support for WooCommerce HPOS to the Google Analytics module. [#33152]
+- Changed dismissed notices endpoint to be a core endpoint [#34544]
+- Like block: Move the block from beta to production [#34930]
+- Related Posts: Get the related posts only when the option is turned on and the current post contains a Related Posts block [#34958]
+- Subscribe block: add buttons transform [#35115]
+
+### Improved compatibility
+- Likes: Flip likers popup when overflowing viewport. [#35065]
+
+### Bug fixes
+- Enhanced WordPress.com API compatibility with third party plugin data. [#34770]
+- iCalendarReader: Support BYDAY recurrence rules for last, second-to-last, or third-to-last weekdays [#35050]
+- Subscribe block: fix spacing of "pending email confirmation" message in some themes [#35133]
+- Subscriptions: Fix subscribtion modal appear right after subscribing [#35128]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- AI Assistant: add contact us event for upgrades over 1000 [#35136]
+- AI Assistant: move usePlanType to shared directory [#35093]
+- AI Assistant: rename upgrade event name, provide placement prop for metrics [#35116]
+- AI Assistant: trigger event on panel uncollapse [#35124]
+- Blogroll block: avoid PHP notices on specific sites. [#35125]
+- Contact Form: add frontend tests [#35074]
+- Contact Form: fix source for concatenated stylesheet [#35091]
+- Content Options: Add new class to post when using the featured images fallback. [#35073]
+- Content Options: Allow themes to hide the default avatar (when author has no custom Gravatar) via `'avatar-default' => false`. [#35073]
+- Filters out deprecated jetpack-google-fonts provider when reading the theme's theme.json. [#35029]
+- In the tracking user link url, the parent of the iframe only listens one redirection post message from its child [#35090]
+- Jetpack Debug: Update Sync related debugging info [#35060]
+- Jetpack plugin: Add 5-star review link in the Jetpack Plugin meta, in the plugins list table (on the plugins page). [#34998]
+- Jetpack_Upcoming_Events_Widget: Return early if no feed url set [#35041]
+- Memberships: Adds translation to paid content modal. [#35092]
+- Payment blocks: Fix cover block alignments on free sites [#35028]
+- Recreate purchase form dialog on openModal(). [#35077]
+- Related Posts: fix accessibility issues [#34925]
+- Subscriber Login: Add styling support to the Subscriber Login block [#35085]
+- Subscriber Login: Allow to transform it to/from core Login/out block [#35161]
+- Subscriber Login: Check also the premium content cookie to determine if user is logged in or not [#35113]
+- Subscriptions: Add Subscriber Login block [#34981]
+- Subscriptions: Fix Newsletter column width [#35101]
+- Update Subscription Modal on comment to use Subscribe Block [#35051]
+
 ## 13.1-a.1 - 2024-01-15
 ### Enhancements
 - GIF Block: Accept Giphy shortlinks as a valid embed. [#34786]

--- a/projects/plugins/jetpack/changelog/add-ai-assistant-shared-use-plan-type
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-shared-use-plan-type
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-AI Assistant: move usePlanType to shared directory

--- a/projects/plugins/jetpack/changelog/add-ai-checkout-events
+++ b/projects/plugins/jetpack/changelog/add-ai-checkout-events
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-AI Assistant: add contact us event for upgrades over 1000

--- a/projects/plugins/jetpack/changelog/add-ai-panel-sidebar-events
+++ b/projects/plugins/jetpack/changelog/add-ai-panel-sidebar-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: trigger event on panel uncollapse

--- a/projects/plugins/jetpack/changelog/add-catch-duplicated-comment-error
+++ b/projects/plugins/jetpack/changelog/add-catch-duplicated-comment-error
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: It's a design improvement
-
-

--- a/projects/plugins/jetpack/changelog/add-contact-form-tests
+++ b/projects/plugins/jetpack/changelog/add-contact-form-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Contact Form: add frontend tests

--- a/projects/plugins/jetpack/changelog/add-flip-likers-popup-when-overflow
+++ b/projects/plugins/jetpack/changelog/add-flip-likers-popup-when-overflow
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Likes: Flip likers popup when overflowing viewport.

--- a/projects/plugins/jetpack/changelog/add-ip-requester-option
+++ b/projects/plugins/jetpack/changelog/add-ip-requester-option
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-jetpack-5-star-link-plugins-page
+++ b/projects/plugins/jetpack/changelog/add-jetpack-5-star-link-plugins-page
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack plugin: Add 5-star review link in the Jetpack Plugin meta, in the plugins list table (on the plugins page).

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-host-provider-check
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-host-provider-check
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-newsletter-modal-translations
+++ b/projects/plugins/jetpack/changelog/add-newsletter-modal-translations
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Memberships: Adds translation to paid content modal.

--- a/projects/plugins/jetpack/changelog/add-subscriber-login-block
+++ b/projects/plugins/jetpack/changelog/add-subscriber-login-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriptions: Add Subscriber Login block

--- a/projects/plugins/jetpack/changelog/change-ai-usage-panel-event-names
+++ b/projects/plugins/jetpack/changelog/change-ai-usage-panel-event-names
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-AI Assistant: rename upgrade event name, provide placement prop for metrics

--- a/projects/plugins/jetpack/changelog/feat-lazy-load-related-posts
+++ b/projects/plugins/jetpack/changelog/feat-lazy-load-related-posts
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Related Posts: Get the related posts only when the option is turned on and the current post contains a Related Posts block

--- a/projects/plugins/jetpack/changelog/fix-api-response-casting-stdclass
+++ b/projects/plugins/jetpack/changelog/fix-api-response-casting-stdclass
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Enhanced WordPress.com API compatibility with third party plugin data.

--- a/projects/plugins/jetpack/changelog/fix-blogrollitemblock
+++ b/projects/plugins/jetpack/changelog/fix-blogrollitemblock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Blogroll block: avoid PHP notices on specific sites.

--- a/projects/plugins/jetpack/changelog/fix-contact-form-concatenated-styles
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-concatenated-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Contact Form: fix source for concatenated stylesheet

--- a/projects/plugins/jetpack/changelog/fix-jetpack-content-options-never-fusioned-changes-from-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-content-options-never-fusioned-changes-from-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Content Options: Allow themes to hide the default avatar (when author has no custom Gravatar) via `'avatar-default' => false`.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-content-options-never-fusioned-changes-from-wpcom#2
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-content-options-never-fusioned-changes-from-wpcom#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
- Content Options: Add new class to post when using the featured images fallback.

--- a/projects/plugins/jetpack/changelog/fix-like-block-editor-loading
+++ b/projects/plugins/jetpack/changelog/fix-like-block-editor-loading
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix Like block (beta) view in the editor when loaded inside the Query Loop block
-
-

--- a/projects/plugins/jetpack/changelog/fix-like-block-looser-legacy-check
+++ b/projects/plugins/jetpack/changelog/fix-like-block-looser-legacy-check
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Does not affect end user since this is a beta plugin
-
-

--- a/projects/plugins/jetpack/changelog/fix-newsletter-column-width
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-column-width
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Fix Newsletter column width

--- a/projects/plugins/jetpack/changelog/fix-paid-blocks-upgrade-nudge-break-cover-block-free
+++ b/projects/plugins/jetpack/changelog/fix-paid-blocks-upgrade-nudge-break-cover-block-free
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Payment blocks: Fix cover block alignments on free sites  

--- a/projects/plugins/jetpack/changelog/fix-parent-iframe-only-listen-one-message
+++ b/projects/plugins/jetpack/changelog/fix-parent-iframe-only-listen-one-message
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-In the tracking user link url, the parent of the iframe only listens one redirection post message from its child 

--- a/projects/plugins/jetpack/changelog/fix-related-post-accessibility
+++ b/projects/plugins/jetpack/changelog/fix-related-post-accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Related Posts: fix accessibility issues

--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-pending-spacing
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-pending-spacing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscribe block: fix spacing of "pending email confirmation" message in some themes

--- a/projects/plugins/jetpack/changelog/fix-subscriber-login-auth-check
+++ b/projects/plugins/jetpack/changelog/fix-subscriber-login-auth-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriber Login: Check also the premium content cookie to determine if user is logged in or not

--- a/projects/plugins/jetpack/changelog/fix-subscribtion-modal-appear-after-subscribing
+++ b/projects/plugins/jetpack/changelog/fix-subscribtion-modal-appear-after-subscribing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscriptions: Fix subscribtion modal appear right after subscribing

--- a/projects/plugins/jetpack/changelog/fix-woo-hpos-google-analytics
+++ b/projects/plugins/jetpack/changelog/fix-woo-hpos-google-analytics
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add support for WooCommerce HPOS to the Google Analytics module.

--- a/projects/plugins/jetpack/changelog/gold-284-fix-cached-iframe
+++ b/projects/plugins/jetpack/changelog/gold-284-fix-cached-iframe
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Recreate purchase form dialog on openModal().

--- a/projects/plugins/jetpack/changelog/google-fonts-filter-out-dirty-data-from-theme-json
+++ b/projects/plugins/jetpack/changelog/google-fonts-filter-out-dirty-data-from-theme-json
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Filters out deprecated jetpack-google-fonts provider when reading the theme's theme.json.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.1-a.2
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.1-a.4
+
+

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/refactor-social-dismissed-notices-endpoint
+++ b/projects/plugins/jetpack/changelog/refactor-social-dismissed-notices-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Changed dismissed notices endpoint to be a core endpoint

--- a/projects/plugins/jetpack/changelog/refactor-social-dismissed-notices-endpoint#2
+++ b/projects/plugins/jetpack/changelog/refactor-social-dismissed-notices-endpoint#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/refactor-social-dismissed-notices-endpoint#3
+++ b/projects/plugins/jetpack/changelog/refactor-social-dismissed-notices-endpoint#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/upcoming-events-widget-return-early
+++ b/projects/plugins/jetpack/changelog/upcoming-events-widget-return-early
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack_Upcoming_Events_Widget: Return early if no feed url set

--- a/projects/plugins/jetpack/changelog/update-backup-wpcom-links-blog-id
+++ b/projects/plugins/jetpack/changelog/update-backup-wpcom-links-blog-id
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/jetpack/changelog/update-changelogger-deduplicate-default
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-ical-negative-recurrence-rules
+++ b/projects/plugins/jetpack/changelog/update-ical-negative-recurrence-rules
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-iCalendarReader: Support BYDAY recurrence rules for last, second-to-last, or third-to-last weekdays

--- a/projects/plugins/jetpack/changelog/update-jetpack-wpcom-links-blog-id
+++ b/projects/plugins/jetpack/changelog/update-jetpack-wpcom-links-blog-id
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add blog ID to the Jetpack Redirect initial state.
-
-

--- a/projects/plugins/jetpack/changelog/update-like-block-status
+++ b/projects/plugins/jetpack/changelog/update-like-block-status
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Like block: Move the block from beta to production

--- a/projects/plugins/jetpack/changelog/update-likes-queuehandler
+++ b/projects/plugins/jetpack/changelog/update-likes-queuehandler
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Just applying changes already made on the WPCOM side
-
-

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-wpcom-links-blog-id
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-wpcom-links-blog-id
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-subscribe-block-buttons-transform
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-buttons-transform
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscribe block: add buttons transform

--- a/projects/plugins/jetpack/changelog/update-subscriber-block
+++ b/projects/plugins/jetpack/changelog/update-subscriber-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriber Login: Add styling support to the Subscriber Login block

--- a/projects/plugins/jetpack/changelog/update-subscriber-login-transforms
+++ b/projects/plugins/jetpack/changelog/update-subscriber-login-transforms
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriber Login: Allow to transform it to/from core Login/out block

--- a/projects/plugins/jetpack/changelog/update-subscription-modal-to-subscribe-block
+++ b/projects/plugins/jetpack/changelog/update-subscription-modal-to-subscribe-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Update Subscription Modal on comment to use Subscribe Block

--- a/projects/plugins/jetpack/changelog/update-sync-debug-info
+++ b/projects/plugins/jetpack/changelog/update-sync-debug-info
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack Debug: Update Sync related debugging info

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_4",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_2",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_3",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -2,7 +2,7 @@
 /**
  * Subscriber Login Block.
  *
- * @since $$next-version$$
+ * @since 13.1
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-a.2
+ * Version: 13.1-a.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-a.2' );
+define( 'JETPACK__VERSION', '13.1-a.3' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-a.3
+ * Version: 13.1-a.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-a.3' );
+define( 'JETPACK__VERSION', '13.1-a.4' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -204,7 +204,7 @@ class Jetpack_Google_Analytics_Universal {
 	 *
 	 * @see https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book
 	 *
-	 * @since $$next-version$$
+	 * @since 13.1
 	 * @param array $command_array Array of commands.
 	 * @return array `$command_array` with additional commands conditionally added.
 	 */

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-a.2",
+	"version": "13.1.0-a.3",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-a.3",
+	"version": "13.1.0-a.4",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,24 +293,22 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.1-a.1 - 2024-01-15
+### 13.1-a.3 - 2024-01-22
 #### Enhancements
-- GIF Block: Accept Giphy shortlinks as a valid embed.
-- GIF Block: fix styling of the search bar input.
-- Subscribe block: don't allow editing the email for subscribing for logged-in members.
+- Add support for WooCommerce HPOS to the Google Analytics module.
+- Changed dismissed notices endpoint to be a core endpoint
+- Like block: Move the block from beta to production
+- Related Posts: Get the related posts only when the option is turned on and the current post contains a Related Posts block
+- Subscribe block: add buttons transform
 
 #### Improved compatibility
-- Post Images: avoid PHP warnings on sites using PHP 8.1+, when a post image has a malformed URL.
+- Likes: Flip likers popup when overflowing viewport.
 
 #### Bug fixes
-- AI Assistant: avoid deprecation notices when using a development version of WordPress.
-- AI Assistant: do not attempt to display the AI Excerpt assistant in the site editor and the widget editor.
-- Fixes recurring payments buttons multiple plan support.
-- Subscribe modal: Don't show in Elementor editor
-- Subscriptions: do not display subscription checkboxes in comment forms displayed on Custom Post Type pages.
-- Subscriptions: Fix broken subscribe button in email
-- Subscriptions: Fix page scrolling up after the subscription modal is dismissed
-- Theme Tools: Ensure that Content Options does not override the Featured Images options set within blocks.
+- Enhanced WordPress.com API compatibility with third party plugin data.
+- iCalendarReader: Support BYDAY recurrence rules for last, second-to-last, or third-to-last weekdays
+- Subscribe block: fix spacing of "pending email confirmation" message in some themes
+- Subscriptions: Fix subscribtion modal appear right after subscribing
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.14 - 2024-01-22
+### Changed
+- Internal updates.
+
 ## 2.0.13 - 2024-01-15
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-temporary-dismiss-to-launchpad
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-temporary-dismiss-to-launchpad
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/live-preview-modal
+++ b/projects/plugins/mu-wpcom-plugin/changelog/live-preview-modal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-changelogger-deduplicate-default
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-changelogger-deduplicate-default
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_14_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_14"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.14-alpha
+ * Version: 2.0.14
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.14-alpha",
+	"version": "2.0.14",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.14, jetpack 13.1-a.3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.