### PR TITLE
Social: Added active plugin slugs to my jetpack initial state

### DIFF
--- a/projects/js-packages/licensing/changelog/update-license-activation
+++ b/projects/js-packages/licensing/changelog/update-license-activation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added active plugins slugs to my jetpack initial state and pass it down as a prop to the license activtion screen.

--- a/projects/js-packages/licensing/components/activation-screen-controls/test/component.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-controls/test/component.jsx
@@ -12,6 +12,7 @@ describe( 'ActivationScreenControls', () => {
 			license: 'test',
 			onLicenseChange: () => null,
 			siteUrl: 'jetpack.com',
+			activePluginSlugs: 'jetpack',
 		};
 
 		it( 'correct license is shown', () => {

--- a/projects/js-packages/licensing/components/activation-screen-success-info/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-success-info/index.jsx
@@ -18,7 +18,8 @@ import './style.scss';
  * @returns {React.Component} The `ActivationSuccessInfo` component.
  */
 const ActivationSuccessInfo = props => {
-	const { productId, siteRawUrl, siteAdminUrl, currentRecommendationsStep } = props;
+	const { productId, siteRawUrl, siteAdminUrl, currentRecommendationsStep, activePluginSlugs } =
+		props;
 	return (
 		<div className="jp-license-activation-screen-success-info">
 			<div className="jp-license-activation-screen-success-info--content">
@@ -31,6 +32,7 @@ const ActivationSuccessInfo = props => {
 					siteAdminUrl={ siteAdminUrl }
 					siteRawUrl={ siteRawUrl }
 					productId={ productId }
+					activePluginSlugs={ activePluginSlugs }
 				/>
 				<ProductLink siteRawUrl={ siteRawUrl } productId={ productId } />
 			</div>
@@ -43,6 +45,7 @@ ActivationSuccessInfo.propTypes = {
 	productId: PropTypes.number,
 	siteAdminUrl: PropTypes.string,
 	currentRecommendationsStep: PropTypes.string,
+	activePluginSlugs: PropTypes.array,
 };
 
 export default ActivationSuccessInfo;

--- a/projects/js-packages/licensing/components/activation-screen-success-info/primary-link/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-success-info/primary-link/index.jsx
@@ -3,24 +3,27 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { getProductGroup, isPluginActive } from '../../activation-screen/utils';
+import { getProductGroup } from '../../activation-screen/utils';
 
 import './style.scss';
 
 const PrimaryLink = props => {
-	const { currentRecommendationsStep, siteAdminUrl, siteRawUrl, productId } = props;
-
+	const { currentRecommendationsStep, siteAdminUrl, siteRawUrl, productId, activePluginSlugs } =
+		props;
 	const productGroup = getProductGroup( productId );
+	const isJetpackPluginActive = activePluginSlugs.includes( 'jetpack' );
+	const isJetpackSocialPluginActive = activePluginSlugs.includes( 'jetpack-social' );
+
 	if (
 		productGroup === 'jetpack_social_advanced' &&
-		( isPluginActive( 'jetpack/jetpack.php' ) || isPluginActive( 'jetpack/jetpack-social.php' ) )
+		( isJetpackPluginActive || isJetpackSocialPluginActive )
 	) {
 		return (
 			<Button
 				className="jp-license-activation-screen-success-info--button"
 				href={
 					siteAdminUrl +
-					( isPluginActive( 'jetpack/jetpack.php' )
+					( isJetpackPluginActive
 						? 'admin.php?page=jetpack#/recommendations/welcome-social-advanced'
 						: 'admin.php?page=jetpack-social' )
 				}
@@ -32,14 +35,14 @@ const PrimaryLink = props => {
 
 	if (
 		productGroup === 'jetpack_social_basic' &&
-		( isPluginActive( 'jetpack/jetpack.php' ) || isPluginActive( 'jetpack/jetpack-social.php' ) )
+		( isJetpackPluginActive || isJetpackSocialPluginActive )
 	) {
 		return (
 			<Button
 				className="jp-license-activation-screen-success-info--button"
 				href={
 					siteAdminUrl +
-					( isPluginActive( 'jetpack/jetpack.php' )
+					( isJetpackPluginActive
 						? 'admin.php?page=jetpack#/recommendations/welcome-social-basic'
 						: 'admin.php?page=jetpack-social' )
 				}
@@ -75,6 +78,7 @@ PrimaryLink.propTypes = {
 	siteAdminUrl: PropTypes.string.isRequired,
 	currentRecommendationsStep: PropTypes.string,
 	siteRawUrl: PropTypes.string.isRequired,
+	activePluginSlugs: PropTypes.array,
 };
 
 export { PrimaryLink };

--- a/projects/js-packages/licensing/components/activation-screen-success-info/test/component.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-success-info/test/component.jsx
@@ -7,6 +7,7 @@ describe( 'ActivationSuccessInfo', () => {
 		productId: 2100,
 		siteAdminUrl: 'http://test-site.jurassic.ninja/wp-admin',
 		siteRawUrl: 'http://test-site.jurassic.ninja',
+		activePluginSlugs: [ 'jetpack' ],
 	};
 
 	describe( 'Render the ActivationSuccessInfo component', () => {

--- a/projects/js-packages/licensing/components/activation-screen/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen/index.jsx
@@ -64,6 +64,7 @@ const ActivationScreen = props => {
 		siteRawUrl,
 		startingLicense,
 		displayName = '',
+		activePluginSlugs,
 	} = props;
 
 	const [ license, setLicense ] = useState( startingLicense ?? '' );
@@ -137,6 +138,7 @@ const ActivationScreen = props => {
 				productId={ activatedProduct }
 				siteAdminUrl={ siteAdminUrl }
 				currentRecommendationsStep={ currentRecommendationsStep }
+				activePluginSlugs={ activePluginSlugs }
 			/>
 			<ActivationScreenIllustration imageUrl={ successImage } showSupportLink={ false } />
 		</div>
@@ -178,6 +180,7 @@ ActivationScreen.propTypes = {
 	siteRawUrl: PropTypes.string.isRequired,
 	startingLicense: PropTypes.string,
 	displayName: PropTypes.string,
+	activePluginSlugs: PropTypes.array,
 };
 
 export default ActivationScreen;

--- a/projects/js-packages/licensing/components/activation-screen/test/component.jsx
+++ b/projects/js-packages/licensing/components/activation-screen/test/component.jsx
@@ -12,6 +12,7 @@ describe( 'ActivationScreen', () => {
 		siteAdminUrl: 'jetpack.com/wp-admin',
 		siteRawUrl: 'jetpack.com',
 		successImage: '/success.png',
+		activePluginSlugs: [ 'jetpack' ],
 	};
 
 	const apiStub = jest.spyOn( restApi, 'attachLicenses' ).mockReturnValue();

--- a/projects/js-packages/licensing/components/activation-screen/utils.js
+++ b/projects/js-packages/licensing/components/activation-screen/utils.js
@@ -63,13 +63,3 @@ export function getProductGroup( productId ) {
 		'default'
 	);
 }
-
-/**
- * Check if a plugin is active.
- *
- * @param {string} plugin -- The name of the plugin such as jetpack/jetpack.php, social/jetpack-social.php, backup/jetpack-backup.php.
- * @returns {boolean} -- True or False.
- */
-export function isPluginActive( plugin ) {
-	return window.myJetpackInitialState?.plugins?.[ plugin ]?.active;
-}

--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -44,6 +44,8 @@ export default function AddLicenseScreen() {
 		setHasActivatedLicense( true );
 	}, [] );
 
+	const activePluginSlugs = window?.myJetpackInitialState?.activePluginSlugs;
+
 	return (
 		<AdminPage showHeader={ false } showBackground={ false }>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
@@ -59,6 +61,7 @@ export default function AddLicenseScreen() {
 						siteAdminUrl={ window?.myJetpackInitialState?.adminUrl }
 						siteRawUrl={ window?.myJetpackInitialState?.siteSuffix }
 						displayName={ displayName }
+						activePluginSlugs={ activePluginSlugs }
 					/>
 				</Col>
 			</Container>

--- a/projects/packages/my-jetpack/changelog/update-license-activation
+++ b/projects/packages/my-jetpack/changelog/update-license-activation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added active plugins slugs to my jetpack initial state and pass it down as a prop to the license activtion screen.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -76,7 +76,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.7.x-dev"
+			"dev-trunk": "4.8.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.7.1-alpha",
+	"version": "4.8.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -34,7 +34,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.7.1-alpha';
+	const PACKAGE_VERSION = '4.8.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -189,6 +189,7 @@ class Initializer {
 					'items' => array(),
 				),
 				'plugins'               => Plugins_Installer::get_plugins(),
+				'activePluginSlugs'     => static::get_active_plugin_slugs(),
 				'myJetpackUrl'          => admin_url( 'admin.php?page=my-jetpack' ),
 				'myJetpackCheckoutUri'  => 'admin.php?page=my-jetpack',
 				'topJetpackMenuItemUrl' => Admin_Menu::get_top_level_menu_item_url(),
@@ -286,6 +287,36 @@ class Initializer {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Returns an array of plugin slugs.
+	 *
+	 * @return array
+	 */
+	public static function get_active_plugin_slugs() {
+		$plugins = Plugins_Installer::get_plugins();
+
+		$active_plugin_slugs = array_values(
+			array_filter(
+				array_keys( $plugins ),
+				function ( $plugin ) use( $plugins ) {
+					return $plugins[ $plugin ]['active'];
+				}
+			)
+		);
+
+		return array_map(
+			function ( $plugin_file_name ) {
+				$parts = explode( '/', $plugin_file_name );
+				if ( empty( $parts ) ) {
+					return '';
+				}
+				// Return the last segment of the filepath without the PHP extension
+				return str_replace( '.php', '', $parts[ count( $parts ) - 1 ] );
+			},
+			$active_plugin_slugs
+		);
 	}
 
 	/**

--- a/projects/plugins/backup/changelog/update-license-activation
+++ b/projects/plugins/backup/changelog/update-license-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1017,7 +1017,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/update-license-activation
+++ b/projects/plugins/boost/changelog/update-license-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1047,7 +1047,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1079,7 +1079,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -590,6 +590,7 @@ class Main extends React.Component {
 				if ( this.props.isLinked && this.props.isConnectionOwner ) {
 					pageComponent = (
 						<ActivationScreen
+							activePluginSlugs={ [ 'jetpack' ] }
 							siteRawUrl={ this.props.siteRawUrl }
 							onActivationSuccess={ this.onLicenseActivationSuccess }
 							siteAdminUrl={ this.props.siteAdminUrl }

--- a/projects/plugins/jetpack/changelog/update-license-activation
+++ b/projects/plugins/jetpack/changelog/update-license-activation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+ Added active plugins slugs to my jetpack initial state and pass it down as a prop to the license activtion screen.

--- a/projects/plugins/jetpack/changelog/update-license-activation#2
+++ b/projects/plugins/jetpack/changelog/update-license-activation#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1681,7 +1681,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+				"reference": "bf778754fb706da75a7c178fa20217ae9281e212"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1713,7 +1713,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.7.x-dev"
+					"dev-trunk": "4.8.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/update-license-activation
+++ b/projects/plugins/migration/changelog/update-license-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1017,7 +1017,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/update-license-activation
+++ b/projects/plugins/protect/changelog/update-license-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -898,7 +898,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -930,7 +930,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/update-license-activation
+++ b/projects/plugins/search/changelog/update-license-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/update-license-activation
+++ b/projects/plugins/social/changelog/update-license-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -841,7 +841,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+				"reference": "bf778754fb706da75a7c178fa20217ae9281e212"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.7.x-dev"
+					"dev-trunk": "4.8.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/update-license-activation
+++ b/projects/plugins/starter-plugin/changelog/update-license-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/update-license-activation
+++ b/projects/plugins/videopress/changelog/update-license-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR refactors the active plugin checks we do when activating a license for Jetpack Social plans. On JN Beta, the plugin file path is jetpack-dev/jetpack.php and jetpack-social-dev/jetpack-social.php. On local for social, it's social/jetpack-social.php and on self-hosted sites such as on pressable, it's jetpack-social/jetpack-social.php.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added active plugin slugs to the my jetpack initial state. 
* Make ActivationScreen pass down the `activePluginSlugs` as a prop

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Boot this branch on JN
- Buy Jetpack Social Basic or Advanced, by going to https://cloud.jetpack.com/pricing/
- Go to your site's wp-admin/admin.php?page=my-jetpack#/add-license page to activate the license you just bought.
- You should see the configure my site button. If the button says 'view my plan' something is wrong.

<img width="888" alt="Screenshot 2024-02-01 at 6 30 45 PM" src="https://github.com/Automattic/jetpack/assets/6594561/e9417c54-2bc7-4289-a19f-dd3a4cb0a94b">

- Do a siteless checkout of another Social Advanced plan. 
- On a different site on the same branch, Go to /wp-admin/admin.php?page=jetpack#/license/activation. Enter the license key and ensure that you see that "configure my site" button.  You can get the license from `https://wordpress.com/me/purchases` buy clicking on your purchase. 


