### PR TITLE
youtube-shortcode: Handle being given an array with a 'url' key

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-youtube-shortcode
+++ b/projects/plugins/jetpack/changelog/fix-youtube-shortcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+youtube-shortcode: Handle being given an array with a 'url' key insteadad of the URL as a string

--- a/projects/plugins/jetpack/functions.compat.php
+++ b/projects/plugins/jetpack/functions.compat.php
@@ -20,7 +20,7 @@ function jetpack_shortcode_get_youtube_id( $url ) {
 /**
  * Extract video ID from a YouTube url.
  *
- * @param string $url YouTube URL.
+ * @param string|array $url YouTube URL.
  * @return bool|mixed The Youtube video ID
  */
 function jetpack_get_youtube_id( $url ) {
@@ -58,10 +58,14 @@ if ( ! function_exists( 'youtube_sanitize_url' ) ) :
 	/**
 	 * Normalizes a YouTube URL to include a v= parameter and a query string free of encoded ampersands.
 	 *
-	 * @param string $url YouTube URL.
+	 * @param string|array $url YouTube URL.
 	 * @return string The normalized URL
 	 */
 	function youtube_sanitize_url( $url ) {
+		if ( is_array( $url ) && isset( $url['url'] ) ) {
+			$url = $url['url'];
+		}
+
 		$url = trim( $url, ' "' );
 		$url = trim( $url );
 		$url = str_replace( array( 'youtu.be/', '/v/', '#!v=', '&amp;', '&#038;', 'playlist' ), array( 'youtu.be/?v=', '/?v=', '?v=', '&', '&', 'videoseries' ), $url );

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -142,6 +142,10 @@ if ( ! function_exists( 'youtube_sanitize_url' ) ) :
 	 * @param string $url Youtube URL.
 	 */
 	function youtube_sanitize_url( $url ) {
+		if ( is_array( $url ) && isset( $url['url'] ) ) {
+			$url = $url['url'];
+		}
+
 		$url = trim( $url, ' "' );
 		$url = trim( $url );
 		$url = str_replace( array( 'youtu.be/', '/v/', '#!v=', '&amp;', '&#038;', 'playlist' ), array( 'youtu.be/?v=', '/?v=', '?v=', '&', '&', 'videoseries' ), $url );

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -132,14 +132,14 @@ function youtube_link_callback( $matches ) {
 /**
  * Normalizes a YouTube URL to include a v= parameter and a query string free of encoded ampersands.
  *
- * @param string $url
+ * @param string|array $url Youtube URL.
  * @return string The normalized URL
  */
 if ( ! function_exists( 'youtube_sanitize_url' ) ) :
 	/**
 	 * Clean up Youtube URL to match a single format.
 	 *
-	 * @param string $url Youtube URL.
+	 * @param string|array $url Youtube URL.
 	 */
 	function youtube_sanitize_url( $url ) {
 		if ( is_array( $url ) && isset( $url['url'] ) ) {


### PR DESCRIPTION
youtube-shortcode: Handle being given an array with a 'url' key insteadad of the URL as a string

I've seen this happen, and under PHP 8 it becomes a fatal because an array is being given to `trim()` when it only accepts strings.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

