### PR TITLE
Sharing Block: refactor block markup output

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sharing-block-markup
+++ b/projects/plugins/jetpack/changelog/update-sharing-block-markup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sharing: update block markup to simplify output and escape as late as possible.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -399,12 +399,12 @@ class Share_Email_Block extends Sharing_Source_Block {
 	/**
 	 * Helper function to return a nonce action based on the current post.
 	 *
-	 * @param WP_Post|null $post The current post if it is defined.
+	 * @param int $post_id The current post id if it is defined.
 	 * @return string The nonce action name.
 	 */
-	protected function get_email_share_nonce_action( $post ) {
-		if ( ! empty( $post ) && $post instanceof WP_Post ) {
-			return 'jetpack-email-share-' . $post->ID;
+	protected function get_email_share_nonce_action( $post_id ) {
+		if ( ! empty( $post_id ) && 0 !== $post_id ) {
+			return 'jetpack-email-share-' . $post_id;
 		}
 
 		return 'jetpack-email-share';
@@ -413,17 +413,17 @@ class Share_Email_Block extends Sharing_Source_Block {
 	/**
 	 * Get the URL for the link.
 	 *
-	 * @param WP_Post     $post            Post object.
+	 * @param int         $post_id         Post ID.
 	 * @param string      $query           Additional query arguments to add to the link. They should be in 'foo=bar&baz=1' format.
 	 * @param bool|string $id              Sharing ID to include in the data-shared attribute.
 	 * @param array       $data_attributes The keys are used as additional attribute names with 'data-' prefix.
 	 *                                     The values are used as the attribute values.
 	 * @return object Link related data (url and data_attributes);
 	 */
-	public function get_link( $post, $query = '', $id = false, $data_attributes = array() ) {
+	public function get_link( $post_id, $query = '', $id = false, $data_attributes = array() ) {
 		// We don't need to open new window, so we set it to false.
 		$id           = false;
-		$tracking_url = $this->get_process_request_url( $post->ID );
+		$tracking_url = $this->get_process_request_url( $post_id );
 		if ( false === stripos( $tracking_url, '?' ) ) {
 			$tracking_url .= '?';
 		} else {
@@ -437,12 +437,12 @@ class Share_Email_Block extends Sharing_Source_Block {
 				"If you're having problems sharing via email, you might not have email set up for your browser. You may need to create a new email yourself.",
 				'jetpack'
 			),
-			'email-share-nonce'       => wp_create_nonce( $this->get_email_share_nonce_action( $post ) ),
+			'email-share-nonce'       => wp_create_nonce( $this->get_email_share_nonce_action( $post_id ) ),
 			'email-share-track-url'   => $tracking_url,
 		);
 
-		$post_title = $this->get_share_title( $post->ID );
-		$post_url   = $this->get_share_url( $post->ID );
+		$post_title = $this->get_share_title( $post_id );
+		$post_url   = $this->get_share_url( $post_id );
 
 		/** This filter is documented in plugins/jetpack/modules/sharedaddy/sharedaddy.php */
 		$email_subject = apply_filters(

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -161,15 +161,15 @@ abstract class Sharing_Source_Block {
 	/**
 	 * Get the URL for the link.
 	 *
-	 * @param WP_Post     $post            Post object.
+	 * @param int         $post_id         Post ID.
 	 * @param string      $query           Additional query arguments to add to the link. They should be in 'foo=bar&baz=1' format.
 	 * @param bool|string $id              Sharing ID to include in the data-shared attribute.
 	 * @param array       $data_attributes The keys are used as additional attribute names with 'data-' prefix.
 	 *                                     The values are used as the attribute values.
 	 * @return object Link related data (url and data_attributes);
 	 */
-	public function get_link( $post, $query = '', $id = false, $data_attributes = array() ) {
-		$url             = $this->get_url( $this->get_process_request_url( $post->ID ), $query, $id );
+	public function get_link( $post_id, $query = '', $id = false, $data_attributes = array() ) {
+		$url             = $this->get_url( $this->get_process_request_url( $post_id ), $query, $id );
 		$data_attributes = $this->get_data_attributes( $id, $data_attributes );
 
 		return array(


### PR DESCRIPTION
Follow-up to #35354

## Proposed changes:

Add extra fallback values, reorganize, and do not rely on global

- We really only need the post ID, not the full `$post` object, so we can update the 2 functions to use only the post ID that is pulled from the block context.
- Let's add some extra fallback values when some values are not provided by the block context.
- Let's only add the SVG if it is needed in the markup. When folks are using the text-only style, we do not need to output the SVG in the markup.
- Let's reorganize the markup output to escape as late as possible, and clearly indicate what is escaped and how. It should make it more readable and easier to understand to new contributors.
- Update docblock to avoid notices in editor

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Enable Beta blocks on your site: 
```php
add_filter( 'jetpack_blocks_variation', function () {
	return 'beta';
} );
```
* Switch to a block-based theme like Twenty Twenty Four
* Go to Appearance > Site Editor > Templates > Single Posts
* Add a Sharing block to your template
* Add different buttons
* Play with the different settings:
    * Button style 
    * Button size
    * Button color (foreground and background)
* Ensure that your changes are properly displayed on the frontend.
* Ensure that clicking on the buttons works.
* Ensure that when reloading the editor screen, no error shows.
