### PR TITLE
Remove sharing buttons from notifications

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-sharing-buttons-from-notifications
+++ b/projects/plugins/jetpack/changelog/remove-sharing-buttons-from-notifications
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Not showing sharing buttons in notifications, emails, etc.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/sharing-buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/sharing-buttons.php
@@ -16,9 +16,28 @@ use Automattic\Jetpack\Blocks;
  * registration if we need to.
  */
 function register_block() {
-	Blocks::jetpack_register_block( __DIR__ );
+	Blocks::jetpack_register_block(
+		__DIR__,
+		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Sharing Buttons block registration/dependency declaration.
+ *
+ * @param array  $attr    Array containing the Sharing Buttons block attributes.
+ * @param string $content String containing the Sharing Buttons block content.
+ *
+ * @return string
+ */
+function render_block( $attr, $content ) {
+	// Render nothing in other contexts than frontend (i.e. feed, emails, API, etc.).
+	if ( ! jetpack_is_frontend() ) {
+		return '';
+	}
+	return $content;
+}
 
 /**
  * Add the services list to the block


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35168

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We remove Sharing Buttons from all non-frontend views (emails, notifications, etc)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use `rsync` or `bin-downloader` tools to sync changes to your sandbox
* Make sure in you hosts file (or using gasmask) your Simple site points to your sandbox, as well as backend `public-api.wordpress.com`
* Subscribe to the posts from a page
<img width="937" alt="Screenshot 2024-01-23 at 10 42 42 AM" src="https://github.com/Automattic/jetpack/assets/60262784/8d6acc9c-b16c-4c8e-aefa-dbaf755db279">
* Create new post with Sharing Buttons
<img width="670" alt="Screenshot 2024-01-23 at 10 46 06 AM" src="https://github.com/Automattic/jetpack/assets/60262784/68e4ba53-c5f4-4874-a69d-640da656af91">

* In your notifications, you should see new post without Sharing Buttons
<img width="392" alt="Screenshot 2024-01-23 at 10 46 25 AM" src="https://github.com/Automattic/jetpack/assets/60262784/b01bb201-b7a0-46a6-bf53-4258e9c6ce95">


