### PR TITLE
Stats: add filter to allow customizing the cache duration

### DIFF
--- a/projects/packages/stats/changelog/update-stats-pulling-jetpack-filter
+++ b/projects/packages/stats/changelog/update-stats-pulling-jetpack-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats fetching mechanism: add filter allowing one to customize how long we cache results.

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -398,7 +398,20 @@ class WPCOM_Stats {
 
 		// To reduce size in storage: store with time as key, store JSON encoded data.
 		$cached_value = is_wp_error( $wpcom_stats ) ? $wpcom_stats : wp_json_encode( $wpcom_stats );
-		$expiration   = self::STATS_CACHE_EXPIRATION_IN_MINUTES * MINUTE_IN_SECONDS;
+
+		/**
+		 * Filters the expiration time for the stats cache.
+		 *
+		 * @module stats
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $expiration The expiration time in minutes.
+		 */
+		$expiration = apply_filters(
+			'jetpack_fetch_stats_cache_expiration',
+			self::STATS_CACHE_EXPIRATION_IN_MINUTES * MINUTE_IN_SECONDS
+		);
 		set_transient( $transient_name, array( time() => $cached_value ), $expiration );
 
 		return $wpcom_stats;
@@ -428,8 +441,13 @@ class WPCOM_Stats {
 				return $data;
 			}
 
-			$time       = key( $data );
-			$expiration = self::STATS_CACHE_EXPIRATION_IN_MINUTES * MINUTE_IN_SECONDS;
+			$time = key( $data );
+
+			/** This filter is already documented in projects/packages/stats/src/class-wpcom-stats.php */
+			$expiration = apply_filters(
+				'jetpack_fetch_stats_cache_expiration',
+				self::STATS_CACHE_EXPIRATION_IN_MINUTES * MINUTE_IN_SECONDS
+			);
 
 			if ( ( time() - $time ) < $expiration ) {
 				return array_merge( array( 'cached_at' => $time ), $data[ $time ] );


### PR DESCRIPTION
## Proposed changes:

This would allow third-parties to change the default caching duration from 5 minutes to something else, when they need their site to make less queries to WordPress.com in general.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This should not change the default behavior, so there isn't much to test here. You can test the stats fetching via the new Stats block for example (stil in Beta so you'll need to eanble Beta blocks on your site).
