### PR TITLE
WordAds: Add option to toggle CMP banner under Monetize settings

### DIFF
--- a/projects/packages/sync/changelog/add-cmp-ad-settings
+++ b/projects/packages/sync/changelog/add-cmp-ad-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Monetize settings: Add option to toggle CMP banner

--- a/projects/packages/sync/changelog/add-cmp-ad-settings
+++ b/projects/packages/sync/changelog/add-cmp-ad-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Ads Settings: Include option to toggle GDPR Consent Banner

--- a/projects/packages/sync/changelog/add-cmp-ad-settings
+++ b/projects/packages/sync/changelog/add-cmp-ad-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Monetize settings: Add option to toggle CMP banner

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.7.x-dev"
+			"dev-trunk": "2.8.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -167,6 +167,7 @@ class Defaults {
 		'videopress_private_enabled_for_site',
 		'wordads_ccpa_enabled',
 		'wordads_ccpa_privacy_policy_url',
+		'wordads_cmp_enabled',
 		'wordads_custom_adstxt',
 		'wordads_custom_adstxt_enabled',
 		'wordads_display_archive',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.7.0';
+	const PACKAGE_VERSION = '2.8.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/backup/changelog/add-cmp-ad-settings
+++ b/projects/plugins/backup/changelog/add-cmp-ad-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1543,7 +1543,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dec31f79e5cf8945b45b67e13b386184d0775c7a"
+                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1575,7 +1575,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.7.x-dev"
+                    "dev-trunk": "2.8.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/add-cmp-ad-settings
+++ b/projects/plugins/boost/changelog/add-cmp-ad-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1533,7 +1533,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dec31f79e5cf8945b45b67e13b386184d0775c7a"
+                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1565,7 +1565,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.7.x-dev"
+                    "dev-trunk": "2.8.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/_inc/client/earn/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/ads.jsx
@@ -358,7 +358,6 @@ export const Ads = withModuleSettingsFormHelpers(
 							</FormFieldset>
 						) }
 					</SettingsGroup>
-					{ ! isSubDirSite && this.renderAdsTxtSection() }
 					<SettingsGroup>
 						<ToggleControl
 							checked={ wordads_cmp_enabled }
@@ -372,6 +371,7 @@ export const Ads = withModuleSettingsFormHelpers(
 							label={ __( 'Enable GDPR Consent Banner', 'jetpack' ) }
 						/>
 					</SettingsGroup>
+					{ ! isSubDirSite && this.renderAdsTxtSection() }
 					{ ! unavailableInOfflineMode && isAdsActive && (
 						<Card
 							compact

--- a/projects/plugins/jetpack/_inc/client/earn/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/ads.jsx
@@ -380,7 +380,7 @@ export const Ads = withModuleSettingsFormHelpers(
 							}
 							toggling={ this.props.isSavingAnyOption( [ 'wordads_cmp_enabled' ] ) }
 							onChange={ this.handleChange( 'wordads_cmp_enabled' ) }
-							label={ __( 'Enable EU Consent Banner', 'jetpack' ) }
+							label={ __( 'Enable GDPR Consent Banner', 'jetpack' ) }
 						/>
 					</SettingsGroup>
 					{ ! unavailableInOfflineMode && isAdsActive && (

--- a/projects/plugins/jetpack/_inc/client/earn/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/ads.jsx
@@ -359,18 +359,7 @@ export const Ads = withModuleSettingsFormHelpers(
 						) }
 					</SettingsGroup>
 					{ ! isSubDirSite && this.renderAdsTxtSection() }
-					<SettingsGroup
-						support={ {
-							text: __(
-								'This enables our GDPR Consent banner in the EU where this is legally required. This allows your site visitors to provide consent for personalized ads.',
-								'jetpack'
-							),
-							// TODO: Activate with EU/CMP support link?
-							// link: this.props.isAtomicSite
-							// 	? getRedirectUrl( 'wpcom-support-us-privacy' )
-							// 	: getRedirectUrl( 'jetpack-support-ads' ),
-						} }
-					>
+					<SettingsGroup>
 						<ToggleControl
 							checked={ wordads_cmp_enabled }
 							disabled={

--- a/projects/plugins/jetpack/_inc/client/earn/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/ads.jsx
@@ -139,6 +139,9 @@ export const Ads = withModuleSettingsFormHelpers(
 				'wordads_ccpa_privacy_policy_url',
 				'wordads'
 			);
+
+			const wordads_cmp_enabled = this.props.getOptionValue( 'wordads_cmp_enabled', 'wordads' );
+
 			const isSubDirSite = this.props.siteRawUrl.indexOf( '::' ) !== -1;
 			return (
 				<SettingsCard
@@ -356,6 +359,30 @@ export const Ads = withModuleSettingsFormHelpers(
 						) }
 					</SettingsGroup>
 					{ ! isSubDirSite && this.renderAdsTxtSection() }
+					<SettingsGroup
+						support={ {
+							text: __(
+								'This enables our GDPR Consent banner in the EU where this is legally required. This allows your site visitors to provide consent for personalized ads.',
+								'jetpack'
+							),
+							// TODO: Activate with EU/CMP support link?
+							// link: this.props.isAtomicSite
+							// 	? getRedirectUrl( 'wpcom-support-us-privacy' )
+							// 	: getRedirectUrl( 'jetpack-support-ads' ),
+						} }
+					>
+						<ToggleControl
+							checked={ wordads_cmp_enabled }
+							disabled={
+								! isAdsActive ||
+								unavailableInOfflineMode ||
+								this.props.isSavingAnyOption( [ 'wordads' ] )
+							}
+							toggling={ this.props.isSavingAnyOption( [ 'wordads_cmp_enabled' ] ) }
+							onChange={ this.handleChange( 'wordads_cmp_enabled' ) }
+							label={ __( 'Enable EU Consent Banner', 'jetpack' ) }
+						/>
+					</SettingsGroup>
 					{ ! unavailableInOfflineMode && isAdsActive && (
 						<Card
 							compact

--- a/projects/plugins/jetpack/_inc/client/earn/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/ads.jsx
@@ -358,7 +358,15 @@ export const Ads = withModuleSettingsFormHelpers(
 							</FormFieldset>
 						) }
 					</SettingsGroup>
-					<SettingsGroup>
+					<SettingsGroup
+						support={ {
+							text: __(
+								'Show a cookie banner to all EU and UK site visitors prompting them to consent to their personal data being used to personalize the ads they see. Without proper consents EU/UK visitors will only see lower paying non-personalized ads.',
+								'jetpack'
+							),
+							link: getRedirectUrl( 'jetpack-support-ads' ),
+						} }
+					>
 						<ToggleControl
 							checked={ wordads_cmp_enabled }
 							disabled={

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2841,6 +2841,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'sanitize_callback' => 'sanitize_text_field',
 				'jp_group'          => 'wordads',
 			),
+			'wordads_cmp_enabled'                  => array(
+				'description'       => esc_html__( 'Enable A8C EU Consent Management Banner for WordAds', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'wordads',
+			),
 
 			// Google Analytics.
 			'google_analytics_tracking_id'         => array(

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2842,7 +2842,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'wordads',
 			),
 			'wordads_cmp_enabled'                  => array(
-				'description'       => esc_html__( 'Enable A8C EU Consent Management Banner for WordAds', 'jetpack' ),
+				'description'       => esc_html__( 'Enable GDPR Consent Management Banner for WordAds', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',

--- a/projects/plugins/jetpack/changelog/add-cmp-ad-settings
+++ b/projects/plugins/jetpack/changelog/add-cmp-ad-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Monetize settings: Add settings to toggle CMP banner

--- a/projects/plugins/jetpack/changelog/add-cmp-ad-settings
+++ b/projects/plugins/jetpack/changelog/add-cmp-ad-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Ads Settings: Include option to toggle GDPR Consent Banner

--- a/projects/plugins/jetpack/changelog/add-cmp-ad-settings
+++ b/projects/plugins/jetpack/changelog/add-cmp-ad-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Monetize settings: Add settings to toggle CMP banner

--- a/projects/plugins/jetpack/changelog/add-cmp-ad-settings#2
+++ b/projects/plugins/jetpack/changelog/add-cmp-ad-settings#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2456,7 +2456,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "dec31f79e5cf8945b45b67e13b386184d0775c7a"
+				"reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2488,7 +2488,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.7.x-dev"
+					"dev-trunk": "2.8.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-params.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-params.php
@@ -93,6 +93,7 @@ class WordAds_Params {
 			'wordads_custom_adstxt_enabled'   => false,
 			'wordads_ccpa_enabled'            => false,
 			'wordads_ccpa_privacy_policy_url' => get_option( 'wp_page_for_privacy_policy' ) ? get_permalink( (int) get_option( 'wp_page_for_privacy_policy' ) ) : '',
+			'wordads_cmp_enabled'             => false,
 		);
 
 		// Grab settings, or set as default if it doesn't exist.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -211,6 +211,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wordads_custom_adstxt_enabled'                => false,
 			'wordads_ccpa_enabled'                         => false,
 			'wordads_ccpa_privacy_policy_url'              => 'pineapple',
+			'wordads_cmp_enabled'                          => false,
 			'woocommerce_custom_orders_table_enabled'      => false,
 			'site_user_type'                               => wp_json_encode( array( 1 => 'pineapple' ) ),
 			'site_segment'                                 => 'pineapple',

--- a/projects/plugins/migration/changelog/add-cmp-ad-settings
+++ b/projects/plugins/migration/changelog/add-cmp-ad-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1543,7 +1543,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dec31f79e5cf8945b45b67e13b386184d0775c7a"
+                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1575,7 +1575,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.7.x-dev"
+                    "dev-trunk": "2.8.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/add-cmp-ad-settings
+++ b/projects/plugins/protect/changelog/add-cmp-ad-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1456,7 +1456,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dec31f79e5cf8945b45b67e13b386184d0775c7a"
+                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1488,7 +1488,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.7.x-dev"
+                    "dev-trunk": "2.8.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-cmp-ad-settings
+++ b/projects/plugins/search/changelog/add-cmp-ad-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1544,7 +1544,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dec31f79e5cf8945b45b67e13b386184d0775c7a"
+                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1576,7 +1576,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.7.x-dev"
+                    "dev-trunk": "2.8.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-cmp-ad-settings
+++ b/projects/plugins/social/changelog/add-cmp-ad-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1476,7 +1476,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "dec31f79e5cf8945b45b67e13b386184d0775c7a"
+				"reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1508,7 +1508,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.7.x-dev"
+					"dev-trunk": "2.8.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/starter-plugin/changelog/add-cmp-ad-settings
+++ b/projects/plugins/starter-plugin/changelog/add-cmp-ad-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1399,7 +1399,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dec31f79e5cf8945b45b67e13b386184d0775c7a"
+                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1431,7 +1431,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.7.x-dev"
+                    "dev-trunk": "2.8.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/add-cmp-ad-settings
+++ b/projects/plugins/videopress/changelog/add-cmp-ad-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1399,7 +1399,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dec31f79e5cf8945b45b67e13b386184d0775c7a"
+                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1431,7 +1431,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.7.x-dev"
+                    "dev-trunk": "2.8.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
## Proposed changes:
Adds the ability to toggle the GDPR consent banner on Wordads sites under the Monetize settings. This allows the site owner to decide if they need to activate the CMP banner. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
N/A
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Enroll your test Jetpack site to WordAds, if you have not enrolled already.
* Go to Jetpack -> Settings -> Monetize tab, under the Ad section, the "Enable GDPR Consent Banner" option should be visible.
* Toggle the option on/off, and save the settings.
* Settings should save correctly
<img width="1727" alt="gdpr option" src="https://github.com/Automattic/jetpack/assets/9039613/c644d61d-3b58-4aca-aac0-a8db7c2159c3">


