### PR TITLE
Untangle: Remove the Import screen exception for Classic admin style

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-classic-view-import-screen-exception
+++ b/projects/plugins/jetpack/changelog/remove-classic-view-import-screen-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin Interface: remove exception for Import screen on Classic style

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -58,7 +58,7 @@ class Admin_Menu extends Base_Admin_Menu {
 	 */
 	public function get_preferred_view( $screen, $fallback_global_preference = true ) {
 		$force_default_view = in_array( $screen, array( 'users.php', 'options-general.php' ), true );
-		$use_wp_admin       = $this->use_wp_admin_interface( $screen );
+		$use_wp_admin       = $this->use_wp_admin_interface();
 
 		// When no preferred view has been set for "Users > All Users" or "Settings > General", keep the previous
 		// behavior that forced the default view regardless of the global preference.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -82,7 +82,7 @@ abstract class Base_Admin_Menu {
 			add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
 
 			// Do not inject core mobile toggle when the user wants to use the WP Admin interface.
-			if ( ! $this->use_wp_admin_interface( 'jetpack' ) ) {
+			if ( ! $this->use_wp_admin_interface() ) {
 				add_action( 'adminmenu', array( $this, 'inject_core_mobile_toggle' ) );
 			}
 		}
@@ -268,7 +268,7 @@ abstract class Base_Admin_Menu {
 		wp_style_add_data( 'jetpack-admin-menu', 'rtl', $this->is_rtl() );
 
 		// Load nav unification styles when the user isn't using wp-admin interface style.
-		if ( ! $this->use_wp_admin_interface( 'jetpack' ) ) {
+		if ( ! $this->use_wp_admin_interface() ) {
 			wp_enqueue_style(
 				'jetpack-admin-nav-unification',
 				plugins_url( 'admin-menu-nav-unification.css', __FILE__ ),
@@ -663,7 +663,7 @@ abstract class Base_Admin_Menu {
 				return self::UNKNOWN_VIEW;
 			}
 
-			$should_link_to_wp_admin = $this->should_link_to_wp_admin( $screen ) || $this->use_wp_admin_interface( $screen );
+			$should_link_to_wp_admin = $this->should_link_to_wp_admin( $screen ) || $this->use_wp_admin_interface();
 			return $should_link_to_wp_admin ? self::CLASSIC_VIEW : self::DEFAULT_VIEW;
 		}
 
@@ -779,29 +779,10 @@ abstract class Base_Admin_Menu {
 	/**
 	 * Whether the current user has indicated they want to use the wp-admin interface for the given screen.
 	 *
-	 * @param string $screen The current screen.
 	 * @return bool
 	 */
-	public function use_wp_admin_interface( $screen ) {
-		$screen_excluded = $this->is_excluded_wp_admin_interface_screen( $screen );
-		return ! $screen_excluded && 'wp-admin' === get_option( 'wpcom_admin_interface' );
-	}
-
-	/**
-	 * Returns whether we should default to wp_admin for the given screen.
-	 *
-	 * Screens that should not default to wp_admin when the wpcom_admin_interface is set.
-	 * This applies to screens that have both a wp-admin and a Calypso interface.
-	 *
-	 * @param string $screen The current screen.
-	 *
-	 * @return bool
-	 */
-	protected function is_excluded_wp_admin_interface_screen( $screen ) {
-		$excluded_screens = array(
-			'import.php',
-		);
-		return in_array( $screen, $excluded_screens, true );
+	public function use_wp_admin_interface() {
+		return 'wp-admin' === get_option( 'wpcom_admin_interface' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5262

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR removes the exception that was made for the Import screen when the global Classic admin interface style is selected.
* Before this PR, even after selecting the "Classic admin interface style," the user would continue to see the Calypso version of the Import screen.
* After this PR the user will see the wp-admin version of the Import screen.
* Because the Import screen is the only existing selection, and it seems unlikely we will have new exceptions given the trajectory of the "Untangle" project (fsHM7-p2), I propose we remove the exception code function completely.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pfsHM7-R-p2
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a fresh Atomic site
* Load this PR using Jetpack Beta Plugin
* Go to /hosting-config/ and select "Classic" in "Admin interface style" at the bottom of the page.
* Now go to Tools -> Import and view that it is the class wp-admin view of the Import screen
* Click around a bit to ensure there are no regressions