### PR TITLE
Jetpack Manage Banner: Add tracking info to the CTA and update event names in Jetpack

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/jetpack-manage-banner/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/jetpack-manage-banner/index.jsx
@@ -1,6 +1,6 @@
 import { UpsellBanner, getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import useAnalytics from '../../hooks/use-analytics';
 import jetpackManageIcon from './jetpack-manage.svg';
 
@@ -13,6 +13,10 @@ import jetpackManageIcon from './jetpack-manage.svg';
 const JetpackManageBanner = props => {
 	const { isAgencyAccount } = props;
 	const { recordEvent } = useAnalytics();
+
+	useEffect( () => {
+		recordEvent( 'jetpack_myjetpack_manage_banner_view' );
+	}, [ recordEvent ] );
 
 	// Handle click events
 	const bannerClickHandler = useCallback(

--- a/projects/packages/my-jetpack/_inc/components/jetpack-manage-banner/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/jetpack-manage-banner/index.jsx
@@ -14,12 +14,13 @@ const JetpackManageBanner = props => {
 	const { isAgencyAccount } = props;
 	const { recordEvent } = useAnalytics();
 
+	// Track banner view.
 	useEffect( () => {
-		recordEvent( 'jetpack_myjetpack_manage_banner_view' );
+		recordEvent( 'jetpack_myjetpack_manage_banner_view', {} );
 	}, [ recordEvent ] );
 
-	// Handle click events
-	const bannerClickHandler = useCallback(
+	// Track click event.
+	const trackClick = useCallback(
 		target => {
 			recordEvent( 'jetpack_myjetpack_manage_banner_click', {
 				target: target,
@@ -29,31 +30,28 @@ const JetpackManageBanner = props => {
 		[ recordEvent ]
 	);
 
-	const learnMoreClick = useCallback( () => {
-		bannerClickHandler( 'jp-manage-learn-more' );
-	}, [ bannerClickHandler ] );
-	const dashboardSitesClick = useCallback( () => {
-		bannerClickHandler( 'jp-manage-dashboard-sites' );
-	}, [ bannerClickHandler ] );
-	const signUpClick = useCallback( () => {
-		bannerClickHandler( 'jp-manage-sign-up' );
-	}, [ bannerClickHandler ] );
+	// Handle CTA banner clicks.
+	const handleLearnMoreClick = useCallback( () => {
+		trackClick( 'jp-manage-learn-more' );
+	}, [ trackClick ] );
+	const handleDashboardSitesClick = useCallback( () => {
+		trackClick( 'jp-manage-dashboard-sites' );
+	}, [ trackClick ] );
+	const handleSignUpClick = useCallback( () => {
+		trackClick( 'jp-manage-sign-up' );
+	}, [ trackClick ] );
 
-	// Set up the secondary CTA
-	const secondaryCtaLabel = __( 'Learn more', 'jetpack-my-jetpack' );
-	const secondaryCtaURL = getRedirectUrl( 'my-jetpack-jetpack-manage-learn-more' );
-
-	// Set up the primary CTA
+	// Set up the primary CTA.
 	let primaryCtaLabel, primaryCtaURL, primaryCtaOnClick;
 
 	if ( isAgencyAccount ) {
 		primaryCtaLabel = __( 'Manage sites', 'jetpack-my-jetpack' );
 		primaryCtaURL = getRedirectUrl( 'my-jetpack-jetpack-manage-dashboard' );
-		primaryCtaOnClick = dashboardSitesClick;
+		primaryCtaOnClick = handleDashboardSitesClick;
 	} else {
 		primaryCtaLabel = __( 'Sign up for free', 'jetpack-my-jetpack' );
 		primaryCtaURL = getRedirectUrl( 'my-jetpack-jetpack-manage-sign-up' );
-		primaryCtaOnClick = signUpClick;
+		primaryCtaOnClick = handleSignUpClick;
 	}
 
 	return (
@@ -64,10 +62,10 @@ const JetpackManageBanner = props => {
 				'Jetpack Manage has the tools you need to manage multiple WordPress sites. Monitor site security, performance, and traffic, and get alerted if a site needs attention. Plus, get bulk discounts.',
 				'jetpack-my-jetpack'
 			) }
-			secondaryCtaLabel={ secondaryCtaLabel }
-			secondaryCtaURL={ secondaryCtaURL }
+			secondaryCtaLabel={ __( 'Learn more', 'jetpack-my-jetpack' ) }
+			secondaryCtaURL={ getRedirectUrl( 'my-jetpack-jetpack-manage-learn-more' ) }
 			secondaryCtaIsExternalLink={ true }
-			secondaryCtaOnClick={ learnMoreClick }
+			secondaryCtaOnClick={ handleLearnMoreClick }
 			primaryCtaLabel={ primaryCtaLabel }
 			primaryCtaURL={ primaryCtaURL }
 			primaryCtaIsExternalLink={ true }

--- a/projects/packages/my-jetpack/_inc/components/jetpack-manage-banner/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/jetpack-manage-banner/index.jsx
@@ -1,5 +1,7 @@
 import { UpsellBanner, getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
+import React, { useCallback } from 'react';
+import useAnalytics from '../../hooks/use-analytics';
 import jetpackManageIcon from './jetpack-manage.svg';
 
 /**
@@ -10,17 +12,45 @@ import jetpackManageIcon from './jetpack-manage.svg';
  */
 const JetpackManageBanner = props => {
 	const { isAgencyAccount } = props;
+	const { recordEvent } = useAnalytics();
 
-	// Set up the first CTA
-	const ctaLearnMoreLabel = __( 'Learn more', 'jetpack-my-jetpack' );
-	const ctaLearnMoreUrl = getRedirectUrl( 'my-jetpack-jetpack-manage-learn-more' );
+	// Handle click events
+	const bannerClickHandler = useCallback(
+		target => {
+			recordEvent( 'jetpack_myjetpack_manage_banner_click', {
+				target: target,
+				feature: 'manage',
+			} );
+		},
+		[ recordEvent ]
+	);
 
-	// Set up the second CTA
-	const ctaManageSitesLabel = __( 'Manage sites', 'jetpack-my-jetpack' );
-	const ctaManageSitesUrl = getRedirectUrl( 'my-jetpack-jetpack-manage-dashboard' );
+	const learnMoreClick = useCallback( () => {
+		bannerClickHandler( 'jp-manage-learn-more' );
+	}, [ bannerClickHandler ] );
+	const dashboardSitesClick = useCallback( () => {
+		bannerClickHandler( 'jp-manage-dashboard-sites' );
+	}, [ bannerClickHandler ] );
+	const signUpClick = useCallback( () => {
+		bannerClickHandler( 'jp-manage-sign-up' );
+	}, [ bannerClickHandler ] );
 
-	const ctaSignUpForFreeLabel = __( 'Sign up for free', 'jetpack-my-jetpack' );
-	const ctaSignUpForFreeUrl = getRedirectUrl( 'my-jetpack-jetpack-manage-sign-up' );
+	// Set up the secondary CTA
+	const secondaryCtaLabel = __( 'Learn more', 'jetpack-my-jetpack' );
+	const secondaryCtaURL = getRedirectUrl( 'my-jetpack-jetpack-manage-learn-more' );
+
+	// Set up the primary CTA
+	let primaryCtaLabel, primaryCtaURL, primaryCtaOnClick;
+
+	if ( isAgencyAccount ) {
+		primaryCtaLabel = __( 'Manage sites', 'jetpack-my-jetpack' );
+		primaryCtaURL = getRedirectUrl( 'my-jetpack-jetpack-manage-dashboard' );
+		primaryCtaOnClick = dashboardSitesClick;
+	} else {
+		primaryCtaLabel = __( 'Sign up for free', 'jetpack-my-jetpack' );
+		primaryCtaURL = getRedirectUrl( 'my-jetpack-jetpack-manage-sign-up' );
+		primaryCtaOnClick = signUpClick;
+	}
 
 	return (
 		<UpsellBanner
@@ -30,12 +60,14 @@ const JetpackManageBanner = props => {
 				'Jetpack Manage has the tools you need to manage multiple WordPress sites. Monitor site security, performance, and traffic, and get alerted if a site needs attention. Plus, get bulk discounts.',
 				'jetpack-my-jetpack'
 			) }
-			secondaryCtaLabel={ ctaLearnMoreLabel }
-			secondaryCtaURL={ ctaLearnMoreUrl }
+			secondaryCtaLabel={ secondaryCtaLabel }
+			secondaryCtaURL={ secondaryCtaURL }
 			secondaryCtaIsExternalLink={ true }
-			primaryCtaLabel={ isAgencyAccount ? ctaManageSitesLabel : ctaSignUpForFreeLabel }
-			primaryCtaURL={ isAgencyAccount ? ctaManageSitesUrl : ctaSignUpForFreeUrl }
+			secondaryCtaOnClick={ learnMoreClick }
+			primaryCtaLabel={ primaryCtaLabel }
+			primaryCtaURL={ primaryCtaURL }
 			primaryCtaIsExternalLink={ true }
+			primaryCtaOnClick={ primaryCtaOnClick }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add tracking info to the Jetpack Manage Banner CTA

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -76,7 +76,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.7.x-dev"
+			"dev-trunk": "4.8.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.7.1-alpha",
+	"version": "4.8.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -34,7 +34,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.7.1-alpha';
+	const PACKAGE_VERSION = '4.8.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/backup/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/plugins/backup/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1017,7 +1017,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/plugins/boost/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1047,7 +1047,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1079,7 +1079,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-manage-banner/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-manage-banner/index.jsx
@@ -6,6 +6,7 @@ import React, { useCallback, useEffect } from 'react';
 import jetpackManageIcon from './jetpack-manage.svg';
 
 const JetpackManageBanner = props => {
+	// Track banner view.
 	useEffect( () => {
 		analytics.tracks.recordEvent( 'jetpack_manage_banner_view', {
 			feature: 'manage',
@@ -13,8 +14,8 @@ const JetpackManageBanner = props => {
 		} );
 	}, [ props.path ] );
 
-	// Handle click events
-	const trackEvent = useCallback(
+	// Track click event.
+	const trackClick = useCallback(
 		target => {
 			analytics.tracks.recordJetpackClick( {
 				target: target,
@@ -25,23 +26,20 @@ const JetpackManageBanner = props => {
 		[ props.path ]
 	);
 
+	// Handle CTA banner clicks.
 	const handleLearnMoreClick = useCallback( () => {
-		trackEvent( 'jp-manage-learn-more' );
-	}, [ trackEvent ] );
+		trackClick( 'jp-manage-learn-more' );
+	}, [ trackClick ] );
 
 	const handleManageSitesClick = useCallback( () => {
-		trackEvent( 'jp-manage-dashboard-sites' );
-	}, [ trackEvent ] );
+		trackClick( 'jp-manage-dashboard-sites' );
+	}, [ trackClick ] );
 
 	const handleSignUpForFreeClick = useCallback( () => {
-		trackEvent( 'jp-manage-sign-up' );
-	}, [ trackEvent ] );
+		trackClick( 'jp-manage-sign-up' );
+	}, [ trackClick ] );
 
-	// Set up the secondary CTA
-	const ctaLearnMoreLabel = __( 'Learn more', 'jetpack' );
-	const ctaLearnMoreUrl = getRedirectUrl( 'jetpack-at-a-glance-to-jetpack-manage-learn-more' );
-
-	// Set up the primary CTA
+	// Set up the primary CTA.
 	let primaryCtaLabel, primaryCtaURL, primaryCtaOnClick;
 
 	if ( props.isAgencyAccount ) {
@@ -62,8 +60,8 @@ const JetpackManageBanner = props => {
 				'Jetpack Manage has the tools you need to manage multiple WordPress sites. Monitor site security, performance, and traffic, and get alerted if a site needs attention. Plus, get bulk discounts.',
 				'jetpack'
 			) }
-			secondaryCtaLabel={ ctaLearnMoreLabel }
-			secondaryCtaURL={ ctaLearnMoreUrl }
+			secondaryCtaLabel={ __( 'Learn more', 'jetpack' ) }
+			secondaryCtaURL={ getRedirectUrl( 'jetpack-at-a-glance-to-jetpack-manage-learn-more' ) }
 			secondaryCtaIsExternalLink={ true }
 			secondaryCtaOnClick={ handleLearnMoreClick }
 			primaryCtaLabel={ primaryCtaLabel }

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-manage-banner/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-manage-banner/index.jsx
@@ -2,10 +2,18 @@ import { getRedirectUrl, UpsellBanner } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import analytics from 'lib/analytics';
 import PropTypes from 'prop-types';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import jetpackManageIcon from './jetpack-manage.svg';
 
 const JetpackManageBanner = props => {
+	useEffect( () => {
+		analytics.tracks.recordEvent( 'jetpack_manage_banner_view', {
+			feature: 'manage',
+			page: props.path,
+		} );
+	}, [ props.path ] );
+
+	// Handle click events
 	const trackEvent = useCallback(
 		target => {
 			analytics.tracks.recordJetpackClick( {

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-manage-banner/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-manage-banner/index.jsx
@@ -18,15 +18,15 @@ const JetpackManageBanner = props => {
 	);
 
 	const handleLearnMoreClick = useCallback( () => {
-		trackEvent( 'jp-manage-learn-more-click' );
+		trackEvent( 'jp-manage-learn-more' );
 	}, [ trackEvent ] );
 
 	const handleManageSitesClick = useCallback( () => {
-		trackEvent( 'jp-manage-dashboard-sites-click' );
+		trackEvent( 'jp-manage-dashboard-sites' );
 	}, [ trackEvent ] );
 
 	const handleSignUpForFreeClick = useCallback( () => {
-		trackEvent( 'jp-manage-sign-up-click' );
+		trackEvent( 'jp-manage-sign-up' );
 	}, [ trackEvent ] );
 
 	// Set up the secondary CTA

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/update-jetpack-manage-banner-cta-tracking-info
+++ b/projects/plugins/jetpack/changelog/update-jetpack-manage-banner-cta-tracking-info
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update the Jetpack Manage Banner trackEvent target name

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1681,7 +1681,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+				"reference": "bf778754fb706da75a7c178fa20217ae9281e212"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1713,7 +1713,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.7.x-dev"
+					"dev-trunk": "4.8.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/plugins/migration/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1017,7 +1017,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/plugins/protect/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -898,7 +898,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -930,7 +930,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/plugins/search/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/plugins/social/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -841,7 +841,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+				"reference": "bf778754fb706da75a7c178fa20217ae9281e212"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.7.x-dev"
+					"dev-trunk": "4.8.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/plugins/starter-plugin/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/plugins/videopress/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-manage/issues/271

Add better tracking to the two Jetpack Manage banners (they exist in the My Jetpack package and the Jetpack plugin).

## Proposed changes:

We aim to improve tracking by listening for all button/link clicks and when the banners are viewed.
We're adding in a "viewed" track as well since the banner is conditionally loaded, so just using page visits would not give an accurate enough representation of usage.
This PR adds tracking info to the CTAs in the Jetpack Manage Banner in My Jetpack:

**Tracked events - My Jetpack**

- View: `jetpack_myjetpack_manage_banner_view`
   - feature: 'manage'
   - page: props.path
- Clicks: `jetpack_myjetpack_manage_banner_click`
   - feature: `manage` 
   - target: _the same event is used with different target values to register different CTA clicks:_
      - `target: jp-manage-learn-more`
      - `target: jp-manage-dashboard-sites`
      - `target: jp-manage-sign-up`

**Tracked events - Jetpack dashboard**

- View: `jetpack_manage_banner_view`
   - feature: `manage`
   - page: `/dashboard`
- Clicks: `jetpack_wpa_click `
   - feature: `manage`
   - page: `/dashboard`
   - target: _the same event is used with different target values to register different CTA clicks:_
      - `target: jp-manage-learn-more`
      - `target: jp-manage-dashboard-sites`
      - `target: jp-manage-sign-up`
      
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack-manage/issues/238

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes. It adds 4 new tracking event as described in the "Proposed changes" section.

## Testing instructions:

- Go to `/wp-admin/admin.php?page=my-jetpack` (with and without a Jetpack Manage user, with 2 or more sites attached to them)
- Click on "Learn more" and "Manage sites" (or "Sign up for free", depending on if the user has access to Jetpack Manage or not).
- Verify that 2-3 `jetpack_myjetpack_manage_banner_click` events are triggered with expected targets:
      - `target: jp-manage-learn-more`
      - `target: jp-manage-dashboard-sites`
      - `target: jp-manage-sign-up`
- Go to `/wp-admin/admin.php?page=jetpack#/dashboard` (with and without a Jetpack Manage user, with 2 or more sites attached to them)
- Verify that the `jetpack_manage_banner_view` event is triggered
- Click on "Learn more" and "Manage sites" (or "Sign up for free", depending on if the user has access to Jetpack Manage or not).
- Verify that 2-3 `jetpack_wpa_click` events are triggered with expected targets:
  - `jp-manage-learn-more`
  - `jp-manage-dashboard-sites`
  - `jp-manage-sign-up`

