### PR TITLE
Added integers 1 and 0 to is_truthy and is_falsy.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-integers-to-is-truthy
+++ b/projects/plugins/jetpack/changelog/add-integers-to-is-truthy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+REST API: fixed the way we treat 0 and 1 integers in boolean context.

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -205,7 +205,7 @@ class WPCOM_JSON_API {
 	 * Determine if a string is truthy. If it's not a string, which can happen with
 	 * not well-formed data coming from Jetpack sites, we still consider it a truthy value.
 	 *
-	 * @param mixed $value 1, "1", "t", and "true" (case insensitive) are truthy, everything else isn't.
+	 * @param mixed $value true, 1, "1", "t", and "true" (case insensitive) are truthy, everything else isn't.
 	 * @return bool
 	 */
 	public static function is_truthy( $value ) {

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -205,7 +205,7 @@ class WPCOM_JSON_API {
 	 * Determine if a string is truthy. If it's not a string, which can happen with
 	 * not well-formed data coming from Jetpack sites, we still consider it a truthy value.
 	 *
-	 * @param string $value "1", "t", and "true" (case insensitive) are truthy, everything else isn't.
+	 * @param mixed $value 1, "1", "t", and "true" (case insensitive) are truthy, everything else isn't.
 	 * @return bool
 	 */
 	public static function is_truthy( $value ) {
@@ -213,11 +213,12 @@ class WPCOM_JSON_API {
 			return true;
 		}
 
-		if ( ! is_string( $value ) ) {
+		if ( ! is_string( $value ) && ! is_int( $value ) ) {
 			return false;
 		}
 
 		switch ( strtolower( (string) $value ) ) {
+			case 1:
 			case '1':
 			case 't':
 			case 'true':
@@ -230,7 +231,7 @@ class WPCOM_JSON_API {
 	/**
 	 * Determine if a string is falsey.
 	 *
-	 * @param string $value "0", "f", and "false" (case insensitive) are falsey, everything else isn't.
+	 * @param mixed $value 0, "0", "f", and "false" (case insensitive) are falsey, everything else isn't.
 	 * @return bool
 	 */
 	public static function is_falsy( $value ) {
@@ -238,11 +239,12 @@ class WPCOM_JSON_API {
 			return true;
 		}
 
-		if ( ! is_string( $value ) ) {
+		if ( ! is_string( $value ) && ! is_int( $value ) ) {
 			return false;
 		}
 
 		switch ( strtolower( (string) $value ) ) {
+			case 0:
 			case '0':
 			case 'f':
 			case 'false':

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -213,12 +213,15 @@ class WPCOM_JSON_API {
 			return true;
 		}
 
-		if ( ! is_string( $value ) && ! is_int( $value ) ) {
+		if ( 1 === $value ) {
+			return true;
+		}
+
+		if ( ! is_string( $value ) ) {
 			return false;
 		}
 
 		switch ( strtolower( (string) $value ) ) {
-			case 1:
 			case '1':
 			case 't':
 			case 'true':
@@ -239,12 +242,15 @@ class WPCOM_JSON_API {
 			return true;
 		}
 
-		if ( ! is_string( $value ) && ! is_int( $value ) ) {
+		if ( 0 === $value ) {
+			return true;
+		}
+
+		if ( ! is_string( $value ) ) {
 			return false;
 		}
 
 		switch ( strtolower( (string) $value ) ) {
-			case 0:
 			case '0':
 			case 'f':
 			case 'false':

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -231,7 +231,7 @@ class WPCOM_JSON_API {
 	/**
 	 * Determine if a string is falsey.
 	 *
-	 * @param mixed $value 0, "0", "f", and "false" (case insensitive) are falsey, everything else isn't.
+	 * @param mixed $value false, 0, "0", "f", and "false" (case insensitive) are falsey, everything else isn't.
 	 * @return bool
 	 */
 	public static function is_falsy( $value ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes cases where actual integers are used in API calls instead of strings in boolean context.

## Proposed changes:
* Add 0 and 1 as integers to is_truthy and is_falsy.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/34770/files#r1463155526

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* TBA

