### PR TITLE
AI Assistant: fix event property

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-suggestion-event-type
+++ b/projects/plugins/jetpack/changelog/fix-ai-suggestion-event-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: add missing property 'type' on event

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -9,6 +9,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { post, postContent, postExcerpt, termDescription } from '@wordpress/icons';
+import debugFactory from 'debug';
 import React from 'react';
 /**
  * Internal dependencies
@@ -33,6 +34,8 @@ import './style.scss';
 import type { ExtendedBlockProp } from '../../extensions/ai-assistant';
 import type { PromptTypeProp } from '../../lib/prompt';
 import type { ToneProp } from '../tone-dropdown-control';
+
+const debug = debugFactory( 'jetpack-ai-assistant:dropdown' );
 
 // Quick edits option: "Correct spelling and grammar"
 const QUICK_EDIT_KEY_CORRECT_SPELLING = 'correct-spelling' as const;
@@ -149,8 +152,9 @@ function AiAssistantDropdownContent( {
 		const content = getBlocksContent( blocks );
 
 		onClose();
-
+		debug( 'requestSuggestion', promptType, options );
 		tracks.recordEvent( 'jetpack_editor_ai_assistant_extension_toolbar_button_click', {
+			type: 'suggestion',
 			suggestion: promptType,
 			block_type: blockType,
 		} );


### PR DESCRIPTION
Property `type` is not being sent on event `jetpack_editor_ai_assistant_extension_toolbar_button_click`

## Proposed changes:
Add property `type` hardcoded as `suggestion` on the AI Assistant extension toolbar

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use the AI Assistant extension toolbar to open the dropdown menu:
<img width="281" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/b807626a-8a27-41d5-a3c0-db8241118850">
Check on the `dops` message to see the triggered event, see that `type` property is set to `suggestion`