### PR TITLE
Update discount price presentation to match jetpack.com

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -308,10 +308,10 @@ const ProductDetailCard = ( {
 				{ needsPurchase && discountPrice && (
 					<>
 						<div className={ styles[ 'price-container' ] }>
+							<Price value={ discountPrice } currency={ currencyCode } isOld={ false } />
 							{ discountPrice < price && (
 								<Price value={ price } currency={ currencyCode } isOld={ true } />
 							) }
-							<Price value={ discountPrice } currency={ currencyCode } isOld={ false } />
 						</div>
 						<Text className={ styles[ 'price-description' ] }>{ priceDescription }</Text>
 					</>

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -117,7 +117,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	align-items: flex-end;
-	color: var( --jp-text-color);
+	color: var( --jp-black );
 }
 
 .price {
@@ -128,7 +128,7 @@
 	}
 
 	&.is-old {
-		color: var( --jp-gray-20);
+		color: var( --jp-gray-20 );
 
 		&:after {
 			content: " ";

--- a/projects/packages/my-jetpack/changelog/update-discount-price-presentation
+++ b/projects/packages/my-jetpack/changelog/update-discount-price-presentation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Small visual change
+
+


### PR DESCRIPTION
## Proposed changes:

* Move crossed out price to the right to match jetpack.com
* Update color of prices, they are black everywhere else, so this was changed from off-black to black

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Using your local environment or the jetpack beta plugin, checkout this branch
2. Go to `/wp-admin/admin.php?page=my-jetpack#/add-backup`
3. Make sure the crossed out price is on the right side
![image](https://github.com/Automattic/jetpack/assets/65001528/f1a50334-bdfb-41c5-8b87-6db04b0562b4)
4. Test other interstitials to make sure it's always on the right
