### PR TITLE
Dotcom patterns: remove theme support for core patterns and unregister Jetpack form patterns for Automatticians

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-hide-core-patterns-for-testing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-hide-core-patterns-for-testing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dotcom patterns: remove theme support for core patterns and unregister Jetpack form patterns


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

# Proposed changes:
<!--- Explain what functional changes your PR includes -->
**Only for Automatticians for testing:**
* Remove theme support for core patterns. That includes the patterns bundled in WordPress and those that come from the Dotorg pattern directory.
* Unregister Jetpack patterns in the category Forms, while they still work when Jetpack blocks use them.
* The following categories don't appear when Assembler theme is active because v2 Dotcom patterns don't use them: 
  - Banners
  - Forms
  - Text

## With Assembler theme
When the Assembler is active, we show v2 Dotcom patterns + theme patterns.
|BEFORE|AFTER|
|-|-|
|<img width="584" alt="Screenshot 2567-01-31 at 22 23 36" src="https://github.com/Automattic/jetpack/assets/1881481/5fd277ea-ac53-499b-b9e3-ac410ed9ec65">|<img width="650" alt="Screenshot 2567-01-31 at 22 22 02" src="https://github.com/Automattic/jetpack/assets/1881481/b5a08980-febe-4099-b03e-a69524d92b4f">|

## With other themes
When any theme other than Assembler is active, we show v1 patterns + theme patterns. I'm testing with Twenty Twenty-four.

|BEFORE|AFTER|
|-|-|
|<img width="521" alt="Screenshot 2567-01-31 at 22 26 12" src="https://github.com/Automattic/jetpack/assets/1881481/68b6e62b-c06b-4002-9c22-c1ea297ec053">|<img width="521" alt="Screenshot 2567-01-31 at 22 24 31" src="https://github.com/Automattic/jetpack/assets/1881481/a6a18e4f-1d27-4e5a-80cb-674e3a69cee6">|


## Patterns we are hiding

### Patterns bundled in WordPress
**Source: "core"** 
**Name prefix: "core"** 

There live in [/wp-includes/block-patterns](https://github.com/WordPress/wordpress-develop/tree/6dd00b1ffac54c20c1c1c7721aeebbcd82d0e378/src/wp-includes/block-patterns ) and registered from [/wp-includes/block-patterns.php](https://github.com/WordPress/wordpress-develop/blob/6dd00b1ffac54c20c1c1c7721aeebbcd82d0e378/src/wp-includes/block-patterns.php#L22)

1. core/query-standard-posts
2. core/query-medium-posts
3. core/query-small-posts
4. core/query-grid-posts
5. core/query-large-title-posts
6. core/query-offset-posts
7. core/social-links-shared-background-color

While we won't show these patterns in the inserter, the Query Loop block modal won't be empty because we show the new v2 Blog Posts patterns. See https://github.com/Automattic/jetpack/pull/35337


https://github.com/Automattic/jetpack/assets/1881481/02bf8ada-4ab0-406f-a1ae-d28e6b2708e5





### Patterns from the Dotorg Pattern Directory
**Source: "pattern-directory/core" and "pattern-directory/featured"** 
**Name prefix: "core"** 

They live in [wordpress.org/patterns](https://wordpress.org/patterns) database and are created by the [wordpressdotorg](https://wordpress.org/patterns/author/wordpressdotorg) user.

1. core/centered-image-with-two-tone-background-color
2. core/fullwidth-dark-banner-with-heading-top-left
3. core/fullwidth-cover-with-repeating-gradient-text
4. core/fullwidth-vertically-aligned-headline-on-right-with-description-on-left
5. core/fullwidth-headline-with-links-and-gradient-offset-background
6. core/heading-paragraph-button-with-two-images
7. core/bold-sale-banner-with-geometric-background
9. core/offset-bold-paragraph-text-with-varying-opacity
10. core/offset-text-with-a-brutalist-design-vibe
11. core/fullscreen-image-with-right-content-area
12. core/cover-image-with-bold-heading-and-button-left
13. core/cover-image-with-bold-heading-and-button
14. core/fullscreen-cover-image-gallery
15. core/fullwidth-posts-with-uppercase-titles
16. core/fullwidth-posts-titles-with-dates
17. core/header-inside-full-width-background-image
18. core/simple-header-with-dark-background
19. core/text-only-header-with-tagline
20. core/simple-header-with-tagline
21. core/fullwidth-site-title-and-menu-button
22. core/fullwidth-header-with-hero-image
23. core/simple-header
24. core/centered-header-with-logo
25. core/fullwidth-header-with-large-font-size
26. core/centered-footer-with-social-links
27. core/footer-with-search-site-title-and-credit-line
28. core/footer-with-site-title-and-credit-line
29. core/footer-with-navigation-and-credit-line
30. core/fullwidth-footer-with-background-color-and-three-columns
31. core/fullwidth-footer-with-navigation-credit-and-social
32. core/left-aligned-footer
33. core/three-columns-with-offset-images
34. core/three-columns-with-images-and-text
35. core/two-columns-of-text-with-offset-heading
36. core/media-and-text-in-a-full-height-container
37. core/media-and-text-with-image-on-the-right
38. core/media-and-text-with-image-on-the-left
39. core/large-header-with-text-and-a-button
40. core/large-header-with-left-aligned-text
41. core/heading
42. core/two-columns-of-text-and-title
43. core/two-images-side-by-side

We still support theme patterns loaded from the Pattern Directory `pattern-directory/theme`. For example, TT4 loads two patterns via the `patterns` property in [TT4's theme.json](https://github.com/WordPress/wordpress-develop/blob/6dd00b1ffac54c20c1c1c7721aeebbcd82d0e378/src/wp-content/themes/twentytwentyfour/theme.json#L4).


https://github.com/Automattic/jetpack/assets/1881481/bceac08d-125c-4aed-a291-4f5dff661af4



### Jetpack patterns
**Source: none** - I intend to raise a follow-up PR to use "jetpack" as the pattern source and name prefix.
**Name prefix: none**

They live in Jetpack repo. See [jetpack/modules/contact-form.php](https://github.com/Automattic/jetpack/blob/b64a145116591e19018cb143a2154f1ac748d3c1/projects/plugins/jetpack/modules/contact-form.php#L58 )

1. contact-form
2. newsletter-form
3. rsvp-form
4. registration-form
5. appointment-form
6. feedback-form

While these patterns won't appear on the inserter on Dotcom, they still work as expected when added from Jetpack blocks, and the button "Explore Form Patterns" will show only Dotcom patterns.

https://github.com/Automattic/jetpack/assets/1881481/95aaedb0-7bf1-476a-aad9-dcd800460b54

cc: @jeherve @richtabor @alaczek @autumnfjeld @ianstewart for awareness and thoughts on the Dotcom plan to hide Jetpack patterns on Dotcom sites.

# Other information:

- [X] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

# Jetpack product discussion
These changes will affect Jetpack in Dotcom sites, but we are only testing for now. These changes are only visible to Automatticians.
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

# Does this pull request change what data or activity we track or use?
No.
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

# Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a site and the public API
* Apply this PR by following the instructions in the automatic comment below.
* Make sure your site has the Assembler theme active
* Access the editors:
  *  `/wp-admin/site-editor.php`
  * `/wp-admin/post-new.php`
  * `/wp-admin/post-new.php?post_type=page`
* Verify you cannot find the core and Jetpack patterns in the pattern inserter
* Verify you don't see the following categories  
  * Banners
  * Forms
  * Text
* Verify Jetpack Form blocks still work as expected
  * Add the Form block and test the different form types
  * Open the modal "Explore Form Patterns"  
* Repeat the test after switching your site theme to TT4 or another theme. 
  * Expect to see different patterns but not Jetpack or core patterns 
  * Expect to see the Banners category because TT4 uses it
  * Expect to see the Text category because v1 Dotcom patterns use it