### PR TITLE
Release Verbum with GB Blocks to 30%

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/release-verbum-to-30
+++ b/projects/packages/jetpack-mu-wpcom/changelog/release-verbum-to-30
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Change Verbum Blocks sample size to 30%

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -555,8 +555,8 @@ HTML;
 		$has_blocks_flag = has_blog_sticker( 'verbum-block-comments', $blog_id );
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$gutenberg_query_param = isset( $_GET['verbum_gutenberg'] ) ? intval( $_GET['verbum_gutenberg'] ) : null;
-		// This will release to 10% of sites.
-		$blog_in_10_percent = $blog_id % 100 >= 90;
+		// This will release to 30% of sites.
+		$blog_in_10_percent = $blog_id % 100 >= 70;
 		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] )
 			? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) )


### PR DESCRIPTION

## Proposed changes:
Increase Verbum's sample size to 30%. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

