### PR TITLE
Jetpack Boost: Abortable DataSync

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2863,9 +2863,6 @@ importers:
       react-use-measure:
         specifier: 2.1.1
         version: 2.1.1(react-dom@18.2.0)(react@18.2.0)
-      use-debounce:
-        specifier: 10.0.0
-        version: 10.0.0(react@18.2.0)
       zod:
         specifier: 3.22.3
         version: 3.22.3
@@ -24036,15 +24033,6 @@ packages:
     dependencies:
       react: 18.2.0
       tslib: 2.5.0
-
-  /use-debounce@10.0.0(react@18.2.0):
-    resolution: {integrity: sha512-XRjvlvCB46bah9IBXVnq/ACP2lxqXyZj0D9hj4K5OzNroMDpTEBg8Anuh1/UfRTRs7pLhQ+RiNxxwZu9+MVl1A==}
-    engines: {node: '>= 16.0.0'}
-    peerDependencies:
-      react: '>=16.8.0'
-    dependencies:
-      react: 18.2.0
-    dev: false
 
   /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.33)(react@18.2.0):
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}

--- a/projects/js-packages/react-data-sync-client/changelog/boost-update-datasync-async-state
+++ b/projects/js-packages/react-data-sync-client/changelog/boost-update-datasync-async-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+React DataSync Client: Use abortController to control mutation requests

--- a/projects/js-packages/react-data-sync-client/package.json
+++ b/projects/js-packages/react-data-sync-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-react-data-sync-client",
-	"version": "0.1.0",
+	"version": "0.1.1-alpha",
 	"description": "DataSync client for React",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/react-data-sync-client/#readme",
 	"bugs": {

--- a/projects/js-packages/react-data-sync-client/src/DataSync.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSync.ts
@@ -287,7 +287,9 @@ export class DataSync< Schema extends z.ZodSchema, Value extends z.infer< Schema
 
 			return result;
 		} catch ( e ) {
-			throw new DataSyncError( url, 'failed_to_sync', e.message );
+			const status =
+				e instanceof DOMException && e.name === 'AbortError' ? 'aborted' : 'failed_to_sync';
+			throw new DataSyncError( url, status, e.message );
 		}
 	}
 

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -7,6 +7,7 @@ export class DataSyncError extends Error {
 		public location: string,
 		public status:
 			| number
+			| 'aborted'
 			| 'error_with_message'
 			| 'failed_to_sync'
 			| 'json_parse_error'

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -140,7 +140,7 @@ export function useDataSync<
 		onError: ( _, __, context ) => {
 			queryClient.setQueryData( queryKey, context.previousValue );
 		},
-		onSuccess: ( data: Schema ) => {
+		onSuccess: ( data: Value ) => {
 			queryClient.setQueryData( queryKey, data );
 		},
 	};

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -164,10 +164,8 @@ export function useDataSync<
 			// Revert the optimistic update to the previous value on error
 			queryClient.setQueryData( queryKey, context.previousValue );
 		},
-		onSuccess: ( data: Value, _, context ) => {
-			if ( context.optimisticValue !== data ) {
-				queryClient.setQueryData( queryKey, data );
-			}
+		onSuccess: ( data: Value ) => {
+			queryClient.setQueryData( queryKey, data );
 		},
 		onSettled: ( _, error ) => {
 			// Clear the abortController on either success or failure that is not an abort

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -126,7 +126,11 @@ export function useDataSync<
 	 */
 	const mutationConfigDefaults = {
 		mutationKey: queryKey,
+
+		// Mutation function that's called when the mutation is triggered
 		mutationFn: value => datasync.SET( value, params, abortController.current.signal ),
+
+		// Mutation actions that occur before the mutationFn is called
 		onMutate: async data => {
 			// If there's an existing mutation in progress, cancel it
 			if ( abortController.current ) {
@@ -157,7 +161,6 @@ export function useDataSync<
 				// the optimistic value, so there's nothing to revert.
 				return;
 			}
-
 			// Revert the optimistic update to the previous value on error
 			queryClient.setQueryData( queryKey, context.previousValue );
 		},
@@ -166,6 +169,10 @@ export function useDataSync<
 			if ( context.optimisticValue !== data ) {
 				queryClient.setQueryData( queryKey, data );
 			}
+		},
+		onSettled: () => {
+			// Clear the abortController on success or failure
+			abortController.current = null;
 		},
 	};
 

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -165,14 +165,15 @@ export function useDataSync<
 			queryClient.setQueryData( queryKey, context.previousValue );
 		},
 		onSuccess: ( data: Value, _, context ) => {
-			abortController.current = null;
 			if ( context.optimisticValue !== data ) {
 				queryClient.setQueryData( queryKey, data );
 			}
 		},
-		onSettled: () => {
-			// Clear the abortController on success or failure
-			abortController.current = null;
+		onSettled: ( _, error ) => {
+			// Clear the abortController on either success or failure that is not an abort
+			if ( ! error || ( error instanceof DataSyncError && error.status !== 'aborted' ) ) {
+				abortController.current = null;
+			}
 		},
 	};
 

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/lib/stores.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/lib/stores.ts
@@ -1,4 +1,3 @@
-import { useDebouncedState } from '$lib/utils/debounce';
 import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
 import { z } from 'zod';
 

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/lib/stores.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/lib/stores.ts
@@ -26,5 +26,6 @@ export function useImageCdnQuality(): [ ImageCdnSettings, ( newValue: ImageCdnSe
 	if ( ! imageCdnQuality ) {
 		throw new Error( 'Image CDN Quality not loaded' );
 	}
-	return useDebouncedState( imageCdnQuality, setImageCdnQuality );
+
+	return [ imageCdnQuality, setImageCdnQuality ];
 }

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/debounce.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/debounce.ts
@@ -1,6 +1,3 @@
-import { useCallback, useState } from 'react';
-import { useDebouncedCallback } from 'use-debounce';
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CallbackFunction = ( ...args: any[] ) => void;
 
@@ -21,34 +18,4 @@ export function debounce( callback: CallbackFunction, wait: number ): CallbackFu
 		clearTimeout( timer );
 		timer = setTimeout( () => callback( ...args ), wait );
 	};
-}
-
-/**
- * State hook that debounces a side effect on state change.
- * This is useful for side effects like mutations (API Calls) when the UI is changing rapidly.
- *
- * @param initialValue - initial value for the state
- * @param sideEffect   - side effect function that should run only after the state has not changed for the delay
- * @param delay        - debounce delay in milliseconds
- */
-export function useDebouncedState< T >(
-	initialValue: T,
-	sideEffect: ( v: T ) => void,
-	delay: number = 1000
-): [ T, ( v: T ) => void ] {
-	const [ value, setValueState ] = useState< T >( initialValue );
-	const debouncedSetValue = useDebouncedCallback( sideEffect, delay, {
-		leading: true,
-		trailing: true,
-	} );
-
-	const setValue = useCallback(
-		( newValue: T ) => {
-			setValueState( newValue );
-			debouncedSetValue( newValue );
-		},
-		[ debouncedSetValue ]
-	);
-
-	return [ value, setValue ];
 }

--- a/projects/plugins/boost/changelog/boost-update-datasync-async-state
+++ b/projects/plugins/boost/changelog/boost-update-datasync-async-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Boost: Remove DataSync Debouncing, instead use abortControllers

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -22,7 +22,6 @@
 		"prettier": "npm:wp-prettier@3.0.3",
 		"react-router-dom": "6.21.0",
 		"react-use-measure": "2.1.1",
-		"use-debounce": "10.0.0",
 		"zod": "3.22.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Proposed changes:
- Reset abortController when mutation is done to ensure it's cleared correctly.
- Add inline documentation for clarity.
- Remove 'use-debounce' dependency to use native debounce implementation.
- Utilize useRef for tracking abortController state.
- Remove useDebouncedState to use native debounce methods.
- Catch and convert AbortException to handle aborts gracefully.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Trigger multiple mutations rapidly and ensure that no errors occur due to lingering AbortController instances.
- Check that abortController correctly clears after each mutation both in successful and error scenarios.
- Test image CDN quality settings change and confirm debounce behavior without useDebouncedState.