### PR TITLE
Provide Type_Literal value correctly

### DIFF
--- a/projects/packages/wp-js-data-sync/changelog/boost-fix-datasync-fallback-value
+++ b/projects/packages/wp-js-data-sync/changelog/boost-fix-datasync-fallback-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP JS Data Sync: Added tests for fallback values and fixed `Type_Literal` value handling in the schema parser.

--- a/projects/packages/wp-js-data-sync/package.json
+++ b/projects/packages/wp-js-data-sync/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wp-js-data-sync",
-	"version": "0.4.1",
+	"version": "0.4.2-alpha",
 	"description": "A package to setup REST API and script localization to pass data to a JavaScript client.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wp-js-data-sync/#readme",
 	"bugs": {

--- a/projects/packages/wp-js-data-sync/src/class-data-sync.php
+++ b/projects/packages/wp-js-data-sync/src/class-data-sync.php
@@ -69,7 +69,7 @@ use Automattic\Jetpack\WP_JS_Data_Sync\Schema\Schema_Context;
 
 final class Data_Sync {
 
-	const PACKAGE_VERSION = '0.4.1';
+	const PACKAGE_VERSION = '0.4.2-alpha';
 
 	/**
 	 * @var Registry

--- a/projects/packages/wp-js-data-sync/src/schema/class-schema-parser.php
+++ b/projects/packages/wp-js-data-sync/src/schema/class-schema-parser.php
@@ -143,7 +143,7 @@ class Schema_Parser implements Parser {
 			$parsers = $this->parser->get_parsers();
 			foreach ( $parsers as $parser ) {
 				if ( $parser instanceof Type_Literal ) {
-					return $parser->parse( null, $this->context);
+					return $parser->parse( null, $this->context );
 				}
 			}
 		}

--- a/projects/packages/wp-js-data-sync/src/schema/class-schema-parser.php
+++ b/projects/packages/wp-js-data-sync/src/schema/class-schema-parser.php
@@ -143,7 +143,7 @@ class Schema_Parser implements Parser {
 			$parsers = $this->parser->get_parsers();
 			foreach ( $parsers as $parser ) {
 				if ( $parser instanceof Type_Literal ) {
-					return $parser;
+					return $parser->parse( null, $this->context);
 				}
 			}
 		}

--- a/projects/packages/wp-js-data-sync/tests/php/schema/integration/test-integration-fallback-values.php
+++ b/projects/packages/wp-js-data-sync/tests/php/schema/integration/test-integration-fallback-values.php
@@ -96,7 +96,6 @@ class Test_Integration_Fallback_Values extends TestCase {
 		$parsed = $true->parse( true );
 		$this->assertSame( true, $parsed );
 
-
 		$parsed = $true->parse( '1' );
 		$this->assertSame( true, $parsed );
 
@@ -194,7 +193,7 @@ class Test_Integration_Fallback_Values extends TestCase {
 		$valid_array = array(
 			'one'          => 100,
 			'array_of_two' => array( 200 ),
-		); 
+		);
 		$this->assertSame( $valid_array, $schema->parse( $valid_array ) );
 		$this->assertSame( $valid_array, $schema_no_fallbacks->parse( $valid_array ) );
 

--- a/projects/packages/wp-js-data-sync/tests/php/schema/integration/test-integration-fallback-values.php
+++ b/projects/packages/wp-js-data-sync/tests/php/schema/integration/test-integration-fallback-values.php
@@ -20,6 +20,7 @@ class Test_Integration_Fallback_Values extends TestCase {
 		// Test with an invalid value
 		$parsed = $string->parse( null );
 		$this->assertSame( 'default_value', $parsed );
+		$this->assertSame( 'default_value', $string->get_fallback() );
 	}
 
 	public function test_context_on_fallback() {
@@ -78,6 +79,7 @@ class Test_Integration_Fallback_Values extends TestCase {
 		// Test with an invald value.
 		$parsed = $test_schema->parse( array( 'child' => null ) );
 		$this->assertSame( $expected_result, $parsed );
+		$this->assertSame( $expected_result, $test_schema->get_fallback() );
 	}
 
 	/**
@@ -89,9 +91,11 @@ class Test_Integration_Fallback_Values extends TestCase {
 	 */
 	public function test_boolean_fallback() {
 		$true = Schema::as_boolean()->fallback( true );
+		$this->assertSame( true, $true->get_fallback() );
 
 		$parsed = $true->parse( true );
 		$this->assertSame( true, $parsed );
+
 
 		$parsed = $true->parse( '1' );
 		$this->assertSame( true, $parsed );
@@ -190,8 +194,7 @@ class Test_Integration_Fallback_Values extends TestCase {
 		$valid_array = array(
 			'one'          => 100,
 			'array_of_two' => array( 200 ),
-		);
-
+		); 
 		$this->assertSame( $valid_array, $schema->parse( $valid_array ) );
 		$this->assertSame( $valid_array, $schema_no_fallbacks->parse( $valid_array ) );
 


### PR DESCRIPTION
## Proposed changes:
- Added unit tests to verify that the proper fallback values are returned by `get_fallback` method.
- Adjusted `Schema_Parser` to correctly return the parsed value of `Type_Literal`.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Run the `Test_Integration_Fallback_Values` test suite to ensure all new and existing tests pass.
- Verify that `Type_Literal` fallback values are correctly returned.