### PR TITLE
Jetpack Boost: Improve image quality control

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-control/quality-control.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-control/quality-control.tsx
@@ -2,7 +2,7 @@ import { NumberSlider } from '@automattic/jetpack-components';
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import styles from './quality-control.module.scss';
-import { useId } from 'react';
+import { useEffect, useId, useState } from 'react';
 
 type QualityControlProps = {
 	label: string;
@@ -24,13 +24,20 @@ const QualityControl = ( {
 	minValue = 20,
 }: QualityControlProps ) => {
 	const checkboxId = useId();
+	const [ value, setValue ] = useState( quality );
+	useEffect( () => {
+		setValue( quality );
+	}, [ quality ] );
 	return (
 		<div className={ styles[ 'quality-control' ] }>
 			<div className={ styles.label }>{ label }</div>
 			<div className={ classNames( styles.slider, { [ styles.disabled ]: lossless } ) }>
 				<NumberSlider
-					value={ quality }
-					onChange={ setQuality }
+					value={ value }
+					onAfterChange={ updatedValue => {
+						setValue( updatedValue );
+						setQuality( updatedValue );
+					} }
 					minValue={ minValue }
 					maxValue={ maxValue }
 				/>
@@ -40,7 +47,7 @@ const QualityControl = ( {
 					type="checkbox"
 					checked={ lossless }
 					id={ checkboxId }
-					onChange={ event => setLossless(event.target.checked) }
+					onChange={ event => setLossless( event.target.checked ) }
 				/>
 				{ __( 'Lossless', 'jetpack-boost' ) }
 			</label>

--- a/projects/plugins/boost/app/assets/src/js/main.tsx
+++ b/projects/plugins/boost/app/assets/src/js/main.tsx
@@ -12,7 +12,7 @@ import AdvancedCriticalCss from './pages/critical-css-advanced/critical-css-adva
 import GettingStarted from './pages/getting-started/getting-started';
 import PurchaseSuccess from './pages/purchase-success/purchase-success';
 import SettingsPage from '$layout/settings-page/settings-page';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import { DataSyncProvider } from '@automattic/jetpack-react-data-sync-client';
 import { useGettingStarted } from '$lib/stores/getting-started';
@@ -141,10 +141,8 @@ const ISAPage = () => {
 
 export default () => {
 	return (
-		<React.StrictMode>
-			<DataSyncProvider>
-				<Main />
-			</DataSyncProvider>
-		</React.StrictMode>
+		<DataSyncProvider>
+			<Main />
+		</DataSyncProvider>
 	);
 };

--- a/projects/plugins/boost/app/assets/src/js/main.tsx
+++ b/projects/plugins/boost/app/assets/src/js/main.tsx
@@ -12,7 +12,7 @@ import AdvancedCriticalCss from './pages/critical-css-advanced/critical-css-adva
 import GettingStarted from './pages/getting-started/getting-started';
 import PurchaseSuccess from './pages/purchase-success/purchase-success';
 import SettingsPage from '$layout/settings-page/settings-page';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import { DataSyncProvider } from '@automattic/jetpack-react-data-sync-client';
 import { useGettingStarted } from '$lib/stores/getting-started';
@@ -141,8 +141,10 @@ const ISAPage = () => {
 
 export default () => {
 	return (
-		<DataSyncProvider>
-			<Main />
-		</DataSyncProvider>
+		<React.StrictMode>
+			<DataSyncProvider>
+				<Main />
+			</DataSyncProvider>
+		</React.StrictMode>
 	);
 };

--- a/projects/plugins/boost/changelog/boost-fix-quality-setting-frequency
+++ b/projects/plugins/boost/changelog/boost-fix-quality-setting-frequency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Boost: Enhanced image quality control behavior and wrapped main component in StrictMode


### PR DESCRIPTION
## Proposed changes:
- Save the image quality control value in the store only after the user is done changing it.
- ~Wrap the main component tree in React.StrictMode to identify potential problems.~

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Verify the quality control slider in the image CDN settings page only updates the store value on release.
- Ensure that the lossless checkbox properly updates its state in the store.
