### PR TITLE
AI Assistant: add prompt show event on control and extension

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-assistant-prompt-show-event
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-prompt-show-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: add menu show events on both control and extension (form)

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -217,6 +217,7 @@ function AiAssistantDropdownContent( {
 		);
 
 		removeBlocks( otherBlocksIds );
+		tracks.recordEvent( 'jetpack_ai_assistant_prompt_show', { block_type: blockType } );
 	};
 
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useAiContext, AIControl, ERROR_QUOTA_EXCEEDED } from '@automattic/jetpack-ai-client';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { serialize } from '@wordpress/blocks';
 import { KeyboardShortcuts } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -79,6 +80,7 @@ export default function AiAssistantBar( {
 } ) {
 	const wrapperRef = useRef< HTMLDivElement >( null );
 	const inputRef = useRef< HTMLInputElement >( null );
+	const { tracks } = useAnalytics();
 
 	const connected = isUserConnected();
 
@@ -200,6 +202,14 @@ export default function AiAssistantBar( {
 			observerRef?.current?.disconnect();
 		};
 	}, [ isAssistantBarFixed, isVisible ] );
+
+	useEffect( () => {
+		if ( isVisible ) {
+			tracks.recordEvent( 'jetpack_ai_assistant_prompt_show', {
+				block_type: 'jetpack/contact-form',
+			} );
+		}
+	}, [ isVisible, tracks ] );
 
 	// focus input on first render only (for a11y reasons, toggling on/off should not focus the input)
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -141,7 +141,7 @@ const jetpackFormEditWithAiComponents = createHigherOrderComponent( BlockEdit =>
 			 * and close the event source.
 			 */
 			return () => {
-				// Only stop when the parent block is unmouted.
+				// Only stop when the parent block is unmounted.
 				if ( props?.name !== 'jetpack/contact-form' ) {
 					return;
 				}

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-a.7
+ * Version: 13.1-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-a.7' );
+define( 'JETPACK__VERSION', '13.1-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-a.7",
+	"version": "13.1.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
## Proposed changes:
This PR adds a show event on the menus for AI Assistant control and the Form extension

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-236-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
See: p1706198132027999-slack-C054LN8RNVA