### PR TITLE
WIP - create global navbar in jetpack-mu-wpcom

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -75,6 +75,8 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/media/heif-support.php';
 
 		require_once __DIR__ . '/features/block-patterns/block-patterns.php';
+
+		require_once __DIR__ . '/features/global-nav-bar/global-nav.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/class-wpcom-global-nav.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/class-wpcom-global-nav.php
@@ -1,16 +1,33 @@
 <?php
+/**
+ * WPCOM Global Navbar Class
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
 
+/**
+ * Provides custom admin bar instead of the default WordPress admin bar.
+ */
 class WPcom_Global_Nav {
 
+	/**
+	 * Constructor
+	 */
 	public function __construct() {
 		add_action( 'admin_bar_init', array( $this, 'init' ) );
 	}
 
+	/**
+	 * Initialize our masterbar.
+	 */
 	public function init() {
-		add_action( 'wp_before_admin_bar_render', array( $this, 'replace_core_masterbar' ), 99999 );
+		add_action( 'wp_before_admin_bar_render', array( $this, 'update_core_masterbar' ), 99999 );
 	}
 
-	public function replace_core_masterbar() {
+	/**
+	 * Update and add items on the core masterbar.
+	 */
+	public function update_core_masterbar() {
 		global $wp_admin_bar;
 
 		if ( ! is_object( $wp_admin_bar ) ) {
@@ -31,15 +48,5 @@ class WPcom_Global_Nav {
 		foreach ( $nodes as $id => $node ) {
 			$wp_admin_bar->add_node( $node );
 		}
-	}
-
-	// temporary because sometimes console goo is easier to read than an error log.
-	public function console_log( $output, $with_script_tags = true ) {
-		$js_code = 'console.log(' . json_encode( $output, JSON_HEX_TAG ) .
-		');';
-		if ( $with_script_tags ) {
-			$js_code = '<script>' . $js_code . '</script>';
-		}
-		echo $js_code;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/class-wpcom-global-nav.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/class-wpcom-global-nav.php
@@ -1,0 +1,35 @@
+<?php
+
+class WPcom_Global_Nav {
+
+	public function __construct() {
+		add_action( 'admin_bar_init', array( $this, 'init' ) );
+	}
+
+	public function init() {
+		add_action( 'wp_before_admin_bar_render', array( $this, 'replace_core_masterbar' ), 99999 );
+	}
+
+	public function replace_core_masterbar() {
+		global $wp_admin_bar;
+
+		if ( ! is_object( $wp_admin_bar ) ) {
+			return false;
+		}
+
+		$nodes = array();
+
+		// First, lets gather all nodes and remove them.
+		foreach ( $wp_admin_bar->get_nodes() as $node ) {
+			$nodes[ $node->id ] = $node;
+			$wp_admin_bar->remove_node( $node->id );
+		}
+
+		// Add custom groups and menus here
+
+		// Re-add original nodes
+		foreach ( $nodes as $id => $node ) {
+			$bar->add_node( $node );
+		}
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/class-wpcom-global-nav.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/class-wpcom-global-nav.php
@@ -29,7 +29,17 @@ class WPcom_Global_Nav {
 
 		// Re-add original nodes
 		foreach ( $nodes as $id => $node ) {
-			$bar->add_node( $node );
+			$wp_admin_bar->add_node( $node );
 		}
+	}
+
+	// temporary because sometimes console goo is easier to read than an error log.
+	public function console_log( $output, $with_script_tags = true ) {
+		$js_code = 'console.log(' . json_encode( $output, JSON_HEX_TAG ) .
+		');';
+		if ( $with_script_tags ) {
+			$js_code = '<script>' . $js_code . '</script>';
+		}
+		echo $js_code;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/global-nav.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/global-nav.php
@@ -6,3 +6,7 @@ function should_use_new_global_nav() {
 	return true;
 }
 add_filter( 'wpcom_global_nav_enabled', 'should_use_new_global_nav' );
+
+if ( should_use_new_global_nav() ) {
+	new WPcom_Global_Nav();
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/global-nav.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/global-nav.php
@@ -1,0 +1,6 @@
+<?php
+
+function should_use_new_global_nav() {
+	return true;
+}
+add_filter( 'wpcom_global_nav_enabled', 'should_use_new_global_nav' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/global-nav.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/global-nav.php
@@ -1,8 +1,18 @@
 <?php
+/**
+ * WPCOM Global Navbar Loader
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
 
 require __DIR__ . '/class-wpcom-global-nav.php';
 
+/**
+ * Determine if new global nav should be loaded.
+ */
 function should_use_new_global_nav() {
+	// True for the sake of simplicity in testing this right now. We may want to check a user
+	// setting or meta here.
 	return true;
 }
 add_filter( 'wpcom_global_nav_enabled', 'should_use_new_global_nav' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/global-nav.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/global-nav-bar/global-nav.php
@@ -1,5 +1,7 @@
 <?php
 
+require __DIR__ . '/class-wpcom-global-nav.php';
+
 function should_use_new_global_nav() {
 	return true;
 }

--- a/projects/plugins/jetpack/modules/masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar.php
@@ -22,7 +22,9 @@ require __DIR__ . '/masterbar/masterbar/class-masterbar.php';
 require __DIR__ . '/masterbar/admin-color-schemes/class-admin-color-schemes.php';
 require __DIR__ . '/masterbar/inline-help/class-inline-help.php';
 
-new Masterbar();
+if ( ! apply_filters( 'wpcom_global_nav_enabled', false ) ) {
+	new Masterbar();
+}
 new Admin_Color_Schemes();
 
 if ( ( new Host() )->is_woa_site() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* WIP - initializing scaffolding for new global nav and top bar. Also disables the masterbar class from the masterbar module while present.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

