### PR TITLE
jetpack-mu-wpcom: Improve Verbum build

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2009,9 +2009,6 @@ importers:
       babel-plugin-transform-rename-properties:
         specifier: 0.1.0
         version: 0.1.0(@babel/core@7.23.5)
-      copy-webpack-plugin:
-        specifier: 11.0.0
-        version: 11.0.0(webpack@5.76.0)
       sass:
         specifier: 1.64.1
         version: 1.64.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum: Avoid copying PHP files into `src/build/verbum-comments/`.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build#2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Verbum: Minify dynamic-loader script.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build#3
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build#3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Verbum: Use jetpack-assets package to register scripts using `.asset.php` file data.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -4,7 +4,8 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=7.0"
+		"php": ">=7.0",
+		"automattic/jetpack-assets": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.1.0",

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.11.0",
+	"version": "5.11.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {
@@ -36,7 +36,6 @@
 		"@types/react": "^18.2.28",
 		"@types/react-dom": "18.2.0",
 		"babel-plugin-transform-rename-properties": "0.1.0",
-		"copy-webpack-plugin": "11.0.0",
 		"sass": "1.64.1",
 		"sass-loader": "12.4.0",
 		"typescript": "^5.0.4",

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.11.0';
+	const PACKAGE_VERSION = '5.11.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;
@@ -262,7 +262,7 @@ class Jetpack_Mu_Wpcom {
 			if ( self::should_disable_comment_experience( $blog_id ) ) {
 				return false;
 			}
-			require_once __DIR__ . '/build/verbum-comments/class-verbum-comments.php';
+			require_once __DIR__ . '/features/verbum-comments/class-verbum-comments.php';
 			new \Automattic\Jetpack\Verbum_Comments();
 		}
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -108,8 +108,6 @@ class Verbum_Comments {
 			return;
 		}
 
-		$version_js       = filemtime( __DIR__ . '/verbum-comments.js' );
-		$version_css      = filemtime( __DIR__ . '/verbum-comments.css' );
 		$connect_url      = site_url( '/public.api/connect/?action=request' );
 		$primary_redirect = get_primary_redirect();
 
@@ -117,20 +115,18 @@ class Verbum_Comments {
 			$connect_url = add_query_arg( 'domain', $primary_redirect, $connect_url );
 		}
 
-		// Enqueue styles
-		wp_enqueue_style( 'verbum', plugins_url( '/verbum-comments.css', __FILE__ ), array(), $version_css );
-
-		// Enqueue scripts
-		wp_register_script(
+		// Enqueue styles and scripts
+		Assets::register_script(
 			'verbum',
-			plugins_url( 'verbum-comments.js', __FILE__ ),
-			array(),
-			$version_js,
+			'../../build/verbum-comments/verbum-comments.js',
+			__FILE__,
 			array(
 				'strategy'  => 'defer',
 				'in_footer' => true,
 			)
 		);
+
+		wp_enqueue_style( 'verbum' );
 		\WP_Enqueue_Dynamic_Script::enqueue_script( 'verbum' );
 
 		// Enqueue settings separately since the main script is dynamic.
@@ -139,7 +135,7 @@ class Verbum_Comments {
 			'verbum-settings',
 			false,
 			array(),
-			$version_js,
+			null, // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- No script, so no version needed.
 			array(
 				'strategy'  => 'defer',
 				'in_footer' => true,
@@ -250,14 +246,14 @@ class Verbum_Comments {
 
 		wp_enqueue_script( 'verbum-settings' );
 
-		wp_enqueue_script(
+		Assets::register_script(
 			'verbum-dynamic-loader',
-			plugins_url( 'assets/dynamic-loader.js', __FILE__ ),
-			array(),
-			$version_js,
+			'../../build/verbum-comments/assets/dynamic-loader.js',
+			__FILE__,
 			array(
 				'strategy'  => 'defer',
 				'in_footer' => true,
+				'enqueue'   => true,
 			)
 		);
 	}

--- a/projects/packages/jetpack-mu-wpcom/verbum.webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/verbum.webpack.config.js
@@ -2,7 +2,6 @@
 const path = require( 'path' );
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const jetpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
-const CopyPlugin = require( 'copy-webpack-plugin' );
 const webpack = require( 'webpack' );
 
 const babelOpts = {
@@ -18,82 +17,111 @@ const babelOpts = {
 	presets: [ [ '@automattic/jetpack-webpack-config/babel/preset' ] ],
 };
 
-module.exports = {
-	entry: {
-		'verbum-comments': './src/features/verbum-comments/src/index.tsx',
-	},
-	mode: jetpackConfig.mode,
-	devtool: jetpackConfig.devtool,
-	output: {
-		...jetpackConfig.output,
-		filename: '[name]/[name].js',
-		path: path.resolve( __dirname, 'src/build' ),
-		environment: {
-			module: true,
-			dynamicImport: true,
+module.exports = [
+	{
+		entry: {
+			'verbum-comments': './src/features/verbum-comments/src/index.tsx',
+		},
+		mode: jetpackConfig.mode,
+		devtool: jetpackConfig.devtool,
+		output: {
+			...jetpackConfig.output,
+			filename: '[name]/[name].js',
+			path: path.resolve( __dirname, 'src/build' ),
+			environment: {
+				module: true,
+				dynamicImport: true,
+			},
+		},
+		optimization: {
+			...jetpackConfig.optimization,
+		},
+		resolve: {
+			...jetpackConfig.resolve,
+		},
+		node: false,
+		plugins: [
+			...jetpackConfig.StandardPlugins( {
+				DependencyExtractionPlugin: { injectPolyfill: false },
+				MiniCssExtractPlugin: { filename: '[name]/[name].css' },
+			} ),
+			new webpack.ProvidePlugin( {
+				h: [ 'preact', 'h' ],
+				Fragment: [ 'preact', 'Fragment' ],
+			} ),
+		],
+		module: {
+			strictExportPresence: true,
+			rules: [
+				// Transpile JavaScript.
+				jetpackConfig.TranspileRule( {
+					exclude: /node_modules\//,
+					babelOpts,
+				} ),
+
+				// Transpile @automattic/jetpack-* in node_modules too.
+				jetpackConfig.TranspileRule( {
+					includeNodeModules: [ '@automattic/jetpack-' ],
+				} ),
+
+				// preact has some `__` internal methods, which confuse i18n-check-webpack-plugin. Hack around that.
+				jetpackConfig.TranspileRule( {
+					includeNodeModules: [ 'preact' ],
+					babelOpts: {
+						configFile: false,
+						plugins: [ [ 'babel-plugin-transform-rename-properties', { rename: { __: '__ǃ' } } ] ],
+						presets: [],
+					},
+				} ),
+
+				// Handle CSS.
+				jetpackConfig.CssRule( {
+					extensions: [ 'css', 'scss' ],
+					extraLoaders: [ 'sass-loader' ],
+				} ),
+
+				// Handle images.
+				jetpackConfig.FileRule(),
+			],
 		},
 	},
-	optimization: {
-		...jetpackConfig.optimization,
-	},
-	resolve: {
-		...jetpackConfig.resolve,
-	},
-	node: false,
-	plugins: [
-		...jetpackConfig.StandardPlugins( {
-			DependencyExtractionPlugin: { injectPolyfill: false },
-			MiniCssExtractPlugin: { filename: '[name]/[name].css' },
-		} ),
-		new webpack.ProvidePlugin( {
-			h: [ 'preact', 'h' ],
-			Fragment: [ 'preact', 'Fragment' ],
-		} ),
-		new CopyPlugin( {
-			patterns: [
-				{
-					from: './src/features/verbum-comments/class-verbum-comments.php',
-					to: './verbum-comments',
-				},
-				{
-					from: './src/features/verbum-comments/assets',
-					to: './verbum-comments/assets',
-				},
-			],
-		} ),
-	],
-	module: {
-		strictExportPresence: true,
-		rules: [
-			// Transpile JavaScript.
-			jetpackConfig.TranspileRule( {
-				exclude: /node_modules\//,
-				babelOpts,
+	{
+		entry: {
+			'verbum-comments/assets/dynamic-loader':
+				'./src/features/verbum-comments/assets/dynamic-loader.js',
+		},
+		mode: jetpackConfig.mode,
+		devtool: jetpackConfig.devtool,
+		output: {
+			...jetpackConfig.output,
+			path: path.resolve( __dirname, 'src/build' ),
+		},
+		optimization: {
+			...jetpackConfig.optimization,
+		},
+		resolve: {
+			...jetpackConfig.resolve,
+		},
+		node: false,
+		plugins: [
+			...jetpackConfig.StandardPlugins( {
+				DependencyExtractionPlugin: { injectPolyfill: false },
 			} ),
-
-			// Transpile @automattic/jetpack-* in node_modules too.
-			jetpackConfig.TranspileRule( {
-				includeNodeModules: [ '@automattic/jetpack-' ],
-			} ),
-
-			// preact has some `__` internal methods, which confuse i18n-check-webpack-plugin. Hack around that.
-			jetpackConfig.TranspileRule( {
-				includeNodeModules: [ 'preact' ],
-				babelOpts: {
-					configFile: false,
-					plugins: [ [ 'babel-plugin-transform-rename-properties', { rename: { __: '__ǃ' } } ] ],
-					presets: [],
-				},
-			} ),
-
-			// Handle CSS.
-			jetpackConfig.CssRule( {
-				extensions: [ 'css', 'scss' ],
-				extraLoaders: [ 'sass-loader' ],
-			} ),
-
-			// Handle images.
-			jetpackConfig.FileRule(),
 		],
+		module: {
+			strictExportPresence: true,
+			rules: [
+				// Transpile JavaScript.
+				jetpackConfig.TranspileRule( {
+					exclude: /node_modules\//,
+					babelOpts,
+				} ),
+
+				// Transpile @automattic/jetpack-* in node_modules too.
+				jetpackConfig.TranspileRule( {
+					includeNodeModules: [ '@automattic/jetpack-' ],
+				} ),
+			],
+		},
 	},
-};
+];

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -5,7 +5,7 @@ const jetpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 const verbumConfig = require( './verbum.webpack.config.js' );
 
 module.exports = [
-	verbumConfig,
+	...verbumConfig,
 	{
 		entry: {
 			'error-reporting': './src/features/error-reporting/index.js',

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-verbum-build
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-verbum-build
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_17"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_18_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -7,14 +7,132 @@
     "content-hash": "eec12a75b7ddd8f85b30cc58ffb814c6",
     "packages": [
         {
+            "name": "automattic/jetpack-assets",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/assets",
+                "reference": "1f713fb83a98dab43f325fe71331d40f9ca47334"
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "brain/monkey": "2.6.1",
+                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-assets",
+                "textdomain": "jetpack-assets",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "actions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Asset management utilities for Jetpack ecosystem packages",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-constants",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/constants",
+                "reference": "3fd2bf1d1ba0bb374918e6b7dd670735ce554c2b"
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "brain/monkey": "2.6.1",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-constants",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-constants/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for defining constants in a more testable way.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-mu-wpcom",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "866010f4eeffe66ad08c737b30885175d6debb74"
+                "reference": "2aacc54b3f715dd4899aa9c3610c85b0e70b7e8b"
             },
             "require": {
+                "automattic/jetpack-assets": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.17
+ * Version: 2.0.18-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.17",
+	"version": "2.0.18-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Avoid copying php files into `src/build/`, as it causes Composer to complain about multiple files providing the classes.
* Run `dynamic-loader.js` through webpack for minification.
* Use the jetpack-assets package to register the scripts using the data in the `.assets.php` files.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1706559158287209/1706556445.671539-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
1. Apply this patch to your sandbox using both of the commands listed [here](https://github.com/Automattic/jetpack/pull/35323#issuecomment-1915666258).
2. Sandbox punsintended418746564.wordpress.com.
3. Comment on this [post](https://punsintended418746564.wordpress.com/2023/12/12/fresh-post).
4. Make sure embeds works (one embed is enough, to make sure embeds endpoint work (relies on PHP files)).

### Regression testing
1. Checkout this branch.
2. Sync jetpack-mu-plugin with your atomic site.
3. Visit any wp-admin page and verify no warnings or errors show up.

