### PR TITLE
Social: Fix isPluginActive checks while activating license

### DIFF
--- a/projects/js-packages/licensing/changelog/fix-plugin-active-check
+++ b/projects/js-packages/licensing/changelog/fix-plugin-active-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the plugin active checks.

--- a/projects/js-packages/licensing/components/activation-screen-success-info/primary-link/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-success-info/primary-link/index.jsx
@@ -3,7 +3,11 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { getProductGroup, isPluginActive } from '../../activation-screen/utils';
+import {
+	getProductGroup,
+	isJetpackPluginActive,
+	isSocialPluginActive,
+} from '../../activation-screen/utils';
 
 import './style.scss';
 
@@ -13,14 +17,14 @@ const PrimaryLink = props => {
 	const productGroup = getProductGroup( productId );
 	if (
 		productGroup === 'jetpack_social_advanced' &&
-		( isPluginActive( 'jetpack/jetpack.php' ) || isPluginActive( 'jetpack/jetpack-social.php' ) )
+		( isJetpackPluginActive() || isSocialPluginActive() )
 	) {
 		return (
 			<Button
 				className="jp-license-activation-screen-success-info--button"
 				href={
 					siteAdminUrl +
-					( isPluginActive( 'jetpack/jetpack.php' )
+					( isJetpackPluginActive()
 						? 'admin.php?page=jetpack#/recommendations/welcome-social-advanced'
 						: 'admin.php?page=jetpack-social' )
 				}
@@ -32,14 +36,14 @@ const PrimaryLink = props => {
 
 	if (
 		productGroup === 'jetpack_social_basic' &&
-		( isPluginActive( 'jetpack/jetpack.php' ) || isPluginActive( 'jetpack/jetpack-social.php' ) )
+		( isJetpackPluginActive() || isSocialPluginActive() )
 	) {
 		return (
 			<Button
 				className="jp-license-activation-screen-success-info--button"
 				href={
 					siteAdminUrl +
-					( isPluginActive( 'jetpack/jetpack.php' )
+					( isJetpackPluginActive()
 						? 'admin.php?page=jetpack#/recommendations/welcome-social-basic'
 						: 'admin.php?page=jetpack-social' )
 				}

--- a/projects/js-packages/licensing/components/activation-screen/utils.js
+++ b/projects/js-packages/licensing/components/activation-screen/utils.js
@@ -1,3 +1,9 @@
+const JETPACK_PLUGIN_FILE_NAME = 'jetpack/jetpack.php';
+const JETPACK_PLUGIN_DEV_FILE_NAME = 'jetpack-dev/jetpack.php';
+const JETPACK_SOCIAL_PLUGIN_FILE_NAME = 'jetpack-social/jetpack-social.php';
+const JETPACK_SOCIAL_PLUGIN_DEV_FILE_NAME = 'jetpack-social-dev/jetpack-social.php';
+const JETPACK_SOCIAL_PLUGIN_LOCAL_FILE_NAME = 'social/jetpack-social.php';
+
 const JETPACK_ANTI_SPAM_PRODUCT_IDS = [ 2110, 2111 ];
 
 const JETPACK_BACKUP_PRODUCT_IDS = [
@@ -65,11 +71,35 @@ export function getProductGroup( productId ) {
 }
 
 /**
- * Check if a plugin is active.
+ * Check if the Social plugin is active.
  *
- * @param {string} plugin -- The name of the plugin such as jetpack/jetpack.php, social/jetpack-social.php, backup/jetpack-backup.php.
  * @returns {boolean} -- True or False.
  */
-export function isPluginActive( plugin ) {
+export function isSocialPluginActive() {
+	return (
+		isPluginActive( JETPACK_SOCIAL_PLUGIN_FILE_NAME ) ||
+		isPluginActive( JETPACK_SOCIAL_PLUGIN_DEV_FILE_NAME ) ||
+		isPluginActive( JETPACK_SOCIAL_PLUGIN_LOCAL_FILE_NAME )
+	);
+}
+
+/**
+ * Check if the Jetpack plugin is active.
+ *
+ * @returns {boolean} -- True or False.
+ */
+export function isJetpackPluginActive() {
+	return (
+		isPluginActive( JETPACK_PLUGIN_FILE_NAME ) || isPluginActive( JETPACK_PLUGIN_DEV_FILE_NAME )
+	);
+}
+
+/**
+ * Check if a plugin is active.
+ *
+ * @param {string} plugin -- Plugin filename.
+ * @returns {boolean} -- True or False.
+ */
+function isPluginActive( plugin ) {
 	return window.myJetpackInitialState?.plugins?.[ plugin ]?.active;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* On JN Beta, the plugin file path is `jetpack-dev/jetpack.php` and `jetpack-social-dev/jetpack-social.php`. On local for social, it's `social/jetpack-social.php` and on self-hosted sites such as on pressable, it's `jetpack-social/jetpack-social.php`. 

This PR incorporates these file name while checking if the Social or the Jetpack plugin is active. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1706712466731389/1706702406.089029-slack-C02JJ910CNL
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I have checked this for all the 3 scenarios: Just Jetpack active, just Social active and both Jetpack and Social being active, you could test for any of these. 

* Boot this branch on JN
* Buy Jetpack Social Basic or Advanced, by going to https://cloud.jetpack.com/pricing/
* Go to your site's wp-admin/admin.php?page=my-jetpack#/add-license page to activate the license you just bought.
* You should see the configure my site button.