### PR TITLE
Boost: Fix Boost_API deprecated method

### DIFF
--- a/projects/packages/boost-core/changelog/fix-boost-client-deprecation
+++ b/projects/packages/boost-core/changelog/fix-boost-client-deprecation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Chaged get_client() visibility so that older versions of boost do not break

--- a/projects/packages/boost-core/package.json
+++ b/projects/packages/boost-core/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-boost-core",
-	"version": "0.2.3",
+	"version": "0.2.4-alpha",
 	"description": "Core functionality for boost and relevant packages to depend on",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/boost-core/#readme",
 	"bugs": {

--- a/projects/packages/boost-core/src/lib/class-boost-api.php
+++ b/projects/packages/boost-core/src/lib/class-boost-api.php
@@ -24,11 +24,21 @@ class Boost_API {
 	private static $api_client;
 
 	/**
+	 * Get the API client instance.
+	 *
+	 * @return Boost_API_Client
+	 * @deprecated $$next_version$$ Use get(), and post() directly instead.
+	 */
+	public static function get_client() {
+		return self::get_api_client();
+	}
+
+	/**
 	 * Instantiate the API client.
 	 *
 	 * @return Boost_API_Client
 	 */
-	private static function get_client() {
+	private static function get_api_client() {
 		if ( ! self::$api_client ) {
 			$class            = apply_filters( 'jetpack_boost_api_client_class', WPCOM_Boost_API_Client::class );
 			self::$api_client = new $class();
@@ -45,7 +55,7 @@ class Boost_API {
 	 * @return array|\WP_Error
 	 */
 	public static function get( $path, $query = array(), $args = null ) {
-		return self::get_client()->get( $path, $query, self::merge_args( $args ) );
+		return self::get_api_client()->get( $path, $query, self::merge_args( $args ) );
 	}
 
 	/**
@@ -57,7 +67,7 @@ class Boost_API {
 	 * @return mixed
 	 */
 	public static function post( $path, $payload = array(), $args = null ) {
-		return self::get_client()->post( $path, $payload, self::merge_args( $args ) );
+		return self::get_api_client()->post( $path, $payload, self::merge_args( $args ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
* Do not make `Boost_API::get_client()` private.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1706148770094439-slack-C03TY6J1A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
None