### PR TITLE
WPCOM_JSON_API_Endpoint document(): Prevent warning when fetching the rest_api_documentation row returns no results

### DIFF
--- a/projects/plugins/jetpack/changelog/update-require-auth
+++ b/projects/plugins/jetpack/changelog/update-require-auth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WPCOM_JSON_API_Endpoint document(): Prevent warning when fetching the rest_api_documentation row returns no results

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1084,7 +1084,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			<?php
 			$requires_auth = $wpdb->get_row( $wpdb->prepare( 'SELECT requires_authentication FROM rest_api_documentation WHERE `version` = %s AND `path` = %s AND `method` = %s LIMIT 1', $version, untrailingslashit( $doc['path_labeled'] ), $doc['method'] ) );
 			?>
-			<td class="type api-index-item-title"><?php echo ( true === (bool) $requires_auth->requires_authentication ? 'Yes' : 'No' ); ?></td>
+			<td class="type api-index-item-title"><?php echo ( ! empty( $requires_auth->requires_authentication ) ? 'Yes' : 'No' ); ?></td>
 		</tr>
 
 	</tbody>


### PR DESCRIPTION
The document() function tries to fetch a row out of the DB and checks `->require_authentication` on it:
```php
<?php
$requires_auth = $wpdb->get_row( $wpdb->prepare( 'SELECT requires_authentication FROM rest_api_documentation WHERE `version` = %s AND `path` = %s AND `method` = %s LIMIT 1', $version, untrailingslashit( $doc['path_labeled'] ), $doc['method'] ) );
?>
<td class="type api-index-item-title"><?php echo ( true === (bool) $requires_auth->requires_authentication ? 'Yes' : 'No' ); ?></td>
```

However, if no row is returned, this creates a warning:
```
Warning: Attempt to read property "requires_authentication" on null in (...)/class.json-api-endpoints.php on line 1088
```

## Proposed changes:

* Instead of using the `true === (bool) $x` pattern, use `!empty( $x )`.  Not empty checks for the value to be isset and truthy, which is basically the same as casting to bool, except it handles $requires_auth being null more gracefully.  This should retain the existing behavior and fix the warning.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox developer.wordpress.com
* Be on trunk.
* Visit https://developer.wordpress.com/?s=invokefunction . The warning (`Attempt to read property "requires_authentication"...`) should be in your error log.
* Apply D135518-code
* Visit https://developer.wordpress.com/?s=invokefunction . The warning should not be in your error log.
* Visit https://developer.wordpress.com/docs/api/1.1/get/me/settings/ . It should continue to read `Requires authentication? 	Yes.`
* Visit https://developer.wordpress.com/docs/api/1.1/get/read/trending/tags/ . It should continue to read `Requires authentication? 	No.`

