### PR TITLE
Fix comment submit event not firing

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-submit-akismet
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-submit-akismet
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Esnsure the submit event is fired by the comments form

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-footer.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-footer.tsx
@@ -5,10 +5,9 @@ import { SettingsButton } from './settings-button';
 
 interface CommentFooterProps {
 	toggleTray: ( event: MouseEvent ) => void;
-	handleOnSubmitClick: ( event: MouseEvent ) => void;
 }
 
-export const CommentFooter = ( { toggleTray, handleOnSubmitClick }: CommentFooterProps ) => {
+export const CommentFooter = ( { toggleTray }: CommentFooterProps ) => {
 	return (
 		<div
 			className={ classNames( 'verbum-footer', {
@@ -30,7 +29,6 @@ export const CommentFooter = ( { toggleTray, handleOnSubmitClick }: CommentFoote
 					} ) }
 					disabled={ isReplyDisabled.value }
 					aria-disabled={ isReplyDisabled.value }
-					onClick={ handleOnSubmitClick }
 				>
 					{ translate( 'Reply' ) }
 				</button>

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/index.tsx
@@ -32,6 +32,7 @@ import type { VerbumComments } from './types';
 import './style.scss';
 
 const Verbum = ( { siteId }: VerbumComments ) => {
+	const formRef = useRef< HTMLFormElement >( null );
 	const [ showMessage, setShowMessage ] = useState( '' );
 	const [ isErrorMessage, setIsErrorMessage ] = useState( false );
 	const [ subscribeModalStatus, setSubscribeModalStatus ] = useState<
@@ -58,6 +59,18 @@ const Verbum = ( { siteId }: VerbumComments ) => {
 	const handleBeforeUnload = useCallback( ( event: BeforeUnloadEvent ) => {
 		event.preventDefault();
 		event.returnValue = '';
+	}, [] );
+
+	useEffect( () => {
+		formRef.current = document.getElementById( 'commentform' ) as HTMLFormElement | null;
+
+		if ( formRef.current ) {
+			formRef.current.addEventListener( 'submit', handleCommentSubmit );
+			return () => {
+				formRef.current.removeEventListener( 'submit', handleCommentSubmit );
+			};
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	useEffect( () => {
@@ -107,11 +120,8 @@ const Verbum = ( { siteId }: VerbumComments ) => {
 		event.preventDefault();
 		setShowMessage( '' );
 
-		const formAction = document.querySelector( '#commentform' ).getAttribute( 'action' );
-
-		const formElement = document.querySelector( '#commentform' ) as HTMLFormElement;
-
-		const formData = new FormData( formElement );
+		const formAction = formRef.current.getAttribute( 'action' );
+		const formData = new FormData( formRef.current );
 
 		// if formData email address is set, set the newUserEmail state
 		if ( formData.get( 'email' ) ) {
@@ -151,8 +161,8 @@ const Verbum = ( { siteId }: VerbumComments ) => {
 		// If no error message and not redirect, we re-submit the form as usual instead of using fetch.
 		setIgnoreSubscriptionModal( true );
 		isSavingComment.value = false;
-		const submitFormFunction = Object.getPrototypeOf( formElement ).submit;
-		submitFormFunction.call( formElement );
+		const submitFormFunction = Object.getPrototypeOf( formRef.current ).submit;
+		submitFormFunction.call( formRef.current );
 	};
 
 	const handleCommentSubmit = async event => {
@@ -229,7 +239,7 @@ const Verbum = ( { siteId }: VerbumComments ) => {
 					/>
 				) }
 			</div>
-			<CommentFooter toggleTray={ handleTrayToggle } handleOnSubmitClick={ handleCommentSubmit } />
+			<CommentFooter toggleTray={ handleTrayToggle } />
 			<CommentMessage message={ showMessage } isError={ isErrorMessage } />
 			{ VerbumComments.enableSubscriptionModal && (
 				<SimpleSubscribeModal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The comment form submit event was not firing. Akismet attaches to the comment form submit event to update the form fields before submission and this was not happening. 

This was because we were attaching the submit callback on the submit button, and preventing the event from propagating in order to show the subscription modal.

This PR modifies Verbum to keep track of the parent form in a ref and attach the submit handler to it.

Fixes #
127-gh-Automattic/verbum

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* useRef to keep track of the parent form
* attach our submit handler to the form instead of the submit button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR
* Submit a comment
* Notice that the payload should be different now and include the akisment fields: `akismet_comment_nonce`, 
`ak_hp_textarea`, `ak_js`, `ak_bib`, `ak_bfs`, `ak_bkpc`, `ak_bkp`, `ak_bmc`, `ak_bmcc`, `ak_bmk` , `ak_bck`, `ak_bmmc`, `ak_btmc`, `ak_bsc`, `ak_bte`, `ak_btec`, `ak_bmm`.
* Test for possible regressions