### PR TITLE
Jetpack_PostImages::from_attachment: Prevent warning when $thumb_post_data cannot be found

### DIFF
--- a/projects/plugins/jetpack/changelog/update-post-images
+++ b/projects/plugins/jetpack/changelog/update-post-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack_PostImages::from_attachment: Prevent warning when $thumb_post_data cannot be found

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -339,7 +339,7 @@ class Jetpack_PostImages {
 				// If wp_get_attachment_image_src returns false but we know that there should be an image that could be used.
 				// we try a bit harder and user the data that we have.
 				$thumb_post_data = get_post( $thumb );
-				$img_src         = array( $thumb_post_data->guid, $meta['width'], $meta['height'] );
+				$img_src         = array( $thumb_post_data->guid ?? null, $meta['width'], $meta['height'] );
 			}
 
 			// Let's try to use the postmeta if we can, since it seems to be


### PR DESCRIPTION
Fixes warnings like:
```
[25-Jan-2024 21:08:38 UTC] Warning: Attempt to read property "guid" on null in (...)/class.jetpack-post-images.php on line 342
```

## Proposed changes:

* When `Jetpack_PostImages::from_attachment` runs, it tries to get data from a thumbnail post:
```php
			if ( ! is_array( $img_src ) ) {
				// If wp_get_attachment_image_src returns false but we know that there should be an image that could be used.
				// we try a bit harder and user the data that we have.
				$thumb_post_data = get_post( $thumb );
				$img_src         = array( $thumb_post_data->guid, $meta['width'], $meta['height'] );
			}
```
`get_post()` can return null, so sometimes `$thumb_post_data->guid` is null and generates a warning.

However, the 0th (first) entry of $img_src isn't always used. The code block after it is:
```php
			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
				$featured_image = get_post_meta( $post->ID, '_jetpack_featured_image' );
				if ( $featured_image ) {
					$url = $featured_image[0];
				} else {
					$url = $img_src[0];
				}
			} else {
				$url = $img_src[0];
			}
			$images = array(
				array( // Other methods below all return an array of arrays.
					'type'       => 'image',
					'from'       => 'thumbnail',
					'src'        => $url,
					'src_width'  => $img_src[1],
					'src_height' => $img_src[2],
					'href'       => get_permalink( $thumb ),
					'alt_text'   => self::get_alt_text( $thumb ),
				),
			);
```

Note that at least one of the code paths uses `$featured_image[0]` instead of `$img_src[0]`. In the real world case that I tried of seeing the warning generated, that was the case.  So my solution is only to silence the warning by using `$thumb_post_data->guid ?? null` instead of `$thumb_post_data->guid`.  That should keep the behavior the same, but stop the warning from happening.

As far as I know, there is no unwanted behavior or bugs happening here, only a warning.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* See D135990-code for a testing helper and directions
