### PR TITLE
WordPress.com REST API: avoid fatals when response is an error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fatal-json-api
+++ b/projects/plugins/jetpack/changelog/fix-fatal-json-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WordPress.com REST API: avoid fatal error when receiving error in API response.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -325,6 +325,15 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 			return $response;
 		}
 
+		// Bail early if we do not have the necessary data.
+		if (
+			is_wp_error( $response )
+			|| ! isset( $response['posts'] )
+			|| ! is_array( $response['posts'] )
+		) {
+			return $response;
+		}
+
 		// Retrieve an array of field paths, such as: [`autosave.modified`, `autosave.post_ID`]
 		$fields = explode( ',', sanitize_text_field( wp_unslash( $_REQUEST['meta_fields'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- we're not making any changes to the site.
 


### PR DESCRIPTION
## Proposed changes:

Do not assume content of the API response; bail early if it is not what is expected.

```
PHP Fatal error:  Uncaught Error: Cannot use object of type WP_Error as array in /json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php:331
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1706725010727279-slack-C02ECE3ML

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

I'm unsure how to reproduce the issue at the moment. It may be easier to test on WordPress.com, by sandboxing one of the sites showing the errors in logstash.

