### PR TITLE
Jetpack AI: Improve simple site redirect after upgrade behavior

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-improve-simple-site-redirect-after-upgrade-behavior
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-improve-simple-site-redirect-after-upgrade-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Build a Calypso URL as the redirect destination for Simple sites after upgrade.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -18,8 +18,8 @@ const getWPComRedirectToURL = () => {
 		// When there is an explicit post, use it as the destination
 		return `https://wordpress.com/post/${ site }/${ searchParams.get( 'post' ) }`;
 	}
-	// When there is no explicit post, use the post list as the destination
-	return `https://wordpress.com/posts/${ site }`;
+	// When there is no explicit post, or the site is not Simple, use the home page as the destination
+	return `https://wordpress.com/home/${ site }`;
 };
 
 export default function useAICheckout(): {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -14,7 +14,7 @@ const getWPComRedirectToURL = () => {
 	const searchParams = new URLSearchParams( window.location.search );
 	const site = getSiteFragment();
 
-	if ( searchParams.has( 'post' ) ) {
+	if ( isSimpleSite() && searchParams.has( 'post' ) ) {
 		// When there is an explicit post, use it as the destination
 		return `https://wordpress.com/post/${ site }/${ searchParams.get( 'post' ) }`;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -10,6 +10,18 @@ import {
 import useAutosaveAndRedirect from '../../../../shared/use-autosave-and-redirect';
 import useAiFeature from '../use-ai-feature';
 
+const getWPComRedirectToURL = () => {
+	const searchParams = new URLSearchParams( window.location.search );
+	const site = getSiteFragment();
+
+	if ( searchParams.has( 'post' ) ) {
+		// When there is an explicit post, use it as the destination
+		return `https://wordpress.com/post/${ site }/${ searchParams.get( 'post' ) }`;
+	}
+	// When there is no explicit post, use the post list as the destination
+	return `https://wordpress.com/posts/${ site }`;
+};
+
 export default function useAICheckout(): {
 	checkoutUrl: string;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -18,11 +30,13 @@ export default function useAICheckout(): {
 } {
 	const { nextTier, tierPlansEnabled } = useAiFeature();
 
+	const wpcomRedirectToURL = getWPComRedirectToURL();
+
 	const wpcomCheckoutUrl = tierPlansEnabled
 		? getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
 				site: getSiteFragment(),
 				path: `jetpack_ai_yearly:-q-${ nextTier?.limit }`,
-				query: `redirect_to=${ encodeURIComponent( window.location.href ) }`,
+				query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
 		  } )
 		: getRedirectUrl( 'jetpack-ai-monthly-plan-ai-assistant-block-banner', {
 				site: getSiteFragment(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #34946.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When the site is a WPCOM site, build a Calypso URL as the redirect destination after the upgrade process
   * For Simple sites, when there is an explicit post ID available on the URL (common case), the redirect destination is the post edit URL (`wordpress.com/post/the-site-url/the-post-id`)
   * For Simple sites, when there is **not** an explicit post ID available on the URL (upgrade from site editor or from a draft of a post), the redirect destination is the site home URL on Calypso (`wordpress.com/home/the-site-url`)
   * For Atomic sites, the redirect destination is always the site home on Calypso, but since Atomic sites have the unlimited plan by the default, there is no upgrade path in this context; this is a way to be ready for the future, when we change the tier included on Atomic sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox (using rsync or the Jetpack Downloader command provided below)
* Sandbox a Simple site for testing
* Edit an existing post (or create a new one and save it), then take note of the URL on the browser
* Look for the upgrade button on the Jetpack AI usage panel and click it
* You should land on the checkout page
* Confirm the checkout page has a `redirect_to` parameter with the exact value of the editor URL you took note above

<img width="500" alt="Screenshot 2024-01-31 at 15 49 32" src="https://github.com/Automattic/jetpack/assets/6760046/5524815a-6168-48d6-840e-40dcbe3bcff0">

* Proceed with checkout and confirm you are redirected back to the post you were editing before
* As an additional test case, open the editor with an empty new post, then look for the upgrade button, click it and check the `redirect_to` URL present on the checkout page; it needs to be the Calypso home page for the site (`wordpress.com/home/the-site-url`)

<img width="500" alt="Screenshot 2024-01-31 at 15 48 16" src="https://github.com/Automattic/jetpack/assets/6760046/3a5e42ed-5c4e-44a8-8afd-bb719ed1862d">