### PR TITLE
Move Monetize and Marketing under WordPress.com menu

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wpcom-menu
+++ b/projects/plugins/jetpack/changelog/update-wpcom-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Move Monetize and Marketing from Tools to the new WordPress.com menu for the calypso untangle project.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -140,7 +140,7 @@ class Admin_Menu extends Base_Admin_Menu {
 			return;
 		}
 
-		add_menu_page( __( 'WordPress.com', 'jetpack' ), __( 'WordPress.com', 'jetpack' ), 'manage_options', 'wpcom', null, 'dashicons-wordpress-alt', 4 );
+		add_menu_page( __( 'WordPress.com', 'jetpack' ), __( 'WordPress.com', 'jetpack' ), 'publish_posts', 'wpcom', null, 'dashicons-wordpress-alt', 4 );
 
 		add_submenu_page( 'wpcom', __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', 'https://wordpress.com/plans/' . $this->domain, null, 0 );
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -156,6 +156,8 @@ class Admin_Menu extends Base_Admin_Menu {
 		}
 
 		add_submenu_page( 'wpcom', __( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, 4 );
+		add_submenu_page( 'wpcom', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 5 );
+		add_submenu_page( 'wpcom', esc_attr__( 'Monetize', 'jetpack' ), __( 'Monetize', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 6 );
 
 		// Remove the submenu auto-created by Core.
 		$this->hide_submenu_page( 'wpcom', 'wpcom' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -383,8 +383,10 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->hide_submenu_page( 'tools.php', 'tools.php' );
 		$this->hide_submenu_page( 'tools.php', 'delete-blog' );
 
-		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 0 );
-		add_submenu_page( 'tools.php', esc_attr__( 'Monetize', 'jetpack' ), __( 'Monetize', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
+		if ( 'wp-admin' !== get_option( 'wpcom_admin_interface' ) ) {
+			add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 0 );
+			add_submenu_page( 'tools.php', esc_attr__( 'Monetize', 'jetpack' ), __( 'Monetize', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -46,7 +46,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Add notices to the settings pages when there is a Calypso page available.
 		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
 			add_action( 'current_screen', array( $this, 'add_settings_page_notice' ) );
-			$this->add_wpcom_menu();
 		}
 	}
 
@@ -578,23 +577,5 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		}
 
 		parent::add_dashboard_switcher();
-	}
-
-	/**
-	 * Adds the WP.com drawer.
-	 */
-	public function add_wpcom_menu() {
-		add_menu_page(
-			'WordPress.com',
-			'WordPress.com',
-			'read',
-			'wordpress.com',
-			'__return_null',
-			'dashicons-wordpress-alt',
-			3
-		);
-
-		add_submenu_page( 'wordpress.com', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 0 );
-		add_submenu_page( 'wordpress.com', esc_attr__( 'Monetize', 'jetpack' ), __( 'Monetize', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -46,6 +46,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Add notices to the settings pages when there is a Calypso page available.
 		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
 			add_action( 'current_screen', array( $this, 'add_settings_page_notice' ) );
+			$this->add_wpcom_menu();
 		}
 	}
 
@@ -577,5 +578,23 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		}
 
 		parent::add_dashboard_switcher();
+	}
+
+	/**
+	 * Adds the WP.com drawer.
+	 */
+	public function add_wpcom_menu() {
+		add_menu_page(
+			'WordPress.com',
+			'WordPress.com',
+			'read',
+			'wordpress.com',
+			'__return_null',
+			'dashicons-wordpress-alt',
+			3
+		);
+
+		add_submenu_page( 'wordpress.com', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 0 );
+		add_submenu_page( 'wordpress.com', esc_attr__( 'Monetize', 'jetpack' ), __( 'Monetize', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5373, https://github.com/Automattic/dotcom-forge/issues/5376

![menu](https://github.com/Automattic/jetpack/assets/6586048/a9931a20-4203-4271-b3c0-55297919fc01)



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move Marketing and Monetize for Classic style to WordPress.com menu

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Apply this branch by following https://github.com/Automattic/jetpack/pull/35365#issuecomment-1918834790
- Head to Settings → Hosting Configuration.
- Scroll to the Admin interface style section, and select Classic style.
- Check the menu to see if Monetize and Marketing are moved to WordPress.com menu and no longer present in tools
- Switch back to default style and see if Monetize and Marketing are back in Tools