### PR TITLE
Untangle: Remove Stats menu and point Jetpack > stats link to Calypso stats

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-stats-link-to-calypso-stats
+++ b/projects/plugins/jetpack/changelog/update-jetpack-stats-link-to-calypso-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Untangle Calypso: Jetpack > stats link to Calypso stats

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -361,7 +361,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_stats_menu() {
 		// When the interface is set to wp-admin, we not add the Stats menu.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
 			return;
 		}
 		$menu_title = __( 'Stats', 'jetpack' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -360,6 +360,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds Stats menu.
 	 */
 	public function add_stats_menu() {
+		// When the interface is set to wp-admin, we not add the Stats menu.
+		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+			return;
+		}
 		$menu_title = __( 'Stats', 'jetpack' );
 		if (
 			! $this->is_api_request &&

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -360,7 +360,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds Stats menu.
 	 */
 	public function add_stats_menu() {
-		// When the interface is set to wp-admin, we not add the Stats menu.
+		// When the interface is set to wp-admin, we don't add the Stats menu.
 		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
 			return;
 		}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -337,6 +337,12 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// This is supposed to be the same as class-admin-menu but with a different position specified for the Jetpack menu.
 		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
 			parent::create_jetpack_menu( 2, false );
+			$this->update_submenus(
+				'jetpack',
+				array(
+					'stats' => 'https://wordpress.com/stats/day/' . $this->domain,
+				)
+			);
 		} else {
 			parent::add_jetpack_menu();
 		}

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -242,7 +242,7 @@ function stats_admin_menu() {
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' && ( ( new Host() )->is_woa_site() || ! Stats_Options::get_option( 'enable_odyssey_stats' ) || isset( $_GET['noheader'] ) ) ) {
+	if ( (  get_option( 'wpcom_admin_interface' ) !== 'wp-admin' && ( new Host() )->is_woa_site() ) || ! Stats_Options::get_option( 'enable_odyssey_stats' ) || isset( $_GET['noheader'] ) ) ) {
 		// Show old Jetpack Stats interface for:
 		// - Interfaces other than wp-admin on WOA sites.
 		// - Atomic sites.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -242,8 +242,9 @@ function stats_admin_menu() {
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( ( new Host() )->is_woa_site() || ! Stats_Options::get_option( 'enable_odyssey_stats' ) || isset( $_GET['noheader'] ) ) {
+	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' && ( ( new Host() )->is_woa_site() || ! Stats_Options::get_option( 'enable_odyssey_stats' ) || isset( $_GET['noheader'] ) ) ) {
 		// Show old Jetpack Stats interface for:
+		// - Interfaces other than wp-admin on WOA sites.
 		// - Atomic sites.
 		// - When the "enable_odyssey_stats" option is disabled.
 		// - When being shown in the adminbar outside of wp-admin.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -242,7 +242,7 @@ function stats_admin_menu() {
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( (  get_option( 'wpcom_admin_interface' ) !== 'wp-admin' && ( new Host() )->is_woa_site() ) || ! Stats_Options::get_option( 'enable_odyssey_stats' ) || isset( $_GET['noheader'] ) ) ) {
+	if ( ( ( new Host() )->is_woa_site() && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) || ! Stats_Options::get_option( 'enable_odyssey_stats' ) || isset( $_GET['noheader'] ) ) {
 		// Show old Jetpack Stats interface for:
 		// - Interfaces other than wp-admin on WOA sites.
 		// - Atomic sites.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -242,7 +242,7 @@ function stats_admin_menu() {
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( ( ( new Host() )->is_woa_site() && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) || ! Stats_Options::get_option( 'enable_odyssey_stats' ) || isset( $_GET['noheader'] ) ) {
+	if ( ( ( new Host() )->is_woa_site() && 'wp-admin' !== get_option( 'wpcom_admin_interface' ) ) || ! Stats_Options::get_option( 'enable_odyssey_stats' ) || isset( $_GET['noheader'] ) ) {
 		// Show old Jetpack Stats interface for:
 		// - Interfaces other than wp-admin on WOA sites.
 		// - Atomic sites.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -242,9 +242,8 @@ function stats_admin_menu() {
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( ( ( new Host() )->is_woa_site() && 'wp-admin' !== get_option( 'wpcom_admin_interface' ) ) || ! Stats_Options::get_option( 'enable_odyssey_stats' ) || isset( $_GET['noheader'] ) ) {
+	if ( ( new Host() )->is_woa_site() || ! Stats_Options::get_option( 'enable_odyssey_stats' ) || isset( $_GET['noheader'] ) ) {
 		// Show old Jetpack Stats interface for:
-		// - Interfaces other than wp-admin on WOA sites.
 		// - Atomic sites.
 		// - When the "enable_odyssey_stats" option is disabled.
 		// - When being shown in the adminbar outside of wp-admin.


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5270

## Proposed changes:
As part of Untangle Calypso, Jetpack > Stats link should point to Calypso stats.

## Jetpack product discussion
Slack: p1705383635295969-slack-C82FZ5T4G

## Does this pull request change what data or activity we track or use?
NO

## Testing instructions:
* Set your `Admin interface style` to `Classic (wp-admin)` in `wordpress.com/hosting-config/site_slug`
* Go to `wp-admin`
* The Stats menu (after Dashboard) should not exist anymore.
* The `Jetpack/Stats` sub-menu should link show Odyssey Stats instead the old stats page.