### PR TITLE
Boost: move writing to files into a Util function

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache.php
@@ -7,6 +7,7 @@ namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
  * As it is loaded before WordPress is loaded, it is not autoloaded by Boost.
  */
 require_once __DIR__ . '/Boost_Cache_Settings.php';
+require_once __DIR__ . '/Boost_Cache_Utils.php';
 
 abstract class Boost_Cache {
 	/*

--- a/projects/plugins/boost/app/modules/cache/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache_Settings.php
@@ -117,9 +117,7 @@ class Boost_Cache_Settings {
 		$this->settings = array_merge( $this->settings, $settings );
 
 		$contents = "<?php die();\n/*\n * Configuration data for Jetpack Boost Cache. Do not edit.\n" . json_encode( $this->settings ) . "\n */"; // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
-		Boost_Cache_Utils::write_to_file( $this->config_file, $contents );
-
-		return true;
+		return Boost_Cache_Utils::write_to_file( $this->config_file, $contents );
 	}
 
 	/*

--- a/projects/plugins/boost/app/modules/cache/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache_Settings.php
@@ -116,17 +116,8 @@ class Boost_Cache_Settings {
 
 		$this->settings = array_merge( $this->settings, $settings );
 
-		$contents     = "<?php die();\n/*\n * Configuration data for Jetpack Boost Cache. Do not edit.\n" . json_encode( $this->settings ) . "\n */"; // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
-		$tmp_filename = $this->config_file . uniqid( uniqid(), true ) . '.tmp';
-		if ( false === file_put_contents( $tmp_filename, $contents ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			$this->last_error = 'Could not write to tmp config file';
-			return false;
-		}
-
-		if ( ! rename( $tmp_filename, $this->config_file ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
-			$this->last_error = 'Could not rename tmp config file';
-			return false;
-		}
+		$contents = "<?php die();\n/*\n * Configuration data for Jetpack Boost Cache. Do not edit.\n" . json_encode( $this->settings ) . "\n */"; // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+		Boost_Cache_Utils::write_to_file( $this->config_file, $contents );
 
 		return true;
 	}

--- a/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
@@ -69,12 +69,12 @@ class Boost_Cache_Utils {
 		$tmp_filename = $filename . uniqid( uniqid(), true ) . '.tmp';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		if ( false === file_put_contents( $tmp_filename, $data ) ) {
-			return new \WP_Error( 'Could not write to tmp file' );
+			return new \WP_Error( 'Could not write to tmp file: ' . $tmp_filename );
 		}
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
 		if ( ! rename( $tmp_filename, $filename ) ) {
-			return new \WP_Error( 'Could not rename tmp file' );
+			return new \WP_Error( 'Could not rename tmp file to final file: ' . $filename );
 		}
 		return true;
 	}

--- a/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
@@ -67,7 +67,7 @@ class Boost_Cache_Utils {
 
 	/*
 	 * Writes data to a file.
-	 * This creates a temporary filename first, then renames the file to the final filename.
+	 * This creates a temporary file first, then renames the file to the final filename.
 	 * This is done to prevent the file from being read while it is being written to.
 	 *
 	 * @param string $filename - The filename to write to.

--- a/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
@@ -65,6 +65,15 @@ class Boost_Cache_Utils {
 		return strpos( $dir, WP_CONTENT_DIR . '/boost-cache' ) !== false;
 	}
 
+	/*
+	 * Writes data to a file.
+	 * This creates a temporary filename first, then renames the file to the final filename.
+	 * This is done to prevent the file from being read while it is being written to.
+	 *
+	 * @param string $filename - The filename to write to.
+	 * @param string $data - The data to write to the file.
+	 * @return bool|WP_Error - true on sucess or WP_Error on failure.
+	 */
 	public static function write_to_file( $filename, $data ) {
 		$tmp_filename = $filename . uniqid( uniqid(), true ) . '.tmp';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents

--- a/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
@@ -64,4 +64,17 @@ class Boost_Cache_Utils {
 		$dir = self::sanitize_file_path( $dir );
 		return strpos( $dir, WP_CONTENT_DIR . '/boost-cache' ) !== false;
 	}
+
+	public static function write_to_file( $filename, $data ) {
+		$tmp_filename = $filename . uniqid( uniqid(), true ) . '.tmp';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		if ( false === file_put_contents( $tmp_filename, $data ) ) {
+			return new \WP_Error( 'Could not write to tmp file' );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+		if ( ! rename( $tmp_filename, $filename ) ) {
+			return new \WP_Error( 'Could not rename tmp file' );
+		}
+	}
 }

--- a/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
@@ -76,5 +76,6 @@ class Boost_Cache_Utils {
 		if ( ! rename( $tmp_filename, $filename ) ) {
 			return new \WP_Error( 'Could not rename tmp file' );
 		}
+		return true;
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/Boost_File_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_File_Cache.php
@@ -107,8 +107,6 @@ class Boost_File_Cache extends Boost_Cache {
 			return new \WP_Error( 'Could not create cache directory' );
 		}
 
-		Boost_Cache_Utils::write_to_file( $cache_filename, $buffer );
-
-		return true;
+		return Boost_Cache_Utils::write_to_file( $cache_filename, $buffer );
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/Boost_File_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_File_Cache.php
@@ -107,16 +107,7 @@ class Boost_File_Cache extends Boost_Cache {
 			return new \WP_Error( 'Could not create cache directory' );
 		}
 
-		$tmp_filename = $cache_filename . uniqid( wp_rand(), true ) . '.tmp';
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		if ( false === file_put_contents( $tmp_filename, $buffer ) ) {
-			return new \WP_Error( 'Could not write to tmp file' );
-		}
-
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
-		if ( ! rename( $tmp_filename, $cache_filename ) ) {
-			return new \WP_Error( 'Could not rename tmp file' );
-		}
+		Boost_Cache_Utils::write_to_file( $cache_filename, $buffer );
 
 		return true;
 	}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -92,11 +92,7 @@ require_once( ABSPATH . \'/wp-content/plugins/boost/app/modules/cache/Boost_File
 
 ( new Automattic\Jetpack_Boost\Modules\Page_Cache\Boost_File_Cache() )->serve();
 ';
-
-			$result = file_put_contents( $advanced_cache_filename, $contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			if ( $result === false ) {
-				return new \WP_Error( 'Could not write to advanced-cache.php' );
-			}
+			Boost_Cache_Utils::write_to_file( $advanced_cache_filename, $contents );
 		}
 
 		return true;

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -92,10 +92,8 @@ require_once( ABSPATH . \'/wp-content/plugins/boost/app/modules/cache/Boost_File
 
 ( new Automattic\Jetpack_Boost\Modules\Page_Cache\Boost_File_Cache() )->serve();
 ';
-			Boost_Cache_Utils::write_to_file( $advanced_cache_filename, $contents );
+			return Boost_Cache_Utils::write_to_file( $advanced_cache_filename, $contents );
 		}
-
-		return true;
 	}
 
 	/*

--- a/projects/plugins/boost/changelog/boost-cache-write-to-file-function
+++ b/projects/plugins/boost/changelog/boost-cache-write-to-file-function
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Boost: consolidate writing to files in one function, write_to_file()


### PR DESCRIPTION
The caching module writes to a temporary file, then renames it to the final filename as that's safer for readers. They won't accidentally see half a html page if it's a cache file.
This PR moves that code into a Boost_Cache_Util function called `write_to_file( $filename, $data )`.


## Proposed changes:
* Instead of using file_put_contents and then rename when writing cache files, config file and advanced-cache.php in 3 places, copy the code into `write_to_file`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2rA-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR.
* Delete wp-content/advanced-cache.php and wp-content/boost-cache/
* Visit the Boost settings page
* Check that wp-content/advanced-cache.php and wp-content/boost-cache/config.php are created
* Visit a page, reload and check the source for "cached" comment at the end.
* Check that cache files were created in  wp-content/boost-cache/cache/, just to be sure.

