### PR TITLE
CRM: Resolves 3259 - issues when creating more than 21 non-sluggifiable custom field slugs

### DIFF
--- a/projects/plugins/crm/admin/settings/custom-fields.page.php
+++ b/projects/plugins/crm/admin/settings/custom-fields.page.php
@@ -244,49 +244,24 @@ if ( zeroBSCRM_isZBSAdminOrAdmin() && isset( $_POST['editwplf'] ) ) {
 		}
 	}
 
-	// update DAL 2 custom fields :) (DAL3 dealt with below)
-	if ( $zbs->isDAL2() && ! $zbs->isDAL3() ) {
+	foreach ( $object_custom_fields_to_save as $obj_key => $obj_type_id ) {
 
-		if ( isset( $custom_fields['customers'] ) && is_array( $custom_fields['customers'] ) ) {
+		if ( isset( $custom_fields[ $obj_key ] ) && is_array( $custom_fields[ $obj_key ] ) ) {
 
 			// slight array reconfig
 			$db2_custom_fields = array();
-			foreach ( $custom_fields['customers'] as $cfArr ) {
-				$db2_custom_fields[ $cfArr[3] ] = $cfArr;
+			foreach ( $custom_fields[ $obj_key ] as $cf_array ) {
+				$db2_custom_fields[ $cf_array[3] ] = $cf_array;
 			}
 
 			// simple maintain DAL2 (needs to also)
-			$zbs->DAL->updateActiveCustomFields(
+			$zbs->DAL->updateActiveCustomFields( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				array(
-					'objtypeid' => 1,
+					'objtypeid' => $obj_type_id,
 					'fields'    => $db2_custom_fields,
 				)
 			);
 
-		}
-	}
-	// DAL3 they all get this :)
-	if ( $zbs->isDAL3() ) {
-
-		foreach ( $object_custom_fields_to_save as $obj_key => $obj_type_id ) {
-
-			if ( isset( $custom_fields[ $obj_key ] ) && is_array( $custom_fields[ $obj_key ] ) ) {
-
-				// slight array reconfig
-				$db2_custom_fields = array();
-				foreach ( $custom_fields[ $obj_key ] as $cfArr ) {
-					$db2_custom_fields[ $cfArr[3] ] = $cfArr;
-				}
-
-				// simple maintain DAL2 (needs to also)
-				$zbs->DAL->updateActiveCustomFields(
-					array(
-						'objtypeid' => $obj_type_id,
-						'fields'    => $db2_custom_fields,
-					)
-				);
-
-			}
 		}
 	}
 
@@ -407,26 +382,14 @@ if ( zeroBSCRM_isZBSAdminOrAdmin() && isset( $_POST['editwplf'] ) ) {
 // load
 $fieldOverride = $settings['fieldoverride'];
 
-// Following overloading code is also replicated in Fields.php, search #FIELDOVERLOADINGDAL2+
+foreach ( $object_custom_fields_to_save as $obj_key => $obj_type_id ) {
 
-// This ALWAYS needs to get overwritten by DAL2 for now :)
-if ( zeroBSCRM_isZBSAdminOrAdmin() && $zbs->isDAL2() && ! $zbs->isDAL3() && isset( $settings['customfields'] ) && isset( $settings['customfields']['customers'] ) ) {
+	if ( isset( $settings['customfields'] ) && isset( $settings['customfields'][ $obj_key ] ) ) {
 
-	$settings['customfields']['customers'] = $zbs->DAL->setting( 'customfields_contact', array() );
-
-}
-// DAL3 ver (all objs in $object_custom_fields_to_save above)
-if ( $zbs->isDAL3() ) {
-
-	foreach ( $object_custom_fields_to_save as $obj_key => $obj_type_id ) {
-
-		if ( isset( $settings['customfields'] ) && isset( $settings['customfields'][ $obj_key ] ) ) {
-
-			// turn ZBS_TYPE_CONTACT (1) into "contact"
-			$typeStr = $zbs->DAL->objTypeKey( $obj_type_id );
-			if ( ! empty( $typeStr ) ) {
-				$settings['customfields'][ $obj_key ] = $zbs->DAL->setting( 'customfields_' . $typeStr, array() );
-			}
+		// turn ZBS_TYPE_CONTACT (1) into "contact"
+		$type_str = $zbs->DAL->objTypeKey( $obj_type_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		if ( ! empty( $type_str ) ) {
+			$settings['customfields'][ $obj_key ] = $zbs->DAL->setting( 'customfields_' . $type_str, array() ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 	}
 }

--- a/projects/plugins/crm/admin/settings/custom-fields.page.php
+++ b/projects/plugins/crm/admin/settings/custom-fields.page.php
@@ -204,12 +204,9 @@ if ( zeroBSCRM_isZBSAdminOrAdmin() && isset( $_POST['editwplf'] ) ) {
 				in_array( $potential_slug, array( 'id', 'status' ) )
 			) {
 
-				$n = 0;
-
-				while ( $n <= 20 ) {
+				for ( $n = 1; $n < $max_custom_fields_per_object; $n++ ) {
 
 					// Search for alternative slugs, n+1
-					++$n;
 					$alternative_slug = "$potential_slug-$n";
 
 					// Check in custom fields

--- a/projects/plugins/crm/admin/settings/custom-fields.page.php
+++ b/projects/plugins/crm/admin/settings/custom-fields.page.php
@@ -204,6 +204,7 @@ if ( zeroBSCRM_isZBSAdminOrAdmin() && isset( $_POST['editwplf'] ) ) {
 				in_array( $potential_slug, array( 'id', 'status' ) )
 			) {
 
+				// Ideally we could do something like gh-33096-jetpack, but custom field definitions are in a JSON-encoded settings field.
 				for ( $n = 1; $n < $max_custom_fields_per_object; $n++ ) {
 
 					// Search for alternative slugs, n+1

--- a/projects/plugins/crm/changelog/fix-crm-3259-i18n_issue_in_custom_fields
+++ b/projects/plugins/crm/changelog/fix-crm-3259-i18n_issue_in_custom_fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Custom fields: More robust fallbacks for slug creation.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3259 - issues when creating more than 21 non-sluggifiable custom field slugs

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When a custom field name can't be converted to a slug, we use `custom-field-n` as a fallback, interating on `n` to find a free slug. The limit was [previously bumped from 10 to 20](https://github.com/Automattic/zero-bs-crm/commit/22385e9edbbd312f45c9456f177aae3d77f1bc16), but this apparently wasn't enough.

I've now bumped this to match the total number of custom fields possible per object (currently 128).

I also removed a bit of pre-DAL3 code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add more than 25 non-transliterable custom fields.

In `trunk`, the first 22 work fine (`custom-field`, `custom-field-1` through `custom-field-20`, and `custom-field-21` due to the way the while loop was written (the incrementing was done at the beginning instead of the end, so the 21st loop would run). Also, adding an additional custom field would override the first `custom-field` name because the loop offered no alternative.

In the `fix/crm/3259-i18n_issue_in_custom_fields` branch, this works fine. Adding additional custom fields works fine, and we don't overwrite the `custom-field` slug name if we hit 128 (like we did in `trunk` when adding a 23rd) because we limit objects to 128 custom fields already.