### PR TITLE
Boost: Fix site health

### DIFF
--- a/projects/plugins/boost/app/lib/Boost_Health.php
+++ b/projects/plugins/boost/app/lib/Boost_Health.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack_Boost\Lib;
 
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Critical_CSS;
 
 /**
  * Class Boost_Health
@@ -50,13 +51,17 @@ class Boost_Health {
 		return $this->issues;
 	}
 
+	private static function is_critical_css_enabled() {
+		return ( new Status( Critical_CSS::get_slug() ) )->is_enabled();
+	}
+
 	/**
 	 * Check if Critical CSS needs regeneration.
 	 *
 	 * @return bool True if regeneration is needed, false otherwise.
 	 */
 	public static function critical_css_needs_regeneration() {
-		if ( Cloud_CSS::is_available() ) {
+		if ( Cloud_CSS::is_available() || ! self::is_critical_css_enabled() ) {
 			return false;
 		}
 
@@ -71,6 +76,9 @@ class Boost_Health {
 	 * @return bool True if errors are present, false otherwise.
 	 */
 	public static function critical_css_has_errors() {
+		if ( ! self::is_critical_css_enabled() ) {
+			return false;
+		}
 		return ( new Critical_CSS_State() )->has_errors();
 	}
 }

--- a/projects/plugins/boost/changelog/fix-site-health
+++ b/projects/plugins/boost/changelog/fix-site-health
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site Health: Fixed showing critical CSS issue in site-health if module is disabled


### PR DESCRIPTION
Fixes #33526

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The site health issues from critical CSS will no longer show if C.CSS is disabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Generate critical CSS
* Change a post. There should be a suggestion in Boost dashboard to regenerate C.CSS (don't regenerate).
* Navigate to site-health (wp-admin/site-health.php)
* The Critical CSS issue in site health should be visible
* Go back to Boost dashboard and disable the C.CSS module.
* The issue shouldn't be visible.

<img width="805" alt="image" src="https://github.com/Automattic/jetpack/assets/3737780/2ad240db-e779-4954-b7cb-9518765e9765">


