### PR TITLE
AI Client: remove call to accept handler from discard handler

### DIFF
--- a/projects/js-packages/ai-client/changelog/remove-ai-client-accept-on-discard-handler
+++ b/projects/js-packages/ai-client/changelog/remove-ai-client-accept-on-discard-handler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Control: do not call onAccept from the discard handler. A fix has been put in place on #35236

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.4.1",
+	"version": "0.5.0-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -118,7 +118,6 @@ export function AIControl(
 
 	const discardHandler = useCallback( () => {
 		onDiscard?.();
-		onAccept?.();
 	}, [] );
 
 	const cancelEdit = useCallback( () => {


### PR DESCRIPTION
See #35236

## Proposed changes:
This PR removes the call to accept handler from within the discard handler. It's a follow up only to be merged and shipped after the change on #35236 is in place.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Repeat test instructions on #35236 
