### PR TITLE
Untangle: Remove Site card from left nav

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-site-card-for-wp-admin
+++ b/projects/plugins/jetpack/changelog/update-remove-site-card-for-wp-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove the site card for wp-admin interface users

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -237,6 +237,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds site card component.
 	 */
 	public function add_site_card_menu() {
+		// When the interface is set to wp-admin, we not add the site_card.
+		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+			return;
+		}
 		$default        = plugins_url( 'globe-icon.svg', __FILE__ );
 		$icon           = get_site_icon_url( 32, $default );
 		$blog_name      = get_option( 'blogname' ) !== '' ? get_option( 'blogname' ) : $this->domain;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -238,7 +238,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_site_card_menu() {
 		// When the interface is set to wp-admin, we not add the site_card.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
 			return;
 		}
 		$default        = plugins_url( 'globe-icon.svg', __FILE__ );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5281

## Proposed changes:
Part of Untangle Calypso.
Remove the site card from the left nav.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/jetpack/assets/402286/488c1e37-641c-4995-9bc2-4c93392fd527) | ![image](https://github.com/Automattic/jetpack/assets/402286/804a8467-d38d-45b5-8235-ae10aed915a3) |

## Jetpack product discussion
paYJgx-4uN-p2#comment-4524

## Does this pull request change what data or activity we track or use?
NO

## Testing instructions:
* Set your `Admin interface style` to `Classic (wp-admin)` in `wordpress.com/hosting-config/site_slug`
* Go to `wp-admin`
* The Site card should not show.