### PR TITLE
AI Proofread: add feature property on event

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-proofread-event-prop
+++ b/projects/plugins/jetpack/changelog/add-ai-proofread-event-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Proofread plugin: add feature to the event props

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
@@ -105,7 +105,6 @@ export default function Proofread( {
 		request( messages, { feature: 'jetpack-ai-proofread-plugin' } );
 		toggleProofreadModal();
 		tracks.recordEvent( 'jetpack_ai_get_feedback', {
-			post_id: postId,
 			feature: 'jetpack-ai-proofread-plugin',
 		} );
 	};

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
@@ -106,6 +106,7 @@ export default function Proofread( {
 		toggleProofreadModal();
 		tracks.recordEvent( 'jetpack_ai_get_feedback', {
 			post_id: postId,
+			feature: 'jetpack-ai-proofread-plugin',
 		} );
 	};
 


### PR DESCRIPTION
The event is equivalent to that of "generate", but it lacks the `feature` property.

## Proposed changes:
Add `feature` property on event

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use a post with some content. Open the Jetpack sidebar and look for the AI panel. Click the "generate feedback" button.