### PR TITLE
Backport mu-wpcom-plugin 2.0.16, jetpack 13.1-a.7 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-01-25
+### Changed
+- AI Control: Do not call onAccept from the discard handler. A fix has been put in place on #35236. [#35238]
+
 ## [0.4.1] - 2024-01-22
 ### Changed
 - Update dependencies. [#35117]
@@ -191,6 +195,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.5.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.3.0...v0.3.1

--- a/projects/js-packages/ai-client/changelog/remove-ai-client-accept-on-discard-handler
+++ b/projects/js-packages/ai-client/changelog/remove-ai-client-accept-on-discard-handler
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-AI Control: do not call onAccept from the discard handler. A fix has been put in place on #35236

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.5.0-alpha",
+	"version": "0.5.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.0 - 2024-01-25
+### Added
+- Automatically determine text domain for `I18nLoaderPlugin` as is done for `I18nCheckPlugin`. [#35231]
+
 ## 3.0.5 - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]

--- a/projects/js-packages/webpack-config/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
+++ b/projects/js-packages/webpack-config/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Automatically determine text domain for `I18nLoaderPlugin` as is done for `I18nCheckPlugin`.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.1.0-alpha",
+	"version": "3.1.0",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/boost-core/CHANGELOG.md
+++ b/projects/packages/boost-core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2024-01-25
+### Fixed
+- Chage get_client() visibility so that older versions of boost do not break. [#35240]
+
 ## [0.2.3] - 2024-01-22
 ### Added
 - Send current boost version with API requests to handle requests accordingly [#35132]
@@ -41,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduce new package. [#31163]
 
+[0.2.4]: https://github.com/Automattic/jetpack-boost-core/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/Automattic/jetpack-boost-core/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Automattic/jetpack-boost-core/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Automattic/jetpack-boost-core/compare/v0.2.0...v0.2.1

--- a/projects/packages/boost-core/changelog/fix-boost-client-deprecation
+++ b/projects/packages/boost-core/changelog/fix-boost-client-deprecation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Chaged get_client() visibility so that older versions of boost do not break

--- a/projects/packages/boost-core/package.json
+++ b/projects/packages/boost-core/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-boost-core",
-	"version": "0.2.4-alpha",
+	"version": "0.2.4",
 	"description": "Core functionality for boost and relevant packages to depend on",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/boost-core/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.10.0] - 2024-01-25
+### Added
+- Add Verbum Comments in jetpack-mu-wpcom plugin. [#35196]
+
 ## [5.9.0] - 2024-01-22
 ### Added
 - Added the completion logic for the 'Install the mobile app' task [#35110]
@@ -537,6 +541,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.10.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.9.0...v5.10.0
 [5.9.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.2...v5.9.0
 [5.8.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.1...v5.8.2
 [5.8.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.0...v5.8.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-verbum-comment-into-jetpack-mu-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-verbum-comment-into-jetpack-mu-wpcom
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add Verbum Comments in jetpack-mu-wpcom plugin

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.10.0",
+	"version": "5.10.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.10.0-alpha",
+	"version": "5.10.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.10.0';
+	const PACKAGE_VERSION = '5.10.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.10.0-alpha';
+	const PACKAGE_VERSION = '5.10.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.0] - 2024-01-25
+### Added
+- Add price and rating to default sort options. [#35167]
+
 ## [0.41.1] - 2024-01-22
 ### Changed
 - Update dependencies. [#35117]
@@ -876,6 +880,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.42.0]: https://github.com/Automattic/jetpack-search/compare/v0.41.1...v0.42.0
 [0.41.1]: https://github.com/Automattic/jetpack-search/compare/v0.41.0...v0.41.1
 [0.41.0]: https://github.com/Automattic/jetpack-search/compare/v0.40.4...v0.41.0
 [0.40.4]: https://github.com/Automattic/jetpack-search/compare/v0.40.3...v0.40.4

--- a/projects/packages/search/changelog/add-jetpack-search-default-sort-by-price
+++ b/projects/packages/search/changelog/add-jetpack-search-default-sort-by-price
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added price and rating to default sort options

--- a/projects/packages/search/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
+++ b/projects/packages/search/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Let webpack-config load the I18nLoaderPlugin textdomain from composer.json.
-
-

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.42.0-alpha",
+	"version": "0.42.0",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.42.0-alpha';
+	const VERSION = '0.42.0';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.1-a.7 - 2024-01-25
+### Enhancements
+- Jetpack Search: Add 'price' as the default sorting option. [#35167]
+- Subscribe Block: Don't include social followers on counts by default. [#34617]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- AI Assistant: add UI events when menus are displayed [#35203]
+- AI Assistant: fix discard handler so we don't need to call discard + accept [#35236]
+- Like block: Remove block rendering in contexts different from front-end [#35226]
+- Not showing sharing buttons in notifications, emails, etc. [#35206]
+- REST API: fixed the way we treat 0 and 1 integers in boolean context. [#35190]
+- Subscriber Login: Add icon, description and redirect to home page by default [#35221]
+- Subscriber Login: Allow custom link labels [#35179]
+- Untangle Calypso from Themes & new sub-menu to Marketplace [#35145]
+
 ## 13.1-a.5 - 2024-01-23
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
 - Jetpack AI: Expose Jetpack AI cost of features on the feature endpoint. [#35178]

--- a/projects/plugins/jetpack/changelog/add-ai-extension-menu-event
+++ b/projects/plugins/jetpack/changelog/add-ai-extension-menu-event
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: add UI events when menus are displayed

--- a/projects/plugins/jetpack/changelog/add-integers-to-is-truthy
+++ b/projects/plugins/jetpack/changelog/add-integers-to-is-truthy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-REST API: fixed the way we treat 0 and 1 integers in boolean context.

--- a/projects/plugins/jetpack/changelog/add-jetpack-search-default-sort-by-price
+++ b/projects/plugins/jetpack/changelog/add-jetpack-search-default-sort-by-price
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Jetpack Search: Added price as default sorting option 

--- a/projects/plugins/jetpack/changelog/add-jetpack-search-sort-by-price-default
+++ b/projects/plugins/jetpack/changelog/add-jetpack-search-sort-by-price-default
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
+++ b/projects/plugins/jetpack/changelog/add-webpack-config-auto-I18nLoaderPlugin-textdomain
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Let webpack-config load the I18nLoaderPlugin textdomain from composer.json.
-
-

--- a/projects/plugins/jetpack/changelog/fix-ai-discard-handler
+++ b/projects/plugins/jetpack/changelog/fix-ai-discard-handler
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: fix discard handler so we don't need to call discard + accept

--- a/projects/plugins/jetpack/changelog/fix-like-block-display-context-rendering
+++ b/projects/plugins/jetpack/changelog/fix-like-block-display-context-rendering
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Like block: Remove block rendering in contexts different from front-end

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.1-a.6
-
-

--- a/projects/plugins/jetpack/changelog/remove-sharing-buttons-from-notifications
+++ b/projects/plugins/jetpack/changelog/remove-sharing-buttons-from-notifications
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Not showing sharing buttons in notifications, emails, etc.

--- a/projects/plugins/jetpack/changelog/update-subscribe-include-social-followers-default
+++ b/projects/plugins/jetpack/changelog/update-subscribe-include-social-followers-default
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscribe block: by default, don't include social followers on counts

--- a/projects/plugins/jetpack/changelog/update-subscriber-login-custom-labels
+++ b/projects/plugins/jetpack/changelog/update-subscriber-login-custom-labels
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriber Login: Allow custom link labels

--- a/projects/plugins/jetpack/changelog/update-subscriber-login-enhancements
+++ b/projects/plugins/jetpack/changelog/update-subscriber-login-enhancements
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriber Login: Add icon, description and redirect to home page by default

--- a/projects/plugins/jetpack/changelog/update-untangle-themes
+++ b/projects/plugins/jetpack/changelog/update-untangle-themes
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Untangle Calypso from Themes & new sub-menu to Marketplace

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_6",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-a.6
+ * Version: 13.1-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-a.6' );
+define( 'JETPACK__VERSION', '13.1-a.7' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-a.6",
+	"version": "13.1.0-a.7",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,7 +293,11 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.1-a.5 - 2024-01-23
+### 13.1-a.7 - 2024-01-25
+#### Enhancements
+- Jetpack Search: Add 'price' as the default sorting option.
+- Subscribe Block: Don't include social followers on counts by default.
+
 --------
 
 [See the previous changelogs here](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/CHANGELOG.md#changelog)

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.16 - 2024-01-25
+### Changed
+- Internal updates.
+
 ## 2.0.15 - 2024-01-23
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-verbum-comment-into-jetpack-mu-wpcom
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-verbum-comment-into-jetpack-mu-wpcom
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_16_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_16"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.16-alpha
+ * Version: 2.0.16
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.16-alpha",
+	"version": "2.0.16",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.16, jetpack 13.1-a.7

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.