### PR TITLE
Hide sharing buttons from print and fix multiple sharing buttons

### DIFF
--- a/projects/plugins/jetpack/changelog/hide-sharing-buttons-from-print
+++ b/projects/plugins/jetpack/changelog/hide-sharing-buttons-from-print
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove sharing buttons on Print view. If multiple sharing buttons on the page they all should work.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/style.scss
@@ -22,6 +22,10 @@
 	&.has-huge-icon-size {
 		font-size: 36px;
 	}
+
+	@media print {
+		display: none !important;
+	}
 }
 
 ul.jetpack-sharing-buttons__services-list.has-background {

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/view.js
@@ -5,42 +5,42 @@ let sharingWindowOpen;
 
 if ( typeof window !== 'undefined' ) {
 	domReady( () => {
-		const servicesContainer = document.getElementById( 'jetpack-sharing-serivces-list' );
-		if ( ! servicesContainer ) {
-			return;
+		const containers = document.getElementsByClassName( 'wp-block-jetpack-sharing-buttons' );
+
+		for ( const servicesContainer of containers ) {
+			servicesContainer.addEventListener( 'click', event => {
+				const link = event.target.closest( 'a' );
+				const service = link?.dataset?.service;
+
+				if ( ! link || ! link.classList.contains( `share-${ service }` ) ) {
+					return;
+				}
+
+				if ( service === 'mail' ) {
+					return;
+				}
+
+				event.preventDefault();
+				event.stopPropagation();
+
+				if ( service === 'print' ) {
+					window.print();
+					return;
+				}
+				if ( sharingWindowOpen ) {
+					sharingWindowOpen.close();
+				}
+
+				sharingWindowOpen = window.open(
+					link.getAttribute( 'href' ),
+					`wpcom${ service }`,
+					'menubar=1,resizable=1,width=600,height=400'
+				);
+
+				if ( sharingWindowOpen ) {
+					sharingWindowOpen.focus();
+				}
+			} );
 		}
-		servicesContainer.addEventListener( 'click', event => {
-			const link = event.target.closest( 'a' );
-			const service = link?.dataset?.service;
-
-			if ( ! link || ! link.classList.contains( `share-${ service }` ) ) {
-				return;
-			}
-
-			if ( service === 'mail' ) {
-				return;
-			}
-
-			event.preventDefault();
-			event.stopPropagation();
-
-			if ( service === 'print' ) {
-				window.print();
-				return;
-			}
-			if ( sharingWindowOpen ) {
-				sharingWindowOpen.close();
-			}
-
-			sharingWindowOpen = window.open(
-				link.getAttribute( 'href' ),
-				`wpcom${ service }`,
-				'menubar=1,resizable=1,width=600,height=400'
-			);
-
-			if ( sharingWindowOpen ) {
-				sharingWindowOpen.focus();
-			}
-		} );
 	} );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35380

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR addresses 2 problems.
- When page is printed, Sharing buttons shouldn't occure on the print.
- When there's multiple sharing buttons (ex on the post and in footer) they work in the same manner.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up your site with local changes
 - Make sure you have beta block enabled. In your environment (example Docker) wp-config.php you should have define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
- In template, add Sharing button to a footer. Add print button
- Add Sharing Buttons block to a post. Add Print button
- Publish the post and observe that buttons works as expected.