### PR TITLE
Admin Page: consider sites with paid products as including support

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
@@ -21,7 +21,7 @@ import {
 	connectUser,
 } from 'state/connection';
 import { isAtomicSite, isDevVersion as _isDevVersion, getUpgradeUrl } from 'state/initial-state';
-import { siteHasFeature, isFetchingSiteData } from 'state/site';
+import { siteHasFeature, hasActiveProductPurchase, isFetchingSiteData } from 'state/site';
 
 class SupportCard extends React.Component {
 	static displayName = 'SupportCard';
@@ -157,7 +157,7 @@ export default connect(
 			isCurrentUserLinked: isCurrentUserLinked( state ),
 			isConnectionOwner: isConnectionOwner( state ),
 			hasConnectedOwner: hasConnectedOwner( state ),
-			hasSupport: siteHasFeature( state, 'support' ),
+			hasSupport: siteHasFeature( state, 'support' ) || hasActiveProductPurchase( state ),
 		};
 	},
 	dispatch => ( {

--- a/projects/plugins/jetpack/changelog/update-support-card-products
+++ b/projects/plugins/jetpack/changelog/update-support-card-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: update the Support card to display the right contents depending on the plan or product used on the site.


### PR DESCRIPTION
Fixes #35144

## Proposed changes:

Until now, only sites with paid plans were considered as including support.

**Before**

<img width="1085" alt="Screenshot 2024-01-31 at 11 27 16" src="https://github.com/Automattic/jetpack/assets/426388/40d0481f-81ea-479f-9a63-f1b2f8b599a9">

**After**

<img width="1090" alt="Screenshot 2024-01-31 at 11 23 13" src="https://github.com/Automattic/jetpack/assets/426388/c3ffd3cf-63c0-4f28-8bee-819c4ebd053d">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a brand new site, running `trunk`.
* Connect it to WordPress.com.
* Go to Jetpack > Dashboard
    * At the bottom of the page, you should see the support card with an invitation to upgrade to a paid plan.
* Go to Jetpack > Plans, and purchase a product like Jetpack VideoPress.
* Go back to Jetpack > Dashboard
    * At the bottom of the page, you should still see the same support card with the upgrade prompt.
* Switch to this branch.
* Reload the page
    * The support card should now show that you have a paid plan.
