### PR TITLE
SSO: Add revoke invite action to users table

### DIFF
--- a/projects/plugins/jetpack/changelog/add-sso-users-table-revoke-invite
+++ b/projects/plugins/jetpack/changelog/add-sso-users-table-revoke-invite
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+SSO: Add user invite revoke row action in users table

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -317,6 +317,7 @@ class Jetpack_SSO {
 
 	/**
 	 * Adds 'Revoke invite' link to user table row actions.
+	 * Removes 'Reset password' link.
 	 *
 	 * @param array   $actions - User row actions.
 	 * @param WP_User $user_object - User object.
@@ -340,6 +341,8 @@ class Jetpack_SSO {
 				esc_html__( 'Revoke invite', 'jetpack' )
 			);
 		}
+
+		unset( $actions['resetpassword'] );
 
 		return $actions;
 	}

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -229,49 +229,38 @@ class Jetpack_SSO {
 		$nonce = wp_create_nonce( 'jetpack-sso-revoke-user-invite' );
 
 		if ( ! current_user_can( 'promote_users' ) ) {
-			$ref = wp_get_referer();
-			$url = add_query_arg(
-				array(
-					'jetpack-sso-revoke-user-invite-error' => 'invalid-permissions',
-					'_wpnonce'                             => $nonce,
-				),
-				$ref
+			$query_params = array(
+				'jetpack-sso-revoke-user-invite-error' => 'invalid-permissions',
+				'_wpnonce'                             => $nonce,
 			);
-			return wp_safe_redirect( $url );
+
+			return self::create_error_notice_and_redirect( $query_params );
 		} elseif ( isset( $_GET['user_id'] ) ) {
 			$user_id    = intval( wp_unslash( $_GET['user_id'] ) );
 			$user       = get_user_by( 'id', $user_id );
 			$user_email = $user->user_email;
 
 			if ( ! $user || ! $user_email ) {
-				$ref = wp_get_referer();
-
 				$reason = ! $user ? 'invalid-user' : 'invalid-email';
 
-				$url = add_query_arg(
-					array(
-						'jetpack-sso-revoke-user-invite' => 'failed',
-						'jetpack-sso-revoke-user-invite-error' => $reason,
-						'_wpnonce'                       => $nonce,
-					),
-					$ref
+				$query_params = array(
+					'jetpack-sso-revoke-user-invite'       => 'failed',
+					'jetpack-sso-revoke-user-invite-error' => $reason,
+					'_wpnonce'                             => $nonce,
 				);
-				return wp_safe_redirect( $url );
+
+				return self::create_error_notice_and_redirect( $query_params );
 			}
 
 			$has_pending_invite = self::has_pending_wpcom_invite( $user_id );
 
 			if ( ! $has_pending_invite ) {
-				$ref = wp_get_referer();
-				$url = add_query_arg(
-					array(
-						'jetpack-sso-revoke-user-invite' => 'failed',
-						'jetpack-sso-revoke-user-invite-error' => 'invalid-invite-revocation',
-						'_wpnonce'                       => $nonce,
-					),
-					$ref
+				$query_params = array(
+					'jetpack-sso-revoke-user-invite'       => 'failed',
+					'jetpack-sso-revoke-user-invite-error' => 'invalid-invite-revocation',
+					'_wpnonce'                             => $nonce,
 				);
-				return wp_safe_redirect( $url );
+				return self::create_error_notice_and_redirect( $query_params );
 			}
 
 			$blog_id = Jetpack_Options::get_option( 'id' );
@@ -289,36 +278,25 @@ class Jetpack_SSO {
 				'wpcom'
 			);
 
-			$body = json_decode( $response['body'] );
-
-			$ref = wp_get_referer();
-			$url = add_query_arg(
-				array(
-					'jetpack-sso-revoke-user-invite' => $body->deleted ? 'success' : 'failed',
-					'_wpnonce'                       => $nonce,
-				),
-				$ref
+			$body         = json_decode( $response['body'] );
+			$query_params = array(
+				'jetpack-sso-revoke-user-invite' => $body->deleted ? 'success' : 'failed',
+				'_wpnonce'                       => $nonce,
 			);
+
 			if ( ! $body->deleted ) {
-				$url = add_query_arg(
-					array(
-						'jetpack-sso-revoke-user-invite-error' => 'invalid-invite-revocation',
-					),
-					$ref
+				$query_params = array(
+					'jetpack-sso-revoke-user-invite-error' => 'invalid-invite-revocation',
 				);
 			}
-			return wp_safe_redirect( $url );
+			return self::create_error_notice_and_redirect( $query_params );
 		} else {
-			$ref = wp_get_referer();
-			$url = add_query_arg(
-				array(
-					'jetpack-sso-revoke-user-invite'       => 'failed',
-					'jetpack-sso-revoke-user-invite-error' => 'invalid-user',
-					'_wpnonce'                             => $nonce,
-				),
-				$ref
+			$query_params = array(
+				'jetpack-sso-revoke-user-invite'       => 'failed',
+				'jetpack-sso-revoke-user-invite-error' => 'invalid-user',
+				'_wpnonce'                             => $nonce,
 			);
-			return wp_safe_redirect( $url );
+			return self::create_error_notice_and_redirect( $query_params );
 		}
 		wp_die();
 	}

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -235,7 +235,7 @@ class Jetpack_SSO {
 				return self::create_error_notice_and_redirect( $query_params );
 			}
 
-			$has_pending_invite = self::has_pending_wpcom_invite( $user_id );
+			$has_pending_invite = $_GET['invite_id'];
 
 			if ( ! $has_pending_invite ) {
 				$query_params = array(
@@ -316,6 +316,7 @@ class Jetpack_SSO {
 						'action'              => 'jetpack_revoke_invite_user_to_wpcom',
 						'user_id'             => $user_id,
 						'revoke_invite_nonce' => $nonce,
+						'invite_id'           => $has_pending_invite,
 					),
 					admin_url( 'admin-post.php' )
 				),

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -235,9 +235,7 @@ class Jetpack_SSO {
 				return self::create_error_notice_and_redirect( $query_params );
 			}
 
-			$has_pending_invite = $_GET['invite_id'];
-
-			if ( ! $has_pending_invite ) {
+			if ( ! isset( $_GET['invite_id'] ) ) {
 				$query_params = array(
 					'jetpack-sso-invite-user'  => 'failed',
 					'jetpack-sso-invite-error' => 'invalid-invite-revoke',
@@ -245,6 +243,8 @@ class Jetpack_SSO {
 				);
 				return self::create_error_notice_and_redirect( $query_params );
 			}
+
+			$has_pending_invite = sanitize_text_field( wp_unslash( $_GET['invite_id'] ) );
 
 			$blog_id = Jetpack_Options::get_option( 'id' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

New branch for changes from: https://github.com/Automattic/jetpack/pull/35272

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* These changes build on the users table improvements from: https://github.com/Automattic/jetpack/pull/35158.
* The logic to revoke user invites has been added to the users table row actions for each user that has a 'pending invite'.

<img width="758" alt="CleanShot 2024-01-25 at 22 49 56@2x" src="https://github.com/Automattic/jetpack/assets/10482592/e55f1f96-bee1-4a6e-b35a-13fc0e87bbce">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. On an Atomic, JN, or whatever non-simple site, install Jetpack.
2. Make sure SSO is on, it should be on by default.
3. Sync this PR to your site.
4. Go to the users table (`wp-admin/users/php`).
5. It should have the status of the user's connection "Connected", "Invite", or "Pending invite".
6. Clicking "Invite" should invite the user and change their status to "Pending invite".
7. If you haven't already, add and invite a few new users to your site.
8. Hover the row actions and verify that rows with 'pending invite' only display the `Revoke invite` action.
9. Verify the 'Revoke invite' row action successfully revokes a user's site invitation.



