### PR TITLE
Backport mu-wpcom-plugin 2.0.17, jetpack 13.1-a.9 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2024-01-29
+### Changed
+- Update dependencies. [#35170]
+
 ## [0.5.0] - 2024-01-25
 ### Changed
 - AI Control: Do not call onAccept from the discard handler. A fix has been put in place on #35236. [#35238]
@@ -195,6 +199,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.5.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.3.1...v0.4.0

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.20] - 2024-01-29
+### Fixed
+- Fix TypeScript type for a Boost Score prop [#35273]
+
 ## [0.1.19] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]
@@ -91,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.20]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.19...v0.1.20
 [0.1.19]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.17...v0.1.18
 [0.1.17]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.16...v0.1.17

--- a/projects/js-packages/boost-score-api/changelog/fix-score-refresh
+++ b/projects/js-packages/boost-score-api/changelog/fix-score-refresh
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix TypeScript type for a Boost Score prop

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.20-alpha",
+	"version": "0.1.20",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.48.0] - 2024-01-29
+### Changed
+- Move the UpsellBanner component to js-packages/components [#35228]
+
+### Fixed
+- Fix TypeScript type for a Boost Score prop [#35273]
+
 ## [0.47.0] - 2024-01-18
 ### Added
 - My Jetpack: add a Jetpack Manage banner. [#35078]
@@ -925,6 +932,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.48.0]: https://github.com/Automattic/jetpack-components/compare/0.47.0...0.48.0
 [0.47.0]: https://github.com/Automattic/jetpack-components/compare/0.46.0...0.47.0
 [0.46.0]: https://github.com/Automattic/jetpack-components/compare/0.45.10...0.46.0
 [0.45.10]: https://github.com/Automattic/jetpack-components/compare/0.45.9...0.45.10

--- a/projects/js-packages/components/changelog/fix-score-refresh
+++ b/projects/js-packages/components/changelog/fix-score-refresh
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix TypeScript type for a Boost Score prop

--- a/projects/js-packages/components/changelog/update-move-upsell-banner-componen-to-js-components
+++ b/projects/js-packages/components/changelog/update-move-upsell-banner-componen-to-js-components
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Move the UpsellBanner component to js-packages/components

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.48.0-alpha",
+	"version": "0.48.0",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.31.2] - 2024-01-29
+### Changed
+- Update dependencies.
+
 ## [0.31.1] - 2024-01-18
 ### Changed
 - Update dependencies.
@@ -688,6 +692,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.31.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.12...v0.31.0
 [0.30.12]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.11...v0.30.12

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.31.1",
+	"version": "0.31.2",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.59 - 2024-01-29
+### Changed
+- Update dependencies.
+
 ## 0.10.58 - 2024-01-18
 ### Changed
 - Minor internal updates.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.58",
+	"version": "0.10.59",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.20 - 2024-01-29
+### Changed
+- Update dependencies.
+
 ## 0.11.19 - 2024-01-18
 ### Changed
 - Minor internal updates.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.11.19",
+	"version": "0.11.20",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.67 - 2024-01-29
+### Changed
+- Update dependencies. [#35170]
+
 ## 0.2.66 - 2024-01-22
 ### Changed
 - Update dependencies. [#35117]

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.66",
+	"version": "0.2.67",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.2] - 2024-01-29
+### Changed
+- Update dependencies. [#35170]
+
 ## [0.45.1] - 2024-01-22
 ### Changed
 - Update dependencies. [#35126]
@@ -571,6 +575,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.45.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.45.1...v0.45.2
 [0.45.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.45.0...v0.45.1
 [0.45.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.44.2...v0.45.0
 [0.44.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.44.1...v0.44.2

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.45.1",
+	"version": "0.45.2",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2024-01-29
+### Added
+- Adds new getJetpackBlocksVariation function [#34179]
+
 ## [0.13.10] - 2024-01-18
 ### Changed
 - Minor internal updates.
@@ -328,6 +332,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.14.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.10...0.14.0
 [0.13.10]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.9...0.13.10
 [0.13.9]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.8...0.13.9
 [0.13.8]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.7...0.13.8

--- a/projects/js-packages/shared-extension-utils/changelog/add-app-upload-media
+++ b/projects/js-packages/shared-extension-utils/changelog/add-app-upload-media
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Adds new getJetpackBlocksVariation function

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.14.0-alpha",
+	"version": "0.14.0",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2024-01-29
+### Fixed
+- Wait until 'admin_menu' action to call `add_menu()`, to avoid triggering the l10n load too early. [#35279]
+
 ## [0.3.1] - 2023-11-24
 
 ## [0.3.0] - 2023-11-20
@@ -132,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.3.2]: https://github.com/Automattic/jetpack-admin-ui/compare/0.3.1...0.3.2
 [0.3.1]: https://github.com/Automattic/jetpack-admin-ui/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.25...0.3.0
 [0.2.25]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.24...0.2.25

--- a/projects/packages/admin-ui/changelog/fix-i18n-loading-too-early-on-atomic
+++ b/projects/packages/admin-ui/changelog/fix-i18n-loading-too-early-on-atomic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Wait until 'admin_menu' action to call `add_menu()`, to avoid triggering the l10n load too early.

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.3.2-alpha",
+	"version": "0.3.2",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.3.2-alpha';
+	const PACKAGE_VERSION = '0.3.2';
 
 	/**
 	 * Whether this class has been initialized

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2024-01-29
+### Changed
+- Update dependencies.
+
 ## [3.1.0] - 2024-01-22
 ### Changed
 - Use blog ID instead site slug for checkout and WPCOM links. [#35020]
@@ -542,6 +546,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.1.1]: https://github.com/Automattic/jetpack-backup/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/Automattic/jetpack-backup/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/Automattic/jetpack-backup/compare/v2.0.5...v3.0.0
 [2.0.5]: https://github.com/Automattic/jetpack-backup/compare/v2.0.4...v2.0.5

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup\V0001;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.1.0';
+	const PACKAGE_VERSION = '3.1.1';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.2] - 2024-01-29
+### Changed
+- Update dependencies. [#35170]
+
 ## [0.15.1] - 2024-01-22
 ### Changed
 - Update dependencies. [#35117]
@@ -269,6 +273,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.15.2]: https://github.com/automattic/jetpack-blaze/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/automattic/jetpack-blaze/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/automattic/jetpack-blaze/compare/v0.14.3...v0.15.0
 [0.14.3]: https://github.com/automattic/jetpack-blaze/compare/v0.14.2...v0.14.3

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.15.1",
+	"version": "0.15.2",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.15.1';
+	const PACKAGE_VERSION = '0.15.2';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.2] - 2024-01-29
+### Changed
+- Update dependencies.
+
 ## [0.30.1] - 2024-01-22
 ### Added
 - Contact Form: test setup for front end script [#35074]
@@ -469,6 +473,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.2]: https://github.com/automattic/jetpack-forms/compare/v0.30.1...v0.30.2
 [0.30.1]: https://github.com/automattic/jetpack-forms/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/automattic/jetpack-forms/compare/v0.29.2...v0.30.0
 [0.29.2]: https://github.com/automattic/jetpack-forms/compare/v0.29.1...v0.29.2

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.1",
+	"version": "0.30.2",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.1';
+	const PACKAGE_VERSION = '0.30.2';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.11.0] - 2024-01-29
+### Security
+- Allow users to post HTML when blocks are enabled [#35276]
+
+### Added
+- Cache the response of the Domain List request, and harden the code [#35070]
+
+### Changed
+- Change Verbum Blocks sample size to 30% [#35255]
+- Hides the "Install the mobile app" task while the completion logic is not fully implemented [#35302]
+- Update Verbum README [#35252]
+
+### Fixed
+- Verbum cache buster depended on build_meta, which is only updated on production builds. It doesn't refresh during development, giving you a stale block-editor bundle. [#35243]
+
 ## [5.10.0] - 2024-01-25
 ### Added
 - Add Verbum Comments in jetpack-mu-wpcom plugin. [#35196]
@@ -541,6 +556,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.11.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.10.0...v5.11.0
 [5.10.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.9.0...v5.10.0
 [5.9.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.2...v5.9.0
 [5.8.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.1...v5.8.2

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-cache-domains-list-request-response
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-cache-domains-list-request-response
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Cache the response of the Domain List request, and harden the code

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-kses-for-blocks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-kses-for-blocks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Allow users to post HTML when blocks are enabled

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-cache-buster
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-cache-buster
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Verbum cache buster depended on build_meta, which is only updated on production builds. It doesn't refresh during development, giving you a stale block-editor bundle. 

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-email-validation
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-email-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/release-verbum-to-30
+++ b/projects/packages/jetpack-mu-wpcom/changelog/release-verbum-to-30
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Change Verbum Blocks sample size to 30%

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-hide-mobile-app-installed
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-hide-mobile-app-installed
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Hides the "Install the mobile app" task while the completion logic is not fully implemented

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-verbum-readme-development-process
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-verbum-readme-development-process
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update Verbum README

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.11.0-alpha",
+	"version": "5.11.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.11.0-alpha';
+	const PACKAGE_VERSION = '5.11.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.7.0] - 2024-01-29
+### Changed
+- Update the UpsellBanner to use the Card component from WP components. [#35223]
+
+### Removed
+- UpsellBanner component moved to js-packages/components [#35228]
+
 ## [4.6.2] - 2024-01-22
 ### Added
 - My Jetpack: add contact us event for Jetpack AI [#35136]
@@ -1207,6 +1214,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.7.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.6.2...4.7.0
 [4.6.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.6.1...4.6.2
 [4.6.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.6.0...4.6.1
 [4.6.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.5.0...4.6.0

--- a/projects/packages/my-jetpack/changelog/update-move-upsell-banner-componen-to-js-components
+++ b/projects/packages/my-jetpack/changelog/update-move-upsell-banner-componen-to-js-components
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-UpsellBanner component moved to js-packages/components

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update the UpsellBanner to use the Card component from WP components.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.7.0-alpha",
+	"version": "4.7.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -34,7 +34,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.7.0-alpha';
+	const PACKAGE_VERSION = '4.7.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.1] - 2024-01-29
+### Changed
+- Update dependencies. [#35170]
+
 ## [0.42.0] - 2024-01-25
 ### Added
 - Add price and rating to default sort options. [#35167]
@@ -880,6 +884,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.42.1]: https://github.com/Automattic/jetpack-search/compare/v0.42.0...v0.42.1
 [0.42.0]: https://github.com/Automattic/jetpack-search/compare/v0.41.1...v0.42.0
 [0.41.1]: https://github.com/Automattic/jetpack-search/compare/v0.41.0...v0.41.1
 [0.41.0]: https://github.com/Automattic/jetpack-search/compare/v0.40.4...v0.41.0

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.42.0",
+	"version": "0.42.1",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.42.0';
+	const VERSION = '0.42.1';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.4] - 2024-01-29
+### Changed
+- Update dependencies.
+
 ## [0.22.3] - 2024-01-22
 ### Fixed
 - Memberships: Removed the use of non-existent class Token_Subscription_Service [#34999]
@@ -1242,6 +1246,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.22.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.3...v0.22.4
 [0.22.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.2...v0.22.3
 [0.22.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.0...v0.22.1

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.22.3",
+	"version": "0.22.4",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.22.3';
+	const PACKAGE_VERSION = '0.22.4';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2024-01-29
+### Changed
+- Update dependencies. [#35170]
+
 ## [0.3.5] - 2024-01-22
 ### Changed
 - Update dependencies. [#35117]
@@ -295,6 +299,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.6]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.2...v0.3.3

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.5';
+	const VERSION = '0.3.6';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.1-a.9 - 2024-01-29
+### Enhancements
+- Subject: A new way to upload media via the Jetpack App [#34179]
+
+### Improved compatibility
+- RNMobile: Disable Story block [#35202]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Adding serivce to a feature which is not live for the users yet. [#35183]
+- AI Assistant: add accept event on title suggestion request [#35281]
+- AI Assistant: add events on block control [#35254]
+- AI Assistant: add menu show events on both control and extension (form) [#35256]
+- AI Assistant: change tool property on event [#35280]
+- AI Content Lens (excerpt): add events on generate, discard and accept [#35251]
+- AI Forms Extension: add events on ai actions [#35257]
+- Feature is not yet released. [#35184]
+- Jetpack_PostImages::from_attachment: Prevent warning when $thumb_post_data cannot be found [#35264]
+- Move Jetpack to the same menu position as standalone Jetpack site. [#35154]
+- Remove the dashboard swither for the wp-admin interface. [#35210]
+- Remove the dotcom warning for wp-admin in Writing and Discussion settings page [#35241]
+- Sharing Buttons Block: Add size controls to the block [#35267]
+- youtube-shortcode: Handle being given an array with a 'url' key insteadad of the URL as a string [#35181]
+
 ## 13.1-a.7 - 2024-01-25
 ### Enhancements
 - Jetpack Search: Add 'price' as the default sorting option. [#35167]

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-app-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-app-media.php
@@ -3,13 +3,13 @@
  * REST API endpoint for the media uploaded by the Jetpack app.
  *
  * @package automattic/jetpack
- * @since $$next-version$$
+ * @since 13.1
  */
 
 /**
  * Media uploaded by the Jetpack app helper API.
  *
- * @since $$next-version$$
+ * @since 13.1
  */
 class WPCOM_REST_API_V2_Endpoint_App_Media extends WP_REST_Controller {
 

--- a/projects/plugins/jetpack/changelog/add-ai-assistant-accept-title-event
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-accept-title-event
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: add accept event on title suggestion request

--- a/projects/plugins/jetpack/changelog/add-ai-assistant-block-events
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-block-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: add events on block control

--- a/projects/plugins/jetpack/changelog/add-ai-assistant-prompt-show-event
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-prompt-show-event
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: add menu show events on both control and extension (form)

--- a/projects/plugins/jetpack/changelog/add-ai-excerpt-events
+++ b/projects/plugins/jetpack/changelog/add-ai-excerpt-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Content Lens (excerpt): add events on generate, discard and accept

--- a/projects/plugins/jetpack/changelog/add-app-upload-media
+++ b/projects/plugins/jetpack/changelog/add-app-upload-media
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subject: A new way to upload media via the Jetpack App

--- a/projects/plugins/jetpack/changelog/add-jetpack-forms-ai-extension-events
+++ b/projects/plugins/jetpack/changelog/add-jetpack-forms-ai-extension-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Forms Extension: add events on ai actions

--- a/projects/plugins/jetpack/changelog/add-size-control-to-sharing-block
+++ b/projects/plugins/jetpack/changelog/add-size-control-to-sharing-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Sharing Buttons Block: Add size controls to the block

--- a/projects/plugins/jetpack/changelog/add-twitter-sharing-button
+++ b/projects/plugins/jetpack/changelog/add-twitter-sharing-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Adding serivce to a feature which is not live for the users yet.

--- a/projects/plugins/jetpack/changelog/change-ai-assistant-dropdown-menu-event
+++ b/projects/plugins/jetpack/changelog/change-ai-assistant-dropdown-menu-event
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: change tool property on event

--- a/projects/plugins/jetpack/changelog/disable-multiple-sharing-blocks
+++ b/projects/plugins/jetpack/changelog/disable-multiple-sharing-blocks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Feature is not yet released.

--- a/projects/plugins/jetpack/changelog/fix-youtube-shortcode
+++ b/projects/plugins/jetpack/changelog/fix-youtube-shortcode
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-youtube-shortcode: Handle being given an array with a 'url' key insteadad of the URL as a string

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.1-a.10
+
+

--- a/projects/plugins/jetpack/changelog/rnmobile-disable-story-block
+++ b/projects/plugins/jetpack/changelog/rnmobile-disable-story-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-RNMobile: Disable Story block

--- a/projects/plugins/jetpack/changelog/update-atomic-jetpack-menu-position
+++ b/projects/plugins/jetpack/changelog/update-atomic-jetpack-menu-position
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Move Jetpack to the same menu position as standalone Jetpack site.

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-upsell-banner-to-use-wp-card
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-post-images
+++ b/projects/plugins/jetpack/changelog/update-post-images
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack_PostImages::from_attachment: Prevent warning when $thumb_post_data cannot be found

--- a/projects/plugins/jetpack/changelog/update-remove-warning-writing-discussion
+++ b/projects/plugins/jetpack/changelog/update-remove-warning-writing-discussion
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Remove the dotcom warning for wp-admin in Writing and Discussion settings page

--- a/projects/plugins/jetpack/changelog/update-untangle-dashboard-switcher
+++ b/projects/plugins/jetpack/changelog/update-untangle-dashboard-switcher
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Remove the dashboard swither for the wp-admin interface.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_8",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_9",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_9",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_10",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-a.8
+ * Version: 13.1-a.9
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-a.8' );
+define( 'JETPACK__VERSION', '13.1-a.9' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-a.9
+ * Version: 13.1-a.10
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-a.9' );
+define( 'JETPACK__VERSION', '13.1-a.10' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-a.8",
+	"version": "13.1.0-a.9",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-a.9",
+	"version": "13.1.0-a.10",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,10 +293,12 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.1-a.7 - 2024-01-25
+### 13.1-a.9 - 2024-01-29
 #### Enhancements
-- Jetpack Search: Add 'price' as the default sorting option.
-- Subscribe Block: Don't include social followers on counts by default.
+- Subject: A new way to upload media via the Jetpack App
+
+#### Improved compatibility
+- RNMobile: Disable Story block
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.17 - 2024-01-29
+### Changed
+- Internal updates.
+
 ## 2.0.16 - 2024-01-25
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-verbum-readme-development-process
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-verbum-readme-development-process
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_17_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_17"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.17-alpha
+ * Version: 2.0.17
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.17-alpha",
+	"version": "2.0.17",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
## Proposed changes:

Backport mu-wpcom-plugin 2.0.17, jetpack 13.1-a.9 Changes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Proofread changes.
