### PR TITLE
Jetpack Boost: Add debouncing to QualityControl properties

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2836,6 +2836,9 @@ importers:
       react-use-measure:
         specifier: 2.1.1
         version: 2.1.1(react-dom@18.2.0)(react@18.2.0)
+      use-debounce:
+        specifier: 10.0.0
+        version: 10.0.0(react@18.2.0)
       zod:
         specifier: 3.22.3
         version: 3.22.3
@@ -23967,6 +23970,15 @@ packages:
     dependencies:
       react: 18.2.0
       tslib: 2.5.0
+
+  /use-debounce@10.0.0(react@18.2.0):
+    resolution: {integrity: sha512-XRjvlvCB46bah9IBXVnq/ACP2lxqXyZj0D9hj4K5OzNroMDpTEBg8Anuh1/UfRTRs7pLhQ+RiNxxwZu9+MVl1A==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.33)(react@18.2.0):
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}

--- a/projects/plugins/boost/.prettierrc.js
+++ b/projects/plugins/boost/.prettierrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-	...require( '../../../.prettierrc.js' ),
-	plugins: [ require.resolve( 'prettier-plugin-svelte' ) ],
-	svelteStrictMode: false,
-	svelteIndentScriptAndStyle: true,
-};

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/lib/stores.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/lib/stores.ts
@@ -1,3 +1,4 @@
+import { useDebouncedState } from '$lib/utils/debounce';
 import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
 import { z } from 'zod';
 
@@ -25,6 +26,5 @@ export function useImageCdnQuality(): [ ImageCdnSettings, ( newValue: ImageCdnSe
 	if ( ! imageCdnQuality ) {
 		throw new Error( 'Image CDN Quality not loaded' );
 	}
-
-	return [ imageCdnQuality, setImageCdnQuality ];
+	return useDebouncedState( imageCdnQuality, setImageCdnQuality );
 }

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-control/quality-control.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-control/quality-control.tsx
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import styles from './quality-control.module.scss';
 import { useId } from 'react';
 import { QualityConfig } from '../lib/stores';
+import { useDebouncedState } from '$lib/utils/debounce';
 
 type QualityControlProps = {
 	label: string;
@@ -21,24 +22,31 @@ const QualityControl = ( {
 	onChange,
 }: QualityControlProps ) => {
 	const checkboxId = useId();
+	const [quality, setQuality] = useDebouncedState( config.quality, (value) => {
+		onChange( { ...config, quality: value } );
+	});
+
+	const [lossless, setLossless] = useDebouncedState( config.lossless, (value) => {
+		onChange( { ...config, lossless: value } );
+	});
 
 	return (
 		<div className={ styles[ 'quality-control' ] }>
 			<div className={ styles.label }>{ label }</div>
 			<div className={ classNames( styles.slider, { [ styles.disabled ]: config.lossless } ) }>
 				<NumberSlider
-					value={ config.quality }
+					value={ quality }
+					onChange={setQuality}
 					minValue={ minValue }
 					maxValue={ maxValue }
-					onChange={ newValue => onChange( { ...config, quality: newValue } ) }
 				/>
 			</div>
 			<label className={ styles.lossless } htmlFor={ checkboxId }>
 				<input
 					type="checkbox"
-					checked={ config.lossless }
+					checked={ lossless }
 					id={ checkboxId }
-					onChange={ event => onChange( { ...config, lossless: event.target.checked } ) }
+					onChange={ event => setLossless( event.target.checked )}
 				/>
 				{ __( 'Lossless', 'jetpack-boost' ) }
 			</label>

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-control/quality-control.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-control/quality-control.tsx
@@ -4,7 +4,6 @@ import { __ } from '@wordpress/i18n';
 import styles from './quality-control.module.scss';
 import { useId } from 'react';
 import { QualityConfig } from '../lib/stores';
-import { useDebouncedState } from '$lib/utils/debounce';
 
 type QualityControlProps = {
 	label: string;

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-control/quality-control.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-control/quality-control.tsx
@@ -22,21 +22,13 @@ const QualityControl = ( {
 	onChange,
 }: QualityControlProps ) => {
 	const checkboxId = useId();
-	const [quality, setQuality] = useDebouncedState( config.quality, (value) => {
-		onChange( { ...config, quality: value } );
-	});
-
-	const [lossless, setLossless] = useDebouncedState( config.lossless, (value) => {
-		onChange( { ...config, lossless: value } );
-	});
-
 	return (
 		<div className={ styles[ 'quality-control' ] }>
 			<div className={ styles.label }>{ label }</div>
 			<div className={ classNames( styles.slider, { [ styles.disabled ]: config.lossless } ) }>
 				<NumberSlider
-					value={ quality }
-					onChange={setQuality}
+					value={ config.quality }
+					onChange={ (value) => onChange( { ...config, quality: value } )}
 					minValue={ minValue }
 					maxValue={ maxValue }
 				/>
@@ -44,9 +36,9 @@ const QualityControl = ( {
 			<label className={ styles.lossless } htmlFor={ checkboxId }>
 				<input
 					type="checkbox"
-					checked={ lossless }
+					checked={ config.lossless }
 					id={ checkboxId }
-					onChange={ event => setLossless( event.target.checked )}
+					onChange={ event => onChange( { ...config, lossless: event.target.checked } ) }
 				/>
 				{ __( 'Lossless', 'jetpack-boost' ) }
 			</label>

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-control/quality-control.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-control/quality-control.tsx
@@ -3,31 +3,34 @@ import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import styles from './quality-control.module.scss';
 import { useId } from 'react';
-import { QualityConfig } from '../lib/stores';
 
 type QualityControlProps = {
 	label: string;
-	config: QualityConfig;
+	quality: number;
+	lossless: boolean;
+	setQuality: ( newValue: number ) => void;
+	setLossless: ( newValue: boolean ) => void;
 	maxValue: number;
 	minValue?: number;
-	onChange: ( newValue: QualityConfig ) => void;
 };
 
 const QualityControl = ( {
 	label,
-	config,
+	quality,
+	lossless,
+	setQuality,
+	setLossless,
 	maxValue,
 	minValue = 20,
-	onChange,
 }: QualityControlProps ) => {
 	const checkboxId = useId();
 	return (
 		<div className={ styles[ 'quality-control' ] }>
 			<div className={ styles.label }>{ label }</div>
-			<div className={ classNames( styles.slider, { [ styles.disabled ]: config.lossless } ) }>
+			<div className={ classNames( styles.slider, { [ styles.disabled ]: lossless } ) }>
 				<NumberSlider
-					value={ config.quality }
-					onChange={ (value) => onChange( { ...config, quality: value } )}
+					value={ quality }
+					onChange={ setQuality }
 					minValue={ minValue }
 					maxValue={ maxValue }
 				/>
@@ -35,9 +38,9 @@ const QualityControl = ( {
 			<label className={ styles.lossless } htmlFor={ checkboxId }>
 				<input
 					type="checkbox"
-					checked={ config.lossless }
+					checked={ lossless }
 					id={ checkboxId }
-					onChange={ event => onChange( { ...config, lossless: event.target.checked } ) }
+					onChange={ event => setLossless(event.target.checked) }
 				/>
 				{ __( 'Lossless', 'jetpack-boost' ) }
 			</label>

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-settings/quality-settings.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-settings/quality-settings.tsx
@@ -1,11 +1,11 @@
-import { createInterpolateElement, useCallback } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 import CollapsibleMeta from '../collapsible-meta/collapsible-meta';
 import { __, sprintf } from '@wordpress/i18n';
 import styles from './quality-settings.module.scss';
 import { IconTooltip } from '@automattic/jetpack-components';
 import QualityControl from '../quality-control/quality-control';
 import Upgraded from '$features/ui/upgraded/upgraded';
-import { type QualityConfig, imageCdnSettingsSchema, useImageCdnQuality } from '../lib/stores';
+import { imageCdnSettingsSchema, useImageCdnQuality } from '../lib/stores';
 import { z } from 'zod';
 import { Link } from 'react-router-dom';
 
@@ -25,12 +25,26 @@ const QualitySettings = ( { isPremium }: QualitySettingsProps ) => {
 
 	const [ imageCdnQuality, setImageCdnQuality ] = useImageCdnQuality();
 
-	const updateFormatQuantity = useCallback(
-		( format: 'jpg' | 'png' | 'webp', newValue: QualityConfig ) => {
-			setImageCdnQuality( { ...imageCdnQuality, [ format ]: newValue } );
-		},
-		[ imageCdnQuality, setImageCdnQuality ]
-	);
+
+	const setQuality = ( format: 'jpg' | 'png' | 'webp', newValue: number ) => {
+		setImageCdnQuality( {
+			...imageCdnQuality,
+			[ format ]: {
+				...imageCdnQuality[ format ],
+				quality: newValue,
+			},
+		} );
+	}
+
+	const setLossless = ( format: 'jpg' | 'png' | 'webp', newValue: boolean ) => {
+		setImageCdnQuality( {
+			...imageCdnQuality,
+			[ format ]: {
+				...imageCdnQuality[ format ],
+				lossless: newValue,
+			},
+		} );
+	}
 
 	return (
 		<CollapsibleMeta
@@ -41,21 +55,27 @@ const QualitySettings = ( { isPremium }: QualitySettingsProps ) => {
 		>
 			<QualityControl
 				label={ __( 'JPEG', 'jetpack-boost' ) }
-				config={ imageCdnQuality.jpg as QualityConfig }
 				maxValue={ 89 }
-				onChange={ newValue => updateFormatQuantity( 'jpg', newValue ) }
+				quality={ imageCdnQuality.jpg.quality }
+				lossless={ imageCdnQuality.jpg.lossless }
+				setQuality={(value) => setQuality('jpg', value)}
+				setLossless={(value) => setLossless('jpg', value)}
 			/>
 			<QualityControl
 				label={ __( 'PNG', 'jetpack-boost' ) }
-				config={ imageCdnQuality.png as QualityConfig }
 				maxValue={ 80 }
-				onChange={ newValue => updateFormatQuantity( 'png', newValue ) }
+				quality={ imageCdnQuality.png.quality }
+				lossless={ imageCdnQuality.png.lossless }
+				setQuality={(value) => setQuality('png', value)}
+				setLossless={(value) => setLossless('png', value)}
 			/>
 			<QualityControl
 				label={ __( 'WEBP', 'jetpack-boost' ) }
-				config={ imageCdnQuality.webp as QualityConfig }
 				maxValue={ 80 }
-				onChange={ newValue => updateFormatQuantity( 'webp', newValue ) }
+				quality={ imageCdnQuality.webp.quality }
+				lossless={ imageCdnQuality.webp.lossless }
+				setQuality={(value) => setQuality('webp', value)}
+				setLossless={(value) => setLossless('webp', value)}
 			/>
 		</CollapsibleMeta>
 	);

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/lib/hooks.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/lib/hooks.ts
@@ -1,7 +1,7 @@
 import { requestSpeedScores } from '@automattic/jetpack-boost-score-api';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import { castToString } from '$lib/utils/cast-to-string';
-import debounce from '$lib/utils/debounce';
+import { debounce } from '$lib/utils/debounce';
 import { useState, useCallback, useEffect, useMemo, useReducer } from 'react';
 
 type SpeedScoreState = {

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/debounce.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/debounce.ts
@@ -19,10 +19,9 @@ export function debounce( callback: CallbackFunction, wait: number ): CallbackFu
 
 	return function ( ...args ) {
 		clearTimeout( timer );
-		timer = setTimeout( () => callback(...args), wait );
+		timer = setTimeout( () => callback( ...args ), wait );
 	};
 }
-
 
 /**
  * State hook that debounces a side effect on state change.
@@ -32,14 +31,24 @@ export function debounce( callback: CallbackFunction, wait: number ): CallbackFu
  * @param sideEffect   - side effect function that should run only after the state has not changed for the delay
  * @param delay        - debounce delay in milliseconds
  */
-export function useDebouncedState<T>(initialValue: T, sideEffect: (v: T) => void, delay: number = 1000): [T, (v: T) => void] {
-	const [value, setValueState] = useState<T>(initialValue);
-	const debouncedSetValue = useDebouncedCallback(sideEffect, delay, { leading: true, trailing: true });
+export function useDebouncedState< T >(
+	initialValue: T,
+	sideEffect: ( v: T ) => void,
+	delay: number = 1000
+): [ T, ( v: T ) => void ] {
+	const [ value, setValueState ] = useState< T >( initialValue );
+	const debouncedSetValue = useDebouncedCallback( sideEffect, delay, {
+		leading: true,
+		trailing: true,
+	} );
 
-	const setValue = useCallback( (newValue: T) => {
-		setValueState(newValue);
-		debouncedSetValue(newValue);
-	}, [debouncedSetValue]);
+	const setValue = useCallback(
+		( newValue: T ) => {
+			setValueState( newValue );
+			debouncedSetValue( newValue );
+		},
+		[ debouncedSetValue ]
+	);
 
-	return [value, setValue];
+	return [ value, setValue ];
 }

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/debounce.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/debounce.ts
@@ -1,3 +1,6 @@
+import { useCallback, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CallbackFunction = ( ...args: any[] ) => void;
 
@@ -18,4 +21,25 @@ export function debounce( callback: CallbackFunction, wait: number ): CallbackFu
 		clearTimeout( timer );
 		timer = setTimeout( () => callback(...args), wait );
 	};
+}
+
+
+/**
+ * State hook that debounces a side effect on state change.
+ * This is useful for side effects like mutations (API Calls) when the UI is changing rapidly.
+ *
+ * @param initialValue - initial value for the state
+ * @param sideEffect   - side effect function that should run only after the state has not changed for the delay
+ * @param delay        - debounce delay in milliseconds
+ */
+export function useDebouncedState<T>(initialValue: T, sideEffect: (v: T) => void, delay: number = 1000): [T, (v: T) => void] {
+	const [value, setValueState] = useState<T>(initialValue);
+	const debouncedSetValue = useDebouncedCallback(sideEffect, delay, { leading: true, trailing: true });
+
+	const setValue = useCallback( (newValue: T) => {
+		setValueState(newValue);
+		debouncedSetValue(newValue);
+	}, [debouncedSetValue]);
+
+	return [value, setValue];
 }

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/debounce.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/debounce.ts
@@ -11,11 +11,11 @@ type CallbackFunction = ( ...args: any[] ) => void;
  * @param {number}   wait     Number of milliseconds to wait.
  * @return {Function} Debounced function.
  */
-export default function debounce( callback: CallbackFunction, wait: number ): CallbackFunction {
+export function debounce( callback: CallbackFunction, wait: number ): CallbackFunction {
 	let timer: number;
 
 	return function ( ...args ) {
 		clearTimeout( timer );
-		timer = setTimeout( () => callback.apply( this, args ), wait );
+		timer = setTimeout( () => callback(...args), wait );
 	};
 }

--- a/projects/plugins/boost/changelog/boost-update-debounce-sliders
+++ b/projects/plugins/boost/changelog/boost-update-debounce-sliders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Boost: Enhanced performance by debouncing QualityControl properties

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -22,6 +22,7 @@
 		"prettier": "npm:wp-prettier@3.0.3",
 		"react-router-dom": "6.21.0",
 		"react-use-measure": "2.1.1",
+		"use-debounce": "10.0.0",
 		"zod": "3.22.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Proposed changes:
- Created and implemented `useDebouncedState` hook for image CDN quality controls
- Updated debounce utility to be a named export
- Added `use-debounce` package to handle debouncing in React components

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Verify that changes to the image quality slider and lossless checkbox in the image CDN quality controls are debounced
- Ensure that other features using the debounce utility continue to work correctly
- Confirm that the new use-debounce package has been added correctly to the package.json and pnpm-lock.yaml files