### PR TITLE
Subscriber Login: Fix log in URL for simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriber-login-login-url
+++ b/projects/plugins/jetpack/changelog/fix-subscriber-login-login-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriber Login: Fix log in URL for simple sites

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -72,15 +72,15 @@ function get_current_url() {
 function get_subscriber_login_url( $redirect ) {
 	$redirect = ! empty( $redirect ) ? $redirect : get_site_url();
 
-	// Copied from projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+	// Taken from projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php and simplified a bit
 	if ( ( new Host() )->is_wpcom_simple() ) {
 		// On WPCOM we will redirect immediately
-		$redirect_url = $redirect;
-	} else {
-		// On self-hosted we will save and hide the token
-		$redirect_url = get_site_url() . '/wp-json/jetpack/v4/subscribers/auth';
-		$redirect_url = add_query_arg( 'redirect_url', $redirect, $redirect_url );
+		return wpcom_logmein_redirect_url( $redirect, false, null, 'link', get_current_blog_id() );
 	}
+
+	// On self-hosted we will save and hide the token
+	$redirect_url = get_site_url() . '/wp-json/jetpack/v4/subscribers/auth';
+	$redirect_url = add_query_arg( 'redirect_url', $redirect, $redirect_url );
 
 	return add_query_arg(
 		array(


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/34884

## Proposed changes:

It fixes the log in URL for simple sites by using `wpcom_logmein_redirect_url` to build it.

### Before

The token is present in the URL after logging in.

<img width="989" alt="Screenshot 2024-01-31 at 15 38 41" src="https://github.com/Automattic/jetpack/assets/4068554/750a3eaa-9e5b-4a73-bbfd-c13ea2c88d8f">

### After

No token in URL after logging in.

<img width="989" alt="Screenshot 2024-01-31 at 15 37 49" src="https://github.com/Automattic/jetpack/assets/4068554/2752ae13-23cf-4212-bf7e-216270ad2e60">

<br>
<br>
Tested it on simple and self-hosted sites.

I didn't mark it as a `bugfix` in the changelog entry since the block is not released yet.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert the Subscriber Login block into a page or post
* Log in using it
* Make sure you are logged in and there is no token in URL

