### PR TITLE
live-branches: specify update/download URLs

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -7,6 +7,8 @@
 // @connect      betadownload.jetpack.me
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*
+// @updateURL    https://github.com/Automattic/jetpack/raw/trunk/tools/jetpack-live-branches/jetpack-live-branches.user.js
+// @downloadURL  https://github.com/Automattic/jetpack/raw/trunk/tools/jetpack-live-branches/jetpack-live-branches.user.js
 // ==/UserScript==
 
 // Need to declare "jQuery" for linting within TamperMonkey, but in the monorepo it's already declared.


### PR DESCRIPTION
## Proposed changes:

Adds explicit [updateURL](https://www.tampermonkey.net/documentation.php?locale=en#meta:updateURL) and downloadURL for the userscript.

I somehow managed to install a version from a non-trunk branch, so was never getting script updates (my updateURL was locked to the dormant branch I installed from). Hopefully this should help with future occurrences of that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

At least with Tampermonkey, you can test by installing a version of the userscript from a non-trunk branch. Then if you manually edit in the update/download URLs and perform a script update check, it should be able to grab the updated version.
