### PR TITLE
Dotcom Patterns: Register wp_block patterns from Dotcompatterns with blockTypes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/chore-register-wp-block-pattern-block-types
+++ b/projects/packages/jetpack-mu-wpcom/changelog/chore-register-wp-block-pattern-block-types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Register wp_block patterns from Dotcompatterns with blockTypes

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -50,7 +50,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.11.x-dev"
+			"dev-trunk": "5.12.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.11.1-alpha",
+	"version": "5.12.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.11.1-alpha';
+	const PACKAGE_VERSION = '5.12.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -116,6 +116,10 @@ class Wpcom_Block_Patterns_From_Api {
 					$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
 					$pattern_name   = self::PATTERN_NAMESPACE . $pattern['name'];
 					$block_types    = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $pattern );
+					if ( empty( $block_types ) ) {
+						// For wp_block patterns because don't use pattern meta for block types.
+						$block_types = $this->utils->get_block_types_from_categories( $pattern );
+					}
 
 					$results[ $pattern_name ] = register_block_pattern(
 						$pattern_name,
@@ -180,7 +184,7 @@ class Wpcom_Block_Patterns_From_Api {
 		if ( $enable_testing_v2_patterns || false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
 			if ( $enable_testing_v2_patterns ) {
 				$request_params = array(
-					'site'      => 'assemblerv2patterns.wordpress.com',
+					'site'      => 'dotcompatterns.wordpress.com',
 					'post_type' => 'wp_block',
 				);
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-utils.php
@@ -118,6 +118,38 @@ class Wpcom_Block_Patterns_Utils {
 	}
 
 	/**
+	 * Using the pattern categories, generate the `blockTypes` property for
+	 * registering the pattern via `register_block_pattern`.
+	 *
+	 * @param array $pattern A pattern with categories.
+	 *
+	 * @return array         An array of block types.
+	 */
+	public function get_block_types_from_categories( $pattern ) {
+		$block_types = array();
+
+		if ( ! isset( $pattern['categories'] ) || empty( $pattern['categories'] ) ) {
+			return $block_types;
+		}
+
+		foreach ( $pattern['categories'] as $key => $value ) {
+			switch ( $key ) {
+				case 'header':
+					$block_types[] = 'core/template-part/header';
+					break;
+				case 'footer':
+					$block_types[] = 'core/template-part/footer';
+					break;
+				case 'posts':
+					$block_types[] = 'core/query';
+					break;
+			}
+		}
+
+		return $block_types;
+	}
+
+	/**
 	 * Return pattern post types based on the pattern's blockTypes.
 	 *
 	 * @param array $pattern A pattern array such as is passed to `register_block_pattern`.

--- a/projects/plugins/mu-wpcom-plugin/changelog/chore-register-wp-block-pattern-block-types
+++ b/projects/plugins/mu-wpcom-plugin/changelog/chore-register-wp-block-pattern-block-types
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -129,7 +129,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "6c1ce5cd32007185f8a9d716c32a0b638f512dc4"
+                "reference": "dae0cc7eec39d1aa18226cc4a392bf989e4ee2eb"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -129,7 +129,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "2aacc54b3f715dd4899aa9c3610c85b0e70b7e8b"
+                "reference": "6c1ce5cd32007185f8a9d716c32a0b638f512dc4"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -151,7 +151,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.11.x-dev"
+                    "dev-trunk": "5.12.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
Related https://github.com/Automattic/wp-calypso/issues/78478
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Register `wp_block` patterns from Dotcompatterns with blockTypes


|BEFORE|AFTER|
|-|-|
|<img width="649" alt="Screenshot 2567-01-30 at 21 10 57" src="https://github.com/Automattic/jetpack/assets/1881481/ad3018af-7d76-4961-97cc-80534165a62e">|<img width="648" alt="Screenshot 2567-01-30 at 21 12 01" src="https://github.com/Automattic/jetpack/assets/1881481/0ddef44d-df23-4dc5-b75b-7000a3f74383">|

#### Pattern BlockTypes

##### Header/Footer Replace Template Part
https://github.com/Automattic/jetpack/assets/1881481/2a9b39ac-c6ec-442a-9abf-f8567aaa829d

##### Add Query Loop Block
https://github.com/Automattic/jetpack/assets/1881481/6e0c6b43-9c20-44b5-ae4d-1942d961b963


### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a site and the public api
* Apply this PR following the instructions on the bot comment below 
* Make sure your site has the Assembler theme active
  * Access the editor, open the pattern inserter, and check that you can see the `wp_block` patterns from Dotcompatterns, not from Assemblerv2patterns
  * Select the Header template part, open the three-dots menus and click "Replace" to confirm you see the new patterns
  * Select the Footer template part, open the three-dots menus and click "Replace" to confirm you see the new patterns
  * Add a Query Loop block, click "Choose" to confirm you see the new patterns
* When the site doesn't use the Assembler theme but still sandboxed, verify that the patterns are the same as on production. See video:

https://github.com/Automattic/jetpack/assets/1881481/40971f37-c5bd-4532-a383-0dada91a5a2b




