### PR TITLE
Boost: Remove logic to reset popup when score changes

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
@@ -2,7 +2,7 @@ import { animated, useSpring } from '@react-spring/web';
 import CloseButton from '$features/ui/close-button/close-button';
 import styles from './pop-out.module.scss';
 import { __ } from '@wordpress/i18n';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { Button } from '@wordpress/components';
 import { useDismissibleAlertState } from '$features/performance-history/lib/hooks';
 import { getRedirectUrl } from '@automattic/jetpack-components';
@@ -65,11 +65,6 @@ function PopOut( { scoreChange }: Props ) {
 	const message = scoreChange && scoreChange < 0 ? slowerMessage : fasterMessage;
 
 	/*
-	 * Track the last message shown so we can detect when it changes.
-	 */
-	const [ lastMessage, setLastMessage ] = useState< ScoreChangeMessage | null >( null );
-
-	/*
 	 * Use datasync to track which score alerts have been dismissed.
 	 * Dismissed means that the user asked to never show us this alert again.
 	 */
@@ -79,16 +74,6 @@ function PopOut( { scoreChange }: Props ) {
 	 * Hide the alert for now. The alert will show up again if the user refreshes the page.
 	 */
 	const [ isClosed, setClose ] = useState( false );
-
-	/*
-	 * If the message has changed, reset the close state.
-	 */
-	useEffect( () => {
-		if ( message.id !== lastMessage?.id ) {
-			setLastMessage( message );
-			setClose( false );
-		}
-	}, [ message, lastMessage ] );
 
 	const hideAlert = () => setClose( true );
 

--- a/projects/plugins/boost/changelog/boost-react-speed-score-popout-revert
+++ b/projects/plugins/boost/changelog/boost-react-speed-score-popout-revert
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Revert speed score popout not showing "fix".
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Revert changes made in https://github.com/Automattic/jetpack/pull/35197 as it introduced more bugs than it fixed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost;
* Request speed scores;
* Rig scores to lower/higher and check if popout behaves correctly.