### PR TITLE
Add/fix language on simple payments button

### DIFF
--- a/projects/plugins/jetpack/changelog/add-fix-language-on-simplepay-button
+++ b/projects/plugins/jetpack/changelog/add-fix-language-on-simplepay-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -42,12 +42,18 @@ export function showModal( url ) {
 	dialog.setAttribute( 'id', 'memberships-modal-window' );
 
 	const iframe = document.createElement( 'iframe' );
-	const siteLanguage = document.querySelector( 'input[name="lang"]' ).value;
+	const inputLanguage = document.querySelector( 'input[name="lang"]' );
+	let siteLanguage = null;
+	if ( inputLanguage ) {
+		siteLanguage = inputLanguage.value;
+	}
 	iframe.setAttribute( 'id', 'memberships-modal-iframe' );
 	iframe.innerText =
 		'This feature requires inline frames. You have iframes disabled or your browser does not support them.';
-	iframe.src =
-		url + '&display=alternate&lang=' + siteLanguage + '&jwt_token=' + getTokenFromCookie();
+	iframe.src = url + '&display=alternate&jwt_token=' + getTokenFromCookie();
+	if ( siteLanguage ) {
+		iframe.src = iframe.src + '&lang=' + siteLanguage;
+	}
 	iframe.setAttribute( 'frameborder', '0' );
 	iframe.setAttribute( 'allowtransparency', 'true' );
 	iframe.setAttribute( 'allowfullscreen', 'true' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix error when there is no "lang" input when opening subscription iframe

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox bestdotcroissants.wordpress.com
* Go to https://bestdotcroissants.wordpress.com/2023/11/23/paid-content-post/ in a private window
* The subscribe button should not work
* Apply this  patch on your sandbox via the below command
* Go to https://bestdotcroissants.wordpress.com/2023/11/23/paid-content-post/ in a private window
* The subscribe button should now work and display the iframe (there will probably be an issue if you are not sandboxing the store, though)