### PR TITLE
Boost: Fix score prompt compatibility

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
@@ -1,13 +1,8 @@
-import {
-	getScoreLetter,
-	didScoresChange,
-	getScoreMovementPercentage,
-} from '@automattic/jetpack-boost-score-api';
+import { getScoreLetter, didScoresChange } from '@automattic/jetpack-boost-score-api';
 import { BoostScoreBar, Button } from '@automattic/jetpack-components';
 import { sprintf, __ } from '@wordpress/i18n';
 import ContextTooltip from './context-tooltip/context-tooltip';
 import RefreshIcon from '$svg/refresh';
-import PopOut from './pop-out/pop-out';
 import PerformanceHistory from '$features/performance-history/performance-history';
 import ErrorNotice from '$features/error-notice/error-notice';
 import classNames from 'classnames';
@@ -40,9 +35,6 @@ const SpeedScore = () => {
 			}, [] ),
 		[ data ]
 	);
-
-	const showScoreChangePopOut =
-		status === 'loaded' && ! scores.isStale && getScoreMovementPercentage( scores );
 
 	// Mark performance history data as stale when speed scores are loaded.
 	useEffect( () => {
@@ -148,8 +140,6 @@ const SpeedScore = () => {
 				</div>
 				{ site.online && <PerformanceHistory /> }
 			</div>
-
-			<PopOut scoreChange={ showScoreChangePopOut } />
 		</>
 	);
 };

--- a/projects/plugins/boost/changelog/remove-popout
+++ b/projects/plugins/boost/changelog/remove-popout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Speed Scores: Temporarily removed the score change popout.

--- a/projects/plugins/boost/compatibility/score-prompt.php
+++ b/projects/plugins/boost/compatibility/score-prompt.php
@@ -5,9 +5,9 @@
  * @package automattic/jetpack-boost
  */
 // Old value is the previous DS key, fallback to even older non-ds value.
-$old_value = get_option( 'jetpack_boost_ds_dismissed_score_prompt', get_option( 'jb_show_score_prompt' ) );
+$old_value = (array) get_option( 'jetpack_boost_ds_dismissed_score_prompt', get_option( 'jb_show_score_prompt' ) );
 if ( false !== $old_value ) {
-	$new_value = get_option( 'jetpack_boost_ds_dismissed_alerts', array() );
+	$new_value = (array) get_option( 'jetpack_boost_ds_dismissed_alerts', array() );
 
 	if ( in_array( 'score-increase', $old_value, true ) ) {
 		$new_value['score_increase'] = true;


### PR DESCRIPTION
## Proposed changes:
* Ensure that the compatibility file does not result in fatal error

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1706675389544359-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Create an option in the database name = `jetpack_boost_ds_dismissed_score_prompt`, value = `0`
* Make sure the site doesn't result in fatal
* Check the DB to make sure the the option is removed after you load boost dashboard