### PR TITLE
Untangle: Rename the Upgrades to the WordPresscom menu

### DIFF
--- a/projects/plugins/jetpack/changelog/untangle-rename-upgrades-to-wpcom
+++ b/projects/plugins/jetpack/changelog/untangle-rename-upgrades-to-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Untangle: move items in Upgrades section to the WordPress.com menu for the classic view

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -140,7 +140,7 @@ class Admin_Menu extends Base_Admin_Menu {
 			return;
 		}
 
-		add_menu_page( __( 'WordPress.com', 'jetpack' ), __( 'WordPress.com', 'jetpack' ), 'manage_options', 'wpcom', null, 'dashicons-wordpress', 4 );
+		add_menu_page( __( 'WordPress.com', 'jetpack' ), __( 'WordPress.com', 'jetpack' ), 'manage_options', 'wpcom', null, 'dashicons-wordpress-alt', 4 );
 
 		add_submenu_page( 'wpcom', __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', 'https://wordpress.com/plans/' . $this->domain, null, 0 );
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -24,7 +24,13 @@ class Admin_Menu extends Base_Admin_Menu {
 		// Remove separators.
 		remove_menu_page( 'separator1' );
 		$this->add_stats_menu();
-		$this->add_upgrades_menu();
+
+		// When the interface is set to wp-admin, move items in Upgrades section to the WordPress.com-specific menu item.
+		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
+			$this->add_wpcom_menu();
+		} else {
+			$this->add_upgrades_menu();
+		}
 		$this->add_posts_menu();
 		$this->add_media_menu();
 		$this->add_page_menu();
@@ -124,6 +130,35 @@ class Admin_Menu extends Base_Admin_Menu {
 	 */
 	public function add_stats_menu() {
 		add_menu_page( __( 'Stats', 'jetpack' ), __( 'Stats', 'jetpack' ), 'view_stats', 'https://wordpress.com/stats/day/' . $this->domain, null, 'dashicons-chart-bar', 3 );
+	}
+
+	/**
+	 * Adds WordPress.com menu.
+	 */
+	public function add_wpcom_menu() {
+		if ( get_option( 'wpcom_is_staging_site' ) ) {
+			return;
+		}
+
+		add_menu_page( __( 'WordPress.com', 'jetpack' ), __( 'WordPress.com', 'jetpack' ), 'manage_options', 'wpcom', null, 'dashicons-wordpress', 4 );
+
+		add_submenu_page( 'wpcom', __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', 'https://wordpress.com/plans/' . $this->domain, null, 0 );
+
+		if ( defined( 'WPCOM_ENABLE_ADD_ONS_MENU_ITEM' ) && WPCOM_ENABLE_ADD_ONS_MENU_ITEM ) {
+			add_submenu_page( 'wpcom', __( 'Add-Ons', 'jetpack' ), __( 'Add-Ons', 'jetpack' ), 'manage_options', 'https://wordpress.com/add-ons/' . $this->domain, null, 1 );
+		}
+
+		add_submenu_page( 'wpcom', __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 2 );
+
+		/** This filter is already documented in modules/masterbar/admin-menu/class-atomic-admin-menu.php */
+		if ( apply_filters( 'jetpack_show_wpcom_upgrades_email_menu', false ) ) {
+			add_submenu_page( 'wpcom', __( 'Emails', 'jetpack' ), __( 'Emails', 'jetpack' ), 'manage_options', 'https://wordpress.com/email/' . $this->domain, null, 3 );
+		}
+
+		add_submenu_page( 'wpcom', __( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, 4 );
+
+		// Remove the submenu auto-created by Core.
+		$this->hide_submenu_page( 'wpcom', 'wpcom' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/5308

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR moves items in the Upgrades menu to the new WordPress.com menu

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/jetpack/assets/13596067/929b6dc4-e6de-4679-82f0-54317e15c72d) | ![image](https://github.com/Automattic/jetpack/assets/13596067/3f1629e3-5b91-4c0d-82f8-35bf0c0c6b46) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Head to Settings → Hosting Configuration.
* Scroll to the Admin interface style section, and select Classic style.
* Refresh the page if needed.
* Ensure that the Upgrades menu is no longer present in the sidebar. Instead, make sure you can see the new WordPress.com menu, and ALL the items under the Upgrades menu are moved to the new menu.

