### PR TITLE
Boost: Update ISA summary group names to align with status icons

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/isa/multi-progress.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/isa/multi-progress.scss
@@ -17,7 +17,7 @@
 	display: grid;
 	gap: 4px;
 	grid-template-columns: 30px 1fr 1fr;
-	grid-template-rows: 36px 18px 18px;
+	grid-template-rows: 36px 1.6rem 18px;
 	grid-template-areas:
 		'progress progress progress'
 		'bubble category category'
@@ -58,6 +58,7 @@
 .jb-category-name {
 	grid-area: category;
 	display: flex;
+	line-height: 1.6rem;
 
 	.jb-score-context {
 		top: 2px;

--- a/projects/plugins/boost/changelog/fix-isa-summary-group-alignment
+++ b/projects/plugins/boost/changelog/fix-isa-summary-group-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image Size Analysis: Update summary groups to align with status icons.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35292

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update position of group names to be on the same line as the status icon.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost premium;
* Make sure the group names in the ISA summary section are aligned with their corresponding status icons.