### PR TITLE
Social: Add activitypub as a feature for the Social Note CPT

### DIFF
--- a/projects/plugins/social/changelog/add-feature-support-social-notes
+++ b/projects/plugins/social/changelog/add-feature-support-social-notes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added feature support for the new CPT to support activitypub.

--- a/projects/plugins/social/src/class-note.php
+++ b/projects/plugins/social/src/class-note.php
@@ -44,7 +44,7 @@ class Note {
 				'items_list'            => esc_html__( 'Notes list', 'jetpack-social' ),
 			),
 			'show_in_rest' => true,
-			'supports'     => array( 'editor', 'thumbnail', 'publicize' ),
+			'supports'     => array( 'editor', 'thumbnail', 'publicize', 'activitypub' ),
 			'menu_icon'    => 'dashicons-welcome-write-blog',
 
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added `activitypub` to the featureslist. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdrWKz-156-p2#comment-1939

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Add define( 'JETPACK_SOCIAL_NOTES_ENABLED', true ); to your wp-config.php. If you're on JN, install the code snippets plugin and copy define( 'JETPACK_SOCIAL_NOTES_ENABLED', true ); into it.
Activate Jetpack Social on this branch
- Ensure you're able to see the new CPT Social Note in the sidebar of your wp-admin and you're able to create new Social Notes.