### PR TITLE
Invite user message: Fix translation

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-translations
+++ b/projects/plugins/jetpack/changelog/fix-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix message translation content

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -219,9 +219,19 @@ class Jetpack_SSO {
 		// Enqueue the CSS for the admin create user page.
 		wp_enqueue_style( 'jetpack-sso-admin-create-user', plugins_url( 'modules/sso/jetpack-sso-admin-create-user.css', JETPACK__PLUGIN_FILE ), array(), time() );
 
-		$message = __(
-			'New users will receive an invite to join WordPress.com, so they can log in securely using <a class="jetpack-sso-admin-create-user-invite-message-link-sso" rel="noopener noreferrer" target="_blank" href="https://jetpack.com/support/sso/">Secure Sign On</a>.',
-			'jetpack'
+		$message = wp_kses(
+			__(
+				'New users will receive an invite to join WordPress.com, so they can log in securely using <a class="jetpack-sso-admin-create-user-invite-message-link-sso" rel="noopener noreferrer" target="_blank" href="https://jetpack.com/support/sso/">Secure Sign On</a>.',
+				'jetpack'
+			),
+			array(
+				'a' => array(
+					'class'  => array(),
+					'href'   => array(),
+					'rel'    => array(),
+					'target' => array(),
+				),
+			)
 		);
 		wp_admin_notice(
 			$message,

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -219,14 +219,9 @@ class Jetpack_SSO {
 		// Enqueue the CSS for the admin create user page.
 		wp_enqueue_style( 'jetpack-sso-admin-create-user', plugins_url( 'modules/sso/jetpack-sso-admin-create-user.css', JETPACK__PLUGIN_FILE ), array(), time() );
 
-		$message = sprintf(
-			// translators: %s is a link to jetpack support site.
-			__( 'New users will receive an invite to join WordPress.com, so they can log in securely using %s', 'jetpack' ),
-			sprintf(
-				'<a class="jetpack-sso-admin-create-user-invite-message-link-sso" rel="noopener noreferrer" target="_blank" href="%s">%s</a>',
-				'https://jetpack.com/support/sso/',
-				__( 'Secure Sign On.', 'jetpack' )
-			)
+		$message = __(
+			'New users will receive an invite to join WordPress.com, so they can log in securely using <a class="jetpack-sso-admin-create-user-invite-message-link-sso" rel="noopener noreferrer" target="_blank" href="https://jetpack.com/support/sso/">Secure Sign On</a>.',
+			'jetpack'
 		);
 		wp_admin_notice(
 			$message,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
* Fixes translation message, this ways translators should get the whole message and context therefore be able to translate it properly

<img width="675" alt="image" src="https://github.com/Automattic/jetpack/assets/2653810/c7390195-b5ec-4ba3-982e-b016e3f6c7cd">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

