### PR TITLE
Jetpack Boost: DataSync Client - Enhanced error handling

### DIFF
--- a/projects/js-packages/react-data-sync-client/changelog/datasync-zod-error-handling
+++ b/projects/js-packages/react-data-sync-client/changelog/datasync-zod-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+React DataSync Client: Enhanced Error Handling and Debugging

--- a/projects/js-packages/react-data-sync-client/src/DataSync.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSync.ts
@@ -157,8 +157,21 @@ export class DataSync< Schema extends z.ZodSchema, Value extends z.infer< Schema
 			? window[ this.namespace ][ valueName ]
 			: { value: undefined, nonce: '' };
 
-		const result = validator.parse( source );
-		return result as ParsedValue< V >;
+		try {
+			return validator.parse( source ) as ParsedValue< V >;
+		} catch ( error ) {
+			throw new DataSyncError(
+				`Failed to parse the window.${ this.namespace }.${ valueName } value`,
+				{
+					...this.describeSelf(),
+					url: 'window',
+					method: '',
+					status: 'schema_error',
+					error,
+					data: source,
+				}
+			);
+		}
 	}
 
 	/**

--- a/projects/js-packages/react-data-sync-client/src/DataSync.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSync.ts
@@ -164,7 +164,7 @@ export class DataSync< Schema extends z.ZodSchema, Value extends z.infer< Schema
 				`Failed to parse global value at 'window.${ this.namespace }.${ valueName }'`,
 				{
 					...this.describeSelf(),
-					location: 'getWindowValue()',
+					location: `window.${ this.namespace }.${ valueName }`,
 					status: 'schema_error',
 					error,
 					data: source,
@@ -399,7 +399,7 @@ export class DataSync< Schema extends z.ZodSchema, Value extends z.infer< Schema
 		if ( ! ( this.namespace in window ) || ! ( this.key in window[ this.namespace ] ) ) {
 			throw new DataSyncError( `"${ this.namespace }.${ this.key }" not found in window object`, {
 				...this.describeSelf(),
-				location: 'ACTION()',
+				location: `window.${ this.namespace }.${ this.key }`,
 				status: 'schema_error',
 				data: null,
 			} );
@@ -416,7 +416,7 @@ export class DataSync< Schema extends z.ZodSchema, Value extends z.infer< Schema
 				`Nonce for Action "${ name }" not found in window.${ this.namespace }.${ this.key }.actions`,
 				{
 					...this.describeSelf(),
-					location: 'ACTION()',
+					location: `window.${ this.namespace }.${ this.key }.actions`,
 					status: 'schema_error',
 					data: actions,
 				}

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -55,6 +55,10 @@ export class DataSyncError extends Error {
 			`🔄 DataSync Debug: %c${ key }`,
 			'color: #dc362e; font-weight: normal;'
 		);
+
+		// Styles
+		const highlightBox = `font-style: italic; solid #e9e9e3; line-height: 1.8;`;
+
 		console.error( this.message );
 		if ( info.error instanceof z.ZodError ) {
 			const msg: string[] = [];
@@ -86,11 +90,11 @@ export class DataSyncError extends Error {
 					if ( issuePath ) {
 						add( `.${ issuePath }`, 'font-weight: bold;' );
 					}
-					add( `\n` );
-					add(
-						`${ issueMessage }`,
-						'font-style: italic; border-left: 3px solid #e9e9e3; margin: 3px 0px 3px 7px; background-color: #f9f9f6; padding: 7px;'
-					);
+
+					add( '\n' );
+					add( '⇢', 'margin-left: 5px; margin-right: 5px; font-size: 15px;' );
+					add( `${ issueMessage }`, highlightBox );
+					add( `\n\n` );
 					console.log( msg.join( '' ), ...styles );
 					msg.length = 0;
 					styles.length = 0;
@@ -132,7 +136,7 @@ export class DataSyncError extends Error {
 					`%cPHP Log%c: PHP Log is disabled. To enable it, place the debug code in your wp-config.php:\n%cdefine( 'DATASYNC_DEBUG', true );`,
 					'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
 					'',
-					'font-style: italic; border-left: 3px solid #e9e9e3; margin: 3px 0px 3px 7px; background-color: #f9f9f6; padding: 7px;'
+					highlightBox
 				);
 			}
 		}

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -56,94 +56,95 @@ export class DataSyncError extends Error {
 			'color: #dc362e; font-weight: normal;'
 		);
 
-		// Styles
-		const highlightBox = `font-style: italic; solid #e9e9e3; line-height: 1.8;`;
+		// Group common styles into a single object
+		const styles = {
+			group: 'color: #6e6e6e; font-weight: 700; font-size: 14px;',
+			bold: 'font-weight: bold;',
+			value: 'color: #827171; font-weight: bold;',
+			spacing: 'margin-top: 5px; margin-bottom: 2px;',
+			arrow: 'margin-left: 5px; margin-right: 5px; font-size: 15px;',
+			highlight: 'font-style: italic; solid #e9e9e3; line-height: 1.8;',
+		};
 
 		console.error( this.message );
 		if ( info.error instanceof z.ZodError ) {
-			const msg: string[] = [];
-			const styles: string[] = [];
+			const msg = [];
+			const stylesArray = [];
 
-			// Shortcut for adding a message and style.
-			const add = ( m: string, s?: string ) => {
+			// Shortcut for adding a message and style
+			const add = ( m, s = '' ) => {
 				if ( s ) {
 					msg.push( `%c${ m }%c` );
-					styles.push( s );
-					styles.push( '' );
+					stylesArray.push( s, '' ); // Reset style after custom
 				} else {
 					msg.push( m );
 				}
 			};
 
 			if ( info.error.issues.length > 0 ) {
-				console.groupCollapsed(
-					`%c🦸 Zod Issues(${ info.error.issues.length })`,
-					'color: #6e6e6e; font-weight: 700; font-size: 14px;'
-				);
+				console.groupCollapsed( `%c🦸 Zod Issues(${ info.error.issues.length })`, styles.group );
 				for ( const issue of info.error.issues ) {
-					const issuePath = `${ issue.path.join( '.' ) }`;
+					const issuePath = issue.path.join( '.' );
 					const issueMessage = issue.message;
-					add( `\nZod Error: `, 'padding-top: 5px;' );
-					add( `${ issue.code }`, 'font-weight: bold;' );
-					add( ` in ` );
-					add( `${ key }`, 'color: #827171; font-weight: bold;' );
+
+					add( '\nZod Error: ', 'padding-top: 5px;' );
+					add( `${ issue.code }`, styles.bold );
+					add( ' in ' );
+					add( `${ key }`, styles.value );
 					if ( issuePath ) {
-						add( `.${ issuePath }`, 'font-weight: bold;' );
+						add( `.${ issuePath }`, styles.bold );
 					}
 
 					add( '\n' );
-					add( '⇢', 'margin-left: 5px; margin-right: 5px; font-size: 15px;' );
-					add( `${ issueMessage }`, highlightBox );
+					add( '⇢', styles.arrow );
+					add( `${ issueMessage }`, styles.highlight );
 					add( `\n\n` );
-					console.log( msg.join( '' ), ...styles );
+
+					console.log( msg.join( '' ), ...stylesArray );
 					msg.length = 0;
-					styles.length = 0;
+					stylesArray.length = 0;
 				}
 				console.groupEnd();
 			}
 		}
 
-		console.groupCollapsed( `%c🪲 Debug`, 'color: #6e6e6e; font-weight: 600; font-size: 14px;' );
+		console.groupCollapsed( `%c🪲 Debug`, styles.group );
 
 		let location = info.location;
 		if ( info.method ) {
 			location = `${ info.method } ${ location }`;
 		}
-		console.log(
-			`%cLocation%c:\n${ location }`,
-			'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
-			''
-		);
+		console.log( `%cLocation%c:\n${ location }`, `${ styles.bold } ${ styles.spacing }`, '' );
 
 		if ( this.info.namespace in window && this.info.key in window[ this.info.namespace ] ) {
 			const value = window[ this.info.namespace ][ this.info.key ];
 
 			console.log(
 				`%cInitial Data%c:\nwindow.${ key }.value =`,
-				'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
+				`${ styles.bold } ${ styles.spacing }`,
 				'',
 				value.value
 			);
 			if ( 'log' in value ) {
 				console.log(
 					`%cPHP Log%c:`,
-					'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
+					`${ styles.bold } ${ styles.spacing }`,
 					'',
 					value.log.length > 0 ? value.log : 'No log messages.'
 				);
 			} else {
 				console.log(
-					`%cPHP Log%c: PHP Log is disabled. To enable it, place the debug code in your wp-config.php:\n%cdefine( 'DATASYNC_DEBUG', true );`,
-					'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
+					`%cPHP Log%c: PHP Log is disabled. To enable it, place the debug code in your wp-config.php:\n%cdefine('DATASYNC_DEBUG', true);`,
+					`${ styles.bold } ${ styles.spacing }`,
 					'',
-					highlightBox
+					styles.highlight
 				);
 			}
 		}
 		if ( info.data !== undefined ) {
 			console.log(
 				`%cRaw Data Received:%c\n`,
-				'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
+				`${ styles.bold } ${ styles.spacing }`,
 				'',
 				info.data
 			);

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -1,21 +1,38 @@
+/* eslint-disable no-console */
+import { z } from 'zod';
+
+const DEBUG = true;
 /**
  * DataSync Error returned by the REST API.
  */
+type ErrorData = {
+	url: string | URL;
+	status:
+		| number
+		| 'aborted'
+		| 'error_with_message'
+		| 'failed_to_sync'
+		| 'json_parse_error'
+		| 'json_empty'
+		| 'schema_error';
+	namespace: string;
+	method: string;
+	key: string;
+	error?: unknown;
+	data: unknown;
+};
+
 export class DataSyncError extends Error {
 	public name = 'DataSyncError';
 	constructor(
-		public location: string,
-		public status:
-			| number
-			| 'aborted'
-			| 'error_with_message'
-			| 'failed_to_sync'
-			| 'json_parse_error'
-			| 'json_empty'
-			| 'schema_error',
-		public message: string
+		public message: string,
+		public info: ErrorData
 	) {
 		super( message );
+
+		if ( DEBUG ) {
+			this.debugMessage();
+		}
 
 		/**
 		 * This makes `foo instanceof DataSyncError` work.
@@ -25,5 +42,90 @@ export class DataSyncError extends Error {
 		 * @see https://stackoverflow.com/a/41102306/1015046
 		 */
 		Object.setPrototypeOf( this, DataSyncError.prototype );
+	}
+
+	private debugMessage() {
+		const info = this.info;
+		const key = `${ info.namespace }.${ info.key }`;
+		console.groupCollapsed( `DataSync Debug: %c${ key }`, 'color: #dc362e; font-weight: normal;' );
+		console.error( this.message );
+		if ( info.error instanceof z.ZodError ) {
+			const msg: string[] = [];
+			const styles: string[] = [];
+
+			// Shortcut for adding a message and style.
+			const add = ( m: string, s?: string ) => {
+				if ( s ) {
+					msg.push( `%c${ m }%c` );
+					styles.push( s );
+					styles.push( '' );
+				} else {
+					msg.push( m );
+				}
+			};
+
+			if ( info.error.issues.length > 0 ) {
+				console.groupCollapsed(
+					`%c🦸 Zod Issues(${ info.error.issues.length })`,
+					'color: #6e6e6e; font-weight: 700; font-size: 14px;'
+				);
+				for ( const issue of info.error.issues ) {
+					const issuePath = `${ issue.path.join( '.' ) }`;
+					const issueMessage = issue.message;
+					add( `\nZod Error: `, 'padding-top: 5px;' );
+					add( `${ issue.code }`, 'font-weight: bold;' );
+					add( ` in ` );
+					add( `${ key }`, 'color: #827171; font-weight: bold;' );
+					if ( issuePath ) {
+						add( `.${ issuePath }`, 'font-weight: bold;' );
+					}
+					add( `\n` );
+					add(
+						`${ issueMessage }`,
+						'font-style: italic; border-left: 3px solid #e9e9e3; margin: 3px 0px 3px 7px; background-color: #f9f9f6; padding: 7px;'
+					);
+					console.log( msg.join( '' ), ...styles );
+					msg.length = 0;
+					styles.length = 0;
+				}
+				console.groupEnd();
+			}
+		}
+
+		console.groupCollapsed( `%c🪲 Debug`, 'color: #6e6e6e; font-weight: 600; font-size: 14px;' );
+
+		console.log(
+			`%cEndpoint%c:\n${ info.method } ${ info.url }`,
+			'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
+			''
+		);
+		if ( this.info.namespace in window && this.info.key in window[ this.info.namespace ] ) {
+			const value = window[ this.info.namespace ][ this.info.key ];
+
+			console.log(
+				`%cInitial Data%c:\nwindow.${ key }.value =`,
+				'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
+				'',
+				value.value
+			);
+			if ( 'log' in value ) {
+				console.log(
+					`%cPHP Log%c:`,
+					'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
+					'',
+					value.log.length > 0 ? value.log : 'No log messages.'
+				);
+			}
+		}
+		if ( info.data !== undefined ) {
+			console.log(
+				`%cRaw Data Received:%c\n`,
+				'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
+				'',
+				info.data
+			);
+		}
+		console.groupEnd();
+		console.groupEnd();
 	}
 }

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -43,6 +43,10 @@ export class DataSyncError extends Error {
 		Object.setPrototypeOf( this, DataSyncError.prototype );
 	}
 
+	/**
+	 * This is a helper method to log and format DataSync errors in the console.
+	 * It's only called when `window.datasync_debug` is set to `true`.
+	 */
 	private debugMessage() {
 		const info = this.info;
 		const key = `${ info.namespace }.${ info.key }`;

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -51,100 +51,112 @@ export class DataSyncError extends Error {
 	private debugMessage() {
 		const info = this.info;
 		const key = `${ info.namespace }.${ info.key }`;
-		console.groupCollapsed(
-			`🔄 DataSync Debug: %c${ key }`,
-			'color: #dc362e; font-weight: normal;'
-		);
 
 		// Group common styles into a single object
-		const styles = {
-			group: 'color: #6e6e6e; font-weight: 700; font-size: 14px;',
+		const darkStyles = {
+			group: 'color: #d3d3d3; font-weight: 700; font-size: 14px;',
 			bold: 'font-weight: bold;',
-			value: 'color: #827171; font-weight: bold;',
+			dim: 'color: #737373;',
 			spacing: 'margin-top: 5px; margin-bottom: 2px;',
 			arrow: 'margin-left: 5px; margin-right: 5px; font-size: 15px;',
-			highlight: 'font-style: italic; solid #e9e9e3; line-height: 1.8;',
+			highlight: 'font-style: italic; line-height: 1.8; color: #a5aeb5;',
+			key: 'color: #ffa280; font-weight: normal;',
 		};
 
+		const lightStyles = {
+			group: 'color: #1d2327; font-weight: 700; font-size: 14px;',
+			bold: 'font-weight: bold;',
+			dim: 'color: #a89e9e;',
+			spacing: 'margin-top: 5px; margin-bottom: 2px;',
+			arrow: 'margin-left: 5px; margin-right: 5px; font-size: 15px;',
+			highlight: 'font-style: italic; line-height: 1.8; color: #606467;',
+			key: 'color: #dc362e; font-weight: normal;',
+		};
+
+		const isDarkMode =
+			window.matchMedia && window.matchMedia( '(prefers-color-scheme: dark)' ).matches;
+		const style = isDarkMode ? darkStyles : lightStyles;
+
+		console.groupCollapsed( `🔄 DataSync Debug: %c${ key }`, style.key );
 		console.error( this.message );
 		if ( info.error instanceof z.ZodError ) {
 			const msg = [];
-			const stylesArray = [];
+			const messageStyle = [];
 
 			// Shortcut for adding a message and style
 			const add = ( m, s = '' ) => {
 				if ( s ) {
 					msg.push( `%c${ m }%c` );
-					stylesArray.push( s, '' ); // Reset style after custom
+					messageStyle.push( s, '' );
 				} else {
 					msg.push( m );
 				}
 			};
 
 			if ( info.error.issues.length > 0 ) {
-				console.groupCollapsed( `%c🦸 Zod Issues(${ info.error.issues.length })`, styles.group );
+				console.groupCollapsed( `%c🦸 Zod Issues(${ info.error.issues.length })`, style.group );
 				for ( const issue of info.error.issues ) {
 					const issuePath = issue.path.join( '.' );
 					const issueMessage = issue.message;
 
 					add( '\nZod Error: ', 'padding-top: 5px;' );
-					add( `${ issue.code }`, styles.bold );
+					add( `${ issue.code }`, style.bold );
 					add( ' in ' );
-					add( `${ key }`, styles.value );
+					add( `${ key }`, style.dim );
 					if ( issuePath ) {
-						add( `.${ issuePath }`, styles.bold );
+						add( `.${ issuePath }`, style.bold );
 					}
 
 					add( '\n' );
-					add( '⇢', styles.arrow );
-					add( `${ issueMessage }`, styles.highlight );
+					add( '⇢', style.arrow );
+					add( `${ issueMessage }`, style.highlight );
 					add( `\n\n` );
 
-					console.log( msg.join( '' ), ...stylesArray );
+					console.log( msg.join( '' ), ...messageStyle );
 					msg.length = 0;
-					stylesArray.length = 0;
+					messageStyle.length = 0;
 				}
 				console.groupEnd();
 			}
 		}
 
-		console.groupCollapsed( `%c🪲 Debug`, styles.group );
+		console.groupCollapsed( `%c🪲 Debug`, style.group );
 
 		let location = info.location;
 		if ( info.method ) {
 			location = `${ info.method } ${ location }`;
 		}
-		console.log( `%cLocation%c:\n${ location }`, `${ styles.bold } ${ styles.spacing }`, '' );
+		console.log( `%cLocation%c:\n${ location }`, `${ style.bold } ${ style.spacing }`, '' );
 
 		if ( this.info.namespace in window && this.info.key in window[ this.info.namespace ] ) {
 			const value = window[ this.info.namespace ][ this.info.key ];
 
 			console.log(
 				`%cInitial Data%c:\nwindow.${ key }.value =`,
-				`${ styles.bold } ${ styles.spacing }`,
+				`${ style.bold } ${ style.spacing }`,
 				'',
 				value.value
 			);
 			if ( 'log' in value ) {
 				console.log(
 					`%cPHP Log%c:`,
-					`${ styles.bold } ${ styles.spacing }`,
+					`${ style.bold } ${ style.spacing }`,
 					'',
 					value.log.length > 0 ? value.log : 'No log messages.'
 				);
 			} else {
 				console.log(
 					`%cPHP Log%c: PHP Log is disabled. To enable it, place the debug code in your wp-config.php:\n%cdefine('DATASYNC_DEBUG', true);`,
-					`${ styles.bold } ${ styles.spacing }`,
+					`${ style.bold } ${ style.spacing }`,
 					'',
-					styles.highlight
+					style.highlight
 				);
 			}
 		}
 		if ( info.data !== undefined ) {
 			console.log(
 				`%cRaw Data Received:%c\n`,
-				`${ styles.bold } ${ styles.spacing }`,
+				`${ style.bold } ${ style.spacing }`,
 				'',
 				info.data
 			);

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import { z } from 'zod';
 
-const DEBUG = true;
 /**
  * DataSync Error returned by the REST API.
  */
@@ -30,7 +29,7 @@ export class DataSyncError extends Error {
 	) {
 		super( message );
 
-		if ( DEBUG ) {
+		if ( 'datasync_debug' in window && window.datasync_debug ) {
 			this.debugMessage();
 		}
 

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -101,11 +101,16 @@ export class DataSyncError extends Error {
 
 		console.groupCollapsed( `%c🪲 Debug`, 'color: #6e6e6e; font-weight: 600; font-size: 14px;' );
 
+		let location = info.location;
+		if ( info.method ) {
+			location = `${ info.method } ${ location }`;
+		}
 		console.log(
-			`%cEndpoint%c:\n${ info.method } ${ info.location }`,
+			`%cLocation%c:\n${ location }`,
 			'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
 			''
 		);
+
 		if ( this.info.namespace in window && this.info.key in window[ this.info.namespace ] ) {
 			const value = window[ this.info.namespace ][ this.info.key ];
 

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -51,7 +51,10 @@ export class DataSyncError extends Error {
 	private debugMessage() {
 		const info = this.info;
 		const key = `${ info.namespace }.${ info.key }`;
-		console.groupCollapsed( `DataSync Debug: %c${ key }`, 'color: #dc362e; font-weight: normal;' );
+		console.groupCollapsed(
+			`🔄 DataSync Debug: %c${ key }`,
+			'color: #dc362e; font-weight: normal;'
+		);
 		console.error( this.message );
 		if ( info.error instanceof z.ZodError ) {
 			const msg: string[] = [];

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -118,6 +118,13 @@ export class DataSyncError extends Error {
 					'',
 					value.log.length > 0 ? value.log : 'No log messages.'
 				);
+			} else {
+				console.log(
+					`%cPHP Log%c: PHP Log is disabled. To enable it, place the debug code in your wp-config.php:\n%cdefine( 'DATASYNC_DEBUG', true );`,
+					'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
+					'',
+					'font-style: italic; border-left: 3px solid #e9e9e3; margin: 3px 0px 3px 7px; background-color: #f9f9f6; padding: 7px;'
+				);
 			}
 		}
 		if ( info.data !== undefined ) {

--- a/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncError.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
  * DataSync Error returned by the REST API.
  */
 type ErrorData = {
-	url: string | URL;
+	location: string | URL;
 	status:
 		| number
 		| 'aborted'
@@ -13,9 +13,10 @@ type ErrorData = {
 		| 'failed_to_sync'
 		| 'json_parse_error'
 		| 'json_empty'
+		| 'response_not_ok'
 		| 'schema_error';
 	namespace: string;
-	method: string;
+	method?: string;
 	key: string;
 	error?: unknown;
 	data: unknown;
@@ -98,7 +99,7 @@ export class DataSyncError extends Error {
 		console.groupCollapsed( `%c🪲 Debug`, 'color: #6e6e6e; font-weight: 600; font-size: 14px;' );
 
 		console.log(
-			`%cEndpoint%c:\n${ info.method } ${ info.url }`,
+			`%cEndpoint%c:\n${ info.method } ${ info.location }`,
 			'font-weight: bold; margin-top: 5px; margin-bottom: 2px;',
 			''
 		);

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -155,7 +155,7 @@ export function useDataSync<
 			return { previousValue, optimisticValue: value };
 		},
 		onError: ( err, _, context ) => {
-			if ( err instanceof DataSyncError && err.status === 'aborted' ) {
+			if ( err instanceof DataSyncError && err.info.status === 'aborted' ) {
 				// If the request was aborted, this means that another mutation
 				// has already been dispatched and has already updated
 				// the optimistic value, so there's nothing to revert.
@@ -169,7 +169,7 @@ export function useDataSync<
 		},
 		onSettled: ( _, error ) => {
 			// Clear the abortController on either success or failure that is not an abort
-			if ( ! error || ( error instanceof DataSyncError && error.status !== 'aborted' ) ) {
+			if ( ! error || ( error instanceof DataSyncError && error.info.status !== 'aborted' ) ) {
 				abortController.current = null;
 			}
 		},


### PR DESCRIPTION
## Proposed changes:

This adds DataSync debug messages when the DataSync debug mode is enabled (based on `window.datasync_debug`) to help with error debugging.


#### Debugging View:
Here's what it looks like when a bunch of errors are thrown:
![2024_01_30S2EYiUlQ 02](https://github.com/Automattic/jetpack/assets/988095/30f6a6c2-4e94-4d3e-a4a5-13f9417508d9)

And this is the expanded view:

![2024_01_30te4Tlw1r 51](https://github.com/Automattic/jetpack/assets/988095/09403eaf-f6fa-44b7-af09-2ce503f2a22a)

#### Previous View
This is what it looks like without the debug mode enabled (like it did before)
![2024_01_302Iyf1s5U 46](https://github.com/Automattic/jetpack/assets/988095/c3e30daa-590d-42d1-ae47-958ebf71e338)

Overview:
- Improved the error source description by including more specific location information.
- Substituted generic Error instances with more informative DataSyncError instances.
- Cleaned up error messages for better readability and consistency.
- Added handling of exceptions to throw more informative DataSyncError instances when window parsing fails.
- Introduced a DATASYNC_DEBUG console message hint for enabling PHP log debugging.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Pull the latest boost-developer plugin
- Go to settings and enable DataSync logging
- Produce various kinds of DataSync errors (wrong data, wrong schema) and view the console output