### PR TITLE
AI Assistant: fix discard handler

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-discard-handler
+++ b/projects/plugins/jetpack/changelog/fix-ai-discard-handler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: fix discard handler so we don't need to call discard + accept

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -316,7 +316,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		}
 	};
 
-	const handleAcceptContent = async () => {
+	const replaceContent = async () => {
 		let newGeneratedBlocks = [];
 		if ( ! useGutenbergSyntax ) {
 			/*
@@ -350,6 +350,11 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		}
 	};
 
+	const handleAcceptContent = () => {
+		replaceContent();
+		tracks.recordEvent( 'jetpack_ai_assistant_block_accept', { feature: 'ai-assistant' } );
+	};
+
 	const handleAcceptTitle = () => {
 		if ( isInBlockEditor ) {
 			editPost( { title: attributes.content ? attributes.content.trim() : '' } );
@@ -359,7 +364,8 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		}
 	};
 
-	const handleTryAgain = () => {
+	const handleDiscard = () => {
+		const isDismiss = attributes?.content === getBlock( clientId ).attributes?.content;
 		setAttributes( {
 			content: attributes?.originalContent,
 			promptType: undefined,
@@ -563,7 +569,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					onSend={ handleSend }
 					onStop={ handleStopSuggestion }
 					onAccept={ handleAccept }
-					onDiscard={ handleTryAgain }
+					onDiscard={ handleDiscard }
 					state={ requestingState }
 					isTransparent={ requireUpgrade || ! connected }
 					showButtonLabels={ ! isMobileViewport }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -371,6 +371,12 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 			promptType: undefined,
 			messages: attributes?.originalMessages,
 		} );
+		replaceContent();
+		if ( isDismiss ) {
+			tracks.recordEvent( 'jetpack_ai_assistant_block_dismiss' );
+		} else {
+			tracks.recordEvent( 'jetpack_ai_assistant_block_discard', { feature: 'ai-assistant' } );
+		}
 	};
 
 	const handleStopSuggestion = () => {


### PR DESCRIPTION
Our current discard handler is outdated and requires the caller to perform the discard and accept in quick succession.

Fixes #

## Proposed changes:
This PR makes discard handler actually handle a discard instead of having to call discard+accept.
This will have a secondary effect of, while this is shipped, the AI Control to fire both events (no collateral damage).
A follow up PR will be up to update AI Control package (TBD)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
On the editor:

- use the AI Assistant button on a paragraph or list. Once the prompt shows, click "Cancel". AI Assistant should be gone and original content should not be changed
- use the AI Assistant button on a paragraph or list, ask for some change. Once the request comes back, click the trash icon button (Discard). The original content should be reinstated
- use the AI Assisstant button on a paragraph or list, choose an option on the dropdown menu. Once the request finishes, click the trash icon button (Discard). Original content should be reinstated
- insert an AI Assistant block, ask for some content ("haiku on something"). Once the request finishes, click the trash icon button (Discard). AI Assistant and generated content should be removed

See: p1706131953263809-slack-C054LN8RNVA