### PR TITLE
Subscriber Login: Allow to add it to the Navigation block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriber-login-allow-in-nav
+++ b/projects/plugins/jetpack/changelog/update-subscriber-login-allow-in-nav
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriber Login: Allow to add it to the Navigation block

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/editor.js
@@ -1,4 +1,5 @@
 import { createBlock } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
 import edit from './edit';
@@ -25,4 +26,15 @@ registerJetpackBlockFromMetadata( metadata, {
 			},
 		],
 	},
+} );
+
+addFilter( 'blocks.registerBlockType', 'jetpack-subscriber-login-nav-item', ( settings, name ) => {
+	if ( name === 'core/navigation' ) {
+		return {
+			...settings,
+			allowedBlocks: [ ...( settings.allowedBlocks ?? [] ), 'jetpack/subscriber-login' ],
+		};
+	}
+
+	return settings;
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/34884

## Proposed changes:

It allows the Subscriber Login block to be added to the Navigation block by modifying the `allowedBlocks` of the Navigation block.

You need to use Gutenberg v17.6 or higher to see it working.

https://make.wordpress.org/core/2024/01/31/whats-new-in-gutenberg-17-6-31-january/#new-block-json-allowed-blocks

<img width="604" alt="Screenshot 2024-02-02 at 10 46 11" src="https://github.com/Automattic/jetpack/assets/4068554/1661a9d0-01ef-4168-bce7-1f6b39b0cac5">

<br>
<br>

E2E are failing because of p1706803935679559-slack-CBG1CP4EN

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Make sure it's allowed to add Subscriber Login block to the Navigation block.