### PR TITLE
Boost: add support for DONOTCACHEPAGE constant to Cache module

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache.php
@@ -69,6 +69,10 @@ abstract class Boost_Cache {
 			return false;
 		}
 
+		if ( defined( 'DONOTCACHEPAGE' ) ) {
+			return false;
+		}
+
 		if ( $this->is_fatal_error() ) {
 			return false;
 		}

--- a/projects/plugins/boost/changelog/boost-cache-donotcachepage-constant
+++ b/projects/plugins/boost/changelog/boost-cache-donotcachepage-constant
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Boost: add support for DONOTCACHEPAGE to Cache module


### PR DESCRIPTION
A number of full page caching plugins support the use of the DONOTCACHEPAGE constant to disable caching in a request when it is set.
This PR adds that to Boost Cache.

Fixes #35056 

## Proposed changes:
* Add a check for this constant to the is_cacheable() function and return false if set

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2rA-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR
* Create an mu-plugin with this code:
```
<?php
function do_not_cache_post() {
        if ( strpos( $_SERVER['REQUEST_URI'], 'hello-world' ) !== false && ! defined( 'DONOTCACHEPAGE' ) ) {
                define( 'DONOTCACHEPAGE', 1 );
        }
}
add_action( 'init', 'do_not_cache_post' );
```
* Load the hello-world post on your server. Load it twice and check the source code to verify the "cached" signature is missing.
