### PR TITLE
Doc Parser: Fix Broken Links

### DIFF
--- a/tools/cli/helpers/doc-parser/docs.json
+++ b/tools/cli/helpers/doc-parser/docs.json
@@ -5,6 +5,7 @@
 			"CODE-OF-CONDUCT.md",
 			"docs/coding-guidelines.md",
 			"docs/development-environment.md",
+			"docs/pull-request.md",
 			"docs/git-workflow.md",
 			"docs/monorepo.md",
 			"docs/quick-start.md",

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -12,9 +12,9 @@ use Michelf\Markdown;
  */
 require __DIR__ . '/vendor/autoload.php';
 
-$args = array_slice( $argv, 1 );
-// $parser = new \Automattic\Jetpack\Doc_Parser();
-// $parser->generate( array( $args, 'phpdoc.json' ) );
+$args   = array_slice( $argv, 1 );
+$parser = new \Automattic\Jetpack\Doc_Parser();
+$parser->generate( array( $args, 'phpdoc.json' ) );
 
 $docs_json = json_decode( file_get_contents( __DIR__ . '/docs.json' ), true );
 
@@ -112,8 +112,6 @@ function get_html_from_markdown( $file_path ) {
 		if ( ! str_starts_with( $link['path'], 'http' ) ) {
 			$link['path'] = str_replace( '.md', '-md', $link['path'] );
 		}
-
-		// This is unfinished, there are still many variations in the kind of slugs we might have.
 
 		echo( $link['path'] . ( isset( $link['fragment'] ) ? '#' . $link['fragment'] : '' ) . PHP_EOL );
 	}

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -127,6 +127,20 @@ function get_html_from_markdown( $file_path ) {
 		$headers[0]->remove();
 	}
 
+	// Add IDs to all headers.
+	$headers_ids = array();
+	for ( $i = 1; $i <= 6; $i++ ) {
+		$elements = $document->getElementsByTagName( 'h' . $i );
+		foreach ( $elements as $element ) {
+			$headers_ids[] = $element;
+		}
+	}
+	foreach ( $headers_ids as $header ) {
+		$header_id = strtolower( str_replace( ' ', '-', $header->textContent ) );
+		$header_id = preg_replace( '/[^A-Za-z0-9\-]/', '', $header_id );
+		$header->setAttribute( 'id', $header_id );
+	}
+
 	return array(
 		'path'    => $file_path,
 		'title'   => $doc_title,

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -107,7 +107,7 @@ function get_html_from_markdown( $file_path ) {
 			str_starts_with( $file_path, 'docs/' ) ) &&
 			substr_count( $link['path'], '/' ) <= 2 ) {
 				$link['path'] = str_replace( array( './docs/', '/docs/', './' ), '', $link['path'] );
-				$link['path'] = 'docs-' . $link['path'];
+				$link['path'] = '/docs-' . $link['path'];
 		}
 
 		// Replace any non-github path endings with -md to link to the correct document page.

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -81,7 +81,7 @@ function get_html_from_markdown( $file_path ) {
 			continue;
 		}
 
-		// Replace any relative links with absolute links to the GitHub repo.
+		// Replace any relative links with absolute links to the GitHub repo. If it's deeper than 2 levels, it's a link to a file in the repo.
 		if ( str_starts_with( $link['path'], '../' ) ||
 			str_starts_with( $link['path'], '/projects/' ) ||
 			( substr_count( $link['path'], '/' ) > 2 ) ) {
@@ -91,6 +91,7 @@ function get_html_from_markdown( $file_path ) {
 					$link['path'];
 		}
 
+		// Handle docs that just live in github, ending in anything other than .md.
 		$extension = pathinfo( $link['path'], PATHINFO_EXTENSION );
 		if ( ( $extension !== 'md' || $extension === '' ) &&
 			! str_starts_with( $link['path'], 'http' ) ) {
@@ -109,6 +110,7 @@ function get_html_from_markdown( $file_path ) {
 				$link['path'] = 'docs-' . $link['path'];
 		}
 
+		// Replace any non-github path endings with -md to link to the correct document page.
 		if ( ! str_starts_with( $link['path'], 'http' ) ) {
 			$link['path'] = str_replace( '.md', '-md', $link['path'] );
 		}

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -115,7 +115,9 @@ function get_html_from_markdown( $file_path ) {
 			$link['path'] = str_replace( '.md', '-md', $link['path'] );
 		}
 
-		echo( $link['path'] . ( isset( $link['fragment'] ) ? '#' . $link['fragment'] : '' ) . PHP_EOL );
+		// Set the parsed attribute.
+		$anchor->setAttribute( 'href', $link['path'] . ( isset( $link['fragment'] ) ? '#' . $link['fragment'] : '' ) );
+
 	}
 	$headers = $document->getElementsByTagName( 'h1' );
 	if ( count( $headers ) ) {

--- a/tools/cli/helpers/doc-parser/runner.php
+++ b/tools/cli/helpers/doc-parser/runner.php
@@ -85,7 +85,7 @@ function get_html_from_markdown( $file_path ) {
 		if ( str_starts_with( $link['path'], '../' ) ||
 			str_starts_with( $link['path'], '/projects/' ) ||
 			( substr_count( $link['path'], '/' ) > 2 ) ) {
-				$link['path'] = preg_replace( '~^(\./|../)~', '', $link['path'], 1 );
+				$link['path'] = preg_replace( '~^(\./|../)~', '', $link['path'], 1 ); // Remove leading ./ or ../
 				$link['path'] = 'https://github.com/Automattic/jetpack/blob/trunk' .
 					( ! str_starts_with( $link['path'], '/' ) ? '/' : '' ) .
 					$link['path'];
@@ -95,7 +95,7 @@ function get_html_from_markdown( $file_path ) {
 		$extension = pathinfo( $link['path'], PATHINFO_EXTENSION );
 		if ( ( $extension !== 'md' || $extension === '' ) &&
 			! str_starts_with( $link['path'], 'http' ) ) {
-				$link['path'] = preg_replace( '~^(\./|/)~', '', $link['path'], 1 );
+				$link['path'] = preg_replace( '~^(\./|/)~', '', $link['path'], 1 ); // Remove leading ./ or /
 				$link['path'] = 'https://github.com/Automattic/jetpack/blob/trunk/' .
 					( str_contains( $link['path'], 'examples/' ) ? 'docs/' : '' ) .
 					$link['path'];
@@ -119,6 +119,7 @@ function get_html_from_markdown( $file_path ) {
 		$anchor->setAttribute( 'href', $link['path'] . ( isset( $link['fragment'] ) ? '#' . $link['fragment'] : '' ) );
 
 	}
+
 	$headers = $document->getElementsByTagName( 'h1' );
 	if ( count( $headers ) ) {
 		$doc_title = $headers[0]->textContent;


### PR DESCRIPTION
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fixes the doc parser so that links redirect properly either to the github links or to the appropriate place on the developer site. 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
tbd
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Run `jetpack docs`
- scp the markdown.json file onto your sandbox
- run `wp --url=YOURSITE--user=USERNAME phpdoc import markdown.json --docs-only`

The links should work on whatever site you import to. 