### PR TITLE
Untangle: Add banner to import.php for Classic style that points to Calypso importer

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-import-admin-customizations
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-import-admin-customizations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Import: adds a banner to wp-admin linking to the Calypso import tool

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -37,6 +37,7 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_launchpad' ), 0 );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_block_theme_previews' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_site_editor_dashboard_link' ) );
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_import_customizations' ) );
 
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_marketplace_products_updater' ) );
 
@@ -265,5 +266,12 @@ class Jetpack_Mu_Wpcom {
 			require_once __DIR__ . '/build/verbum-comments/class-verbum-comments.php';
 			new \Automattic\Jetpack\Verbum_Comments();
 		}
+	}
+
+	/**
+	 * Load import.php customizations.
+	 */
+	public static function load_import_customizations() {
+		require_once __DIR__ . '/features/import-customizations/import-customizations.php';
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/css/import-customizations.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/css/import-customizations.css
@@ -1,28 +1,27 @@
-.wrap {
-	display: grid;
+.import-php .wrap {
+	display: grid; /* Use CSS grid to order elements */
 	grid-template-columns: 1fr;
 }
-.wrap > h1, .wrap > p:first-of-type {
+.import-php .wrap > h1, .wrap > p:first-of-type {
 	order: 1; /* h1 and first p are placed first */
 }
-#wpcom-import-banner {
+.import-php #wpcom-import-banner {
 	order: 2; /* Banner is placed second */
 	padding: 20px;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	max-width: 726px;
-	border-left: 4px solid grey;
 }
-#wpcom-import-banner p {
+.import-php #wpcom-import-banner p {
 	margin: 0;
 	flex-grow: 1;
 }
-#wpcom-import-banner a.button {
+.import-php #wpcom-import-banner a.button {
 	flex-shrink: 0;
 	margin-left: 20px;
 }
-.wrap > .importers {
+.import-php .wrap > .importers {
 	order: 3; /* Table is placed third */
 	max-width: 771px;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/css/import-customizations.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/css/import-customizations.css
@@ -1,0 +1,28 @@
+.wrap {
+	display: grid;
+	grid-template-columns: 1fr;
+}
+.wrap > h1, .wrap > p:first-of-type {
+	order: 1; /* h1 and first p are placed first */
+}
+#wpcom-import-banner {
+	order: 2; /* Banner is placed second */
+	padding: 20px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	max-width: 726px;
+	border-left: 4px solid grey;
+}
+#wpcom-import-banner p {
+	margin: 0;
+	flex-grow: 1;
+}
+#wpcom-import-banner a.button {
+	flex-shrink: 0;
+	margin-left: 20px;
+}
+.wrap > .importers {
+	order: 3; /* Table is placed third */
+	max-width: 771px;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/css/import-customizations.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/css/import-customizations.css
@@ -5,7 +5,7 @@
 .import-php .wrap > h1, .wrap > p:first-of-type {
 	order: 1; /* h1 and first p are placed first */
 }
-.import-php #wpcom-import-banner {
+.import-php .wpcom-import-banner {
 	order: 2; /* Banner is placed second */
 	padding: 20px;
 	display: flex;
@@ -13,11 +13,11 @@
 	align-items: center;
 	max-width: 726px;
 }
-.import-php #wpcom-import-banner p {
+.import-php .wpcom-import-banner p {
 	margin: 0;
 	flex-grow: 1;
 }
-.import-php #wpcom-import-banner a.button {
+.import-php .wpcom-import-banner a.button {
 	flex-shrink: 0;
 	margin-left: 20px;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -1,20 +1,21 @@
-<?php
+<?php // phpcs:ignore Squiz.Commenting.FileComment.Missing
 /**
  * Customizations to the wp-admin/import.php page.
  *
- * Adds a custom banner and associated styles to the WordPress import page.
- *
  * @package automattic/jetpack-mu-wpcom
  */
+
+require_once __DIR__ . '/../../utils.php';
 
 /**
  * Displays a banner on the wp-admin/import.php page that links to the Calypso importer.
  */
 function import_admin_banner() {
 	if ( $GLOBALS['pagenow'] === 'import.php' ) {
+		$import_url = '/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
 		echo '<div id="wpcom-import-banner" class="notice">';
 		echo '<p>Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.</p>';
-		echo '<a href="" class="button">Start Importing</a>';
+		echo '<a href="' . esc_url( $import_url ) . '" class="button">Start Importing</a>';
 		echo '</div>';
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -9,7 +9,9 @@
  * Only add_action if the current screen is the wp-admin/import.php page.
  */
 function import_page_customizations_init() {
-	if ( $GLOBALS['pagenow'] === 'import.php' ) {
+	$screen = get_current_screen();
+
+	if ( $screen && $screen->id === 'import' ) {
 		// Only add the banner if the user is using the wp-admin interface.
 		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
 			add_action( 'admin_notices', 'import_admin_banner' );
@@ -17,7 +19,7 @@ function import_page_customizations_init() {
 		}
 	}
 }
-add_action( 'admin_init', 'import_page_customizations_init' );
+add_action( 'current_screen', 'import_page_customizations_init' );
 
 /**
  * Displays a banner on the wp-admin/import.php page that links to the Calypso importer.

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -9,20 +9,19 @@
  * Only add_action if the current screen is the wp-admin/import.php page.
  */
 function import_page_customizations_init() {
-	$screen = get_current_screen();
-	if ( $screen->id === 'import' ) {
+	if ( $GLOBALS['pagenow'] === 'import.php' ) {
 		add_action( 'admin_notices', 'import_admin_banner' );
 		add_action( 'admin_enqueue_scripts', 'import_admin_banner_css' );
 	}
 }
-add_action( 'current_screen', 'import_page_customizations_init' );
+add_action( 'admin_init', 'import_page_customizations_init' );
 
 /**
  * Displays a banner on the wp-admin/import.php page that links to the Calypso importer.
  */
 function import_admin_banner() {
 	require_once __DIR__ . '/../../utils.php';
-	$import_url = 'https://wordpress.com/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
+	$import_url = '/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
 	echo '<div id="wpcom-import-banner" class="notice">';
 	echo '<p>Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.</p>';
 	echo '<a href="' . esc_url( $import_url ) . '" class="button">Start Importing</a>';

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -23,12 +23,23 @@ add_action( 'admin_init', 'import_page_customizations_init' );
  * Displays a banner on the wp-admin/import.php page that links to the Calypso importer.
  */
 function import_admin_banner() {
-	require_once __DIR__ . '/../../utils.php';
+	if ( ! function_exists( 'wpcom_get_site_slug' ) ) {
+		require_once __DIR__ . '/../../utils.php';
+	}
+
 	$import_url = 'https://wordpress.com/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
-	echo '<div id="wpcom-import-banner" class="notice">';
-	echo '<p>Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.</p>';
-	echo '<a href="' . esc_url( $import_url ) . '" class="button">Start Importing</a>';
-	echo '</div>';
+
+	$banner_content = sprintf(
+		'<div id="wpcom-import-banner" class="notice">
+			<p>%s</p>
+			<a href="%s" class="button">%s</a>
+		</div>',
+		esc_html__( 'Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.', 'jetpack-mu-wpcom' ),
+		esc_url( $import_url ),
+		esc_html__( 'Start Importing', 'jetpack-mu-wpcom' )
+	);
+
+	echo wp_kses_post( $banner_content );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Customizations to the wp-admin/import.php page.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+if ( $GLOBALS['pagenow'] === 'import.php' ) {
+	echo '<div class="notice notice-success is-dismissible">';
+	echo '<p>Effortlessly import your content with <a href="">WordPress.com’s guided importer</a>. Designed for seamless integration from multiple platforms. <a href="">Learn more and get started</a>.</p>';
+	echo '</div>';
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -37,7 +37,7 @@ function import_admin_banner() {
 			<p>%s</p>
 			<a href="%s" class="button">%s</a>
 		</div>',
-		esc_html__( 'Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.', 'jetpack-mu-wpcom' ),
+		esc_html__( 'Use WordPress.com’s guided importer to import posts and comments from Medium, Substack, Squarespace, Wix, and more.', 'jetpack-mu-wpcom' ),
 		$import_url,
 		esc_html__( 'Get started', 'jetpack-mu-wpcom' )
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -29,15 +29,16 @@ function import_admin_banner() {
 		require_once __DIR__ . '/../../utils.php';
 	}
 
-	$import_url = 'https://wordpress.com/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
+	$site_slug  = wpcom_get_site_slug();
+	$import_url = esc_url( "https://wordpress.com/setup/import-focused/import?siteSlug={$site_slug}&ref=wp-admin" );
 
 	$banner_content = sprintf(
-		'<div id="wpcom-import-banner" class="notice">
+		'<div class="notice wpcom-import-banner">
 			<p>%s</p>
 			<a href="%s" class="button">%s</a>
 		</div>',
 		esc_html__( 'Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.', 'jetpack-mu-wpcom' ),
-		esc_url( $import_url ),
+		$import_url,
 		esc_html__( 'Get started', 'jetpack-mu-wpcom' )
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -21,7 +21,7 @@ add_action( 'admin_init', 'import_page_customizations_init' );
  */
 function import_admin_banner() {
 	require_once __DIR__ . '/../../utils.php';
-	$import_url = '/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
+	$import_url = 'https://wordpress.com/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
 	echo '<div id="wpcom-import-banner" class="notice">';
 	echo '<p>Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.</p>';
 	echo '<a href="' . esc_url( $import_url ) . '" class="button">Start Importing</a>';

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -38,7 +38,7 @@ function import_admin_banner() {
 		</div>',
 		esc_html__( 'Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.', 'jetpack-mu-wpcom' ),
 		esc_url( $import_url ),
-		esc_html__( 'Start Importing', 'jetpack-mu-wpcom' )
+		esc_html__( 'Get started', 'jetpack-mu-wpcom' )
 	);
 
 	echo wp_kses_post( $banner_content );

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -22,7 +22,7 @@ add_action( 'current_screen', 'import_page_customizations_init' );
  */
 function import_admin_banner() {
 	require_once __DIR__ . '/../../utils.php';
-	$import_url = '/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
+	$import_url = 'https://wordpress.com/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
 	echo '<div id="wpcom-import-banner" class="notice">';
 	echo '<p>Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.</p>';
 	echo '<a href="' . esc_url( $import_url ) . '" class="button">Start Importing</a>';

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -2,11 +2,32 @@
 /**
  * Customizations to the wp-admin/import.php page.
  *
+ * Adds a custom banner and associated styles to the WordPress import page.
+ *
  * @package automattic/jetpack-mu-wpcom
  */
 
-if ( $GLOBALS['pagenow'] === 'import.php' ) {
-	echo '<div class="notice notice-success is-dismissible">';
-	echo '<p>Effortlessly import your content with <a href="">WordPress.com’s guided importer</a>. Designed for seamless integration from multiple platforms. <a href="">Learn more and get started</a>.</p>';
-	echo '</div>';
+/**
+ * Displays a banner on the wp-admin/import.php page that links to the Calypso importer.
+ */
+function import_admin_banner() {
+	if ( $GLOBALS['pagenow'] === 'import.php' ) {
+		echo '<div id="wpcom-import-banner" class="notice">';
+		echo '<p>Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.</p>';
+		echo '<a href="" class="button">Start Importing</a>';
+		echo '</div>';
+	}
 }
+add_action( 'admin_notices', 'import_admin_banner' );
+
+/**
+ * Enqueues CSS for the wp-admin/import.php Calypso import banner.
+ */
+function import_admin_banner_css() {
+	if ( $GLOBALS['pagenow'] === 'import.php' ) {
+		// Cache-bust the CSS file using the file modification time.
+		$version = filemtime( plugin_dir_path( __FILE__ ) . 'css/import-customizations.css' );
+		wp_enqueue_style( 'import_admin_banner_css', plugin_dir_url( __FILE__ ) . 'css/import-customizations.css', array(), $version );
+	}
+}
+add_action( 'admin_enqueue_scripts', 'import_admin_banner_css' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -10,8 +10,11 @@
  */
 function import_page_customizations_init() {
 	if ( $GLOBALS['pagenow'] === 'import.php' ) {
-		add_action( 'admin_notices', 'import_admin_banner' );
-		add_action( 'admin_enqueue_scripts', 'import_admin_banner_css' );
+		// Only add the banner if the user is using the wp-admin interface.
+		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+			add_action( 'admin_notices', 'import_admin_banner' );
+			add_action( 'admin_enqueue_scripts', 'import_admin_banner_css' );
+		}
 	}
 }
 add_action( 'admin_init', 'import_page_customizations_init' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -5,30 +5,38 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-require_once __DIR__ . '/../../utils.php';
+/**
+ * Only add_action if the current screen is the wp-admin/import.php page.
+ */
+function import_page_customizations_init() {
+	$screen = get_current_screen();
+	if ( $screen->id === 'import' ) {
+		add_action( 'admin_notices', 'import_admin_banner' );
+		add_action( 'admin_enqueue_scripts', 'import_admin_banner_css' );
+	}
+}
+add_action( 'current_screen', 'import_page_customizations_init' );
 
 /**
  * Displays a banner on the wp-admin/import.php page that links to the Calypso importer.
  */
 function import_admin_banner() {
-	if ( $GLOBALS['pagenow'] === 'import.php' ) {
-		$import_url = '/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
-		echo '<div id="wpcom-import-banner" class="notice">';
-		echo '<p>Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.</p>';
-		echo '<a href="' . esc_url( $import_url ) . '" class="button">Start Importing</a>';
-		echo '</div>';
-	}
+	require_once __DIR__ . '/../../utils.php';
+	$import_url = '/setup/import-focused/import?siteSlug=' . wpcom_get_site_slug();
+	echo '<div id="wpcom-import-banner" class="notice">';
+	echo '<p>Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms.</p>';
+	echo '<a href="' . esc_url( $import_url ) . '" class="button">Start Importing</a>';
+	echo '</div>';
 }
-add_action( 'admin_notices', 'import_admin_banner' );
 
 /**
  * Enqueues CSS for the wp-admin/import.php Calypso import banner.
  */
 function import_admin_banner_css() {
-	if ( $GLOBALS['pagenow'] === 'import.php' ) {
-		// Cache-bust the CSS file using the file modification time.
-		$version = filemtime( plugin_dir_path( __FILE__ ) . 'css/import-customizations.css' );
+	$css_file_path = plugin_dir_path( __FILE__ ) . 'css/import-customizations.css';
+
+	if ( file_exists( $css_file_path ) ) {
+		$version = filemtime( $css_file_path );
 		wp_enqueue_style( 'import_admin_banner_css', plugin_dir_url( __FILE__ ) . 'css/import-customizations.css', array(), $version );
 	}
 }
-add_action( 'admin_enqueue_scripts', 'import_admin_banner_css' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5262

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

- This PR uses `admin_notices` to create a banner on top of wp-admin/import.php with a CTA to direct the user to the Calypso import tool (found at https://wordpress.com/setup/import-focused/import?siteSlug=[site_slug])
- CSS grid is used to place the banner directly above the table of registered importers.
- The banner is inserted using action hooks and ONLY if the `wpcom_admin_interface` option is set `wp-admin` AKA the "Classic style".
- The sibling PR https://github.com/Automattic/jetpack/pull/35258 will update the Masterbar menu item to redirect the Import menu item from Calypso to import.php.
- The proposed banner copy is "Import your content with WordPress.com’s guided importer. Designed for seamless integration from multiple platforms." and the CTA is "Get started" (As seen in the screenshot below.)
- The CTA click tracking is handled by ref in the URL. While that doesn't track clicks directly, it sets the reference on the destination page, so we know they came from this CTA.

<img width="1192" alt="Screenshot 2024-01-31 at 2 07 50 PM" src="https://github.com/Automattic/jetpack/assets/140841/de4dc946-a4b5-460c-a836-1c41f5cd348c">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have the Jetpack Beta plugin on the WoA site
* Make sure you have `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` in your wp-config.php
* Choose "WordPress.com Features" in `/wp-admin/admin.php?page=jetpack-beta`
* Search for the feature branch `add/import-admin-customizations`
* Go to `/wp-admin/import.php`