### PR TITLE
Fix email form validation to happen on input instead of blur

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-email-validation
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-email-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/index.tsx
@@ -15,17 +15,12 @@ interface EmailFormProps {
 }
 
 const isValidEmail = signal( true );
+const isEmailTouched = signal( false );
+const isNameTouched = signal( false );
 const isValidAuthor = signal( true );
 const userEmail = computed( () => mailLoginData.value.email || '' );
 const userName = computed( () => mailLoginData.value.author || '' );
 const userUrl = computed( () => mailLoginData.value.url || '' );
-
-const setFormData = ( event: ChangeEvent< HTMLInputElement > ) => {
-	mailLoginData.value = {
-		...mailLoginData.peek(),
-		[ event.currentTarget.name ]: event.currentTarget.value,
-	};
-};
 
 const validateFormData = () => {
 	const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
@@ -34,6 +29,14 @@ const validateFormData = () => {
 			Boolean( userEmail.value ) && Boolean( emailRegex.test( userEmail.value ) );
 		isValidAuthor.value = Boolean( userName.value.length > 0 );
 	} );
+};
+
+const setFormData = ( event: ChangeEvent< HTMLInputElement > ) => {
+	mailLoginData.value = {
+		...mailLoginData.peek(),
+		[ event.currentTarget.name ]: event.currentTarget.value,
+	};
+	validateFormData();
 };
 
 export const EmailForm = ( { shouldShowEmailForm }: EmailFormProps ) => {
@@ -84,15 +87,17 @@ export const EmailForm = ( { shouldShowEmailForm }: EmailFormProps ) => {
 							<Email />
 							<input
 								className={ classNames( 'verbum-form__email', {
-									'invalid-form-data': isValidEmail.value === false,
+									'invalid-form-data': isValidEmail.value === false && isEmailTouched.value,
 								} ) }
 								type="email"
 								spellCheck={ false }
 								autoCorrect="off"
 								autoComplete="email"
 								required={ authRequired }
-								onInput={ setFormData }
-								onBlur={ validateFormData }
+								onInput={ event => {
+									isEmailTouched.value = true;
+									setFormData( event );
+								} }
 								value={ userEmail }
 								name="email"
 								placeholder={ `${ translate( 'Email' ) } ${ translate(
@@ -105,15 +110,17 @@ export const EmailForm = ( { shouldShowEmailForm }: EmailFormProps ) => {
 							<Name />
 							<input
 								className={ classNames( 'verbum-form__name', {
-									'invalid-form-data': isValidAuthor.value === false,
+									'invalid-form-data': isValidAuthor.value === false && isNameTouched.value,
 								} ) }
 								type="text"
 								spellCheck={ false }
 								autoCorrect="off"
 								autoComplete="name"
 								required={ authRequired }
-								onInput={ setFormData }
-								onBlur={ validateFormData }
+								onInput={ event => {
+									isNameTouched.value = true;
+									setFormData( event );
+								} }
 								value={ userName }
 								name="author"
 								placeholder={ translate( 'Name' ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Our email and author validations were running on blur.
The PR changes the validation to run on input, for a better user experience.

Fixes #
144-gh-Automattic/verbum

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change comment email form validation to run on input instead of blur

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR to your sandbox
* Open a post from your site
* Without being logged in, test the comment email form validation
* The submit button should be enabled once the fields satisfy the minimum criteria