### PR TITLE
Repo Gardening: automate triage of Verbum-related issues

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-verbum-board
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-verbum-board
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Board triage: automate triage of Verbum-related issues.

--- a/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
@@ -149,6 +149,12 @@ export const automatticAssignments = {
 		slack_id: 'C016BBAFHHS',
 		board_id: 'https://github.com/orgs/Automattic/projects/548',
 	},
+	Verbum: {
+		team: 'Vertex',
+		labels: [ '[mu wpcom Feature] Verbum Comments' ],
+		slack_id: 'C02T4NVL4JJ',
+		board_id: 'https://github.com/orgs/Automattic/projects/908/views/1',
+	},
 	VideoPress: {
 		team: 'Agora',
 		labels: [ '[Package] VideoPress', '[Feature] VideoPress', '[Plugin] VideoPress' ],


### PR DESCRIPTION
See #35314

## Proposed changes:

Automatically assign issues that touch the Verbum comment experience:

- Add those issues to the related project board.
- Warn the Vertex team in slack when high/blocker issues are created.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This cannot be tested before this gets merged, unfortunately. I would recommend checking that the slack ID is correct, that the project board URL is correct, and that the Vertex team exists in the Automattic Prioritization board's "Team" column.
