### PR TITLE
AI Content Lens (excerpt): add events

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-excerpt-events
+++ b/projects/plugins/jetpack/changelog/add-ai-excerpt-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Content Lens (excerpt): add events on generate, discard and accept

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -2,8 +2,11 @@
  * External dependencies
  */
 import { useAiSuggestions } from '@automattic/jetpack-ai-client';
-import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import {
+	isAtomicSite,
+	isSimpleSite,
+	useAnalytics,
+} from '@automattic/jetpack-shared-extension-utils';
 import { TextareaControl, ExternalLink, Button, Notice, BaseControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
@@ -23,7 +26,7 @@ import { AiExcerptControl } from '../../components/ai-excerpt-control';
  */
 import type { LanguageProp } from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
 import type { ToneProp } from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
-import type { AiModelTypeProp } from '@automattic/jetpack-ai-client';
+import type { AiModelTypeProp, PromptProp } from '@automattic/jetpack-ai-client';
 
 import './style.scss';
 
@@ -161,7 +164,7 @@ ${ postContent }
 `,
 		};
 
-		const prompt = [
+		const prompt: PromptProp = [
 			{
 				role: 'jetpack-ai',
 				context: messageContext,

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useAiSuggestions } from '@automattic/jetpack-ai-client';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { TextareaControl, ExternalLink, Button, Notice, BaseControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -47,6 +48,8 @@ function AiPostExcerpt() {
 			postId: getCurrentPostId() ?? 0,
 		};
 	}, [] );
+
+	const { tracks } = useAnalytics();
 
 	const { editPost } = useDispatch( 'core/editor' );
 
@@ -173,15 +176,24 @@ ${ postContent }
 		dequeueAiAssistantFeatureAyncRequest();
 
 		request( prompt, { feature: 'jetpack-ai-content-lens', model } );
+		tracks.recordEvent( 'jetpack_ai_assistant_block_generate', {
+			feature: 'jetpack-ai-content-lens',
+		} );
 	}
 
 	function setExcerpt() {
 		editPost( { excerpt: suggestion } );
+		tracks.recordEvent( 'jetpack_ai_assistant_block_accept', {
+			feature: 'jetpack-ai-content-lens',
+		} );
 		reset();
 	}
 
 	function discardExcerpt() {
 		editPost( { excerpt: excerpt } );
+		tracks.recordEvent( 'jetpack_ai_assistant_block_discard', {
+			feature: 'jetpack-ai-content-lens',
+		} );
 		reset();
 	}
 

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-a.7
+ * Version: 13.1-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-a.7' );
+define( 'JETPACK__VERSION', '13.1-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-a.7",
+	"version": "13.1.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
## Proposed changes:
This PR adds the events for generate, discard and accept on the content lens extension

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-236-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create or use a post with some content in it. Go to the sidebar and use the Excerpt panel to generate, discard and accept.

See: p1706195147825629-slack-C054LN8RNVA