### PR TITLE
Boost: Remove score change popout

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
@@ -1,13 +1,8 @@
-import {
-	getScoreLetter,
-	didScoresChange,
-	getScoreMovementPercentage,
-} from '@automattic/jetpack-boost-score-api';
+import { getScoreLetter, didScoresChange } from '@automattic/jetpack-boost-score-api';
 import { BoostScoreBar, Button } from '@automattic/jetpack-components';
 import { sprintf, __ } from '@wordpress/i18n';
 import ContextTooltip from './context-tooltip/context-tooltip';
 import RefreshIcon from '$svg/refresh';
-import PopOut from './pop-out/pop-out';
 import PerformanceHistory from '$features/performance-history/performance-history';
 import ErrorNotice from '$features/error-notice/error-notice';
 import classNames from 'classnames';
@@ -40,9 +35,6 @@ const SpeedScore = () => {
 			}, [] ),
 		[ data ]
 	);
-
-	const showScoreChangePopOut =
-		status === 'loaded' && ! scores.isStale && getScoreMovementPercentage( scores );
 
 	// Mark performance history data as stale when speed scores are loaded.
 	useEffect( () => {
@@ -148,8 +140,6 @@ const SpeedScore = () => {
 				</div>
 				{ site.online && <PerformanceHistory /> }
 			</div>
-
-			<PopOut scoreChange={ showScoreChangePopOut } />
 		</>
 	);
 };

--- a/projects/plugins/boost/changelog/remove-popout
+++ b/projects/plugins/boost/changelog/remove-popout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Speed Scores: Temporarily removed the score change popout.


### PR DESCRIPTION
## Proposed changes:
* Remove the score change popout.

This is a temporary removal until we have better solution in place to skip no-boost score during initial load.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1706602692832499-slack-C0232B8CUHG

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to Jetpack Boost dashboard
* Try enabling all the modules and making sure there is a score improvement
* Make sure that the speed score popout doesn't show