### PR TITLE
Jetpack Sync: Disable Sync sending while a Pull is in progress

### DIFF
--- a/projects/packages/sync/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/packages/sync/changelog/update-sync-disable-sending-while-pulling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack Sync: Disable Sync sending while a Pull is in progress

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.4.x-dev"
+			"dev-trunk": "2.5.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -1086,6 +1086,8 @@ class Actions {
 		// Dedicated sync locks.
 		\Jetpack_Options::delete_raw_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME );
 		delete_transient( Dedicated_Sender::DEDICATED_SYNC_TEMPORARY_DISABLE_FLAG );
+		// Lock for disabling Sync sending temporarily.
+		delete_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME );
 
 		// Queue locks.
 		// Note that we are just unlocking the queues here, not reseting them.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.4.2';
+	const PACKAGE_VERSION = '2.5.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/class-rest-endpoints.php
+++ b/projects/packages/sync/src/class-rest-endpoints.php
@@ -622,6 +622,9 @@ class REST_Endpoints {
 			return rest_ensure_response( $sender->immediate_full_sync_pull( $number_of_items ) );
 		}
 
+		// Disable sending while pulling.
+		set_transient( Sender::DEDICATED_SYNC_TEMPORARY_DISABLE_FLAG, time(), HOUR_IN_SECONDS );
+
 		return rest_ensure_response( $sender->queue_pull( $queue_name, $number_of_items, $args ) );
 	}
 
@@ -694,6 +697,9 @@ class REST_Endpoints {
 
 		$buffer   = new Queue_Buffer( $request_body['buffer_id'], $request_body['item_ids'] );
 		$response = $queue->close( $buffer, $request_body['item_ids'] );
+
+		// Re-enable sending in case it was disabled while pulling.
+		delete_transient( Sender::DEDICATED_SYNC_TEMPORARY_DISABLE_FLAG );
 
 		// Perform another checkout?
 		if ( isset( $request_body['continue'] ) && $request_body['continue'] ) {

--- a/projects/packages/sync/src/class-rest-endpoints.php
+++ b/projects/packages/sync/src/class-rest-endpoints.php
@@ -623,7 +623,7 @@ class REST_Endpoints {
 		}
 
 		// Disable sending while pulling.
-		set_transient( Sender::DEDICATED_SYNC_TEMPORARY_DISABLE_FLAG, time(), HOUR_IN_SECONDS );
+		set_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME, time(), HOUR_IN_SECONDS );
 
 		return rest_ensure_response( $sender->queue_pull( $queue_name, $number_of_items, $args ) );
 	}
@@ -699,7 +699,7 @@ class REST_Endpoints {
 		$response = $queue->close( $buffer, $request_body['item_ids'] );
 
 		// Re-enable sending in case it was disabled while pulling.
-		delete_transient( Sender::DEDICATED_SYNC_TEMPORARY_DISABLE_FLAG );
+		delete_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME );
 
 		// Perform another checkout?
 		if ( isset( $request_body['continue'] ) && $request_body['continue'] ) {

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -25,6 +25,15 @@ class Sender {
 	const NEXT_SYNC_TIME_OPTION_NAME = 'jetpack_next_sync_time';
 
 	/**
+	 * Name of the transient responsible for temprorarily disabling Sync sending during Pulls.
+	 *
+	 * @access public
+	 *
+	 * @var string
+	 */
+	const TEMP_SYNC_DISABLE_TRANSIENT_NAME = 'jetpack_disable_sync_sending';
+
+	/**
 	 * Sync timeout after a WPCOM error.
 	 *
 	 * @access public
@@ -438,6 +447,10 @@ class Sender {
 
 		if ( ! Settings::is_sender_enabled( $queue->id ) ) {
 			return new WP_Error( 'sender_disabled_for_queue_' . $queue->id );
+		}
+
+		if ( get_transient( self::TEMP_SYNC_DISABLE_TRANSIENT_NAME ) ) {
+			return new WP_Error( 'sender_temporarily_disabled_while_pulling' );
 		}
 
 		// Return early if we've gotten a retry-after header response.

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -34,6 +34,15 @@ class Sender {
 	const TEMP_SYNC_DISABLE_TRANSIENT_NAME = 'jetpack_disable_sync_sending';
 
 	/**
+	 * Expiry of the transient responsible for temprorarily disabling Sync sending during Pulls.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
+	const TEMP_SYNC_DISABLE_TRANSIENT_EXPIRY = MINUTE_IN_SECONDS;
+
+	/**
 	 * Sync timeout after a WPCOM error.
 	 *
 	 * @access public

--- a/projects/packages/sync/tests/php/test-actions.php
+++ b/projects/packages/sync/tests/php/test-actions.php
@@ -132,6 +132,8 @@ class Test_Actions extends BaseTestCase {
 		$this->assertTrue( $sync_queue->lock() );
 		$full_sync_queue = new Queue( 'full_sync' );
 		$this->assertTrue( $full_sync_queue->lock() );
+		// Lock for disabling Sync sending temporarily.
+		set_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME, time() );
 
 		Actions::reset_sync_locks();
 
@@ -142,6 +144,7 @@ class Test_Actions extends BaseTestCase {
 		$this->assertFalse( get_option( Actions::RETRY_AFTER_PREFIX . 'full_sync' ) );
 		$this->assertFalse( $sync_queue->is_locked() );
 		$this->assertFalse( $full_sync_queue->is_locked() );
+		$this->assertFalse( get_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME ) );
 	}
 
 	/**

--- a/projects/plugins/backup/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/plugins/backup/changelog/update-sync-disable-sending-while-pulling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1405,7 +1405,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "4177bb100fe6147574606715814e4254840459b2"
+                "reference": "881ee276f976f70720788b61cf3bde923ec8008d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1437,7 +1437,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.4.x-dev"
+                    "dev-trunk": "2.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/plugins/boost/changelog/update-sync-disable-sending-while-pulling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1532,7 +1532,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "4177bb100fe6147574606715814e4254840459b2"
+                "reference": "881ee276f976f70720788b61cf3bde923ec8008d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1564,7 +1564,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.4.x-dev"
+                    "dev-trunk": "2.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/plugins/jetpack/changelog/update-sync-disable-sending-while-pulling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2456,7 +2456,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "4177bb100fe6147574606715814e4254840459b2"
+				"reference": "881ee276f976f70720788b61cf3bde923ec8008d"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2488,7 +2488,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.4.x-dev"
+					"dev-trunk": "2.5.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/migration/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/plugins/migration/changelog/update-sync-disable-sending-while-pulling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1405,7 +1405,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "4177bb100fe6147574606715814e4254840459b2"
+                "reference": "881ee276f976f70720788b61cf3bde923ec8008d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1437,7 +1437,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.4.x-dev"
+                    "dev-trunk": "2.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/plugins/protect/changelog/update-sync-disable-sending-while-pulling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1318,7 +1318,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "4177bb100fe6147574606715814e4254840459b2"
+                "reference": "881ee276f976f70720788b61cf3bde923ec8008d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1350,7 +1350,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.4.x-dev"
+                    "dev-trunk": "2.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/plugins/search/changelog/update-sync-disable-sending-while-pulling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1407,7 +1407,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "4177bb100fe6147574606715814e4254840459b2"
+                "reference": "881ee276f976f70720788b61cf3bde923ec8008d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1439,7 +1439,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.4.x-dev"
+                    "dev-trunk": "2.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/plugins/social/changelog/update-sync-disable-sending-while-pulling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1338,7 +1338,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "4177bb100fe6147574606715814e4254840459b2"
+				"reference": "881ee276f976f70720788b61cf3bde923ec8008d"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1370,7 +1370,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.4.x-dev"
+					"dev-trunk": "2.5.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/starter-plugin/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/plugins/starter-plugin/changelog/update-sync-disable-sending-while-pulling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1261,7 +1261,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "4177bb100fe6147574606715814e4254840459b2"
+                "reference": "881ee276f976f70720788b61cf3bde923ec8008d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1293,7 +1293,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.4.x-dev"
+                    "dev-trunk": "2.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/plugins/videopress/changelog/update-sync-disable-sending-while-pulling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1261,7 +1261,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "4177bb100fe6147574606715814e4254840459b2"
+                "reference": "881ee276f976f70720788b61cf3bde923ec8008d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1293,7 +1293,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.4.x-dev"
+                    "dev-trunk": "2.5.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
This PR disables sending of Sync queue actions to WPCOM while Pull is in progress.
This will ensure that no concurrent request errors will occur during Pulls.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Sender`: Introduce a new transient that when present, will disable sending of Sync actions
* `Automattic\Jetpack\Sync\REST_Endpoints`: Set the transient in the `checkout` endpoint (Pull initiated)
* `Automattic\Jetpack\Sync\REST_Endpoints`: Delete the transient in the `checkout` endpoint when the queue is empty

Note that the transient is set to expire in 1m to ensure sending will start again, as a fallback, in case the `checkout` endpoint is not called due to failures on the WPCOM side or is only called once without emptying the queue. 

I've also considered removing the transient in the `close` endpoint (usually called after `checkout` to empty the queue), however there are still concurrent requests after calling `close` and before the next `checkout` remote call.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf5801-q7-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
D135496-code