### PR TITLE
AI Assistant: add Jetpack forms extension events

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-forms-ai-extension-events
+++ b/projects/plugins/jetpack/changelog/add-jetpack-forms-ai-extension-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Forms Extension: add events on ai actions

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -136,6 +136,9 @@ export default function AiAssistantBar( {
 		dequeueAiAssistantFeatureAyncRequest();
 
 		requestSuggestion( prompt, { feature: 'jetpack-form-ai-extension' } );
+		tracks.recordEvent( 'jetpack_ai_assistant_block_generate', {
+			feature: 'jetpack-form-ai-extension',
+		} );
 		wrapperRef?.current?.focus();
 	}, [
 		clientId,
@@ -143,12 +146,16 @@ export default function AiAssistantBar( {
 		inputValue,
 		removeNotice,
 		requestSuggestion,
+		tracks,
 	] );
 
 	const handleStopSuggestion = useCallback( () => {
 		stopSuggestion();
 		focusOnPrompt();
-	}, [ stopSuggestion ] );
+		tracks.recordEvent( 'jetpack_ai_assistant_block_stop', {
+			feature: 'jetpack-form-ai-extension',
+		} );
+	}, [ stopSuggestion, tracks ] );
 
 	/*
 	 * Fix the assistant bar when the viewport is mobile,


### PR DESCRIPTION
## Proposed changes:
This PR adds the events on the Jetpack Forms AI extension actions

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-236-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
See: p1706203372364469-slack-C054LN8RNVA