### PR TITLE
Jetpack AI: Add cost of requests on feature endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -381,6 +381,7 @@ class Jetpack_AI_Helper {
 				'next-tier'            => WPCOM\Jetpack_AI\Usage\Helper::get_next_tier( $blog_id ),
 				'tier-plans'           => WPCOM\Jetpack_AI\Usage\Helper::get_tier_plans_list(),
 				'tier-plans-enabled'   => WPCOM\Jetpack_AI\Usage\Helper::ai_tier_plans_enabled(),
+				'costs'                => WPCOM\Jetpack_AI\Usage\Helper::get_costs(),
 			);
 		}
 

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-expose-cost-on-feature-endpoint
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-expose-cost-on-feature-endpoint
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: other
 
 Jetpack AI: Expose Jetpack AI cost of features on the feature endpoint.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-expose-cost-on-feature-endpoint
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-expose-cost-on-feature-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack AI: Expose Jetpack AI cost of features on the feature endpoint.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #34720.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Include the property `costs` on the `ai-assistant-feature` endpoint response to inform the client code on how much a given request type costs
* Include the cost of the `jetpack-ai-logo-generator` `logo` request

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Pull the last changes of `trunk` in your sandbox
* Apply this change to your sandbox (use either `rsync` or the Jetpack downloader command that will be provided automatically bellow)
* Sandbox the `public-api` domain
* Go to the WordPress.com Developer https://developer.wordpress.com/docs/api/console/
* Execute a request to `wpcom/v2` `/sites/YOUR-SITE/jetpack-ai/ai-assistant-feature`
* Before this change, there was no `costs` field in the response:

<img width="600" alt="Screenshot 2024-01-22 at 18 28 42" src="https://github.com/Automattic/jetpack/assets/6760046/445bb753-f636-412c-8bbb-0eec41d36063">

* After this change, a new `costs` field must be present:

<img width="600" alt="Screenshot 2024-01-22 at 18 28 19" src="https://github.com/Automattic/jetpack/assets/6760046/747a38c3-7959-40da-9465-b80f09365de9">

* Confirm it contains the following value:

```
{
    "jetpack-ai-logo-generator": {
        "logo": 10
    }
}
```
