### PR TITLE
My Jetpack: remove unnecessary VideoPress dev dependency

### DIFF
--- a/projects/packages/my-jetpack/changelog/rm-videopress-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/rm-videopress-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Dependencies: remove unnecessary VideoPress dev dependency.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -18,8 +18,7 @@
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.1.0",
 		"automattic/jetpack-changelogger": "@dev",
-		"automattic/wordbless": "@dev",
-		"automattic/jetpack-videopress": "@dev"
+		"automattic/wordbless": "@dev"
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."

--- a/projects/plugins/backup/changelog/rm-videopress-my-jetpack
+++ b/projects/plugins/backup/changelog/rm-videopress-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "a48de5e5c58c4b58bf17e83ee19ea7f7a86aedd8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1001,7 +1001,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
-                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.1.0"
             },

--- a/projects/plugins/boost/changelog/rm-videopress-my-jetpack
+++ b/projects/plugins/boost/changelog/rm-videopress-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1047,7 +1047,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "a48de5e5c58c4b58bf17e83ee19ea7f7a86aedd8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1063,7 +1063,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
-                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.1.0"
             },

--- a/projects/plugins/jetpack/changelog/rm-videopress-my-jetpack
+++ b/projects/plugins/jetpack/changelog/rm-videopress-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1681,7 +1681,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+				"reference": "a48de5e5c58c4b58bf17e83ee19ea7f7a86aedd8"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1697,7 +1697,6 @@
 			},
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
-				"automattic/jetpack-videopress": "@dev",
 				"automattic/wordbless": "@dev",
 				"yoast/phpunit-polyfills": "1.1.0"
 			},

--- a/projects/plugins/migration/changelog/rm-videopress-my-jetpack
+++ b/projects/plugins/migration/changelog/rm-videopress-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "a48de5e5c58c4b58bf17e83ee19ea7f7a86aedd8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1001,7 +1001,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
-                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.1.0"
             },

--- a/projects/plugins/protect/changelog/rm-videopress-my-jetpack
+++ b/projects/plugins/protect/changelog/rm-videopress-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -898,7 +898,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "a48de5e5c58c4b58bf17e83ee19ea7f7a86aedd8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -914,7 +914,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
-                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.1.0"
             },

--- a/projects/plugins/search/changelog/rm-videopress-my-jetpack
+++ b/projects/plugins/search/changelog/rm-videopress-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "a48de5e5c58c4b58bf17e83ee19ea7f7a86aedd8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -857,7 +857,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
-                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.1.0"
             },

--- a/projects/plugins/social/changelog/rm-videopress-my-jetpack
+++ b/projects/plugins/social/changelog/rm-videopress-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -841,7 +841,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+				"reference": "a48de5e5c58c4b58bf17e83ee19ea7f7a86aedd8"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -857,7 +857,6 @@
 			},
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
-				"automattic/jetpack-videopress": "@dev",
 				"automattic/wordbless": "@dev",
 				"yoast/phpunit-polyfills": "1.1.0"
 			},

--- a/projects/plugins/starter-plugin/changelog/rm-videopress-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/rm-videopress-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "a48de5e5c58c4b58bf17e83ee19ea7f7a86aedd8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -857,7 +857,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
-                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.1.0"
             },

--- a/projects/plugins/videopress/changelog/rm-videopress-my-jetpack
+++ b/projects/plugins/videopress/changelog/rm-videopress-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "a48de5e5c58c4b58bf17e83ee19ea7f7a86aedd8"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -857,7 +857,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
-                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.1.0"
             },


### PR DESCRIPTION
## Proposed changes:

We added the VideoPress package as a dev dependency of the My Jetpack package in #28097. We should be able to do without it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start a fresh new site with just the Jetpack plugin.
* Go to Jetpack > My Jetpack
* The VideoPress card should be displayed
* When clicking on it, the VideoPress intersticial should appear
* No errors should appear in your logs.
