### PR TITLE
Boost: Fix showing incorrect message while generating Cloud CSS

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
@@ -9,6 +9,7 @@ export default function CloudCssMetaProps() {
 
 	const isPending = cssState.status === 'pending';
 	const hasCompletedSome = cssState.providers.some( provider => provider.status !== 'pending' );
+	const notGenerated = cssState.status === 'not_generated';
 
 	// If CSS generation has made some progress but is not finished indicate that.
 	const extraText =
@@ -18,7 +19,7 @@ export default function CloudCssMetaProps() {
 
 	// If waiting for the back-end generator to begin, provide a blank message.
 	const overrideText =
-		isPending &&
+		( isPending || notGenerated ) &&
 		! hasCompletedSome &&
 		__( 'Jetpack Boost will generate Critical CSS for you automatically.', 'jetpack-boost' );
 

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
@@ -68,7 +68,7 @@ const Status: React.FC< StatusTypes > = ( {
 						successCount
 					) }
 
-					{ cssState.updated && (
+					{ !! cssState.updated && (
 						<>
 							{ ' ' }
 							<TimeAgo time={ new Date( cssState.updated * 1000 ) } />

--- a/projects/plugins/boost/changelog/boost-react-fix-ccss-ui-on-missing-css-state
+++ b/projects/plugins/boost/changelog/boost-react-fix-ccss-ui-on-missing-css-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed message while generating cloud css for the first time.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35218

### Proposed changes:

<details><summary>Before</summary>

![CleanShot 2024-01-26 at 11 48 15](https://github.com/Automattic/jetpack/assets/11799079/1cf0328c-06c2-47f2-a5b8-58467226206b)


</details>

<details><summary>Now</summary>

![CleanShot 2024-01-26 at 11 48 40](https://github.com/Automattic/jetpack/assets/11799079/f59de228-cc60-447a-9c42-d21df5d90388)


</details>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost premium;
* Check the Cloud CSS UI and make sure it's no longer showing "0 files generated.0".