### PR TITLE
Boost: Fix empty performance history on initial page load

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/performance-history/lib/hooks.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/performance-history/lib/hooks.ts
@@ -27,7 +27,12 @@ export const usePerformanceHistoryQuery = () => {
 	const [ query ] = useDataSync(
 		'jetpack_boost_ds',
 		'performance_history',
-		performanceHistoryDataSchema
+		performanceHistoryDataSchema,
+		{
+			query: {
+				staleTime: 12 * 60 * 60 * 1000, // 12 hours
+			},
+		}
 	);
 
 	return query;

--- a/projects/plugins/boost/app/assets/src/js/features/performance-history/performance-history.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/performance-history/performance-history.tsx
@@ -12,6 +12,7 @@ import { Button } from '@automattic/jetpack-components';
 import { useNavigate } from 'react-router-dom';
 import { useSingleModuleState } from '$features/module/lib/stores';
 import styles from './performance-history.module.scss';
+import { useEffect } from 'react';
 
 const PerformanceHistoryBody = () => {
 	const [ performanceHistoryState ] = useSingleModuleState( 'performance_history' );
@@ -22,6 +23,10 @@ const PerformanceHistoryBody = () => {
 		'performance_history_fresh_start'
 	);
 	const navigate = useNavigate();
+
+	useEffect( () => {
+		refetch();
+	}, [ refetch ] );
 
 	if ( isError && ! isFetching ) {
 		return (
@@ -44,7 +49,7 @@ const PerformanceHistoryBody = () => {
 			needsUpgrade={ needsUpgrade }
 			handleUpgrade={ () => navigate( '/upgrade' ) }
 			handleDismissFreshStart={ dismissFreshStart }
-			isLoading={ isFetching }
+			isLoading={ isFetching && ( ! data || data.periods.length === 0 ) }
 		/>
 	);
 };

--- a/projects/plugins/boost/app/assets/src/js/features/performance-history/performance-history.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/performance-history/performance-history.tsx
@@ -24,6 +24,9 @@ const PerformanceHistoryBody = () => {
 	);
 	const navigate = useNavigate();
 
+	/*
+	 * Fetch new data on initial page-load. This is a lazy data-sync and initially empty.
+	 */
 	useEffect( () => {
 		refetch();
 	}, [ refetch ] );

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
@@ -18,6 +18,7 @@ import styles from './speed-score.module.scss';
 import { useModulesState } from '$features/module/lib/stores';
 import { useCriticalCssState } from '$features/critical-css/lib/stores/critical-css-state';
 import { useLocalCriticalCssGeneratorStatus } from '$features/critical-css/local-generator/local-generator-provider';
+import { queryClient } from '@automattic/jetpack-react-data-sync-client';
 
 const SpeedScore = () => {
 	const { site } = Jetpack_Boost;
@@ -49,6 +50,13 @@ const SpeedScore = () => {
 			loadScore();
 		}
 	}, [ loadScore, site.online ] );
+
+	// Mark performance history data as stale when speed scores are loaded.
+	useEffect( () => {
+		if ( site.online && status === 'loaded' ) {
+			queryClient.invalidateQueries( { queryKey: [ 'performance_history' ] } );
+		}
+	}, [ site.online, status ] );
 
 	useDebouncedRefreshScore(
 		{ moduleStates, criticalCssCreated: cssState.created || 0, criticalCssIsGenerating },

--- a/projects/plugins/boost/changelog/fix-performance-history
+++ b/projects/plugins/boost/changelog/fix-performance-history
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed empty performance history on initial page load. Introduced during react migration
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35189

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fetch performance history when first mounted
* Do not show loading spinner even while loading, if there is existing data
* Refetch performance history on speed score loaded

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Upgrade to boost premium
* See performance history and wait until speed score loaded
* Make sure the history reloads when speed score is done
* Refresh the page
* Make sure performance history loads on the new page

