### PR TITLE
Connection: Don't run package version tracker if not all packages were initialized

### DIFF
--- a/projects/packages/connection/changelog/fix-package-versions-videopress-2
+++ b/projects/packages/connection/changelog/fix-package-versions-videopress-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent package versions tracker from running before all packages were initialized.
+
+

--- a/projects/packages/connection/src/class-package-version-tracker.php
+++ b/projects/packages/connection/src/class-package-version-tracker.php
@@ -35,6 +35,11 @@ class Package_Version_Tracker {
 	 * version tracking. If the package versions have changed, updates the option and notifies WPCOM.
 	 */
 	public function maybe_update_package_versions() {
+		// Do not run too early or all the modules may not be loaded.
+		if ( ! did_action( 'init' ) ) {
+			return;
+		}
+
 		/**
 		 * Obtains the package versions.
 		 *

--- a/projects/packages/connection/src/class-package-version-tracker.php
+++ b/projects/packages/connection/src/class-package-version-tracker.php
@@ -50,9 +50,8 @@ class Package_Version_Tracker {
 			return;
 		}
 
+		// The version check is being rate limited.
 		if ( $this->is_rate_limiting() ) {
-			// The version check is being rate limited.
-
 			return;
 		}
 


### PR DESCRIPTION
## Proposed changes:
* Make sure the `init` action was run before sending out the package versions to make sure we never send incomplete data.

Props to @chrisbliss18 and @jeherve for the idea.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1706561650832669-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

1. Connect Jetpack
2. Open a private browser window, load the `/wp-login.php` page and enter invalid login/password. Send the form, and don't close it after you do.
3. Add this constant into the `wp-config.php`: `define( 'JETPACK_ALWAYS_PROTECT_LOGIN', true );`
4. Reload the login form you sent to resend the data.
5. Go to Jetpack Dashboard and confirm the package versions were (before applying the PR) or weren't (after applying the PR) sent in Kibana's nginx logs (replace the blog ID with yours in c06aef671133a135b190d14bcb71a6f3-logstash).