### PR TITLE
Launchpad: Add the "Install the mobile app" task completion logic for Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-request-last-seen-app-from-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-request-last-seen-app-from-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds the completion logic for the Install the mobile app task to Atomic sites"

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -957,18 +957,6 @@ function wpcom_launchpad_is_domain_upsell_task_visible() {
 }
 
 /**
- * Determines whether or not the Install the mobile app task should be visible.
- *
- * @return bool True if the Install the mobile app task should be visible.
- */
-function wpcom_launchpad_is_mobile_app_installed_visible() {
-	// TODO: We are hidding the task for now because we the completion logic
-	// is not fully implemented yet. We should make it return true for simple sites
-	// once we get the completion logic in place.
-	return false;
-}
-
-/**
  * Verifies if the Mobile App is installed for the current user.
  *
  * @param array $task The task object.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -971,9 +971,14 @@ function wpcom_launchpad_is_mobile_app_installed_visible() {
 /**
  * Verifies if the Mobile App is installed for the current user.
  *
+ * @param bool $is_complete The current task status.
  * @return bool True if the Mobile App is installed for the current user.
  */
-function wpcom_launchpad_is_mobile_app_installed() {
+function wpcom_launchpad_is_mobile_app_installed( $is_complete ) {
+	if ( $is_complete ) {
+		return true;
+	}
+
 	$mobile_last_seen = null;
 	$is_atomic_site   = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
 	if ( $is_atomic_site ) {
@@ -982,11 +987,11 @@ function wpcom_launchpad_is_mobile_app_installed() {
 			return false;
 		}
 
-		if ( ! isset( $user_attributes->jp_mobile_app_last_seen ) ) {
+		if ( ! isset( $user_attributes['jp_mobile_app_last_seen'] ) ) {
 			return false;
 		}
 
-		$mobile_last_seen = $user_attributes->jp_mobile_app_last_seen;
+		$mobile_last_seen = $user_attributes['jp_mobile_app_last_seen'];
 	} else {
 		if ( ! function_exists( 'get_user_attribute' ) ) {
 			return false;
@@ -999,6 +1004,8 @@ function wpcom_launchpad_is_mobile_app_installed() {
 	if ( empty( $mobile_last_seen ) ) {
 		return false;
 	}
+
+	wpcom_mark_launchpad_task_complete( 'mobile_app_installed' );
 
 	return true;
 }
@@ -1162,31 +1169,33 @@ function wpcom_launchpad_request_domains_list() {
  * Make a request to the WordPress.com API to get the values of the user
  * attributes sent by the client.
  *
- * @param array $attributes The attributes to request.
+ * @param string[]                                  $attributes The attributes to request.
+ * @param Automattic\Jetpack\Connection\Client|null $client_wrapper Optional client wrapper to use, this is only used for testing.
  * @return array|WP_Error Array of user attributes or WP_Error if the request fails.
  */
-function wpcom_launchpad_request_user_attributes( $attributes ) {
+function wpcom_launchpad_request_user_attributes( $attributes, $client_wrapper = null ) {
+	if ( ! is_array( $attributes ) || $attributes === array() ) {
+		return array();
+	}
 	// Use a static variable as a temporary in-memory cache to avoid multiple outbound
 	// HTTP requests within a single incoming request.
 	// We don't expect this to be triggered multiple times, but it's worth adding some
 	// light caching to avoid multiple, possibly slow HTTP requests where the underlying data
 	// is highly unlikely to change.
 	// The "cache" only lasts as long as the current request/memory space, so we don't need to invalidate it.
-	static $cached_attributes = null;
+	static $cached_attributes = array();
 
-	if ( null !== $cached_attributes ) {
-		return $cached_attributes;
+	// Check if all requested attributes are available in the cache
+	$resolved_values = array_intersect_key( $cached_attributes, array_flip( $attributes ) );
+	if ( count( $resolved_values ) === count( $attributes ) ) {
+		return $resolved_values;
 	}
 
-	if ( ! is_array( $attributes ) ) {
-		return new \WP_Error(
-			'invalid_attributes',
-			esc_html__( 'Invalid attributes.', 'jetpack-mu-wpcom' )
-		);
-	}
+	$attributes_to_fetch = array_diff( $attributes, array_keys( $resolved_values ) );
 
-	$query_params  = build_query( array( 'attributes' => $attributes ) );
-	$wpcom_request = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+	$query_params  = build_query( array( 'attributes' => $attributes_to_fetch ) );
+	$client        = $client_wrapper ? $client_wrapper : new Automattic\Jetpack\Connection\Client();
+	$wpcom_request = $client->wpcom_json_api_request_as_user(
 		'/jetpack-user-attributes?' . $query_params,
 		'v2',
 		array(
@@ -1209,14 +1218,22 @@ function wpcom_launchpad_request_user_attributes( $attributes ) {
 	$body         = wp_remote_retrieve_body( $wpcom_request );
 	$decoded_body = json_decode( $body );
 
-	if ( ! is_array( $decoded_body->user_attributes ) && ! isset( $decoded_body->user_attributes ) ) {
+	if ( ! isset( $decoded_body->user_attributes ) ) {
 		return new \WP_Error(
 			'failed_to_fetch_data',
 			esc_html__( 'Unable to fetch the requested data.', 'jetpack-mu-wpcom' )
 		);
 	}
 
-	$cached_attributes = $decoded_body->user_attributes;
+	$user_attributes = get_object_vars( $decoded_body->user_attributes );
+	if ( ! is_array( $user_attributes ) ) {
+		return new \WP_Error(
+			'failed_to_fetch_data',
+			esc_html__( 'Unable to fetch the requested data.', 'jetpack-mu-wpcom' )
+		);
+	}
+
+	$cached_attributes = array_merge( $cached_attributes, $user_attributes );
 
 	return $cached_attributes;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -971,10 +971,11 @@ function wpcom_launchpad_is_mobile_app_installed_visible() {
 /**
  * Verifies if the Mobile App is installed for the current user.
  *
- * @param bool $is_complete The current task status.
+ * @param array $task The task object.
+ * @param bool  $is_complete The current task status.
  * @return bool True if the Mobile App is installed for the current user.
  */
-function wpcom_launchpad_is_mobile_app_installed( $is_complete ) {
+function wpcom_launchpad_is_mobile_app_installed( $task, $is_complete ) {
 	if ( $is_complete ) {
 		return true;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -982,11 +982,11 @@ function wpcom_launchpad_is_mobile_app_installed() {
 			return false;
 		}
 
-		if ( ! isset( $user_attributes['jp_mobile_app_last_seen'] ) ) {
+		if ( ! isset( $user_attributes->jp_mobile_app_last_seen ) ) {
 			return false;
 		}
 
-		$mobile_last_seen = $user_attributes['jp_mobile_app_last_seen'];
+		$mobile_last_seen = $user_attributes->jp_mobile_app_last_seen;
 	} else {
 		if ( ! function_exists( 'get_user_attribute' ) ) {
 			return false;
@@ -1185,17 +1185,15 @@ function wpcom_launchpad_request_user_attributes( $attributes ) {
 		);
 	}
 
-	$wpcom_request = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
-		'/jetpack-user-attributes',
+	$query_params  = build_query( array( 'attributes' => $attributes ) );
+	$wpcom_request = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+		'/jetpack-user-attributes?' . $query_params,
 		'v2',
 		array(
 			'method'  => 'GET',
 			'headers' => array(
 				'X-Forwarded-For' => ( new Automattic\Jetpack\Status\Visitor() )->get_ip( true ),
 			),
-		),
-		array(
-			'attributes' => $attributes,
 		)
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -968,29 +968,29 @@ function wpcom_launchpad_is_mobile_app_installed( $task, $is_complete ) {
 		return true;
 	}
 
-	$mobile_last_seen = null;
-	$is_atomic_site   = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
+	$has_used_jetpack_app = null;
+	$is_atomic_site       = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
 	if ( $is_atomic_site ) {
-		$user_attributes = wpcom_launchpad_request_user_attributes( array( 'jp_mobile_app_last_seen' ) );
+		$user_attributes = wpcom_launchpad_request_user_attributes( array( 'has_used_jetpack_app' ) );
 		if ( is_wp_error( $user_attributes ) ) {
 			return false;
 		}
 
-		if ( ! isset( $user_attributes['jp_mobile_app_last_seen'] ) ) {
+		if ( ! isset( $user_attributes['has_used_jetpack_app'] ) ) {
 			return false;
 		}
 
-		$mobile_last_seen = $user_attributes['jp_mobile_app_last_seen'];
+		$has_used_jetpack_app = $user_attributes['has_used_jetpack_app'];
 	} else {
 		if ( ! function_exists( 'get_user_attribute' ) ) {
 			return false;
 		}
 
-		$user_id          = get_current_user_id();
-		$mobile_last_seen = get_user_attribute( $user_id, 'jp_mobile_app_last_seen' );
+		$user_id              = get_current_user_id();
+		$has_used_jetpack_app = get_user_attribute( $user_id, 'jp_mobile_app_last_seen' );
 	}
 
-	if ( empty( $mobile_last_seen ) ) {
+	if ( empty( $has_used_jetpack_app ) ) {
 		return false;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -580,6 +580,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Install the mobile app', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_mobile_app_installed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_mobile_app_installed_visible',
 			'get_calypso_path'     => function () {
 				return '/me/get-apps';
 			},
@@ -954,6 +955,18 @@ function wpcom_launchpad_is_domain_upsell_task_visible() {
 	);
 
 	return empty( $bundle_purchases );
+}
+
+/**
+ * Determines whether or not the Install the mobile app task should be visible.
+ *
+ * @return bool True if the Install the mobile app task should be visible.
+ */
+function wpcom_launchpad_is_mobile_app_installed_visible() {
+	// TODO: We are hidding the task for now because we the completion logic
+	// is not fully implemented yet. We should make it return true for simple sites
+	// once we get the completion logic in place.
+	return false;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-jetpack-connection-client-mock.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-jetpack-connection-client-mock.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Mocking Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Status and information regarding the site visitor.
+ *
+ * @package automattic/jetpack-status
+ */
+class Launchpad_Jetpack_Connection_Client_Mock {
+	/**
+	 * Mocking Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user
+	 *
+	 * @return mixed
+	 */
+	public function wpcom_json_api_request_as_user() {}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-wpcom-requests-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-wpcom-requests-test.php
@@ -34,7 +34,19 @@ class Launchpad_WPCOM_Requests_Test extends \WorDBless\BaseTestCase {
 
 		// Mocking Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user
 		$client_mock = $this->getMockBuilder( Launchpad_Jetpack_Connection_Client_Mock::class )->getMock();
-		$client_mock->expects( $this->exactly( 2 ) )->method( 'wpcom_json_api_request_as_user' )->willReturn( $response );
+		$client_mock->expects( $this->once() )
+			->method( 'wpcom_json_api_request_as_user' )
+			->with(
+				'/jetpack-user-attributes?attributes%5B0%5D=attribute1&attributes%5B1%5D=attribute2',
+				'v2',
+				array(
+					'method'  => 'GET',
+					'headers' => array(
+						'X-Forwarded-For' => '',
+					),
+				)
+			)
+			->willReturn( $response );
 
 		$result = wpcom_launchpad_request_user_attributes( $attributes, $client_mock );
 
@@ -46,6 +58,20 @@ class Launchpad_WPCOM_Requests_Test extends \WorDBless\BaseTestCase {
 			$result
 		);
 
+		$client_mock = $this->getMockBuilder( Launchpad_Jetpack_Connection_Client_Mock::class )->getMock();
+		$client_mock->expects( $this->once() )
+			->method( 'wpcom_json_api_request_as_user' )
+			->with(
+				'/jetpack-user-attributes?attributes%5B1%5D=attribute3',
+				'v2',
+				array(
+					'method'  => 'GET',
+					'headers' => array(
+						'X-Forwarded-For' => '',
+					),
+				)
+			)
+			->willReturn( $response );
 		// Test that a new request is made because the attribute3 is not cached.
 		$second_attributes = array( 'attribute1', 'attribute3' );
 		wpcom_launchpad_request_user_attributes( $second_attributes, $client_mock );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-wpcom-requests-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-wpcom-requests-test.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Test class for requests to the WPCOM api.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+require_once Jetpack_Mu_Wpcom::PKG_DIR . '../status/src/class-visitor.php';
+require_once __DIR__ . '/class-launchpad-jetpack-connection-client-mock.php';
+
+/**
+ * Test class for requests to the WPCOM api.
+ */
+class Launchpad_WPCOM_Requests_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Test that the request to the WPCOM api returns the expected result.
+	 *
+	 * @covers ::wpcom_launchpad_request_user_attributes
+	 */
+	public function test_wpcom_launchpad_request_user_attributes() {
+		$attributes = array( 'attribute1', 'attribute2' );
+		// Mocking Automattic\Jetpack\Status\Visitor::get_ip
+		$visitor_mock = $this->getMockBuilder( Automattic\Jetpack\Status\Visitor::class )
+			->getMock();
+		$visitor_mock->method( 'get_ip' )->willReturn( 'mocked_ip' );
+
+		$response = array(
+			'response' => array(
+				'code' => 200,
+			),
+			'body'     => '{"user_attributes": {"attribute1": "value1", "attribute2": "value2"}}',
+		);
+
+		// Mocking Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user
+		$client_mock = $this->getMockBuilder( Launchpad_Jetpack_Connection_Client_Mock::class )->getMock();
+		$client_mock->expects( $this->exactly( 2 ) )->method( 'wpcom_json_api_request_as_user' )->willReturn( $response );
+
+		$result = wpcom_launchpad_request_user_attributes( $attributes, $client_mock );
+
+		$this->assertEquals(
+			array(
+				'attribute1' => 'value1',
+				'attribute2' => 'value2',
+			),
+			$result
+		);
+
+		// Test that a new request is made because the attribute3 is not cached.
+		$second_attributes = array( 'attribute1', 'attribute3' );
+		wpcom_launchpad_request_user_attributes( $second_attributes, $client_mock );
+
+		// If the value is not cached, the test would fail because the mocked wpcom_json_api_request_as_user
+		// method should be called only two times.
+		$cached_result = wpcom_launchpad_request_user_attributes( array( 'attribute1' ), $client_mock );
+
+		$this->assertEquals(
+			array(
+				'attribute1' => 'value1',
+			),
+			$cached_result
+		);
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* At first, we decided not to add the "Install the mobile app" task on Atomic sites because we couldn't access the user attribute(`jp_mobile_app_last_seen`) that we use for marking the task as complete.
* I followed Enej's suggestion of requesting the attribute through an endpoint, which I created here: D135972-code
* We now make a request to WPCOM when the site is Atomic to fetch the `jp_mobile_app_last_seen` so we can decide if the "Install the mobile app" is complete or not.

More context: paYKcK-3Hy-p2#comment-2790

Ps: We faced some problems related to the `jp_mobile_app_last_seen` attribute, which is being addressed here: D135809-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D135972-code to your sandbox and make sure the `public-api` is sandboxed.
* Use the command below to apply this PR to your sandbox:
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/request-last-seen-app-from-wpcom
```
* Make sure your `jp_mobile_app_last_seen` is empty by running the following code on `wpsh`:
```
return delete_user_attribute(<YOUR USER ID>, 'jp_mobile_app_last_seen');
```
* Create a new site through the `/setup/free` flow
* Launch your site once you reach the Fullscreen Launchpad
* You should land on the Customer Home page. Click on the `Show site setup` button on the main banner.
* You should see the `Install the mobile app` task as incomplete.
* Use `wpsh` to update the `jp_mobile_app_last_seen` to check if the completion logic is still working for simple:
```
return update_user_attribute(<YOUR USER ID>, 'jp_mobile_app_last_seen', '2024-01-25');
```
* Refresh the Customer Home page. The `Install the mobile app` should be marked as complete.
* Empty your `jp_mobile_app_last_seen` again by running the following code on your `wpsh`:
```
return delete_user_attribute(<YOUR USER ID>, 'jp_mobile_app_last_seen');
return switch_to_blog(<YOUR SITE ID>);
return wpcom_mark_launchpad_task_incomplete( 'mobile_app_installed' );
```
* Now, add your site to the WoA Developer list.
* Transfer it to Atomic by navigating to `/hosting-config/:siteSlug` and activating the SSH. You'll need to add the Creator plan to your site.
* Once your site is Atomic, use the credentials on `/hosting-config/:siteSlug` to access the SSH
* Edit your `~/htdocs/wp-config.php` to add the constants listed below:
```
// define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true ); // Only add this line if you are using the Jetpack Beta Tester plugin
define( 'JETPACK__SANDBOX_DOMAIN', 'YOU_SANDBOX_HOST' );
```
* Use the Jetpack Beta plugin to apply this PR to your site(You may have to update the files manually, as the plugin doesn't seem to work on my end)
* On the Customer Home, make sure you can see the "Install the mobile app" task
* Use `wpsh` to update the `jp_mobile_app_last_seen` to check if the completion logic is still working for atomic:
```
return update_user_attribute(<YOUR USER ID>, 'jp_mobile_app_last_seen', '2024-01-25');
```
* Refresh the Customer Home page. The "Install the mobile app" task should be marked as complete.