### PR TITLE
webpack-config: Auto-set textdomain for I18nLoaderPlugin

### DIFF
--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -187,8 +187,6 @@ This provides an instance of [@wordpress/dependency-extraction-webpack-plugin](h
 
 This provides an instance of [@automattic/i18n-loader-webpack-plugin](https://www.npmjs.com/package/@automattic/i18n-loader-webpack-plugin). The `options` are passed to the plugin.
 
-Note that if the plugin actually does anything in your build, you'll need to specify at least the `domain` option for it.
-
 ##### `I18nCheckPlugin( options )`
 
 This provides an instance of [@wordpress/i18n-check-webpack-plugin](https://www.npmjs.com/package/@wordpress/i18n-check-webpack-plugin). The `options` are passed to the plugin.

--- a/projects/js-packages/webpack-config/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
+++ b/projects/js-packages/webpack-config/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Automatically determine text domain for `I18nLoaderPlugin` as is done for `I18nCheckPlugin`.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.0.5",
+	"version": "3.1.0-alpha",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/search/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
+++ b/projects/packages/search/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Let webpack-config load the I18nLoaderPlugin textdomain from composer.json.
+
+

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.41.1",
+	"version": "0.41.2-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.41.1';
+	const VERSION = '0.41.2-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/tools/webpack.customberg.config.js
+++ b/projects/packages/search/tools/webpack.customberg.config.js
@@ -31,7 +31,6 @@ module.exports = {
 	plugins: [
 		...jetpackWebpackConfig.StandardPlugins( {
 			DependencyExtractionPlugin: { injectPolyfill: true },
-			I18nLoaderPlugin: { textdomain: 'jetpack-search-pkg' },
 		} ),
 		definePaletteColorsAsStaticVariables(),
 	],

--- a/projects/packages/search/tools/webpack.instant.config.js
+++ b/projects/packages/search/tools/webpack.instant.config.js
@@ -64,7 +64,6 @@ module.exports = {
 				requestToExternal,
 				requestToHandle: defaultRequestToHandle,
 			},
-			I18nLoaderPlugin: { textdomain: 'jetpack-search-pkg' },
 		} ),
 		// Replace 'debug' module with a dummy implementation in production
 		...( jetpackWebpackConfig.isDevelopment

--- a/projects/plugins/jetpack/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
+++ b/projects/plugins/jetpack/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Let webpack-config load the I18nLoaderPlugin textdomain from composer.json.
+
+

--- a/projects/plugins/jetpack/tools/webpack.config.widget-visibility.js
+++ b/projects/plugins/jetpack/tools/webpack.config.widget-visibility.js
@@ -33,7 +33,6 @@ module.exports = {
 	plugins: [
 		...jetpackWebpackConfig.StandardPlugins( {
 			DependencyExtractionPlugin: { injectPolyfill: true },
-			I18nLoaderPlugin: { textdomain: 'jetpack' },
 		} ),
 		definePaletteColorsAsStaticVariables(),
 	],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We already pull the expected text domain for I18nCheckPlugin from composer.json in the usual case where it's not already set. Let's do the same for I18nLoaderPlugin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None linkable

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is the build happy?
* There should be no relevant changes in the build artifacts.