### PR TITLE
Verbum: Fix Block Editor cache buster

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-cache-buster
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-cache-buster
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum cache buster depended on build_meta, which is only updated on production builds. It doesn't refresh during development, giving you a stale block-editor bundle. 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -174,7 +174,9 @@ class Verbum_Comments {
 		$post_id = isset( $_GET['postid'] ) ? intval( $_GET['postid'] ) : get_queried_object_id();
 		$locale  = get_locale();
 
-		$vbe_cache_buster = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/build_meta.json' );
+		$js_mtime         = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.css' );
+		$css_mtime        = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.min.js' );
+		$vbe_cache_buster = max( $js_mtime, $css_mtime );
 
 		wp_add_inline_script(
 			'verbum-settings',

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -174,8 +174,8 @@ class Verbum_Comments {
 		$post_id = isset( $_GET['postid'] ) ? intval( $_GET['postid'] ) : get_queried_object_id();
 		$locale  = get_locale();
 
-		$js_mtime         = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.css' );
-		$css_mtime        = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.min.js' );
+		$css_mtime        = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.css' );
+		$js_mtime         = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.min.js' );
 		$vbe_cache_buster = max( $js_mtime, $css_mtime );
 
 		wp_add_inline_script(


### PR DESCRIPTION
Currently, the Verbum relies on the block editor's build_meta file to determine when was the block-editor bundle was last updated. But this file is only generated during production builds and isn't touched during development.

This means that developers who run `yarn dev --sync` in [here](https://github.com/Automattic/wp-calypso/blob/trunk/packages/verbum-block-editor/README.md) will not see their changes taking effect due to the outdated cache buster. 

## Proposed changes:
Depend on the actual files to bust the cache. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Sync this with your sandbox using the instructions [below](https://github.com/Automattic/jetpack/pull/35243#issuecomment-1909995617). Only Simple sites are relevant here.
2. Go to Calypso and run `yarn dev --sync` in `packages/verbum-block-editor`.
3. Visit a blog post like this: https://punsintended418746564.wordpress.com/2023/12/12/fresh-post/
4. Open DevTools then click the comment area to load the editor.
5. The `ver` param of `https://widgets.wp.com/verbum-block-editor/block-editor.min.js?from=jetpack&ver=1706181925` should contain a fresh timestamp.

