### PR TITLE
Verbum: Fix KSES filtering for users without posting caps

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-kses-for-blocks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-kses-for-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Allow users to post HTML when blocks are enabled

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-gutenberg-editor.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-gutenberg-editor.php
@@ -29,9 +29,21 @@ class Verbum_Gutenberg_Editor {
 			},
 			9999
 		);
+		add_filter( 'init', array( $this, 'remove_strict_kses_filters' ) );
 		add_filter( 'comment_text', array( $this, 'render_verbum_blocks' ) );
 		add_filter( 'pre_comment_content', array( $this, 'remove_blocks' ) );
 		add_filter( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+	}
+
+	/**
+	 * Default KSES filters on wpcom only allow HTML for admins and people who can post "posts" to the blog they're commenting on.
+	 * See: wp-includes/kses.php (this one adds the restrictions).
+	 * See: wp-content/mu-plugins/misc.php (this one removes it, but only has_cap('publish_posts')).
+	 */
+	public function remove_strict_kses_filters() {
+		// Allow HTML when blocks are enabled.
+		remove_filter( 'pre_comment_content', 'wp_filter_kses' );
+		add_filter( 'pre_comment_content', 'wp_filter_post_kses' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes p1706269066050039-slack-C02T4NVL4JJ

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Using a non-admin account, post on a blogpost that the user you're using does **not** own, like [here](https://punsintended418746564.wordpress.com/2023/12/12/fresh-post). 
2. Post a list, a blockquote or whatever obvious block.
3. The block should be rendered in the comment. 