### PR TITLE
Jetpack Sync: make jetpack media extraction more consistent

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -437,7 +437,7 @@ class Jetpack_Media_Meta_Extractor {
 	}
 
 	/**
-	 * Given an extracted image array reduce to src and alt_text.
+	 * Given an extracted image array reduce to src,  alt_text, src_width, and src_height.
 	 *
 	 * @param array $images extracted image array.
 	 *
@@ -450,10 +450,12 @@ class Jetpack_Media_Meta_Extractor {
 			if ( empty( $image['src'] ) ) {
 				continue;
 			}
-			if ( ! empty( $image['alt_text'] ) ) {
+			if ( ! empty( $image['alt_text'] ) || ! empty( $image['src_height'] ) || ! empty( $image['src_width'] ) ) {
 				$ret_images[] = array(
-					'url'      => $image['src'],
-					'alt_text' => $image['alt_text'],
+					'url'        => $image['src'],
+					'alt_text'   => $image['alt_text'] ? $image['alt_text'] : '',
+					'src_width'  => $image['src_width'] ? $image['src_width'] : '',
+					'src_height' => $image['src_height'] ? $image['src_height'] : '',
 				);
 			} else {
 				$ret_images[] = $image['src'];
@@ -543,10 +545,12 @@ class Jetpack_Media_Meta_Extractor {
 			}
 
 			if ( ! in_array( $queryless, $image_list, true ) ) {
-				if ( $extract_alt_text && ! empty( $extracted_image['alt_text'] ) ) {
+				if ( $extract_alt_text ) {
 					$image_list[] = array(
-						'url'      => $queryless,
-						'alt_text' => $extracted_image['alt_text'],
+						'url'        => $queryless,
+						'alt_text'   => $extracted_image['alt_text'],
+						'src_width'  => $extracted_image['src_width'],
+						'src_height' => $extracted_image['src_height'],
 					);
 				} else {
 					$image_list[] = $queryless;

--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -472,11 +472,12 @@ class Jetpack_Media_Meta_Extractor {
 	 *
 	 * @param string $content HTML content.
 	 * @param array  $image_list Array of already found images.
+	 * @param string $extract_alt_text Whether or not to extract the alt text.
 	 *
 	 * @return array|array[] Array of images.
 	 */
-	public static function extract_images_from_content( $content, $image_list ) {
-		$image_list = self::get_images_from_html( $content, $image_list );
+	public static function extract_images_from_content( $content, $image_list, $extract_alt_text = false ) {
+		$image_list = self::get_images_from_html( $content, $image_list, $extract_alt_text );
 		return self::build_image_struct( $image_list, array() );
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -450,16 +450,19 @@ class Jetpack_Media_Meta_Extractor {
 			if ( empty( $image['src'] ) ) {
 				continue;
 			}
-			if ( ! empty( $image['alt_text'] ) || ! empty( $image['src_height'] ) || ! empty( $image['src_width'] ) ) {
-				$ret_images[] = array(
-					'url'        => $image['src'],
-					'alt_text'   => $image['alt_text'] ? $image['alt_text'] : '',
-					'src_width'  => $image['src_width'] ? $image['src_width'] : '',
-					'src_height' => $image['src_height'] ? $image['src_height'] : '',
-				);
-			} else {
-				$ret_images[] = $image['src'];
+			$ret_image = array(
+				'url' => $image['src'],
+			);
+			if ( ! empty( $image['src_height'] ) || ! empty( $image['src_width'] ) ) {
+				$ret_image['src_width']  = $image['src_width'] ?? '';
+				$ret_image['src_height'] = $image['src_height'] ?? '';
 			}
+			if ( ! empty( $image['alt_text'] ) ) {
+				$ret_image['alt_text'] = $image['alt_text'];
+			} else {
+				$ret_image = $image['src'];
+			}
+			$ret_images[] = $ret_image;
 		}
 		return $ret_images;
 	}
@@ -545,16 +548,21 @@ class Jetpack_Media_Meta_Extractor {
 			}
 
 			if ( ! in_array( $queryless, $image_list, true ) ) {
+				$image_to_add = array(
+					'url' => $queryless,
+				);
 				if ( $extract_alt_text ) {
-					$image_list[] = array(
-						'url'        => $queryless,
-						'alt_text'   => $extracted_image['alt_text'],
-						'src_width'  => $extracted_image['src_width'],
-						'src_height' => $extracted_image['src_height'],
-					);
+					if ( ! empty( $extracted_image['alt_text'] ) ) {
+						$image_to_add['alt_text'] = $extracted_image['alt_text'];
+					}
+					if ( ! empty( $extracted_image['src_width'] ) || ! empty( $extracted_image['src_width'] ) ) {
+							$image_to_add['src_width']  = $extracted_image['src_width'];
+							$image_to_add['src_height'] = $extracted_image['src_height'];
+					}
 				} else {
-					$image_list[] = $queryless;
+					$image_to_add = $queryless;
 				}
+				$image_list[] = $image_to_add;
 			}
 		}
 		return $image_list;

--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -558,7 +558,7 @@ class Jetpack_Media_Meta_Extractor {
 					if ( ! empty( $extracted_image['alt_text'] ) ) {
 						$image_to_add['alt_text'] = $extracted_image['alt_text'];
 					}
-					if ( ! empty( $extracted_image['src_width'] ) || ! empty( $extracted_image['src_width'] ) ) {
+					if ( ! empty( $extracted_image['src_width'] ) || ! empty( $extracted_image['src_height'] ) ) {
 							$image_to_add['src_width']  = $extracted_image['src_width'];
 							$image_to_add['src_height'] = $extracted_image['src_height'];
 					}

--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -294,12 +294,14 @@ class Jetpack_Media_Meta_Extractor {
 						}
 					}
 
-					// @todo Check unique before adding
-					$links[] = array(
+					$link = array(
 						'url'           => $link_all_but_proto,
 						'host_reversed' => $host_reversed,
 						'host'          => $url['host'],
 					);
+					if ( ! in_array( $link, $links, true ) ) {
+						$links[] = $link;
+					}
 				}
 			}
 

--- a/projects/plugins/jetpack/changelog/fix-make-jetpack-media-extraction-more-consistent
+++ b/projects/plugins/jetpack/changelog/fix-make-jetpack-media-extraction-more-consistent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack Sync: Make media extraction more consistent with regards to getting alt text and image size information

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -141,9 +141,11 @@ class Jetpack_PostImages {
 	 * If a gallery is detected, then get all the images from it.
 	 *
 	 * @param int $post_id Post ID.
+	 * @param int $width Minimum image width to consider.
+	 * @param int $height Minimum image height to consider.
 	 * @return array Images.
 	 */
-	public static function from_gallery( $post_id ) {
+	public static function from_gallery( $post_id, $width = 200, $height = 200 ) {
 		$images = array();
 
 		$post = get_post( $post_id );
@@ -180,20 +182,35 @@ class Jetpack_PostImages {
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		foreach ( $galleries as $gallery ) {
-			if ( isset( $gallery['type'] ) && 'slideshow' === $gallery['type'] && ! empty( $gallery['ids'] ) ) {
+			if ( ! empty( $gallery['ids'] ) ) {
 				$image_ids  = explode( ',', $gallery['ids'] );
 				$image_size = isset( $gallery['size'] ) ? $gallery['size'] : 'thumbnail';
 				foreach ( $image_ids as $image_id ) {
 					$image = wp_get_attachment_image_src( $image_id, $image_size );
+					$meta  = wp_get_attachment_metadata( $image_id );
+
+					if ( isset( $gallery['type'] ) && 'slideshow' === $gallery['type'] ) {
+						// Must be larger than 200x200 (or user-specified).
+						if ( ! isset( $meta['width'] ) || $meta['width'] < $width ) {
+							continue;
+						}
+						if ( ! isset( $meta['height'] ) || $meta['height'] < $height ) {
+							continue;
+						}
+					}
+
 					if ( ! empty( $image[0] ) ) {
 						list( $raw_src ) = explode( '?', $image[0] ); // pull off any Query string (?w=250).
 						$raw_src         = wp_specialchars_decode( $raw_src ); // rawify it.
 						$raw_src         = esc_url_raw( $raw_src ); // clean it.
 						$images[]        = array(
-							'type' => 'image',
-							'from' => 'gallery',
-							'src'  => $raw_src,
-							'href' => $permalink,
+							'type'       => 'image',
+							'from'       => 'gallery',
+							'src'        => $raw_src,
+							'src_width'  => $meta['width'] ? $meta['width'] : 0,
+							'src_height' => $meta['height'] ? $meta['height'] : 0,
+							'href'       => $permalink,
+							'alt_text'   => self::get_alt_text( $image_id ),
 						);
 					}
 				}
@@ -339,7 +356,7 @@ class Jetpack_PostImages {
 				// If wp_get_attachment_image_src returns false but we know that there should be an image that could be used.
 				// we try a bit harder and user the data that we have.
 				$thumb_post_data = get_post( $thumb );
-				$img_src         = array( $thumb_post_data->guid ?? null, $meta['width'], $meta['height'] );
+				$img_src         = array( $thumb_post_data->guid, $meta['width'], $meta['height'] );
 			}
 
 			// Let's try to use the postmeta if we can, since it seems to be
@@ -498,10 +515,33 @@ class Jetpack_PostImages {
 			if ( stripos( $img_src, '/smilies/' ) ) {
 				continue;
 			}
+			// First try to get the width and height from the img attributes, but if they are not set, check to see if they are specified in the url. WordPress automatically names files like foo-1024x768.jpg during the upload process
+			$width  = (int) $image_tag->getAttribute( 'width' );
+			$height = (int) $image_tag->getAttribute( 'height' );
+			if ( 0 === $width && 0 === $height ) {
+				preg_match( '/-([0-9]+)x([0-9]+)\.(?:jpg|jpeg|png|gif|webp)$/i', $img_src, $matches );
+				if ( isset( $matches[1] ) && ! empty( $matches[1] ) ) {
+					$width = (int) $matches[1];
+				}
+				if ( isset( $matches[2] ) && ! empty( $matches[2] ) ) {
+					$height = (int) $matches[2];
+				}
+			}
+			// If width and height are still 0, try to get the id of the image from the class, e.g. wp-image-1234
+			if ( 0 === $width && 0 === $height ) {
+
+				preg_match( '/wp-image-([0-9]+)/', $image_tag->getAttribute( 'class' ), $matches );
+				if ( isset( $matches[1] ) && ! empty( $matches[1] ) ) {
+					$attachment_id = $matches[1];
+					$meta          = wp_get_attachment_metadata( $attachment_id );
+					$height        = $meta['height'] ? $meta['height'] : 0;
+					$width         = $meta['width'] ? $meta['width'] : 0;
+				}
+			}
 
 			$meta = array(
-				'width'    => (int) $image_tag->getAttribute( 'width' ),
-				'height'   => (int) $image_tag->getAttribute( 'height' ),
+				'width'    => $width,
+				'height'   => $height,
 				'alt_text' => $image_tag->getAttribute( 'alt' ),
 			);
 

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -356,7 +356,7 @@ class Jetpack_PostImages {
 				// If wp_get_attachment_image_src returns false but we know that there should be an image that could be used.
 				// we try a bit harder and user the data that we have.
 				$thumb_post_data = get_post( $thumb );
-				$img_src         = array( $thumb_post_data->guid, $meta['width'], $meta['height'] );
+				$img_src         = array( $thumb_post_data->guid ?? null, $meta['width'], $meta['height'] );
 			}
 
 			// Let's try to use the postmeta if we can, since it seems to be

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -207,8 +207,8 @@ class Jetpack_PostImages {
 							'type'       => 'image',
 							'from'       => 'gallery',
 							'src'        => $raw_src,
-							'src_width'  => $meta['width'] ? $meta['width'] : 0,
-							'src_height' => $meta['height'] ? $meta['height'] : 0,
+							'src_width'  => $meta['width'] ?? 0,
+							'src_height' => $meta['height'] ?? 0,
 							'href'       => $permalink,
 							'alt_text'   => self::get_alt_text( $image_id ),
 						);
@@ -520,10 +520,10 @@ class Jetpack_PostImages {
 			$height = (int) $image_tag->getAttribute( 'height' );
 			if ( 0 === $width && 0 === $height ) {
 				preg_match( '/-([0-9]+)x([0-9]+)\.(?:jpg|jpeg|png|gif|webp)$/i', $img_src, $matches );
-				if ( isset( $matches[1] ) && ! empty( $matches[1] ) ) {
+				if ( ! empty( $matches[1] ) ) {
 					$width = (int) $matches[1];
 				}
-				if ( isset( $matches[2] ) && ! empty( $matches[2] ) ) {
+				if ( ! empty( $matches[2] ) ) {
 					$height = (int) $matches[2];
 				}
 			}
@@ -531,11 +531,11 @@ class Jetpack_PostImages {
 			if ( 0 === $width && 0 === $height ) {
 
 				preg_match( '/wp-image-([0-9]+)/', $image_tag->getAttribute( 'class' ), $matches );
-				if ( isset( $matches[1] ) && ! empty( $matches[1] ) ) {
+				if ( ! empty( $matches[1] ) ) {
 					$attachment_id = $matches[1];
 					$meta          = wp_get_attachment_metadata( $attachment_id );
-					$height        = $meta['height'] ? $meta['height'] : 0;
-					$width         = $meta['width'] ? $meta['width'] : 0;
+					$height        = $meta['height'] ?? 0;
+					$width         = $meta['width'] ?? 0;
 				}
 			}
 
@@ -570,15 +570,18 @@ class Jetpack_PostImages {
 				continue;
 			}
 
-			$images[] = array(
+			$image = array(
 				'type'       => 'image',
 				'from'       => 'html',
 				'src'        => $img_src,
 				'src_width'  => $meta['width'],
 				'src_height' => $meta['height'],
 				'href'       => $html_info['post_url'],
-				'alt_text'   => $meta['alt_text'],
 			);
+			if ( ! empty( $meta['alt_text'] ) ) {
+				$image['alt_text'] = $meta['alt_text'];
+			}
+			$images[] = $image;
 		}
 		return $images;
 	}

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-extractor.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-extractor.php
@@ -28,19 +28,43 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 	 * @since 3.2
 	 */
 	public function test_mediaextractor_extract_image() {
-		$img_title = 'title.jpg';
+		$img_title = 'alt_title.jpg';
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_content' => "<img src='$img_title' width='200' height='200'>",
+				'post_content' => "<img src='$img_title' width='250' height='200'>",
 			)
 		);
 
-		$extract = Jetpack_Media_Meta_Extractor::extract( Jetpack_Options::get_option( 'id' ), $post_id );
+		$extract = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id );
 
 		$this->assertIsArray( $extract );
 		$this->assertArrayHasKey( 'image', $extract );
 		$this->assertEquals( $extract['image'][0]['url'], $img_title );
+	}
+
+	/**
+	 * @author robfelty
+	 * @covers Jetpack_Media_Meta_Extractor::extract
+	 * @since 13.2
+	 */
+	public function test_mediaextractor_extract_image_with_alttext() {
+		$img_title = 'title.jpg';
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => "<img alt='alt text' src='$img_title' width='250' height='200'>",
+			)
+		);
+
+		$extract = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id, Jetpack_Media_Meta_Extractor::ALL, true );
+
+		$this->assertIsArray( $extract );
+		$this->assertArrayHasKey( 'image', $extract );
+		$this->assertEquals( $extract['image'][0]['url'], $img_title );
+		$this->assertEquals( 'alt text', $extract['image'][0]['alt_text'] );
+		$this->assertEquals( 250, $extract['image'][0]['src_width'] );
+		$this->assertEquals( 200, $extract['image'][0]['src_height'] );
 	}
 
 	public function shortcode_nop() {

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-extractor.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-extractor.php
@@ -16,7 +16,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 			)
 		);
 
-		$extract = Jetpack_Media_Meta_Extractor::extract( Jetpack_Options::get_option( 'id' ), $post_id );
+		$extract = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id );
 
 		$this->assertIsArray( $extract );
 		$this->assertEmpty( $extract );
@@ -46,7 +46,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 	/**
 	 * @author robfelty
 	 * @covers Jetpack_Media_Meta_Extractor::extract
-	 * @since 13.2
+	 * @since 13.1
 	 */
 	public function test_mediaextractor_extract_image_with_alttext() {
 		$img_title = 'title.jpg';
@@ -85,7 +85,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 			)
 		);
 
-		$extract = Jetpack_Media_Meta_Extractor::extract( Jetpack_Options::get_option( 'id' ), $post_id );
+		$extract = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id );
 
 		$this->assertIsArray( $extract );
 		$this->assertArrayHasKey( 'shortcode', $extract );
@@ -108,7 +108,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 			)
 		);
 
-		$extract = Jetpack_Media_Meta_Extractor::extract( Jetpack_Options::get_option( 'id' ), $post_id );
+		$extract = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id );
 
 		$this->assertIsArray( $extract );
 		$this->assertArrayHasKey( 'link', $extract );
@@ -194,7 +194,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 	/**
 	 * @author robfelty
 	 * @covers Jetpack_Media_Meta_Extractor::extract_images_from_content
-	 * @since 13.2
+	 * @since 13.1
 	 */
 	public function test_mediaextractor_extract_images_from_content_with_alttext_return_correct_image_struct() {
 		$img_name = 'image.jpg';
@@ -258,8 +258,44 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 	}
 
 	private function add_test_post() {
-		$post_id = self::factory()->post->create(
+		$post_id        = self::factory()->post->create();
+		$img_name       = 'image1.jpg';
+		$alt_text       = 'one image';
+		$img_dimensions = array(
+			'width'  => 300,
+			'height' => 250,
+		);
+
+		$attachment_id_1 = self::factory()->attachment->create_object(
+			$img_name,
+			$post_id,
 			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			)
+		);
+		wp_update_attachment_metadata( $attachment_id_1, $img_dimensions );
+		update_post_meta( $attachment_id_1, '_wp_attachment_image_alt', $alt_text );
+		$img_name       = 'image2.jpg';
+		$alt_text       = 'second image';
+		$img_dimensions = array(
+			'width'  => 350,
+			'height' => 240,
+		);
+
+		$attachment_id_2 = self::factory()->attachment->create_object(
+			$img_name,
+			$post_id,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			)
+		);
+		wp_update_attachment_metadata( $attachment_id_2, $img_dimensions );
+		update_post_meta( $attachment_id_2, '_wp_attachment_image_alt', $alt_text );
+		wp_update_post(
+			array(
+				'ID'                    => $post_id,
 				'post_author'           => '1046316',
 				'post_date'             => '2013-03-15 22:55:05',
 				'post_date_gmt'         => '2013-03-15 22:55:05',
@@ -314,13 +350,13 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 
 			An Image:
 
-			<a href="http://mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png"><img class="alignnone size-full wp-image-32" alt="Screen Shot 2013-03-15 at 1.27.05 PM" src="http://mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png?w=519" width="519" height="317" /></a>
+			<a href="http://example.org/wp-content/uploads/image1.jpg"><img class="alignnone size-full wp-image-32" alt="Screen Shot 2013-03-15 at 1.27.05 PM" src="http://example.org/wp-content/uploads/image1.jpg" width="519" height="317" /></a>
 
 			&nbsp;
 
 			A Gallery:
 
-			[gallery ids="37,36"]
+			[gallery ids="' . $attachment_id_1 . ',' . $attachment_id_2 . '"]
 
 			Twitter:
 
@@ -361,7 +397,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 		$post_id = $this->add_test_post();
 
 		$expected = array(
-			'has'  => array( 'link' => 8 ),
+			'has'  => array( 'link' => 7 ),
 			'link' => array(
 				array(
 					'url'           => 'alink.com',
@@ -389,14 +425,9 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 					'host_reversed' => 'com.anotherlink',
 				),
 				array(
-					'url'           => 'mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png',
-					'host_reversed' => 'com.wordpress.files.mrwpsandbox',
-					'host'          => 'mrwpsandbox.files.wordpress.com',
-				),
-				array(
-					'url'           => 'mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png?w=519',
-					'host_reversed' => 'com.wordpress.files.mrwpsandbox',
-					'host'          => 'mrwpsandbox.files.wordpress.com',
+					'url'           => 'example.org/wp-content/uploads/image1.jpg',
+					'host_reversed' => 'org.example',
+					'host'          => 'example.org',
 				),
 				array(
 					'host_reversed' => 'com.twitter',
@@ -421,15 +452,56 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 
 		$expected = array(
 			'image' => array(
-				0 => array( 'url' => 'http://mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png' ),
+				0 => array( 'url' => 'http://example.org/wp-content/uploads/image1.jpg' ),
+				1 => array( 'url' => 'http://example.org/wp-content/uploads/image2.jpg' ),
 			),
 			'has'   => array(
-				'image'   => 1,
-				'gallery' => 0,
+				'image'   => 2,
+				'gallery' => 1,
 			),
 		);
 
 		$result = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id, Jetpack_Media_Meta_Extractor::IMAGES );
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * @author scotchfield
+	 * @covers Jetpack_Media_Meta_Extractor::extract
+	 * @since 3.2
+	 */
+	public function test_extract_images_with_alt_text() {
+		$post_id = $this->add_test_post();
+
+		$expected = array(
+			'image' => array(
+				0 => array(
+					'url'        => 'http://example.org/wp-content/uploads/image1.jpg',
+					'src_width'  => 300,
+					'src_height' => 250,
+					'alt_text'   => 'one image',
+				),
+				1 => array(
+					'url'        => 'http://example.org/wp-content/uploads/image2.jpg',
+					'src_width'  => 350,
+					'src_height' => 240,
+					'alt_text'   => 'second image',
+				),
+				2 => array(
+					'url'        => 'http://example.org/wp-content/uploads/image1.jpg',
+					'alt_text'   => 'Screen Shot 2013-03-15 at 1.27.05 PM',
+					'src_width'  => 519,
+					'src_height' => 317,
+				),
+			),
+			'has'   => array(
+				'image'   => 3,
+				'gallery' => 1,
+			),
+		);
+
+		$result = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id, Jetpack_Media_Meta_Extractor::IMAGES, true );
 
 		$this->assertEquals( $expected, $result );
 	}

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-extractor.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-extractor.php
@@ -192,6 +192,28 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @author robfelty
+	 * @covers Jetpack_Media_Meta_Extractor::extract_images_from_content
+	 * @since 13.2
+	 */
+	public function test_mediaextractor_extract_images_from_content_with_alttext_return_correct_image_struct() {
+		$img_name = 'image.jpg';
+		$content  = "<img src='$img_name' width='250' height='200' alt='alternative image'>";
+
+		$image_struct = Jetpack_Media_Meta_Extractor::extract_images_from_content( $content, array(), true );
+
+		$this->assertIsArray( $image_struct );
+		$this->assertArrayHasKey( 'has', $image_struct );
+		$this->assertArrayHasKey( 'image', $image_struct );
+		$this->assertCount( 1, $image_struct['image'] );
+		$this->assertEquals( $image_struct['image'][0]['url'], $img_name );
+		$this->assertEquals( 'alternative image', $image_struct['image'][0]['alt_text'] );
+		$this->assertEquals( 250, $image_struct['image'][0]['src_width'] );
+		$this->assertEquals( 200, $image_struct['image'][0]['src_height'] );
+		$this->assertSame( 1, $image_struct['has']['image'] );
+	}
+
+	/**
 	 * @author scotchfield
 	 * @covers Jetpack_Media_Meta_Extractor::get_images_from_html
 	 * @since 3.2

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
@@ -233,16 +233,10 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 				'post_content' => $img_html,
 			)
 		);
-		l();
-		l( 'post id' );
-		l( $post_id );
 
 		add_filter( 'jetpack_postimages_ignore_minimum_dimensions', '__return_true', 66 );
 		$images = Jetpack_PostImages::from_html( $post_id );
 		remove_filter( 'jetpack_postimages_ignore_minimum_dimensions', '__return_true', 66 );
-		l();
-		l( 'IMAGES' );
-		l( $images );
 
 		$this->assertCount( 1, $images );
 		$this->assertEquals( $img_url, $images[0]['src'] );

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
@@ -18,6 +18,8 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertNotEmpty( $result );
 		$this->assertEquals( 'Alt Text.', $result[0]['alt_text'] );
+		$this->assertEquals( 200, $result[0]['src_width'] );
+		$this->assertEquals( 200, $result[0]['src_height'] );
 	}
 
 	/**
@@ -34,6 +36,8 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertNotEmpty( $result );
 		$this->assertEquals( 'Alt Text.', $result[0]['alt_text'] );
+		$this->assertEquals( 200, $result[0]['src_width'] );
+		$this->assertEquals( 200, $result[0]['src_height'] );
 	}
 
 	/**
@@ -56,20 +60,98 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Create a post with a gallery shortcode containing a few images attached to the post.
+	 *
+	 * @since 13.2.0
+	 *
+	 * @return array $post_info {
+	 * An array of information about our post.
+	 *  @type int   $post_id  Post ID.
+	 *  @type array $img_urls Image URLs we'll look to extract.
+	 * }
+	 */
+	protected function get_post_with_gallery_shortcode() {
+		$img_urls       = array(
+			'image.jpg'  => 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/image.jpg',
+			'image2.jpg' => 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/image2.jpg',
+		);
+		$img_dimensions = array(
+			'width'  => 300,
+			'height' => 250,
+		);
+		$alt_text       = 'An image in a gallery shortcode';
+
+		// Create post.
+		$post_id = self::factory()->post->create();
+		// Attach images.
+		foreach ( $img_urls as $img_name => $img_url ) {
+			$attachment_id = self::factory()->attachment->create_object(
+				$img_name,
+				$post_id,
+				array(
+					'post_mime_type' => 'image/jpeg',
+					'post_type'      => 'attachment',
+				)
+			);
+			wp_update_attachment_metadata( $attachment_id, $img_dimensions );
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
+
+			// Update our array to store attachment IDs. We'll need them later.
+			$img_urls[ $attachment_id ] = wp_get_attachment_url( $attachment_id );
+			unset( $img_urls[ $img_name ] );
+		}
+
+		// Gallery markup.
+		$gallery_html = sprintf(
+			'[gallery ids="%s"]',
+			implode( ',', array_keys( $img_urls ) )
+		);
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $gallery_html,
+			)
+		);
+
+		return array(
+			'post_id'  => $post_id,
+			'img_urls' => array_values( $img_urls ),
+		);
+	}
+
+	/**
 	 * @author scotchfield
 	 * @covers Jetpack_PostImages::from_gallery
 	 * @since 3.2
 	 */
 	public function test_from_gallery_is_array() {
-		$post_id = self::factory()->post->create(
-			array(
-				'post_content' => '[gallery 1,2,3]',
-			)
-		);
+		$post_info = $this->get_post_with_gallery_shortcode();
 
-		$images = Jetpack_PostImages::from_gallery( $post_id );
+		$images = Jetpack_PostImages::from_gallery( $post_info['post_id'] );
 
 		$this->assertIsArray( $images );
+	}
+
+	/**
+	 * @author robfelty
+	 * @covers Jetpack_PostImages::from_gallery
+	 * @since 13.2
+	 */
+	public function test_from_gallery_is_correct_array() {
+		$post_info = $this->get_post_with_gallery_shortcode();
+
+		$images   = Jetpack_PostImages::from_gallery( $post_info['post_id'] );
+		$alt_text = 'An image in a gallery shortcode';
+
+		$this->assertIsArray( $images );
+		$this->assertCount( 2, $images );
+		$this->assertEquals( $post_info['img_urls'][0], $images[0]['src'] );
+		$this->assertEquals( 300, $images[0]['src_width'] );
+		$this->assertEquals( 250, $images[0]['src_height'] );
+		$this->assertEquals( $alt_text, $images[0]['alt_text'] );
+		$this->assertEquals( $post_info['img_urls'][1], $images[1]['src'] );
+		$this->assertEquals( 300, $images[1]['src_width'] );
+		$this->assertEquals( 250, $images[1]['src_height'] );
 	}
 
 	/**
@@ -82,7 +164,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 		$img_name       = 'image.jpg';
 		$alt_text       = 'Alt Text.';
 		$img_dimensions = array(
-			'width'  => 250,
+			'width'  => 300,
 			'height' => 250,
 		);
 
@@ -99,7 +181,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 		update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
 
 		$img_url  = wp_get_attachment_url( $attachment_id );
-		$img_html = '<img src="' . $img_url . '" width="250" height="250" alt="' . $alt_text . '"/>';
+		$img_html = '<img src="' . $img_url . '" width="300" height="250" alt="' . $alt_text . '"/>';
 
 		wp_update_post(
 			array(
@@ -112,6 +194,8 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $images );
 		$this->assertEquals( $img_url, $images[0]['src'] );
+		$this->assertEquals( 300, $images[0]['src_width'] );
+		$this->assertEquals( 250, $images[0]['src_height'] );
 		$this->assertEquals( $alt_text, $images[0]['alt_text'] );
 	}
 
@@ -130,7 +214,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 		$img_name       = 'image.jpg';
 		$alt_text       = 'Alt Text.';
 		$img_dimensions = array(
-			'width'  => 250,
+			'width'  => 300,
 			'height' => 250,
 		);
 
@@ -205,6 +289,8 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 
 		$this->assertEquals( $post_info['img_url'], $images[0]['src'] );
 		$this->assertEquals( $post_info['alt_text'], $images[0]['alt_text'] );
+		$this->assertEquals( 300, $images[0]['src_width'] );
+		$this->assertEquals( 250, $images[0]['src_height'] );
 	}
 
 	/**
@@ -243,7 +329,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 			'image2.jpg' => 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/image2.jpg',
 		);
 		$img_dimensions = array(
-			'width'  => 250,
+			'width'  => 300,
 			'height' => 250,
 		);
 
@@ -311,6 +397,8 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 
 		$this->assertEquals( $images[0]['src'], $post_info['img_urls'][0] );
 		$this->assertEquals( $images[1]['src'], $post_info['img_urls'][1] );
+		$this->assertEquals( 300, $images[0]['src_width'] );
+		$this->assertEquals( 250, $images[0]['src_height'] );
 	}
 
 	/**
@@ -346,7 +434,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 		$img_name       = 'image.jpg';
 		$alt_text       = 'Alt Text.';
 		$img_dimensions = array(
-			'width'  => 250,
+			'width'  => 300,
 			'height' => 250,
 		);
 
@@ -423,6 +511,8 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 
 		$this->assertEquals( $post_info['img_url'], $images[0]['src'] );
 		$this->assertEquals( $post_info['alt_text'], $images[0]['alt_text'] );
+		$this->assertEquals( 300, $images[0]['src_width'] );
+		$this->assertEquals( 250, $images[0]['src_height'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently we extract image size info in some cases, but not in all. For example, the `from_slideshow` method will return image width and height, but not `from_gallery`. These changes aim to make this more consistent across all the ways we can extract image information.

<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
This copies much of the logic around extracting image size info to all of the various methods in the `Jetpack_PostImages` class, and adds a number of additional tests for that class and the media extractor class.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Run the newly added unit tests
```
$ jetpack docker phpunit -- --filter=WP_Test_Jetpack_MediaExtractor
$ jetpack docker phpunit -- --filter=WP_Test_Jetpack_PostImages
```
