### PR TITLE
Add tracking for Checkout Block additional fields

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/add-custom-fields-tracking
+++ b/projects/packages/woocommerce-analytics/changelog/add-custom-fields-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: This is a tracking PR, it's not user facing.
+
+

--- a/projects/packages/woocommerce-analytics/src/class-checkout-flow.php
+++ b/projects/packages/woocommerce-analytics/src/class-checkout-flow.php
@@ -95,24 +95,33 @@ class Checkout_Flow {
 			$checkout_page_used = 'No';
 		}
 
+		$fields_data = $this->get_additional_fields_data();
+
+		$data = array(
+			'coupon_used'                               => $coupon_used,
+			'create_account'                            => $create_account,
+			'express_checkout'                          => 'null', // TODO: not solved yet.
+			'guest_checkout'                            => $order->get_customer_id() ? 'No' : 'Yes',
+			'oi'                                        => $order->get_id(),
+			'order_value'                               => $order->get_total(),
+			'payment_option'                            => $order->get_payment_method(),
+			'products_count'                            => $order->get_item_count(),
+			'products'                                  => $this->format_items_to_json( $order->get_items() ),
+			'order_note'                                => $order->get_customer_note(),
+			'shipping_option'                           => $order->get_shipping_method(),
+			'from_checkout'                             => $checkout_page_used,
+			'checkout_page_contains_checkout_block'     => $checkout_page_contains_checkout_block,
+			'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
+		);
+
+		$data = array_merge(
+			$data,
+			$fields_data
+		);
+
 		$this->record_event(
 			'woocommerceanalytics_order_confirmation_view',
-			array(
-				'coupon_used'                           => $coupon_used,
-				'create_account'                        => $create_account,
-				'express_checkout'                      => 'null', // TODO: not solved yet.
-				'guest_checkout'                        => $order->get_customer_id() ? 'No' : 'Yes',
-				'oi'                                    => $order->get_id(),
-				'order_value'                           => $order->get_total(),
-				'payment_option'                        => $order->get_payment_method(),
-				'products_count'                        => $order->get_item_count(),
-				'products'                              => $this->format_items_to_json( $order->get_items() ),
-				'order_note'                            => $order->get_customer_note(),
-				'shipping_option'                       => $order->get_shipping_method(),
-				'from_checkout'                         => $checkout_page_used,
-				'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
-				'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
-			)
+			$data
 		);
 	}
 
@@ -151,6 +160,11 @@ class Checkout_Flow {
 			return;
 		}
 
+		// Order received page is also a checkout page, so we need to bail out if we are on that page.
+		if ( is_order_received_page() ) {
+			return;
+		}
+
 		$is_in_checkout_page                       = $checkout_page_id === $post->ID ? 'Yes' : 'No';
 		$checkout_page_contains_checkout_block     = '0';
 		$checkout_page_contains_checkout_shortcode = '1';
@@ -166,10 +180,7 @@ class Checkout_Flow {
 			}
 		}
 
-		// Order received page is also a checkout page, so we need to bail out if we are on that page.
-		if ( is_order_received_page() ) {
-			return;
-		}
+		$fields_data = $this->get_additional_fields_data();
 
 		$this->record_event(
 			'woocommerceanalytics_checkout_view',
@@ -179,7 +190,8 @@ class Checkout_Flow {
 					'from_checkout' => $is_in_checkout_page,
 					'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
 					'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
-				)
+				),
+				$fields_data
 			)
 		);
 	}

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -581,6 +581,7 @@ trait Woo_Analytics_Trait {
 	public function get_additional_fields_data() {
 		$data = array();
 		if ( class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && class_exists( 'Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassReference
 			$additional_fields_controller = \Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::class );
 			$additional_fields            = $additional_fields_controller->get_additional_fields();
 			$fields_count                 = count( $additional_fields );

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -8,8 +8,6 @@
 namespace Automattic\Woocommerce_Analytics;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
-use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
-use Automattic\WooCommerce\Blocks\Package;
 use WC_Order_Item;
 use WC_Order_Item_Product;
 use WC_Payment_Gateway;
@@ -583,7 +581,7 @@ trait Woo_Analytics_Trait {
 	public function get_additional_fields_data() {
 		$data = array();
 		if ( class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && class_exists( 'Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields' ) ) {
-			$additional_fields_controller = Package::container()->get( CheckoutFields::class );
+			$additional_fields_controller = \Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::class );
 			$additional_fields            = $additional_fields_controller->get_additional_fields();
 			$fields_count                 = count( $additional_fields );
 			$fields_data                  = array_map(

--- a/projects/plugins/jetpack/changelog/add-custom-fields-tracking
+++ b/projects/plugins/jetpack/changelog/add-custom-fields-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This is a tracking PR, it's not user facing.
+
+

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
@@ -109,7 +109,7 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 			$checkout_page_used = 'No';
 		}
 
-		$fields_data = $this->get_additional_fields_data( $order );
+		$fields_data = $this->get_additional_fields_data();
 
 		$data = array(
 			'coupon_used'                               => $coupon_used,

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -611,11 +611,9 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	/**
 	 * Get additional fields data for Checkout and Post-Checkout events.
 	 *
-	 * @param WC_Order|null $order The order object or null if we don't have an order.
-	 *
-	 * return array An array containing the additional fields data.
+	 * @return array Additional fields data.
 	 */
-	private function get_additional_fields_data( $order = null ) {
+	private function get_additional_fields_data() {
 		$data = array();
 
 		if ( class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && class_exists( 'Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields' ) ) {
@@ -625,31 +623,17 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 			$fields_data                  = array_map(
 				function ( $field_key, $field ) use ( $additional_fields_controller ) {
 					return array(
-						$field_key,
-						$additional_fields_controller->get_field_location( $field_key ),
-						$field['type'],
-						$field['required'] ? '1' : '0',
+						'key'      => $field_key,
+						'location' => $additional_fields_controller->get_field_location( $field_key ),
+						'type'     => $field['type'],
+						'required' => $field['required'] ? '1' : '0',
+						'label'    => $field['label'],
 					);
 				},
 				array_keys( $additional_fields ),
 				$additional_fields
 			);
 
-			if ( $order ) {
-				$fields_data = array_map(
-					function ( $field ) use ( $additional_fields_controller, $order ) {
-						// For additional and contact, they have the default group, which is ''.
-						$field_group = $field[1] === 'address' ? 'shipping' : '';
-						$field[]     = $additional_fields_controller->get_field_from_order( $field[0], $order, $field_group );
-						// If we have no value in shipping, try billing.
-						if ( $field[1] === 'address' && ! $field[4] ) {
-							$field[4] = $additional_fields_controller->get_field_from_order( $field[0], $order, 'billing' );
-						}
-						return $field;
-					},
-					$fields_data
-				);
-			}
 			$data = array(
 				'fields_count' => $fields_count,
 				'fields'       => wp_json_encode( $fields_data ),

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -617,6 +617,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		$data = array();
 
 		if ( class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && class_exists( 'Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassReference
 			$additional_fields_controller = Automattic\WooCommerce\Blocks\Package::container()->get( Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::class );
 			$additional_fields            = $additional_fields_controller->get_additional_fields();
 			$fields_count                 = count( $additional_fields );

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -223,6 +223,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			$session->save_data();
 		}
 
+		$fields_data = $this->get_additional_fields_data();
+
 		foreach ( $cart as $cart_item_key => $cart_item ) {
 			/**
 			* This filter is already documented in woocommerce/templates/cart/cart.php
@@ -234,6 +236,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			}
 
 			$data = $this->get_cart_checkout_shared_data();
+
+			$data = array_merge( $data, $fields_data );
 
 			$data['from_checkout'] = $is_in_checkout_page;
 
@@ -361,6 +365,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			$checkout_page_contains_checkout_shortcode = '1';
 		}
 
+		$fields_data = $this->get_additional_fields_data( $order );
+
 		// loop through products in the order and queue a purchase event.
 		foreach ( $order->get_items() as $order_item ) {
 			$product_id = is_callable( array( $order_item, 'get_product_id' ) ) ? $order_item->get_product_id() : -1;
@@ -375,22 +381,27 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			if ( is_array( $order_coupons ) ) {
 				$order_coupons_count = count( $order_coupons );
 			}
+
+			$data = array(
+				'oi'                                    => $order->get_order_number(),
+				'pq'                                    => $order_item->get_quantity(),
+				'payment_option'                        => $payment_option,
+				'create_account'                        => $create_account,
+				'guest_checkout'                        => $guest_checkout,
+				'express_checkout'                      => $express_checkout,
+				'products_count'                        => $order_items_count,
+				'coupon_used'                           => $order_coupons_count,
+				'order_value'                           => $order->get_total(),
+				'from_checkout'                         => $checkout_page_used,
+				'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
+				'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
+			);
+
+			$data = array_merge( $data, $fields_data );
+
 			$this->record_event(
 				'woocommerceanalytics_product_purchase',
-				array(
-					'oi'               => $order->get_order_number(),
-					'pq'               => $order_item->get_quantity(),
-					'payment_option'   => $payment_option,
-					'create_account'   => $create_account,
-					'guest_checkout'   => $guest_checkout,
-					'express_checkout' => $express_checkout,
-					'products_count'   => $order_items_count,
-					'coupon_used'      => $order_coupons_count,
-					'order_value'      => $order->get_total(),
-					'from_checkout'    => $checkout_page_used,
-					'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
-					'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
-				),
+				$data,
 				$product_id
 			);
 		}

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -365,7 +365,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			$checkout_page_contains_checkout_shortcode = '1';
 		}
 
-		$fields_data = $this->get_additional_fields_data( $order );
+		$fields_data = $this->get_additional_fields_data();
 
 		// loop through products in the order and queue a purchase event.
 		foreach ( $order->get_items() as $order_item ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This issue is part of https://github.com/woocommerce/woocommerce/issues/42116 it adds custom fields tracking, mainly adding how many fields there are in checkout and post checkout, their names, requirement, location, type, and value for post checkout events.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Add some custom Checkout fields like this snippet https://gist.github.com/senadir/bff581c05cb4a0d6a72cab4cd7ca5df1
* Load up Checkout and Tracks Vigilante.
* Make sure you're seeing 3 fields for field count and the fields values in both Checkout view event and product_checkout event.
* Fill up the values and place an order.
* Make sure you're seeing the fields in post checkout events like product_purchase and order_confirmation_view.
* Disable the snippet and make sure the events are running fine still.
