### PR TITLE
Like block: Remove the "Like this:" heading section

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-like-block-heading-section
+++ b/projects/plugins/jetpack/changelog/remove-like-block-heading-section
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Like block: Remove the "Like this:" heading

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -96,7 +96,6 @@ function render_block( $attr, $content, $block ) {
 		$domain       = $bloginfo->domain;
 		$reblog_param = $show_reblog_button ? '&amp;reblog=1' : '';
 		$src          = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout, $reblog_param );
-		$headline     = '';
 
 		// provide the mapped domain when needed
 		if ( isset( $_SERVER['HTTP_HOST'] ) && strpos( sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ), '.wordpress.com' ) === false ) {
@@ -109,18 +108,12 @@ function render_block( $attr, $content, $block ) {
 		$url_parts = wp_parse_url( $url );
 		$domain    = $url_parts['host'];
 		$src       = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout );
-		$headline  = sprintf(
-			/** This filter is already documented in modules/sharedaddy/sharing-service.php */
-			apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>', esc_html__( 'Like this:', 'jetpack' ), 'likes' ),
-			esc_html__( 'Like this:', 'jetpack' )
-		);
 	}
 
 	$name    = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 	$wrapper = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 
 	$html = "<div class='sharedaddy sd-block sd-like jetpack-likes-widget-wrapper jetpack-likes-widget-unloaded' id='" . esc_attr( $wrapper ) . "' data-src='" . esc_attr( $src ) . "' data-name='" . esc_attr( $name ) . "' data-title='" . esc_attr( $title ) . "'>"
-		. $headline
 		. "<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='button'><span>" . esc_html__( 'Like', 'jetpack' ) . "</span></span> <span class='loading'>" . esc_html__( 'Loading...', 'jetpack' ) . '</span></div>'
 		. "<span class='sd-text-color'></span><a class='sd-link-color'></a>"
 		. '</div>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/87041.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* remove the "Like this:" heading section

Reasoning:

- users can add a similar leading text themselves using other blocks (if they want to)
- having the Like block displaying just the button itself makes the block more versatile
- Simple sites don't display that section either

| Before | After |
|--------|--------|
| ![Markup on 2024-02-05 at 17:17:34](https://github.com/Automattic/jetpack/assets/25105483/7aa1fec8-8775-4305-bf79-a223b8a12ce5) | ![Markup on 2024-02-05 at 17:18:06](https://github.com/Automattic/jetpack/assets/25105483/93569372-74a2-4ac6-a7d3-e6027f7fa382) | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

- https://github.com/Automattic/wp-calypso/issues/87041

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add the Like block to any post / page on your test site (self-hosted JP or WoA).
2. The "Like this:" heading should not be present.
3. There should be no regressions. The Like button that's displayed on each post by default (when the Likes module is enabled) will still include the "Like this:" heading. This PR does not introduce any changes there. There should be no effect on Simple sites either.

ℹ️ When testing on a self-hosted JP site, make sure that Jetpack is connected to your WordPress.com account. 