### PR TITLE
Untangle: Remove width overrides in the admin menu

### DIFF
--- a/projects/plugins/jetpack/changelog/update-admin-menu-width
+++ b/projects/plugins/jetpack/changelog/update-admin-menu-width
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update admin nav width to 160px

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -2,6 +2,16 @@
 	margin: 0;
 }
 
+@media (min-width: 961px) {
+	.jp-dialogue-modern-full__container {
+		left: 160px;
+	}
+
+	.global-notices {
+		max-width: calc( 100% - 48px - 160px );
+	}
+}
+
 /**
  * Jetpack logo
  */

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -3,53 +3,6 @@
 }
 
 /**
- * Menu width
- */
-#wpcontent,
-#wpfooter {
-	margin-left: 160px;
-}
-
-#adminmenuback,
-#adminmenuwrap,
-#adminmenu,
-#adminmenu .wp-submenu {
-	width: 160px;
-}
-
-#adminmenu .wp-submenu {
-	left: 160px;
-}
-
-#adminmenu .wp-not-current-submenu .wp-submenu,
-.folded #adminmenu .wp-has-current-submenu .wp-submenu {
-	min-width: 160px;
-}
-
-/**
- * Fixes Gutenberg in not fullscreen mode.
- */
- @media (min-width: 783px) {
-	.interface-interface-skeleton,
-	.edit-post-layout .components-editor-notices__snackbar {
-		left: 160px;
-	}
-}
-
-@media (min-width: 961px) {
-	body:not(.folded).auto-fold .interface-interface-skeleton,
-	.auto-fold .edit-post-layout .components-editor-notices__snackbar,
-	.components-snackbar-list.edit-widgets-notices__snackbar,
-	.jp-dialogue-modern-full__container {
-		left: 160px;
-	}
-
-	.global-notices {
-		max-width: calc( 100% - 48px - 160px );
-	}
-}
-
-/**
  * Jetpack logo
  */
 #adminmenu [class*="activity-log"] .wp-menu-image img {
@@ -306,12 +259,6 @@
 
 /* Auto-folding of the admin menu */
 @media only screen and (max-width: 960px) {
-	#adminmenu,
-	#adminmenuwrap,
-	#adminmenuback {
-		width: 160px;
-	}
-
 	.auto-fold #adminmenu a[class*="toplevel_page_http"].wp-first-item {
 		height: auto;
 	}
@@ -344,14 +291,6 @@
 
 	.wp-responsive-open #wpbody {
 		right: inherit;
-	}
-
-	.wp-responsive-open #wpcontent {
-		margin-left: 160px;
-	}
-
-	.auto-fold #adminmenu, .auto-fold #adminmenuback, .auto-fold #adminmenuwrap {
-		width: 160px;
 	}
 
 	.auto-fold #adminmenu a.site-switcher,

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -7,23 +7,23 @@
  */
 #wpcontent,
 #wpfooter {
-	margin-left: 272px;
+	margin-left: 160px;
 }
 
 #adminmenuback,
 #adminmenuwrap,
 #adminmenu,
 #adminmenu .wp-submenu {
-	width: 272px;
+	width: 160px;
 }
 
 #adminmenu .wp-submenu {
-	left: 272px;
+	left: 160px;
 }
 
 #adminmenu .wp-not-current-submenu .wp-submenu,
 .folded #adminmenu .wp-has-current-submenu .wp-submenu {
-	min-width: 272px;
+	min-width: 160px;
 }
 
 /**
@@ -32,7 +32,7 @@
  @media (min-width: 783px) {
 	.interface-interface-skeleton,
 	.edit-post-layout .components-editor-notices__snackbar {
-		left: 272px;
+		left: 160px;
 	}
 }
 
@@ -41,11 +41,11 @@
 	.auto-fold .edit-post-layout .components-editor-notices__snackbar,
 	.components-snackbar-list.edit-widgets-notices__snackbar,
 	.jp-dialogue-modern-full__container {
-		left: 272px;
+		left: 160px;
 	}
 
 	.global-notices {
-		max-width: calc( 100% - 48px - 272px );
+		max-width: calc( 100% - 48px - 160px );
 	}
 }
 
@@ -309,7 +309,7 @@
 	#adminmenu,
 	#adminmenuwrap,
 	#adminmenuback {
-		width: 272px;
+		width: 160px;
 	}
 
 	.auto-fold #adminmenu a[class*="toplevel_page_http"].wp-first-item {
@@ -347,11 +347,11 @@
 	}
 
 	.wp-responsive-open #wpcontent {
-		margin-left: 272px;
+		margin-left: 160px;
 	}
 
 	.auto-fold #adminmenu, .auto-fold #adminmenuback, .auto-fold #adminmenuwrap {
-		width: 272px;
+		width: 160px;
 	}
 
 	.auto-fold #adminmenu a.site-switcher,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5284

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR reverts the admin menu width in Classic styles to align with core.

> [!NOTE]
> Elements such as the site card, upsell banner, and stats will be removed in separate PRs. We can merge this PR after those have already been merged.

| Before | After |
| --- | --- |
| ![Screenshot 2024-01-24 at 10 47 09 AM](https://github.com/Automattic/jetpack/assets/797888/9f359a6e-29f8-4199-9804-d95a1485b991) | ![Screenshot 2024-01-24 at 10 46 19 AM](https://github.com/Automattic/jetpack/assets/797888/5a02be6c-80ee-4bc4-b259-88b261c3dbf6) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Head to Settings → Hosting Configuration.
* Scroll to the Admin interface style section, and select Classic style.
* Refresh the page if needed.
* Ensure that the admin menu width is updated as described above.

