### PR TITLE
Jetpack AI: Move error message closer to AI Assistant input

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-move-error-closer-to-assistant-input
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-move-error-closer-to-assistant-input
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack AI: Support floating error messaging on the AI Control component.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.5.1",
+	"version": "0.6.0-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -43,6 +43,7 @@ type AiControlProps = {
 	onDiscard?: () => void;
 	showRemove?: boolean;
 	bannerComponent?: React.ReactElement;
+	errorComponent?: React.ReactElement;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -74,6 +75,7 @@ export function AIControl(
 		onDiscard = null,
 		showRemove = false,
 		bannerComponent = null,
+		errorComponent = null,
 	}: AiControlProps,
 	ref: React.MutableRefObject< null > // eslint-disable-line @typescript-eslint/ban-types
 ): React.ReactElement {
@@ -153,6 +155,7 @@ export function AIControl(
 
 	return (
 		<div className="jetpack-components-ai-control__container-wrapper">
+			{ errorComponent }
 			<div className="jetpack-components-ai-control__container">
 				{ bannerComponent }
 				<div

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-move-error-closer-to-assistant-input
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-move-error-closer-to-assistant-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: move error handling from top of block to closer the AI Control input.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -432,6 +432,20 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		</>
 	);
 
+	const error = (
+		<>
+			{ errorData?.message && ! errorDismissed && errorData?.code !== 'error_quota_exceeded' && (
+				<Notice
+					status={ errorData.status }
+					isDismissible={ false }
+					className="jetpack-ai-assistant__error"
+				>
+					{ errorData.message }
+				</Notice>
+			) }
+		</>
+	);
+
 	return (
 		<KeyboardShortcuts
 			bindGlobal
@@ -444,16 +458,6 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 			} }
 		>
 			<div { ...blockProps }>
-				{ errorData?.message && ! errorDismissed && errorData?.code !== 'error_quota_exceeded' && (
-					<Notice
-						status={ errorData.status }
-						isDismissible={ false }
-						className="jetpack-ai-assistant__error"
-					>
-						{ errorData.message }
-					</Notice>
-				) }
-
 				{ contentIsLoaded && ! useGutenbergSyntax && (
 					<div className="jetpack-ai-assistant__content">
 						<RawHTML>{ markdownConverter.render( attributes.content ) }</RawHTML>
@@ -587,6 +591,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					showGuideLine={ contentIsLoaded }
 					showRemove={ attributes?.content?.length > 0 }
 					bannerComponent={ banner }
+					errorComponent={ error }
 				/>
 
 				{ ! loadingImages && resultImages.length > 0 && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35162.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the AI Assistant error messages closer to the AI Assistant input, floating/scrolling together with it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and ask for a long piece of content (example: "5 long paragraphs about ship building")
* Wait for it to complete, and then execute an incomprehensible follow up request to trigger an error message (example: "add more details about qazwsxedcrfvtgbyhnujmikolp")
* Before this PR, the error would show up at the top of the block, becoming almost invisible to the user:

| The input after the error, no feedback to the user | The error, hidden way up on the editor |
| --- | --- |
| ![Screenshot 2024-01-20 at 14 43 39](https://github.com/Automattic/jetpack/assets/6760046/afff0c7b-7831-4336-87fc-08e7e46372cc) | ![Screenshot 2024-01-20 at 14 43 45](https://github.com/Automattic/jetpack/assets/6760046/cfdf75f2-9194-4f39-a45b-3c6272bc366a) |

* After this PR, the error will show up right above the AI Assistant input field and will scroll/become sticky with the assistant itself:

| Sticky | At the bottom of the block |
| --- | --- |
| <img width="300" alt="Screenshot 2024-01-29 at 18 24 43" src="https://github.com/Automattic/jetpack/assets/6760046/f7180ada-4f60-43f5-933c-2b6dcf3f24aa"> | <img width="300" alt="Screenshot 2024-01-29 at 18 34 24" src="https://github.com/Automattic/jetpack/assets/6760046/91b5ca0b-e56f-4b0a-b3f0-ea66b1ec9ecb"> |