### PR TITLE
Fix/standalone installation for all products

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-standalone-installation-for-all-products
+++ b/projects/packages/my-jetpack/changelog/fix-standalone-installation-for-all-products
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fix issue where most products are not installing their standalone product upon purchase

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -76,7 +76,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.7.x-dev"
+			"dev-trunk": "4.8.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.7.1-alpha",
+	"version": "4.8.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -34,7 +34,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.7.1-alpha';
+	const PACKAGE_VERSION = '4.8.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -235,4 +235,22 @@ class Backup extends Hybrid_Product {
 			return 'admin.php?page=jetpack-backup';
 		}
 	}
+
+	/**
+	 * Activates the product by installing and activating its plugin
+	 *
+	 * @param bool|WP_Error $current_result Is the result of the top level activation actions. You probably won't do anything if it is an WP_Error.
+	 * @return boolean|\WP_Error
+	 */
+	public static function do_product_specific_activation( $current_result ) {
+
+		$product_activation = parent::do_product_specific_activation( $current_result );
+
+		if ( is_wp_error( $product_activation ) && 'module_activation_failed' === $product_activation->get_error_code() ) {
+			// Scan is not a module. There's nothing in the plugin to be activated, so it's ok to fail to activate the module.
+			$product_activation = true;
+		}
+
+		return $product_activation;
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -235,22 +235,4 @@ class Backup extends Hybrid_Product {
 			return 'admin.php?page=jetpack-backup';
 		}
 	}
-
-	/**
-	 * Activates the product by installing and activating its plugin
-	 *
-	 * @param bool|WP_Error $current_result Is the result of the top level activation actions. You probably won't do anything if it is an WP_Error.
-	 * @return boolean|\WP_Error
-	 */
-	public static function do_product_specific_activation( $current_result ) {
-
-		$product_activation = parent::do_product_specific_activation( $current_result );
-
-		if ( is_wp_error( $product_activation ) && 'module_activation_failed' === $product_activation->get_error_code() ) {
-			// Scan is not a module. There's nothing in the plugin to be activated, so it's ok to fail to activate the module.
-			$product_activation = true;
-		}
-
-		return $product_activation;
-	}
 }

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -15,10 +15,6 @@ use WP_Error;
  * Class responsible for handling the hybrid products
  *
  * Hybrid products are those that may work both as a stand-alone plugin or with the Jetpack plugin.
- *
- * In case Jetpack plugin is active, it will not attempt to install its stand-alone plugin.
- *
- * But if Jetpack plugin is not active, then it will prompt to install and activate its stand-alone plugin.
  */
 abstract class Hybrid_Product extends Product {
 

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -48,15 +48,6 @@ abstract class Hybrid_Product extends Product {
 	}
 
 	/**
-	 * Checks whether the plugin is installed
-	 *
-	 * @return boolean
-	 */
-	public static function is_plugin_installed() {
-		return parent::is_plugin_installed() || static::is_jetpack_plugin_installed();
-	}
-
-	/**
 	 * Checks whether the Jetpack module is active only if a module_name is defined
 	 *
 	 * @return bool

--- a/projects/plugins/backup/changelog/fix-standalone-installation-for-all-products
+++ b/projects/plugins/backup/changelog/fix-standalone-installation-for-all-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1017,7 +1017,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/fix-standalone-installation-for-all-products
+++ b/projects/plugins/boost/changelog/fix-standalone-installation-for-all-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1047,7 +1047,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1079,7 +1079,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/fix-standalone-installation-for-all-products
+++ b/projects/plugins/jetpack/changelog/fix-standalone-installation-for-all-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1681,7 +1681,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+				"reference": "bf778754fb706da75a7c178fa20217ae9281e212"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1713,7 +1713,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.7.x-dev"
+					"dev-trunk": "4.8.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/fix-standalone-installation-for-all-products
+++ b/projects/plugins/migration/changelog/fix-standalone-installation-for-all-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1017,7 +1017,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/fix-standalone-installation-for-all-products
+++ b/projects/plugins/protect/changelog/fix-standalone-installation-for-all-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -898,7 +898,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -930,7 +930,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/fix-standalone-installation-for-all-products
+++ b/projects/plugins/search/changelog/fix-standalone-installation-for-all-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/fix-standalone-installation-for-all-products
+++ b/projects/plugins/social/changelog/fix-standalone-installation-for-all-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -841,7 +841,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+				"reference": "bf778754fb706da75a7c178fa20217ae9281e212"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.7.x-dev"
+					"dev-trunk": "4.8.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/fix-standalone-installation-for-all-products
+++ b/projects/plugins/starter-plugin/changelog/fix-standalone-installation-for-all-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/fix-standalone-installation-for-all-products
+++ b/projects/plugins/videopress/changelog/fix-standalone-installation-for-all-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "800ea60c7c03b2caf037d0cd0ccb7e08eeb2786e"
+                "reference": "bf778754fb706da75a7c178fa20217ae9281e212"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -873,7 +873,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
## Proposed changes:

Remove custom `is_plugin_installed` function for Hybrid_Product class. This function was returning true if Jetpack Core was installed and preventing Standalone plugins from being installed when being purchased from My Jetpack (and potentially other places I am unaware of). Removing it fixes the issue and installs standalone products when the CTA on the product interstitials is clicked

The products fixed are:
* Jetpack Social
* Jetpack Backup
* Jetpack VideoPress
* Jetpack Search

Boost and Protect use the Product class, not the Hybrid_Product class, so they did not have this issue

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1705686143723779-slack-C06CVN9QVFY

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Use the Jetpack beta plugin to checkout this branch (don't run this locally. The docker setup, by default, has all the standalone plugins installed and I don't know how to easily uninstall and test reinstalling them from the local setup. I debugged this by editing the code on an ephemeral site)
2. Without any standalone plugins installed, go to `/wp-admin/admin.php?page=my-jetpack`
3. Click on "Learn More" on the Jetpack Backup card to get to the interstitial
4. Click on "Get Jetpack VaultPress Backup". You do not need to purchase the product for this test
![image](https://github.com/Automattic/jetpack/assets/65001528/ba26aca9-1514-4871-8bbd-e57805e36d7b)
5. Now go to `/wp-admin/plugins.php` and make sure the VaultPress Backup standalone plugin is installed and active
![image](https://github.com/Automattic/jetpack/assets/65001528/04194597-71a8-4918-a7a1-a312af9e984b)
6. Repeat steps 2-5 for Social, VideoPress, and Search to make sure they work as well
