### PR TITLE
Untangle: Move the Site Monitoring item into the WordPress.com menu

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wpcom-menu
+++ b/projects/plugins/jetpack/changelog/update-wpcom-menu
@@ -1,4 +1,7 @@
 Significance: minor
 Type: other
 
-Move Monetize and Marketing from Tools to the new WordPress.com menu for the calypso untangle project.
+Move the following items from Tools to the new WordPress.com menu for the calypso untangle project:
+* Monetize
+* Marketing
+* Site Monitoring

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -134,33 +134,38 @@ class Admin_Menu extends Base_Admin_Menu {
 
 	/**
 	 * Adds WordPress.com menu.
+	 *
+	 * @return number The current position of the submenu.
 	 */
 	public function add_wpcom_menu() {
-		if ( get_option( 'wpcom_is_staging_site' ) ) {
-			return;
+		add_menu_page( esc_attr__( 'WordPress.com', 'jetpack' ), __( 'WordPress.com', 'jetpack' ), 'publish_posts', 'wpcom', null, 'dashicons-wordpress-alt', 4 );
+
+		$submenu_position = 0;
+		// We don't want to show the items related to the Upgrades on the staging site.
+		if ( ! get_option( 'wpcom_is_staging_site' ) ) {
+			add_submenu_page( 'wpcom', esc_attr__( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', 'https://wordpress.com/plans/' . $this->domain, null, $submenu_position++ );
+
+			if ( defined( 'WPCOM_ENABLE_ADD_ONS_MENU_ITEM' ) && WPCOM_ENABLE_ADD_ONS_MENU_ITEM ) {
+				add_submenu_page( 'wpcom', esc_attr__( 'Add-Ons', 'jetpack' ), __( 'Add-Ons', 'jetpack' ), 'manage_options', 'https://wordpress.com/add-ons/' . $this->domain, null, $submenu_position++ );
+			}
+
+			add_submenu_page( 'wpcom', esc_attr__( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, $submenu_position++ );
+
+			/** This filter is already documented in modules/masterbar/admin-menu/class-atomic-admin-menu.php */
+			if ( apply_filters( 'jetpack_show_wpcom_upgrades_email_menu', false ) ) {
+				add_submenu_page( 'wpcom', esc_attr__( 'Emails', 'jetpack' ), __( 'Emails', 'jetpack' ), 'manage_options', 'https://wordpress.com/email/' . $this->domain, null, $submenu_position++ );
+			}
+
+			add_submenu_page( 'wpcom', esc_attr__( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, $submenu_position++ );
 		}
 
-		add_menu_page( __( 'WordPress.com', 'jetpack' ), __( 'WordPress.com', 'jetpack' ), 'publish_posts', 'wpcom', null, 'dashicons-wordpress-alt', 4 );
-
-		add_submenu_page( 'wpcom', __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', 'https://wordpress.com/plans/' . $this->domain, null, 0 );
-
-		if ( defined( 'WPCOM_ENABLE_ADD_ONS_MENU_ITEM' ) && WPCOM_ENABLE_ADD_ONS_MENU_ITEM ) {
-			add_submenu_page( 'wpcom', __( 'Add-Ons', 'jetpack' ), __( 'Add-Ons', 'jetpack' ), 'manage_options', 'https://wordpress.com/add-ons/' . $this->domain, null, 1 );
-		}
-
-		add_submenu_page( 'wpcom', __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 2 );
-
-		/** This filter is already documented in modules/masterbar/admin-menu/class-atomic-admin-menu.php */
-		if ( apply_filters( 'jetpack_show_wpcom_upgrades_email_menu', false ) ) {
-			add_submenu_page( 'wpcom', __( 'Emails', 'jetpack' ), __( 'Emails', 'jetpack' ), 'manage_options', 'https://wordpress.com/email/' . $this->domain, null, 3 );
-		}
-
-		add_submenu_page( 'wpcom', __( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, 4 );
-		add_submenu_page( 'wpcom', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 5 );
-		add_submenu_page( 'wpcom', esc_attr__( 'Monetize', 'jetpack' ), __( 'Monetize', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 6 );
+		add_submenu_page( 'wpcom', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, $submenu_position++ );
+		add_submenu_page( 'wpcom', esc_attr__( 'Monetize', 'jetpack' ), __( 'Monetize', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, $submenu_position++ );
 
 		// Remove the submenu auto-created by Core.
 		$this->hide_submenu_page( 'wpcom', 'wpcom' );
+
+		return $submenu_position;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -371,6 +371,15 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Adds WordPress.com menu.
+	 */
+	public function add_wpcom_menu() {
+		$submenu_position = parent::add_wpcom_menu();
+
+		add_submenu_page( 'wpcom', esc_attr__( 'Site Monitoring', 'jetpack' ), __( 'Site Monitoring', 'jetpack' ), 'manage_options', 'https://wordpress.com/site-monitoring/' . $this->domain, null, $submenu_position++ );
+	}
+
+	/**
 	 * Adds Upgrades menu.
 	 *
 	 * @param string $plan The current WPCOM plan of the blog.
@@ -443,9 +452,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		}
 
 		/**
-		 * Adds the WordPress.com Site Monitoring submenu under the main Tools menu.
+		 * Adds the WordPress.com Site Monitoring submenu under the main Tools menu when the interface is not set to wp-admin.
 		 */
-		add_submenu_page( 'tools.php', esc_attr__( 'Site Monitoring', 'jetpack' ), __( 'Site Monitoring', 'jetpack' ), 'manage_options', 'https://wordpress.com/site-monitoring/' . $this->domain, null, 7 );
+		if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+			add_submenu_page( 'tools.php', esc_attr__( 'Site Monitoring', 'jetpack' ), __( 'Site Monitoring', 'jetpack' ), 'manage_options', 'https://wordpress.com/site-monitoring/' . $this->domain, null, 7 );
+		}
 
 		/**
 		 * Adds the WordPress.com Github Deployments submenu under the main Tools menu.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5465

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move "Tools > Site Monitoring" to "WordPress.com > Site Monitoring"

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/jetpack/assets/13596067/03cd90e1-37fe-489a-9b02-b80232662d19) | ![image](https://github.com/Automattic/jetpack/assets/13596067/203a5256-5fa5-4115-a1c7-8c9ee3b0100a) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this branch to your WoA site via the Jetpack Beta Tester
* Head to Settings → Hosting Configuration.
* Scroll to the Admin interface style section, and select Classic style.
* Refresh the page if needed.
* Check the menu to see if the “Site Monitoring” item is moved into the WordPress.com menu and no longer present in the Tools
* Switch back to the default style and see if the “Site Monitoring” item is back in the Tools

