### PR TITLE
SSO: Apply design feedback to table

### DIFF
--- a/projects/plugins/jetpack/changelog/update-improve-users-table
+++ b/projects/plugins/jetpack/changelog/update-improve-users-table
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+SSO: Updated column heading and row background color when invitation is pending.

--- a/projects/plugins/jetpack/changelog/y
+++ b/projects/plugins/jetpack/changelog/y
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-SSO: improve messaging and account binding between local and wp.com users
+SSO: update the user status column heading and change the color of not connected users

--- a/projects/plugins/jetpack/changelog/y
+++ b/projects/plugins/jetpack/changelog/y
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-SSO: update the user status column heading and change the color of not connected users
+SSO: improve messaging and account binding between local and wp.com users

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -364,7 +364,7 @@ class Jetpack_SSO {
 	public function jetpack_show_connection_status( $val, $col, $user_id ) {
 		if ( 'user_jetpack' === $col && Jetpack::connection()->is_user_connected( $user_id ) ) {
 			$connection_html = sprintf(
-				'<span title="%1$s" class="jetpack-sso-invitatio sso-connected-user">%2$s</span>',
+				'<span title="%1$s" class="jetpack-sso-invitation">%2$s</span>',
 				esc_attr__( 'This user is connected and can log-in to this site.', 'jetpack' ),
 				esc_html__( 'Connected', 'jetpack' )
 			);
@@ -417,14 +417,12 @@ class Jetpack_SSO {
 			.jetpack-sso-invitation {
 				background: none;
 				border: none;
+				color: #50575e;
 				padding: 0;
-				color: #0073aa;
 				text-align: unset;
 			}
-			.jetpack-sso-invitation.sso-connected-user {
-				color: #50575e;
-			}
 			.jetpack-sso-invitation.sso-disconnected-user {
+				color: #0073aa;
 				cursor: pointer;
 				text-decoration: underline;
 			}

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -307,8 +307,9 @@ class Jetpack_SSO {
 	 */
 	public function jetpack_user_connected_th( $columns ) {
 		$columns['user_jetpack'] = sprintf(
-			'<span title="%1$s">[?]</span>',
-			esc_attr__( 'Connected users can log-in to this site using their WordPress.com account.', 'jetpack' )
+			'<span title="%1$s">%2$s</span>',
+			esc_attr__( 'Connected users can log-in to this site using their WordPress.com account.', 'jetpack' ),
+			esc_html__( 'Status', 'jetpack' )
 		);
 		return $columns;
 	}

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -554,6 +554,11 @@ class Jetpack_SSO {
 				cursor: pointer;
 				text-decoration: underline;
 			}
+			.jetpack-sso-invitation.sso-disconnected-user:hover,
+			.jetpack-sso-invitation.sso-disconnected-user:focus,
+			.jetpack-sso-invitation.sso-disconnected-user:active {
+				color: #0096dd;
+			}
 		</style>
 		<?php
 	}

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -406,7 +406,7 @@ class Jetpack_SSO {
 		?>
 		<style>
 			#the-list tr:has(.sso-disconnected-user) {
-				background: #ffe8eb;
+				background: #F5E6B3;
 			}
 			#the-list tr:has(.sso-pending-invite) {
 				background: #ccedef;

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -364,7 +364,7 @@ class Jetpack_SSO {
 	public function jetpack_show_connection_status( $val, $col, $user_id ) {
 		if ( 'user_jetpack' === $col && Jetpack::connection()->is_user_connected( $user_id ) ) {
 			$connection_html = sprintf(
-				'<span title="%1$s" class="jetpack-sso-invitation">%2$s</span>',
+				'<span title="%1$s" class="jetpack-sso-invitatio sso-connected-user">%2$s</span>',
 				esc_attr__( 'This user is connected and can log-in to this site.', 'jetpack' ),
 				esc_html__( 'Connected', 'jetpack' )
 			);
@@ -421,7 +421,10 @@ class Jetpack_SSO {
 				color: #0073aa;
 				text-align: unset;
 			}
-			button.sso-disconnected-user {
+			.jetpack-sso-invitation.sso-connected-user {
+				color: #50575e;
+			}
+			.jetpack-sso-invitation.sso-disconnected-user {
 				cursor: pointer;
 				text-decoration: underline;
 			}


### PR DESCRIPTION
Related to:
- https://github.com/Automattic/jetpack/issues/35278#issuecomment-1914384127
- https://github.com/Automattic/jetpack/issues/35278#issuecomment-1914446418


## Proposed Changes

These changes build on the users table improvements from: https://github.com/Automattic/jetpack/pull/35158.

This PR updates:
- The column heading is now `Status`.
- The row color of a non-connected user.
- The color of `Connected`.
- Fixes the style of `Invite` 

![image](https://github.com/Automattic/jetpack/assets/52076348/af3014cf-c54f-4ee3-bdd2-6b852f071a15)

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

1. On an Atomic, JN, or whatever non-simple site, install Jetpack.
2. Make sure SSO is on, it should be on by default.
3. Sync this PR to your site.
4. Go to the users table (`wp-admin/users/php`).
5. It should have the status of the user's connection "Connected", "Invite", or "Pending invite".
6. Check that the status column has the heading `Status`.
7. Check 