### PR TITLE
Update jetpack ai card title in my jetpack

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-card-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-card-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a title change
+
+

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -63,7 +63,7 @@ class Jetpack_Ai extends Product {
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Jetpack AI', 'jetpack-my-jetpack' );
+		return __( 'AI', 'jetpack-my-jetpack' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* Update AI card name from "Jetpack AI" to "AI"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Using your local environment or the jetpack beta plugin, checkout this branch
2. Go to `/wp-admin/admin.php?page=my-jetpack`
3. Make sure the Jetpack AI card says "AI" instead of "Jetpack AI"
![image](https://github.com/Automattic/jetpack/assets/65001528/a6ee9947-2e40-4f88-abbd-33c5422d86d8)

