### PR TITLE
Boost: Fix not showing popup after close and score increased/decreased

### DIFF
--- a/projects/plugins/boost/changelog/boost-react-speed-score-changed-popup-not-showing-without-refresh
+++ b/projects/plugins/boost/changelog/boost-react-speed-score-changed-popup-not-showing-without-refresh
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix not showing Speed Score increase/decrease popup when a user closed it.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35102

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Show popup after used closed (not dismissed) it and it needed to show again (due to score increase/decrease).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost;
* Cause the Speed Score popup to show up;
* Close the popup and don't refresh the page;
* Rig the scores to fall/drop (the opposite of the first popup) and request them again;
* After the request finishes, the popup should show, showing the appropriate increase/decrease version and should be closable;
* You should be able to repeat this process many times.