### PR TITLE
Launchpad: Hides the "Install the mobile app" task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-hide-mobile-app-installed
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-hide-mobile-app-installed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Hides the "Install the mobile app" task while the completion logic is not fully implemented

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -969,7 +969,10 @@ function wpcom_launchpad_is_mobile_app_installed_visible() {
 		return false;
 	}
 
-	return true;
+	// TODO: We are hidding the task for now because we the completion logic
+	// is not fully implemented yet. We should make it return true once the
+	// completion logic is shipped.
+	return false;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -963,15 +963,9 @@ function wpcom_launchpad_is_domain_upsell_task_visible() {
  * @return bool True if the Install the mobile app task should be visible.
  */
 function wpcom_launchpad_is_mobile_app_installed_visible() {
-	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
-	// If the site is an Atomic site, we should not show the task.
-	if ( $is_atomic_site ) {
-		return false;
-	}
-
 	// TODO: We are hidding the task for now because we the completion logic
-	// is not fully implemented yet. We should make it return true once the
-	// completion logic is shipped.
+	// is not fully implemented yet. We should make it return true for simple sites
+	// once we get the completion logic in place.
 	return false;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We decided to hide the "Install the mobile app" task, until we have the completion logic in place. Currently, there are still some issues we are addressing, and the task would not work properly for users who have never accessed the app before.

Once the D135809-code diff is deployed we can make this task visible to simple sites again.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visual inspection is enough