### PR TITLE
AI Assistant: add accept event on title suggestion

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-assistant-accept-title-event
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-accept-title-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: add accept event on title suggestion request

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -360,6 +360,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		if ( isInBlockEditor ) {
 			editPost( { title: attributes.content ? attributes.content.trim() : '' } );
 			removeBlock( clientId );
+			tracks.recordEvent( 'jetpack_ai_assistant_block_accept', { feature: 'ai-assistant' } );
 		} else {
 			handleAcceptContent();
 		}


### PR DESCRIPTION
## Proposed changes:
This PR adds the accept event when accepting the title suggestion

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-236-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
See: p1706291481220279-slack-C054LN8RNVA