### PR TITLE
exploring masterbar module for new global nav changes

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -17,15 +17,24 @@ require_once __DIR__ . '/class-admin-menu.php';
  * Class Atomic_Admin_Menu.
  */
 class Atomic_Admin_Menu extends Admin_Menu {
+	/**
+	 * If the new global navbar should be used;
+	 *
+	 * @var bool
+	 */
+	private $use_new_global_navbar;
 
 	/**
 	 * Atomic_Admin_Menu constructor.
 	 */
 	protected function __construct() {
 		parent::__construct();
+		$this->use_new_global_navbar = true;
 
-		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
+		if ( ! $this->use_new_global_navbar ) {
+			add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
+			add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
+		}
 		add_action( 'wp_ajax_sidebar_state', array( $this, 'ajax_sidebar_state' ) );
 		add_action( 'wp_ajax_jitm_dismiss', array( $this, 'wp_ajax_jitm_dismiss' ) );
 		add_action( 'wp_ajax_upsell_nudge_jitm', array( $this, 'wp_ajax_upsell_nudge_jitm' ) );

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -296,7 +296,6 @@ class Masterbar {
 		if ( ! Jetpack::is_module_active( 'notes' ) && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' && ! $this->use_new_global_navbar ) {
 			wp_dequeue_style( 'admin-bar' );
 		}
-		wp_dequeue_style( 'admin-bar' );
 	}
 
 	/**
@@ -305,7 +304,7 @@ class Masterbar {
 	public function add_styles_and_scripts() {
 		// WoA sites: If wpcom_admin_interface is set to wp-admin, load the wp-admin styles.
 		// These include only styles to enable the "My Sites" and "Reader" links that will be added.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' || $this->use_new_global_navbar ) {
+		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' && ! $this->use_new_global_navbar ) {
 			$css_file = $this->is_rtl ? 'masterbar-wp-admin-rtl.css' : 'masterbar-wp-admin.css';
 			wp_enqueue_style( 'a8c-wpcom-masterbar-overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/' . $css_file ), array(), JETPACK__VERSION );
 			return;
@@ -315,11 +314,14 @@ class Masterbar {
 			wp_enqueue_style( 'a8c-wpcom-masterbar-rtl', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/rtl/wpcom-admin-bar-rtl.css' ), array(), JETPACK__VERSION );
 			wp_enqueue_style( 'a8c-wpcom-masterbar-overrides-rtl', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/rtl/masterbar-rtl.css' ), array(), JETPACK__VERSION );
 		} else {
+			// Fixes size of site logos and other things?
 			wp_enqueue_style( 'a8c-wpcom-masterbar', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/wpcom-admin-bar.css' ), array(), JETPACK__VERSION );
+			// includes styles that make the slide-out hidden, but also effects the dropdowns button styles on core menus.
 			wp_enqueue_style( 'a8c-wpcom-masterbar-overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.css' ), array(), JETPACK__VERSION );
 		}
 
 		// Local overrides.
+		// Effects size of buttons in the my sides dropdown
 		wp_enqueue_style( 'a8c_wpcom_css_override', plugins_url( 'overrides.css', __FILE__ ), array(), JETPACK__VERSION );
 
 		if ( ! Jetpack::is_module_active( 'notes ' ) ) {
@@ -345,6 +347,7 @@ class Masterbar {
 			false
 		);
 
+		// Adds scripts to prevent popup submenus and make them click toggles.
 		wp_enqueue_script(
 			'a8c_wpcom_masterbar_overrides',
 			$this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This explores customizing the masterbar module for the purposes of the new top nav.
* We will probably do this in jetpack-mu-wpcom, but exploring this has been helpful to understand what is currently in place and how it works. Our global nav bar is very similar outside of the styles.
* This achieves the slide-out bar for atomic sites, while reverting the admin bar styles. The slide-out bar is still outdated in terms of styles and items compared to our design.
* Current css and js that is enqueued for these is a bit conflated. Ex: to get the style file for the slide-out bar also contains styles that overwrite the way the core dropdown menu buttons look, enabling the slide out bar contains css/js that disables the core user dropdown/button, etc.

My plan to move forward is to create a new class like this in jetpack-mu-wpcom. When it is present, these admin bar customizations will be disabled and reverted to core, while the nav unification level will still be loaded. The jetpack-mu-wpcom class will then customize the specific areas we need, and we will pull in only specific JS and CSS required for our new features.

![atomic-nav-slide](https://github.com/Automattic/jetpack/assets/28742426/61ea2a25-a5bb-47c6-b912-e75c6c583a01)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

