### PR TITLE
CRM: 3416 - SQLite + WP Playground compatibility tweaks

### DIFF
--- a/projects/plugins/crm/.wordpress-org/blueprints/blueprint.json
+++ b/projects/plugins/crm/.wordpress-org/blueprints/blueprint.json
@@ -10,6 +10,10 @@
 			"step": "login",
 			"username": "admin",
 			"password": "password"
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php require_once 'wordpress/wp-load.php'; global $wp_rewrite; $wp_rewrite->set_permalink_structure('/%postname%/'); $wp_rewrite->flush_rules();"
 		}
 	]
 }

--- a/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
+++ b/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
@@ -76,7 +76,7 @@ function jetpackcrm_dash_refresh() {
 	$sql     = $wpdb->prepare( 'SELECT count(ID) as count, zbsc_created as ts, MONTH(FROM_UNIXTIME(zbsc_created)) as month, YEAR(FROM_UNIXTIME(zbsc_created)) as year FROM ' . $ZBSCRM_t['contacts'] . ' WHERE zbsc_created > %d AND zbsc_created < %d GROUP BY month, year ORDER BY year, month', $start_date, $end_date ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$monthly = $wpdb->get_results( $sql );
 
-	$sql    = $wpdb->prepare( 'SELECT count(ID) as count, zbsc_created as ts, WEEK(FROM_UNIXTIME(zbsc_created)) as week, YEAR(FROM_UNIXTIME(zbsc_created)) as year FROM ' . $ZBSCRM_t['contacts'] . ' WHERE zbsc_created > %d AND zbsc_created < %d GROUP BY week, year ORDER BY year, week', $start_date, $end_date ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$sql    = $wpdb->prepare( 'SELECT count(ID) as count, zbsc_created as ts, WEEK(FROM_UNIXTIME(zbsc_created), 1) as week, YEAR(FROM_UNIXTIME(zbsc_created)) as year FROM ' . $ZBSCRM_t['contacts'] . ' WHERE zbsc_created > %d AND zbsc_created < %d GROUP BY week, year ORDER BY year, week', $start_date, $end_date ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$weekly = $wpdb->get_results( $sql );
 
 	$sql   = $wpdb->prepare( 'SELECT count(ID) as count, zbsc_created as ts, DAY(FROM_UNIXTIME(zbsc_created)) as day, MONTH(FROM_UNIXTIME(zbsc_created)) as month, YEAR(FROM_UNIXTIME(zbsc_created)) as year FROM ' . $ZBSCRM_t['contacts'] . ' WHERE zbsc_created > %d AND zbsc_created < %d GROUP BY day, month, year ORDER BY year, month, day', $start_date, $end_date ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/projects/plugins/crm/changelog/fix-crm-3416-sqlite_compatibility
+++ b/projects/plugins/crm/changelog/fix-crm-3416-sqlite_compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Adjust queries for SQLite compatibility

--- a/projects/plugins/crm/changelog/fix-crm-3416-sqlite_compatibility
+++ b/projects/plugins/crm/changelog/fix-crm-3416-sqlite_compatibility
@@ -1,4 +1,5 @@
 Significance: patch
 Type: fixed
 
-Dashboard: Adjust queries for SQLite compatibility
+Dashboard: Adjust queries for SQLite compatibility.
+REST API: Allow calls when not using pretty permalinks.

--- a/projects/plugins/crm/includes/ZeroBSCRM.CustomerFilters.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CustomerFilters.php
@@ -50,14 +50,19 @@ function zeroBSCRM_CustomerTypeList( $jsCallbackFuncStr = '', $inputDefaultValue
 		global $haszbscrmBHURLCustomersOut;
 	if ( ! isset( $haszbscrmBHURLCustomersOut ) ) {
 
-		// cachebusting for now... (ESP needed when migrating from DAL1 -> DAL2)
+		$nonce         = wp_create_nonce( 'wp_rest' );
+		$rest_base_url = get_rest_url();
 
-		$cacheBusterStr = '&time=' . time();
+		// handle bare permalink structure
+		if ( empty( get_option( 'permalink_structure' ) ) ) {
+			$param_separator = '&';
+		} else {
+			$param_separator = '?';
+		}
+		$rest_url = $rest_base_url . 'zbscrm/v1/contacts' . $param_separator . '_wpnonce=' . $nonce;
 
-		// change to proper WP REST (not cached) and wont be impacted by setup connection issues. Is also the "proper" way to do it
-		$nonce                      = wp_create_nonce( 'wp_rest' );
-		$rest_url                   = esc_url( get_rest_url() . 'zbscrm/v1/contacts?_wpnonce=' . $nonce );
-		$ret                       .= '<script type="text/javascript">var zbscrmBHURLCustomers = "' . $rest_url . '";</script>';
+		$ret .= '<script type="text/javascript">var zbscrmBHURLCustomers = "' . $rest_url . '";</script>';
+
 		$haszbscrmBHURLCustomersOut = true;
 	}
 
@@ -125,9 +130,19 @@ function zeroBSCRM_CompanyTypeList( $jsCallbackFuncStr = '', $inputDefaultValue 
 		global $haszbscrmBHURLCompaniesOut;
 		if ( ! isset( $haszbscrmBHURLCompaniesOut ) ) {
 
-			$nonce                      = wp_create_nonce( 'wp_rest' );
-			$rest_url                   = esc_url( get_rest_url() . 'zbscrm/v1/companies?_wpnonce=' . $nonce );
-			$ret                       .= '<script type="text/javascript">var zbscrmBHURLCompanies = "' . $rest_url . '";</script>';
+			$nonce         = wp_create_nonce( 'wp_rest' );
+			$rest_base_url = get_rest_url();
+
+			// handle bare permalink structure
+			if ( empty( get_option( 'permalink_structure' ) ) ) {
+				$param_separator = '&';
+			} else {
+				$param_separator = '?';
+			}
+			$rest_url = $rest_base_url . 'zbscrm/v1/companies' . $param_separator . '_wpnonce=' . $nonce;
+
+			$ret .= '<script type="text/javascript">var zbscrmBHURLCompanies = "' . $rest_url . '";</script>';
+
 			$haszbscrmBHURLCompaniesOut = true;
 		}
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -1660,7 +1660,8 @@ function zbscrm_JS_calculatediscount() {
  */
 function zbscrm_JS_invoice_typeahead_bind() {
 	// endpoint - pass nonce this was as before send wasn't working weirdly in Bloodhound.
-	endpoint = wpApiSettings.root + 'zbscrm/v1/concom?_wpnonce=' + wpApiSettings.nonce;
+	param_separator = wpApiSettings.root.indexOf('?rest_route=/') === -1 ? '?' : '&';
+	endpoint = wpApiSettings.root + 'zbscrm/v1/concom' + param_separator + '_wpnonce=' + wpApiSettings.nonce;
 
 	var zbsInvoiceTo = new Bloodhound( {
 		datumTokenizer: function ( d ) {
@@ -1684,7 +1685,7 @@ function zbscrm_JS_invoice_typeahead_bind() {
 		},
 		remote: {
 			// this checks when users type, via ajax search ... useful addition to (cached) prefetch
-			url: wpApiSettings.root + 'zbscrm/v1/concom?_wpnonce=' + wpApiSettings.nonce + '&s=%QUERY',
+			url: wpApiSettings.root + 'zbscrm/v1/concom' + param_separator + '_wpnonce=' + wpApiSettings.nonce + '&s=%QUERY',
 			wildcard: '%QUERY',
 		},
 	} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3416 - SQLite + WP Playground compatibility tweaks

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
I found a few more errors on a final walkthrough in WP Playground:

1. If there are contacts, the widgets at the top of the dashboard fail to load due to a 500. This is because the MySQL → SQLite translation for `WEEK()` requires a second (albeit unused) param, which I've now added.
2. When trying to associate a contact with an item, we would get a 404 error. This is because permalinks need to be set to make the custom REST call (see WordPress/wordpress-playground#607).

Associated with the second item, I updated the REST API calls so they work with non-pretty permalinks as well.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In WP Playground or a local SQLite setup:

1. Add a contact: `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact`
2. Go to the dashboard: `/wp-admin/admin.php?page=zerobscrm-dash`

With `trunk` or JPCRM 6.3.2, the top dashboard widgets and first chart don't load properly after adding a contact:
![image](https://github.com/Automattic/jetpack/assets/32492176/c2e5e13e-6da1-40ec-a9f7-3c5672a4ae38)

In the `fix/crm/3416-sqlite_compatibility` branch, they do:

![image](https://github.com/Automattic/jetpack/assets/32492176/bd043bb6-4f8d-4aff-be78-25562db6b584)

To test the other issue, you can do it locally with any install:

1. Create a contact or company.
2. Switch permalinks to plain: `/wp-admin/options-permalink.php`
3. Go to add a new invoice or transaction.
4. Try to assign a contact or company to the new object.

In `trunk`, the typeahead will not appear, and you'll see a 404 in the browser network requests.

In the `fix/crm/3416-sqlite_compatibility` branch, the typeahead appears as expected:
![image](https://github.com/Automattic/jetpack/assets/32492176/561c6068-5681-4c80-96f3-09de6903de04)
