### PR TITLE
Social: Remove the flow to update broken connections directly from the editor. 

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-hide-magic-link-for-connection-refresh
+++ b/projects/js-packages/publicize-components/changelog/update-hide-magic-link-for-connection-refresh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed the flow to reconnect a broken social connection from the editor.

--- a/projects/js-packages/publicize-components/src/components/connection-verify/index.js
+++ b/projects/js-packages/publicize-components/src/components/connection-verify/index.js
@@ -8,11 +8,10 @@
  * not render anything.
  */
 
-import { Button, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component, Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { SOCIAL_STORE_ID } from '../../social-store';
 
 class PublicizeConnectionVerify extends Component {
@@ -42,37 +41,6 @@ class PublicizeConnectionVerify extends Component {
 		}, 500 );
 	};
 
-	renderRefreshableConnections() {
-		const { failedConnections } = this.props;
-		const refreshableConnections = failedConnections.filter( connection => connection.can_refresh );
-
-		if ( refreshableConnections.length ) {
-			return (
-				<Notice className="jetpack-publicize-notice" isDismissible={ false } status="error">
-					<p>
-						{ __(
-							'Before you hit Publish, please refresh the following connection(s) to make sure we can share your post:',
-							'jetpack'
-						) }
-					</p>
-					{ refreshableConnections.map( connection => (
-						<Button
-							href={ connection.refresh_url }
-							isSmall
-							key={ connection.id }
-							onClick={ this.refreshConnectionClick }
-							title={ connection.refresh_text }
-						>
-							{ connection.refresh_text }
-						</Button>
-					) ) }
-				</Notice>
-			);
-		}
-
-		return null;
-	}
-
 	renderNonRefreshableConnections() {
 		const { failedConnections } = this.props;
 		const nonRefreshableConnections = failedConnections.filter(
@@ -91,12 +59,7 @@ class PublicizeConnectionVerify extends Component {
 	}
 
 	render() {
-		return (
-			<Fragment>
-				{ this.renderRefreshableConnections() }
-				{ this.renderNonRefreshableConnections() }
-			</Fragment>
-		);
+		return <Fragment>{ this.renderNonRefreshableConnections() }</Fragment>;
 	}
 }
 

--- a/projects/js-packages/publicize-components/src/components/connection-verify/index.js
+++ b/projects/js-packages/publicize-components/src/components/connection-verify/index.js
@@ -8,10 +8,9 @@
  * not render anything.
  */
 
-import { Notice } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { SOCIAL_STORE_ID } from '../../social-store';
 
 class PublicizeConnectionVerify extends Component {
@@ -19,47 +18,8 @@ class PublicizeConnectionVerify extends Component {
 		this.props.refreshConnections();
 	}
 
-	/**
-	 * Opens up popup so user can refresh connection
-	 *
-	 * Displays pop up with to specified URL where user
-	 * can refresh a specific connection.
-	 *
-	 * @param {object} event - Event instance for onClick.
-	 */
-	refreshConnectionClick = event => {
-		const { href, title } = event.target;
-		event.preventDefault();
-		// open a popup window
-		// when it is closed, kick off the tests again
-		const popupWin = window.open( href, title, '' );
-		const popupTimer = window.setInterval( () => {
-			if ( false !== popupWin.closed ) {
-				window.clearInterval( popupTimer );
-				this.props.refreshConnections();
-			}
-		}, 500 );
-	};
-
-	renderNonRefreshableConnections() {
-		const { failedConnections } = this.props;
-		const nonRefreshableConnections = failedConnections.filter(
-			connection => ! connection.can_refresh
-		);
-
-		if ( nonRefreshableConnections.length ) {
-			return nonRefreshableConnections.map( connection => (
-				<Notice className="jetpack-publicize-notice" isDismissible={ false } status="error">
-					<p>{ connection.test_message }</p>
-				</Notice>
-			) );
-		}
-
-		return null;
-	}
-
 	render() {
-		return <Fragment>{ this.renderNonRefreshableConnections() }</Fragment>;
+		return null;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The reconnection flow doesn't work well and is broken, when you try to reconnect a broken connection using magic link URLs. See the refresh connection with Facebook bit in the image below. We are going to get rid of that link and instead rely on the second notice we show, so the users re-connect their connections from the connection management screen. 
<img width="304" alt="Screenshot 2024-01-30 at 7 54 41 PM" src="https://github.com/Automattic/jetpack/assets/6594561/811cc3e4-fc0e-4b18-846a-89bc76da10a3">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On trunk, connect a Facebook Jetpack Social connection. 
* Go to https://www.facebook.com/settings/?tab=business_tools, and under business integrations remove Facebook.
* Go to Publicize RC and test the Facebook connection. It will be broken.
* Try creating a post and see that in the editor sidebar, you see the magic link to refresh the Facebook connection as shown in the image in the proposed changes section on this PR. 
* Checkout this branch and ensure that the magic link section goes away and only the connection management screen notice shows up. 

