### PR TITLE
Admin-UI: Avoid loading l10n too early in admin

### DIFF
--- a/projects/packages/admin-ui/changelog/fix-i18n-loading-too-early-on-atomic
+++ b/projects/packages/admin-ui/changelog/fix-i18n-loading-too-early-on-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Wait until 'admin_menu' action to call `add_menu()`, to avoid triggering the l10n load too early.

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.3.1",
+	"version": "0.3.2-alpha",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.3.1';
+	const PACKAGE_VERSION = '0.3.2-alpha';
 
 	/**
 	 * Whether this class has been initialized
@@ -50,17 +50,17 @@ class Admin_Menu {
 	 */
 	private static function handle_akismet_menu() {
 		if ( class_exists( 'Akismet_Admin' ) ) {
-			// Prevent Akismet from adding a menu item.
 			add_action(
 				'admin_menu',
 				function () {
+					// Prevent Akismet from adding a menu item.
 					remove_action( 'admin_menu', array( 'Akismet_Admin', 'admin_menu' ), 5 );
+
+					// Add an Anti-spam menu item for Jetpack.
+					self::add_menu( __( 'Akismet Anti-spam', 'jetpack-admin-ui' ), __( 'Akismet Anti-spam', 'jetpack-admin-ui' ), 'manage_options', 'akismet-key-config', array( 'Akismet_Admin', 'display_page' ) );
 				},
 				4
 			);
-
-			// Add an Anti-spam menu item for Jetpack.
-			self::add_menu( __( 'Akismet Anti-spam', 'jetpack-admin-ui' ), __( 'Akismet Anti-spam', 'jetpack-admin-ui' ), 'manage_options', 'akismet-key-config', array( 'Akismet_Admin', 'display_page' ) );
 
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When on a plan with anti-spam, the Akismet menu is being added during the 'plugins_loaded' action, which is before the user has been determined and so it loads the l10n in the site language for the plugin's text domain.

Delay that addition until the 'admin_menu' action (at the same time as when we remove Akismet's copy of the menu) to avoid triggering the l10n so early.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1706220616642649-slack-CBG1CP4EN
Seems like someone should have reported this as a bug at some point before, but I didn't find it in a quick search 🤷

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site with a plan that includes Jetpack Anti-Spam. Also be sure the Akismet plugin is installed. Activate and connect Jetpack.
* Set different languages for the user language and the site language. For example, set user language to English while site language is Spanish.
* In the sidebar, look at the submenus of the Jetpack menu. With trunk they will be in the site language. With this PR, they'll correctly be in the user language.

Repeat the testing above on an Atomic site too.