### PR TITLE
Add woocommerce options to sync

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/woo-add-options-to-sync
+++ b/projects/packages/jetpack-mu-wpcom/changelog/woo-add-options-to-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add a specific option to force run headstart after transfer.

--- a/projects/packages/jetpack-mu-wpcom/src/common/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/index.php
@@ -29,3 +29,26 @@ function get_iso_639_locale( $language ) {
 
 	return $language;
 }
+
+/**
+ * Add Woo specific options to Jetpack Sync.
+ *
+ * @param array $allowed_options The allowed options.
+ */
+function add_woo_options_to_jetpack_sync( $allowed_options ) {
+	// We are not either in Simple or Atomic
+	if ( ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
+		return $allowed_options;
+	}
+
+	if ( ! ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
+		return $allowed_options;
+	}
+
+	if ( ! is_array( $allowed_options ) ) {
+		return $allowed_options;
+	}
+
+	return array_merge( $allowed_options, array( 'woocommerce_should_run_headstart_for_theme' ) );
+}
+add_filter( 'jetpack_sync_options_whitelist', 'add_woo_options_to_jetpack_sync', 10, 1 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/85793

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds option to sync so the `woocommerce_should_run_headstart_for_theme` is brought over to the AT site after transfer.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start by setting up a WoA dev blog
* Apply this PR on your WoA site. 
*  Remember to edit your `~/htdocs/wp-config.php` if using Jetpack Beta Tester plugin
```
define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );
```
* In one terminal window, open up an SSH session to your WPCOM sandbox
* On your Atomic dev site, run the following commands to delete and then re-add the relevant options:
  - `wp option update woocommerce_should_run_headstart_for_theme yes`
* Now go to the site in this comment and look for your site id: p1687789079246689/1687552631.470649-slack-C0Q664T29
* Filter

