### PR TITLE
My Jetpack: Update the UpsellBanner component to use the Card component from WP

### DIFF
--- a/projects/js-packages/components/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/js-packages/components/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update the UpsellBanner to use the Card component from WP components.

--- a/projects/js-packages/components/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/js-packages/components/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update the UpsellBanner to use the Card component from WP components.

--- a/projects/packages/my-jetpack/_inc/components/upsell-banner/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/upsell-banner/index.jsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/jetpack-components';
+import { Card, CardBody } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import React from 'react';
-import { CardWrapper } from '../card';
 
 import './style.scss';
 
@@ -31,45 +31,47 @@ const UpsellBanner = props => {
 	} = props;
 
 	return (
-		<CardWrapper className="upsell-banner">
-			{ icon && (
-				<div className="upsell-banner--icon">
-					<img src={ icon } alt="" />
+		<Card isRounded={ true } size="large">
+			<CardBody className="upsell-banner" size="large">
+				{ icon && (
+					<div className="upsell-banner--icon">
+						<img src={ icon } alt="" />
+					</div>
+				) }
+				<div className="upsell-banner--content">
+					<div className="upsell-banner--content-info">
+						<h3>{ title }</h3>
+						<p>
+							{ createInterpolateElement( description, {
+								br: <br />,
+							} ) }
+						</p>
+					</div>
+					<div className="upsell-banner--content-cta">
+						{ secondaryCtaLabel && secondaryCtaURL && (
+							<Button
+								className="upsell-banner--content-cta-button secondary"
+								href={ secondaryCtaURL }
+								onClick={ secondaryCtaOnClick ?? null }
+								isExternalLink={ secondaryCtaIsExternalLink }
+							>
+								{ secondaryCtaLabel }
+							</Button>
+						) }
+						{ primaryCtaLabel && primaryCtaURL && (
+							<Button
+								className="upsell-banner--content-cta-button primary"
+								href={ primaryCtaURL }
+								onClick={ primaryCtaOnClick ?? null }
+								isExternalLink={ primaryCtaIsExternalLink }
+							>
+								{ primaryCtaLabel }
+							</Button>
+						) }
+					</div>
 				</div>
-			) }
-			<div className="upsell-banner--content">
-				<div className="upsell-banner--content-info">
-					<h3>{ title }</h3>
-					<p>
-						{ createInterpolateElement( description, {
-							br: <br />,
-						} ) }
-					</p>
-				</div>
-				<div className="upsell-banner--content-cta">
-					{ secondaryCtaLabel && secondaryCtaURL && (
-						<Button
-							className="upsell-banner--content-cta-button secondary"
-							href={ secondaryCtaURL }
-							onClick={ secondaryCtaOnClick ?? null }
-							isExternalLink={ secondaryCtaIsExternalLink }
-						>
-							{ secondaryCtaLabel }
-						</Button>
-					) }
-					{ primaryCtaLabel && primaryCtaURL && (
-						<Button
-							className="upsell-banner--content-cta-button primary"
-							href={ primaryCtaURL }
-							onClick={ primaryCtaOnClick ?? null }
-							isExternalLink={ primaryCtaIsExternalLink }
-						>
-							{ primaryCtaLabel }
-						</Button>
-					) }
-				</div>
-			</div>
-		</CardWrapper>
+			</CardBody>
+		</Card>
 	);
 };
 

--- a/projects/packages/my-jetpack/_inc/components/upsell-banner/style.scss
+++ b/projects/packages/my-jetpack/_inc/components/upsell-banner/style.scss
@@ -1,13 +1,21 @@
+.components-surface.components-card {
+  border-radius: var(--jp-border-radius-rna);
+}
+
 .upsell-banner {
 	display: flex;
 	flex-direction: column;
-	padding: 36px;
 
 	background: rgb(249, 249, 246);
 	background: linear-gradient(133deg, rgb(206, 217, 242) 0%, rgb(249, 249, 246) 10%, rgb(249, 249, 246) 80%, rgb(245, 230, 179) 100%);
   
     @media screen and (min-width: 660px) {
 		flex-direction: row;
+	}
+
+    &.components-card__body.components-card-body {
+		border-radius: var(--jp-border-radius-rna);
+		padding: 36px;
 	}
 
 	.upsell-banner--icon {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update the UpsellBanner to use the Card component from WP components.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -76,7 +76,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.6.x-dev"
+			"dev-trunk": "4.7.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.6.2",
+	"version": "4.7.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -34,7 +34,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.6.2';
+	const PACKAGE_VERSION = '4.7.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/backup/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/plugins/backup/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0ee01ddf6b05477477f92987e200d72431580389"
+                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1017,7 +1017,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.6.x-dev"
+                    "dev-trunk": "4.7.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/plugins/boost/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1047,7 +1047,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0ee01ddf6b05477477f92987e200d72431580389"
+                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1079,7 +1079,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.6.x-dev"
+                    "dev-trunk": "4.7.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1681,7 +1681,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "0ee01ddf6b05477477f92987e200d72431580389"
+				"reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1713,7 +1713,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.6.x-dev"
+					"dev-trunk": "4.7.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/plugins/migration/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0ee01ddf6b05477477f92987e200d72431580389"
+                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1017,7 +1017,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.6.x-dev"
+                    "dev-trunk": "4.7.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/plugins/protect/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -898,7 +898,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0ee01ddf6b05477477f92987e200d72431580389"
+                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -930,7 +930,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.6.x-dev"
+                    "dev-trunk": "4.7.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/plugins/search/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0ee01ddf6b05477477f92987e200d72431580389"
+                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.6.x-dev"
+                    "dev-trunk": "4.7.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/plugins/social/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -841,7 +841,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "0ee01ddf6b05477477f92987e200d72431580389"
+				"reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.6.x-dev"
+					"dev-trunk": "4.7.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0ee01ddf6b05477477f92987e200d72431580389"
+                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.6.x-dev"
+                    "dev-trunk": "4.7.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/plugins/videopress/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0ee01ddf6b05477477f92987e200d72431580389"
+                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.6.x-dev"
+                    "dev-trunk": "4.7.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-manage/issues/254

## Proposed changes:

This PR updates the `UpsellBanner` component to use the `Card` component from `@wordpress/jetpack-components`. This PR is the first step and part of the work to extract the `UpsellBanner` component from `my-jetpack/components` to `@automattic/components` to be reusable outside of My Jetpack, in the Jetpack plugin sections.

The PR introduces the `Card` (top wrapper) and the `CardBody` (the wrapper for the banner). The styles were updated to match the current design (the border-radius and padding).

![image](https://github.com/Automattic/jetpack/assets/9832440/db8731a5-d6de-4d07-ac74-391289643b09)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

The work to do: https://github.com/Automattic/jetpack-manage/issues/238
About to extract components: p1706097984566499-slack-CBG1CP4EN

**PRs:** 1 of 3

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Check the code
- Apply this change
- Check that the design is the same as the current one, without any noticeable difference.