### PR TITLE
Image Guide: Fix image name pushing preview image to the side

### DIFF
--- a/projects/js-packages/image-guide/changelog/fix-image-guide-long-title-pushing-image
+++ b/projects/js-packages/image-guide/changelog/fix-image-guide-long-title-pushing-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix image name causing image to go outside details panel.

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-image-guide",
-	"version": "0.5.5",
+	"version": "0.5.6-alpha",
 	"description": "Go through the dom to analyze image size on screen vs actual file size.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/image-guide/#readme",
 	"type": "module",

--- a/projects/js-packages/image-guide/src/ui/Popup.svelte
+++ b/projects/js-packages/image-guide/src/ui/Popup.svelte
@@ -234,6 +234,7 @@
 
 	.title {
 		font-weight: 600;
+		overflow-wrap: anywhere;
 	}
 	.explanation {
 		margin-top: 5px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35295

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add overflow break for image name to prevent it from pushing the preview image.

	<details><summary>Before</summary>
	
	![CleanShot 2024-01-29 at 18 07 06](https://github.com/Automattic/jetpack/assets/11799079/c0acd531-2219-44c6-b9ed-4ea29cb33c4a)
	
	
	</details>
	
	<details><summary>Now</summary>

	![CleanShot 2024-01-29 at 18 05 57](https://github.com/Automattic/jetpack/assets/11799079/89ac806f-c55f-4fce-9191-471b562da9b1)
	
	</details>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost;
* Add an image with a very long name (no spaces, dashes or any other separators, just letters or numbers);
* Enable Image Guide and hover over the image on the page to make sure the title isn't pushing the preview outside of the container.