### PR TITLE
[Boost] Do not cache 500 internal fatal errors

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache.php
@@ -34,6 +34,28 @@ abstract class Boost_Cache {
 	}
 
 	/*
+	 * Returns true if the current request has a fatal error.
+	 *
+	 * @return bool
+	 */
+	private function is_fatal_error() {
+		$error = error_get_last();
+		if ( $error === null ) {
+			return false;
+		}
+
+		$fatal_errors = array(
+			E_ERROR,
+			E_PARSE,
+			E_CORE_ERROR,
+			E_COMPILE_ERROR,
+			E_USER_ERROR,
+		);
+
+		return in_array( $error['type'], $fatal_errors, true );
+	}
+
+	/*
 	 * Returns true if the request is cacheable.
 	 *
 	 * If a request is in the backend, or is a POST request, or is not an
@@ -44,6 +66,10 @@ abstract class Boost_Cache {
 	 */
 	public function is_cacheable() {
 		if ( ! apply_filters( 'boost_cache_cacheable', $this->request_uri ) ) {
+			return false;
+		}
+
+		if ( $this->is_fatal_error() ) {
 			return false;
 		}
 

--- a/projects/plugins/boost/changelog/add-fatal_error_check_cache
+++ b/projects/plugins/boost/changelog/add-fatal_error_check_cache
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Boost: do not cache pages with internal fatal errors.


### PR DESCRIPTION
If an internal fatal error occurs, the output buffer callback may still be called and cache the page. WordPress now handles these errors and displays a warning message.
This PR is an attempt detect the error and stop the plugin from caching the page. It's based on the code from WP Super Cache.

Fixes [#35297](https://github.com/Automattic/jetpack/issues/35297)

## Proposed changes:
* It adds a new function called `is_fatal_error()` that uses `error_get_last()` to examine the last triggered PHP error. If it's a fatal error, it returns true.
* The `is_cacheable()` function checks `is_fatal_error()` and if true, it return false.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2rA-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply the PR
* To make testing easier, add an error_log() to the is_fatal_error() check in Boost_Cache.php
* Create a new mu-plugin and add this code:
```
<?php

function tester() {
        require( 'blah' );
}
add_action( 'init', 'tester' );
```
* Delete all cached files
* Load a frontend page on your site and check the error log.
* Check if there's a cached file for the page you just requested.