### PR TITLE
Like block: update styles

### DIFF
--- a/projects/plugins/jetpack/changelog/add-like-block-styles-update-container
+++ b/projects/plugins/jetpack/changelog/add-like-block-styles-update-container
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Tint style update
+
+

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -10,7 +10,10 @@
 	display: none;
 }
 
-/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-01-15T08:02:21.397Z */
+/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-01-23T11:29:16.073Z */
+.wpl-likebox {
+	container-type:inline-size;
+}
 .wpl-likebox,.wpl-follow a,.wpl-count a {
 	font-size:11px!important;
 	font-family:"Open Sans",sans-serif!important;
@@ -77,8 +80,21 @@
 .wpl-button.like a span,.wpl-button.liked a span,.wpl-button.reblog a span {
 	margin-left:3px;
 }
+@container (max-width:320px) {
+	.wpl-button {
+		min-width:auto;
+	}
+	.wpl-button a {
+		padding-bottom:10px;
+	}
+	.wpl-button a span {
+		display:none;
+	}
+}
 .wpl-count {
 	clear:both;
+	text-overflow:ellipsis;
+	overflow:hidden;
 }
 .wpl-count-text {
 	line-height:1.6;

--- a/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
@@ -31,7 +31,11 @@ function processCSS( css ) {
 	// Remove body and HTML styles
 	let processedCSS = css.replace( /body[^{]*\{[^}]*\}/g, '' );
 	processedCSS = processedCSS.replace( /html[^{]*\{[^}]*\}/g, '' );
-
+	// Convert media queries to container queries
+	processedCSS = processedCSS.replace(
+		/@media(?:\s+only\s+screen)?\s*(and)?\s*\(([^)]+)\)/g,
+		'@container ($2)'
+	);
 	// Pretty print the CSS
 	processedCSS = prettyPrintCSS( processedCSS );
 
@@ -42,7 +46,13 @@ function processCSS( css ) {
         padding: 0 16px 16px 52px;
         margin-top: -12px;
     }
-}`;
+}
+
+// Hide the Like block if it tries to load in the editor (e.g. as a part of the Query Loop block).
+.wp-block-jetpack-like .sharedaddy {
+	display: none;
+}
+`;
 
 	const customRule2 = `
 	/* Overrides to fix CSS conflicts within editor. */


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/86748

## Proposed changes:
- Brings over the latest style changes to the Like widget
- Updates the `projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js` script to convert media queries into container queries.

⚠️ The script doesn't do multi-level indentation very good at this moment. I'll fix this in a follow up PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Apply this PR
- Create a new post
- Use this markup:

```
<!-- wp:paragraph -->
<p>Three columns:</p>
<!-- /wp:paragraph -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:jetpack/like {"showReblogButton":true} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:jetpack/like {"showReblogButton":true} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:jetpack/like {"showReblogButton":true} /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:paragraph -->
<p>Two columns:</p>
<!-- /wp:paragraph -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:jetpack/like {"showReblogButton":true} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:jetpack/like {"showReblogButton":true} /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:paragraph -->
<p>Regular:</p>
<!-- /wp:paragraph -->

<!-- wp:jetpack/like {"showReblogButton":true} /-->
``` 

The label should be removed from the block on smaller widths (3/2 columns):

![CleanShot 2024-01-23 at 12 36 18@2x](https://github.com/Automattic/jetpack/assets/528287/f864f821-5eef-41df-b537-a43a6e852652)
