### PR TITLE
Jetpack AI: Add loading state to usage panel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-usage-panel-loading-state
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-usage-panel-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: add loading state to the usage panel.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { LoadingPlaceholder } from '@automattic/jetpack-components';
 import { BaseControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
@@ -60,6 +61,7 @@ function UsageControl( {
 	requestsLimit,
 	daysUntilReset = null,
 	requireUpgrade = false,
+	loading = false,
 }: UsageControlProps ) {
 	// Trust on the isOverLimit flag, but also do a local check
 	const limitReached = isOverLimit || requestsCount >= requestsLimit;
@@ -86,11 +88,8 @@ function UsageControl( {
 
 	const usage = requestsCount / requestsLimit;
 
-	return (
-		<BaseControl
-			help={ helpMessages.length ? helpMessages.join( ' ' ) : null }
-			label={ __( 'Usage', 'jetpack' ) }
-		>
+	const usageDisplay = (
+		<>
 			{ planType === PLAN_TYPE_FREE && (
 				<p>
 					{ sprintf(
@@ -115,6 +114,20 @@ function UsageControl( {
 			{ ( planType === PLAN_TYPE_FREE || planType === PLAN_TYPE_TIERED ) && (
 				<UsageBar usage={ usage } limitReached={ limitReached } requireUpgrade={ requireUpgrade } />
 			) }
+		</>
+	);
+
+	const loadingPlaceholder = (
+		<LoadingPlaceholder height={ 100 } className="jetpack-ai-usage-panel__loading-placeholder" />
+	);
+
+	return (
+		<BaseControl
+			help={ ! loading && helpMessages.length ? helpMessages.join( ' ' ) : null }
+			label={ __( 'Usage', 'jetpack' ) }
+		>
+			{ ! loading && usageDisplay }
+			{ loading && loadingPlaceholder }
 		</BaseControl>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/style.scss
@@ -37,4 +37,9 @@
 
 		}
 	}
+
+	.jetpack-ai-usage-panel__loading-placeholder {
+		background-color: var(--jp-gray-10);
+		margin-top: var( --spacing-base );
+	}
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-bar/types.ts
@@ -24,4 +24,5 @@ export type UsageControlProps = {
 	planType: PlanType;
 	daysUntilReset: number;
 	requireUpgrade: boolean;
+	loading?: boolean;
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -119,6 +119,7 @@ export default function UsagePanel( { placement = null }: UsagePanelProps ) {
 		currentTier,
 		nextTier,
 		requireUpgrade,
+		loading,
 	} = useAiFeature();
 	const planType = usePlanType( currentTier );
 	const daysUntilReset = useDaysUntilReset( usagePeriod?.nextStart );
@@ -170,36 +171,39 @@ export default function UsagePanel( { placement = null }: UsagePanelProps ) {
 					daysUntilReset={ daysUntilReset }
 					planType={ planType }
 					requireUpgrade={ requireUpgrade }
+					loading={ loading }
 				/>
 
-				{ ( planType === PLAN_TYPE_FREE || planType === PLAN_TYPE_TIERED ) && canUpgrade && (
-					<div className="jetpack-ai-usage-panel-upgrade-button">
-						{ showContactUsCallToAction && (
-							<>
-								<p>{ __( 'Need more requests?', 'jetpack' ) }</p>
+				{ ! loading &&
+					( planType === PLAN_TYPE_FREE || planType === PLAN_TYPE_TIERED ) &&
+					canUpgrade && (
+						<div className="jetpack-ai-usage-panel-upgrade-button">
+							{ showContactUsCallToAction && (
+								<>
+									<p>{ __( 'Need more requests?', 'jetpack' ) }</p>
+									<Button
+										variant="primary"
+										label={ __( 'Contact us for more requests', 'jetpack' ) }
+										href={ contactUsURL }
+										onClick={ trackContactUsClick }
+									>
+										{ __( 'Contact Us', 'jetpack' ) }
+									</Button>
+								</>
+							) }
+							{ ! showContactUsCallToAction && (
 								<Button
 									variant="primary"
-									label={ __( 'Contact us for more requests', 'jetpack' ) }
-									href={ contactUsURL }
-									onClick={ trackContactUsClick }
+									label={ __( 'Upgrade your Jetpack AI plan', 'jetpack' ) }
+									href={ checkoutUrl }
+									onClick={ trackUpgradeClick }
+									disabled={ isRedirecting }
 								>
-									{ __( 'Contact Us', 'jetpack' ) }
+									{ upgradeButtonText }
 								</Button>
-							</>
-						) }
-						{ ! showContactUsCallToAction && (
-							<Button
-								variant="primary"
-								label={ __( 'Upgrade your Jetpack AI plan', 'jetpack' ) }
-								href={ checkoutUrl }
-								onClick={ trackUpgradeClick }
-								disabled={ isRedirecting }
-							>
-								{ upgradeButtonText }
-							</Button>
-						) }
-					</div>
-				) }
+							) }
+						</div>
+					) }
 			</>
 		</div>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34945.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Support a loading state with loading placeholder on the usage control component of the usage panel
* Enable this loading state based on the loading state of the Jetpack AI feature data request

<img width="250" alt="Screenshot 2024-01-30 at 18 13 08" src="https://github.com/Automattic/jetpack/assets/6760046/1cd95705-4307-4b8c-9bff-0270e597b0de">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Look for the usage panel on the Jetpack sidebar, inside the AI Assistant section:

<img width="300" alt="Screenshot 2024-01-30 at 18 14 49" src="https://github.com/Automattic/jetpack/assets/6760046/3e0bfe04-5031-4ef7-836e-a5fca1271308">

* Open the browser console, go to the network tab and set the throttling option to some very slow connection, so we can see the loading state while the request is slowly processed; on Chrome:

<img width="200" alt="Screenshot 2024-01-30 at 18 17 17" src="https://github.com/Automattic/jetpack/assets/6760046/a842f8a2-14ff-4e28-b505-8204e1270433">

* On the browser console, execute the following command and notice the usage panel:

```

wp.data.dispatch( 'wordpress-com/plans' ).fetchAiAssistantFeature();
```

* The command will trigger a new request for the AI Assistant feature data, and the usage panel should enter on the loading state while the request is procressed:

<img width="250" alt="Screenshot 2024-01-30 at 18 13 08" src="https://github.com/Automattic/jetpack/assets/6760046/df2d29d3-f55f-4cb6-8234-9a081efd3de0">

* The placeholder is a standard one, grey, with a small animation changing the opacity of it
* Once the request is finished, the placeholder should go away and the usage panel should be visible:

<img width="250" alt="Screenshot 2024-01-30 at 18 25 10" src="https://github.com/Automattic/jetpack/assets/6760046/75a3db19-607b-48f4-8d0c-69fb448dc0e9">

* Don't forget to change the network throttling setting back to "No throttling"