### PR TITLE
tiled gallery: carousel-image-args.php: Fix PHP warnings from nested arrays in image meta

### DIFF
--- a/projects/plugins/jetpack/changelog/update-tiled-gallery-images
+++ b/projects/plugins/jetpack/changelog/update-tiled-gallery-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+tiled gallery: carousel-image-args.php: Fix PHP warnings from nested arrays in image meta

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
@@ -12,7 +12,7 @@ if ( isset( $fuzzy_image_meta['keywords'] ) ) {
 }
 
 // Using JSON_HEX_AMP avoids breakage due to `esc_attr()` refusing to double-encode.
-$fuzzy_image_meta = wp_json_encode( Jetpack_Tiled_Gallery_Layout::stringify_array_values( $fuzzy_image_meta ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+$fuzzy_image_meta = wp_json_encode( map_deep( $fuzzy_image_meta, 'strval' ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 
 ?>
 data-attachment-id="<?php echo esc_attr( $item->image->ID ); ?>"

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
@@ -12,7 +12,7 @@ if ( isset( $fuzzy_image_meta['keywords'] ) ) {
 }
 
 // Using JSON_HEX_AMP avoids breakage due to `esc_attr()` refusing to double-encode.
-$fuzzy_image_meta = wp_json_encode( array_map( 'strval', $fuzzy_image_meta ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+$fuzzy_image_meta = wp_json_encode( Jetpack_Tiled_Gallery_Layout::stringify_array_values( $fuzzy_image_meta ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 
 ?>
 data-attachment-id="<?php echo esc_attr( $item->image->ID ); ?>"

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-layout.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-layout.php
@@ -177,21 +177,4 @@ abstract class Jetpack_Tiled_Gallery_Layout {
 
 		return $extra_data;
 	}
-
-	/**
-	 * Converts all elements of an array to strings, recursively handling nested arrays.
-	 *
-	 * @param array $array The array to process.
-	 * @return array The array with all values converted to strings.
-	 */
-	public static function stringify_array_values( $array ) {
-		foreach ( $array as $key => $value ) {
-			if ( is_array( $value ) ) {
-				$array[ $key ] = self::stringify_array_values( $value );
-			} else {
-				$array[ $key ] = strval( $value );
-			}
-		}
-		return $array;
-	}
 }

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-layout.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-layout.php
@@ -177,4 +177,21 @@ abstract class Jetpack_Tiled_Gallery_Layout {
 
 		return $extra_data;
 	}
+
+	/**
+	 * Converts all elements of an array to strings, recursively handling nested arrays.
+	 *
+	 * @param array $array The array to process.
+	 * @return array The array with all values converted to strings.
+	 */
+	public static function stringify_array_values( $array ) {
+		foreach ( $array as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$array[ $key ] = self::stringify_array_values( $value );
+			} else {
+				$array[ $key ] = strval( $value );
+			}
+		}
+		return $array;
+	}
 }


### PR DESCRIPTION
`carousel-image-args.php` can create PHP warnings when encoding image metadata with containing nested arrays.  The line responsible is:
```php
$fuzzy_image_meta = wp_json_encode( array_map( 'strval', $fuzzy_image_meta ),  ... 
```

An example $fuzzy_image_meta triggering the warning is:
```
Array                                                                          
(                                      
    [aperture] => 74099370.67          
    [credit] =>                        
    [camera] => aterma                                                         
    [caption] =>                       
    [created_timestamp] =>             
    [copyright] =>                     
    [focal_length] => 74099370.666667                                          
    [iso] => Array                     
        (                              
            [0] => 64                  
            [1] => 64                  
        )                              
                                                                               
    [shutter_speed] => 74099370.666667 
    [title] =>                         
)  
```

The warning is: ` Warning: Array to string conversion in (...)/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php on line 15 `.

Because `$fuzzy_image_meta['iso']` is an array, it gets converted to `Array` when running strval on it.
Solution: Create a new recursive function for strval, that aligns with the original intention of changing numbers to strings, but also handles nested arrays.

## Proposed changes:

* Instead of using `wp_json_encode( array_map( 'strval', $fuzzy_image_meta )` to encode image meta, use `$fuzzy_image_meta = wp_json_encode( Jetpack_Tiled_Gallery_Layout::stringify_array_values( $fuzzy_image_meta )` after introducing a new function that handles nested arrays correctly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See D136291-code for a WPCOM testing helper and testing instructions.

