### PR TITLE
Blaze: do not enable module by default

### DIFF
--- a/projects/plugins/jetpack/changelog/update-blaze-auto-activate
+++ b/projects/plugins/jetpack/changelog/update-blaze-auto-activate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Blaze: do not enable feature by default.

--- a/projects/plugins/jetpack/modules/blaze.php
+++ b/projects/plugins/jetpack/modules/blaze.php
@@ -6,7 +6,7 @@
  * Recommendation Order: 12
  * First Introduced: 12.3
  * Requires Connection: Yes
- * Auto Activate: Yes
+ * Auto Activate: No
  * Module Tags: Traffic, Social
  * Additional Search Queries: advertising, ads
  *


### PR DESCRIPTION
## Proposed changes:

Follow-up to #31479. Do not enable the Blaze feature by default.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See pbNhbs-9Bz-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a fresh new site.
* Connect it to WordPress.com.
* Go to Jetpack > Settings > Traffic
    * The Blaze feature should not be enabled by default.
