### PR TITLE
Github Deployments i1: Add Github deployments submenu to Tools menu item

### DIFF
--- a/projects/plugins/jetpack/changelog/add-github-deployments-menu
+++ b/projects/plugins/jetpack/changelog/add-github-deployments-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Wordpress.com Tools Menu: Add Github Deployments submenu and gate behind a constant

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -432,6 +432,13 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		 * Adds the WordPress.com Site Monitoring submenu under the main Tools menu.
 		 */
 		add_submenu_page( 'tools.php', esc_attr__( 'Site Monitoring', 'jetpack' ), __( 'Site Monitoring', 'jetpack' ), 'manage_options', 'https://wordpress.com/site-monitoring/' . $this->domain, null, 7 );
+
+		/**
+		 * Adds the WordPress.com Github Deployments submenu under the main Tools menu.
+		 */
+		if ( apply_filters( 'jetpack_show_wpcom_github_deployments_menu', false ) ) {
+			add_submenu_page( 'tools.php', esc_attr__( 'Github Deployments', 'jetpack' ), __( 'Github Deployments', 'jetpack' ), 'manage_options', 'https://wordpress.com/github-deployments/' . $this->domain, null, 7 );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -366,4 +366,29 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 
 		$this->assertSame( 'https://wordpress.com/site-monitoring/' . static::$domain, $submenu['tools.php'][ $menu_position ][2] );
 	}
+
+	/**
+	 * Tests add_github_deployments_menu
+	 *
+	 * @covers ::add_tools_menu
+	 */
+	public function test_add_github_deployments_menu() {
+		global $submenu;
+
+		add_filter( 'jetpack_show_wpcom_github_deployments_menu', '__return_false', 99 );
+		static::$admin_menu->add_tools_menu();
+		remove_filter( 'jetpack_show_wpcom_github_deployments_menu', '__return_false', 99 );
+
+		$links = wp_list_pluck( array_values( $submenu['tools.php'] ), 2 );
+
+		$this->assertNotContains( 'https://wordpress.com/github-deployments/' . static::$domain, $links );
+
+		add_filter( 'jetpack_show_wpcom_github_deployments_menu', '__return_true', 99 );
+		static::$admin_menu->add_tools_menu();
+		remove_filter( 'jetpack_show_wpcom_github_deployments_menu', '__return_true', 99 );
+
+		$links = wp_list_pluck( array_values( $submenu['tools.php'] ), 2 );
+
+		$this->assertContains( 'https://wordpress.com/github-deployments/' . static::$domain, $links );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5247

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Jetpack plugin can add an optional new Github Deployments menu item to the Tools menu.
* Github Deploymentsis only on WoA sites
* Menu item is hidden by default and can be added with the jetpack_show_wpcom_github_deployments_menu filter

![image](https://github.com/Automattic/jetpack/assets/47489215/8c4ff9de-e9eb-4e5d-9098-bbcb2371b22f)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test WoA using a dev blog
  * Install [Jetpack Beta Tester Plugin](https://jetpack.com/download-jetpack-beta/)
  * Configure beta plugin `/wp-admin/admin.php?page=jetpack-beta`
  * Configure Jetpack to use the `add/github-deployments-menu` feature branch
  * Deploy [Automattic/wpcomsh#1315 ](https://github.com/Automattic/wpcomsh/pull/1672)to your WoA dev blog
  * If you are on the dev team specified in `wpcomsh`, you should now see the Github Deployments menu item in Calypso and wp-admin

* Test on simple site using https://github.com/Automattic/jetpack/pull/35350#issuecomment-1917868534 and ensure item menu is not shown