### PR TITLE
Config: Load WAF the last to allow other packages to properly load

### DIFF
--- a/projects/packages/config/changelog/fix-package-versions-videopress
+++ b/projects/packages/config/changelog/fix-package-versions-videopress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Load Waf the last to allow other packages to properly load. 

--- a/projects/packages/config/src/class-config.php
+++ b/projects/packages/config/src/class-config.php
@@ -164,7 +164,7 @@ class Config {
 		}
 
 		/*
-		Ensure that waf is loaded last. Failure to do so can result in only some of the modules
+		 * Ensure that waf is loaded last. Failure to do so can result in only some of the modules
 		 * loading when waf exits early which can result in faulty requests to the
 		 * jetpack-package-versions endpoint.
 		 *

--- a/projects/packages/config/src/class-config.php
+++ b/projects/packages/config/src/class-config.php
@@ -163,6 +163,14 @@ class Config {
 				&& $this->ensure_feature( 'import' );
 		}
 
+		/*
+		Ensure that waf is loaded last. Failure to do so can result in only some of the modules
+		 * loading when waf exits early which can result in faulty requests to the
+		 * jetpack-package-versions endpoint.
+		 *
+		 * TODO: Update Package_Version_Tracker::maybe_update_package_versions to exit if called too
+		 *     early (such as using did_action) to avoid this timing issue.
+		 */
 		if ( $this->config['waf'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\Waf\Waf_Initializer' )
 			&& $this->ensure_feature( 'waf' );

--- a/projects/packages/config/src/class-config.php
+++ b/projects/packages/config/src/class-config.php
@@ -144,11 +144,6 @@ class Config {
 				&& $this->ensure_feature( 'wordads' );
 		}
 
-		if ( $this->config['waf'] ) {
-			$this->ensure_class( 'Automattic\Jetpack\Waf\Waf_Initializer' )
-				&& $this->ensure_feature( 'waf' );
-		}
-
 		if ( $this->config['videopress'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\VideoPress\Initializer' ) && $this->ensure_feature( 'videopress' );
 		}
@@ -166,6 +161,11 @@ class Config {
 		if ( $this->config['import'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\Import\Main' )
 				&& $this->ensure_feature( 'import' );
+		}
+
+		if ( $this->config['waf'] ) {
+			$this->ensure_class( 'Automattic\Jetpack\Waf\Waf_Initializer' )
+			&& $this->ensure_feature( 'waf' );
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:
* Load WAF the last to allow other packages to properly load if the request gets blocked by the firewall.

## The problem
1. Waf initializes before VideoPress.
2. Waf receives the “block IP” response (blocking-hard) from cache or WPCOM API.
3. Waf dies right there, and Config::on_plugins_loaded() never reaches VideoPress initialization.
4. Version tracker runs on shutdown, and VideoPress is not there because the code never reached that point.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1706561650832669-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Please test before and after applying the PR to confirm the issue got fixed.

1. Connect Jetpack
2. Open a private browser window, load the `/wp-login.php` page and enter invalid login/password. Do not send the form yet.
3. Edit the file `jetpack/jetpack_vendor/automattic/jetpack-waf/src/class-brute-force-protection.php` by hardcoding `blocked-hard` return for the `get_cached_status()` method.
4. Send the login form now.
5. Go to Jetpack Dashboard and confirm the package versions were (before applying the PR) or weren't (after applying the PR) sent in Kibana's nginx logs (replace the blog ID with yours in c06aef671133a135b190d14bcb71a6f3-logstash).