### PR TITLE
Map block: Increase Mapkit accuracy. [Draft]

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mapkit-accuracy
+++ b/projects/plugins/jetpack/changelog/fix-mapkit-accuracy
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor bugfix
+
+

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
@@ -274,9 +274,9 @@ const useMapkitAddressLookup = ( address, onSetPointsRef ) => {
 							latitude: place.coordinate.latitude,
 						},
 						// mapkit doesn't give us an id, so we'll make one containing the place name and coordinates
-						id: `${ title } ${ Number( place.coordinate.latitude ).toFixed( 2 ) } ${ Number(
+						id: `${ title } ${ Number( place.coordinate.latitude ).toFixed( 5 ) } ${ Number(
 							place.coordinate.longitude
-						).toFixed( 2 ) }`,
+						).toFixed( 5 ) }`,
 					};
 
 					onSetPointsRef.current( [ point ] );


### PR DESCRIPTION
Fixes #33370

## Proposed changes:
This fixes the accuracy of markers added through the search. Previously we only accounted for two digits of accuracy, which is clearly not enough.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply this PR on your Simple site as per the instructions below
2. Add a map block
3. Search for a specific address 
4. Verify that the marker is placed at the exact spot
