### PR TITLE
Site Settings: Add new site option for WooCommerce themes headstart flag

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-new-headstart-option
+++ b/projects/plugins/jetpack/changelog/update-add-new-headstart-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+WooCommerce: Add new site option with validation

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -878,7 +878,12 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$updated[ $key ] = $sanitized_value;
 					}
 					break;
-
+				case 'woocommerce_should_run_headstart_for_theme':
+					// This value should always be 'yes' or empty.
+					if ( 'yes' !== $value ) {
+						$updated[ $key ] = '';
+					}
+					break;
 				case 'woocommerce_store_address':
 				case 'woocommerce_store_address_2':
 				case 'woocommerce_store_city':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/85793

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When a WooCommerce theme is initially bundled with a site, we need to know if we should run Headstart for the theme. We've introduced a new site option `woocommerce_should_run_headstart_for_theme` for this purpose. This diff adds the option to the site settings endpoint and sanitizes it (the value must be `yes` or empty).
* We only want to run Headstart for product categories _once_, so we'll be checking this value in wpcomsh Automattic/wpcomsh#1665 If we have already run Headstart, the site option gets deleted. This should prevent product categories from being added every time a new WC theme is activated/Headstart is run.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD

