### PR TITLE
Backport mu-wpcom-plugin 2.0.18, jetpack 13.1-beta Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-02-05
+### Added
+- Jetpack AI: Support floating error messaging on the AI Control component. [#35322]
+
+### Changed
+- Updated package dependencies. [#35384]
+
 ## [0.5.1] - 2024-01-29
 ### Changed
 - Update dependencies. [#35170]
@@ -199,6 +206,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.6.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.4.0...v0.4.1

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-move-error-closer-to-assistant-input
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-move-error-closer-to-assistant-input
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Jetpack AI: Support floating error messaging on the AI Control component.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.6.0-alpha",
+	"version": "0.6.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.16.9] - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+
 ## [0.16.8] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]
@@ -290,6 +294,7 @@
 - Add the API methods left behind by the previous PR.
 - Initial release of jetpack-api package
 
+[0.16.9]: https://github.com/Automattic/jetpack-api/compare/v0.16.8...v0.16.9
 [0.16.8]: https://github.com/Automattic/jetpack-api/compare/v0.16.7...v0.16.8
 [0.16.7]: https://github.com/Automattic/jetpack-api/compare/v0.16.6...v0.16.7
 [0.16.6]: https://github.com/Automattic/jetpack-api/compare/v0.16.5...v0.16.6

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.16.9-alpha",
+	"version": "0.16.9",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.16] - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+
 ## [0.6.15] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]
@@ -242,6 +246,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.16]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.15...0.6.16
 [0.6.15]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.14...0.6.15
 [0.6.14]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.13...0.6.14
 [0.6.13]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.12...0.6.13

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.16-alpha",
+	"version": "0.6.16",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.21] - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+
 ## [0.1.20] - 2024-01-29
 ### Fixed
 - Fix TypeScript type for a Boost Score prop [#35273]
@@ -95,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.21]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.19...v0.1.20
 [0.1.19]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.17...v0.1.18

--- a/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.21-alpha",
+	"version": "0.1.21",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.48.1] - 2024-02-05
+### Changed
+- Update clicking an icon tooltip to cause the tooltip to show/hide instead of always showing. [#35312]
+- Updated package dependencies.
+
 ## [0.48.0] - 2024-01-29
 ### Changed
 - Move the UpsellBanner component to js-packages/components [#35228]
@@ -932,6 +937,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.48.1]: https://github.com/Automattic/jetpack-components/compare/0.48.0...0.48.1
 [0.48.0]: https://github.com/Automattic/jetpack-components/compare/0.47.0...0.48.0
 [0.47.0]: https://github.com/Automattic/jetpack-components/compare/0.46.0...0.47.0
 [0.46.0]: https://github.com/Automattic/jetpack-components/compare/0.45.10...0.46.0

--- a/projects/js-packages/components/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/components/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/update-js-packages-icon-tooltip-toggle-on-icon-click
+++ b/projects/js-packages/components/changelog/update-js-packages-icon-tooltip-toggle-on-icon-click
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update clicking an icon tooltip to cause the tooltip to show/hide instead of always showing.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.48.1-alpha",
+	"version": "0.48.1",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.32.0] - 2024-02-05
+### Changed
+- Allow using blog ID instead of site suffix in checkout URL. [#34996]
+- Allow using blog ID instead of site suffix in checkout URL. [#35004]
+- Updated package dependencies.
+
 ## [0.31.2] - 2024-01-29
 ### Changed
 - Update dependencies.
@@ -692,6 +698,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.32.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.2...v0.32.0
 [0.31.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.30.12...v0.31.0

--- a/projects/js-packages/connection/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/connection/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/changelog/update-protect-2-wpcom-links-blog-id
+++ b/projects/js-packages/connection/changelog/update-protect-2-wpcom-links-blog-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Allow using blog ID instead of site suffix in checkout URL.

--- a/projects/js-packages/connection/changelog/update-videopress-wpcom-links-blog-id
+++ b/projects/js-packages/connection/changelog/update-videopress-wpcom-links-blog-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Allow using blog ID instead of site suffix in checkout URL.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.32.0-alpha",
+	"version": "0.32.0",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.44] - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+
 ## [2.0.43] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]
@@ -201,6 +205,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.44]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.43...v2.0.44
 [2.0.43]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.42...v2.0.43
 [2.0.42]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.41...v2.0.42
 [2.0.41]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.40...v2.0.41

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.44-alpha",
+	"version": "2.0.44",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.60 - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+
 ## 0.10.59 - 2024-01-29
 ### Changed
 - Update dependencies.

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.60-alpha",
+	"version": "0.10.60",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 - 2024-02-05
+### Added
+- Added social specific success card on Jetpack Social license activation. [#35224]
+
+### Changed
+- Updated package dependencies.
+
 ## 0.11.20 - 2024-01-29
 ### Changed
 - Update dependencies.

--- a/projects/js-packages/licensing/changelog/add-social-license-activation
+++ b/projects/js-packages/licensing/changelog/add-social-license-activation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added social specific success card on Jetpack Social license activation.

--- a/projects/js-packages/licensing/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/licensing/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.12.0-alpha",
+	"version": "0.12.0",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.68 - 2024-02-05
+### Changed
+- Updated package dependencies.
+
 ## 0.2.67 - 2024-01-29
 ### Changed
 - Update dependencies. [#35170]

--- a/projects/js-packages/partner-coupon/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/partner-coupon/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.68-alpha",
+	"version": "0.2.68",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.46.0] - 2024-02-05
+### Added
+- Add blog ID to the initial state. [#35006]
+
+### Changed
+- Updated package dependencies.
+
 ## [0.45.2] - 2024-01-29
 ### Changed
 - Update dependencies. [#35170]
@@ -575,6 +582,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.46.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.45.2...v0.46.0
 [0.45.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.45.1...v0.45.2
 [0.45.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.45.0...v0.45.1
 [0.45.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.44.2...v0.45.0

--- a/projects/js-packages/publicize-components/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/publicize-components/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/update-social-wpcom-links-blog-id
+++ b/projects/js-packages/publicize-components/changelog/update-social-wpcom-links-blog-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add blog ID to the initial state.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.46.0-alpha",
+	"version": "0.46.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2024-02-05
+### Changed
+- Updated package dependencies.
+
 ## [0.14.0] - 2024-01-29
 ### Added
 - Adds new getJetpackBlocksVariation function [#34179]
@@ -332,6 +336,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.14.1]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.0...0.14.1
 [0.14.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.10...0.14.0
 [0.13.10]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.9...0.13.10
 [0.13.9]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.8...0.13.9

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.14.1-alpha",
+	"version": "0.14.1",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.1 - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+
 ## 3.1.0 - 2024-01-25
 ### Added
 - Automatically determine text domain for `I18nLoaderPlugin` as is done for `I18nCheckPlugin`. [#35231]

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.1.1-alpha",
+	"version": "3.1.1",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2024-02-05
+### Added
+- Add support for script enqueuing strategies implemented in WordPress 6.3 [#34072]
+
+### Changed
+- Updated package dependencies. [#35384]
+
 ## [2.0.4] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]
@@ -396,6 +403,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[2.1.0]: https://github.com/Automattic/jetpack-assets/compare/v2.0.4...v2.1.0
 [2.0.4]: https://github.com/Automattic/jetpack-assets/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/Automattic/jetpack-assets/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-assets/compare/v2.0.1...v2.0.2

--- a/projects/packages/assets/changelog/add-script-strategy-support
+++ b/projects/packages/assets/changelog/add-script-strategy-support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add support for script enqueuing strategies implemented in WordPress 6.3

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -62,12 +62,12 @@ class Assets {
 	/**
 	 * A public method for adding the async script.
 	 *
-	 * @deprecated Since $$next-version$$, the `strategy` feature should be used instead, with the "defer" setting.
+	 * @deprecated Since 2.1.0, the `strategy` feature should be used instead, with the "defer" setting.
 	 *
 	 * @param string $script_handle Script handle.
 	 */
 	public static function add_async_script( $script_handle ) {
-		_deprecated_function( __METHOD__, '$$next-version$$' );
+		_deprecated_function( __METHOD__, '2.1.0' );
 
 		wp_script_add_data( $script_handle, 'strategy', 'defer' );
 	}
@@ -76,13 +76,13 @@ class Assets {
 	 * Add an async attribute to scripts that can be loaded deferred.
 	 * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
 	 *
-	 * @deprecated Since $$next-version$$, the `strategy` feature should be used instead.
+	 * @deprecated Since 2.1.0, the `strategy` feature should be used instead.
 	 *
 	 * @param string $tag    The <script> tag for the enqueued script.
 	 * @param string $handle The script's registered handle.
 	 */
 	public function script_add_async( $tag, $handle ) {
-		_deprecated_function( __METHOD__, '$$next-version$$' );
+		_deprecated_function( __METHOD__, '2.1.0' );
 		if ( empty( $this->defer_script_handles ) ) {
 			return $tag;
 		}
@@ -98,7 +98,7 @@ class Assets {
 	/**
 	 * A helper function that lets you enqueue scripts in an async fashion.
 	 *
-	 * @deprecated Since $$next-version$$ - use the strategy feature instead.
+	 * @deprecated Since 2.1.0 - use the strategy feature instead.
 	 *
 	 * @param string $handle        Name of the script. Should be unique.
 	 * @param string $min_path      Minimized script path.
@@ -108,7 +108,7 @@ class Assets {
 	 * @param bool   $in_footer       Should the script be included in the footer.
 	 */
 	public static function enqueue_async_script( $handle, $min_path, $non_min_path, $deps = array(), $ver = false, $in_footer = true ) {
-		_deprecated_function( __METHOD__, '$$next-version$$' );
+		_deprecated_function( __METHOD__, '2.1.0' );
 		$assets_instance = self::instance();
 		$assets_instance->add_async_script( $handle );
 		wp_enqueue_script( $handle, self::get_file_url_for_environment( $min_path, $non_min_path ), $deps, $ver, $in_footer );
@@ -305,7 +305,7 @@ class Assets {
 	 * This wrapper handles all of that.
 	 *
 	 * @since 1.12.0
-	 * @since $$next-version$$ Add a new `strategy` option to leverage WP >= 6.3 script strategy feature. The `async` option is deprecated.
+	 * @since 2.1.0 Add a new `strategy` option to leverage WP >= 6.3 script strategy feature. The `async` option is deprecated.
 	 * @param string $handle      Name of the script. Should be unique across both scripts and styles.
 	 * @param string $path        Minimized script path.
 	 * @param string $relative_to File that `$path` is relative to. Pass `__FILE__`.
@@ -331,7 +331,7 @@ class Assets {
 		}
 
 		if ( isset( $options['async'] ) ) {
-			_deprecated_argument( __METHOD__, '$$next-version$$', 'The `async` option is deprecated in favor of `strategy`' );
+			_deprecated_argument( __METHOD__, '2.1.0', 'The `async` option is deprecated in favor of `strategy`' );
 		}
 
 		$dir      = dirname( $relative_to );

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.2] - 2024-02-05
+### Changed
+- Updated package dependencies.
+
 ## [3.1.1] - 2024-01-29
 ### Changed
 - Update dependencies.
@@ -546,6 +550,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.1.2]: https://github.com/Automattic/jetpack-backup/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/Automattic/jetpack-backup/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/Automattic/jetpack-backup/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/Automattic/jetpack-backup/compare/v2.0.5...v3.0.0

--- a/projects/packages/backup/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/backup/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup\V0001;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.1.2-alpha';
+	const PACKAGE_VERSION = '3.1.2';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.3] - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+
 ## [0.15.2] - 2024-01-29
 ### Changed
 - Update dependencies. [#35170]
@@ -273,6 +277,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.15.3]: https://github.com/automattic/jetpack-blaze/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/automattic/jetpack-blaze/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/automattic/jetpack-blaze/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/automattic/jetpack-blaze/compare/v0.14.3...v0.15.0

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.15.3-alpha",
+	"version": "0.15.3",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.15.3-alpha';
+	const PACKAGE_VERSION = '0.15.3';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2024-02-05
+### Added
+- Add rate limiter to the package versions endpoint calls. [#35379]
+
+### Changed
+- Adjust 'get_site_id()' method to return null if there's no blog ID. [#35004]
+- Adjust 'get_site_id()' method to return null if there's no blog ID. [#35006]
+- Jetpack Connection: Add jetpack_package_versions to Sync [#35409]
+- Updated package dependencies. [#35384]
+
 ## [2.2.0] - 2024-01-18
 ### Added
 - Adding support for IDC when site URL is an IP address. [#34753]
@@ -950,6 +960,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.3.0]: https://github.com/Automattic/jetpack-connection/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/Automattic/jetpack-connection/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/Automattic/jetpack-connection/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/Automattic/jetpack-connection/compare/v2.0.3...v2.1.0

--- a/projects/packages/connection/changelog/add-package-versions-rate-limiter
+++ b/projects/packages/connection/changelog/add-package-versions-rate-limiter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add rate limiter to the package versions endpoint calls.

--- a/projects/packages/connection/changelog/fix-package-versions-videopress-2
+++ b/projects/packages/connection/changelog/fix-package-versions-videopress-2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent package versions tracker from running before all packages were initialized.
-
-

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/changelog/update-jetpack-package-versions-add-to-sync
+++ b/projects/packages/connection/changelog/update-jetpack-package-versions-add-to-sync
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Jetpack Connection: Add jetpack_package_versions to Sync

--- a/projects/packages/connection/changelog/update-protect-2-wpcom-links-blog-id
+++ b/projects/packages/connection/changelog/update-protect-2-wpcom-links-blog-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Adjust 'get_site_id()' method to return null if there's no blog ID.

--- a/projects/packages/connection/changelog/update-social-wpcom-links-blog-id
+++ b/projects/packages/connection/changelog/update-social-wpcom-links-blog-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Adjust 'get_site_id()' method to return null if there's no blog ID.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.3.0-alpha';
+	const PACKAGE_VERSION = '2.3.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.3] - 2024-02-05
+### Changed
+- Asset enqueuing: switch to enqueuing strategy introduced in WordPress 6.3. [#34072]
+- Updated package dependencies.
+
+### Fixed
+- Center submit button content horizontally [#35319]
+
 ## [0.30.2] - 2024-01-29
 ### Changed
 - Update dependencies.
@@ -473,6 +481,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.3]: https://github.com/automattic/jetpack-forms/compare/v0.30.2...v0.30.3
 [0.30.2]: https://github.com/automattic/jetpack-forms/compare/v0.30.1...v0.30.2
 [0.30.1]: https://github.com/automattic/jetpack-forms/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/automattic/jetpack-forms/compare/v0.29.2...v0.30.0

--- a/projects/packages/forms/changelog/add-script-strategy-support
+++ b/projects/packages/forms/changelog/add-script-strategy-support
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Asset enqueuing: switch to enqueuing strategy introduced in WordPress 6.3.

--- a/projects/packages/forms/changelog/fix-contact-form-submit-btn-align
+++ b/projects/packages/forms/changelog/fix-contact-form-submit-btn-align
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Center submit button content horizontally

--- a/projects/packages/forms/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/forms/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.3-alpha",
+	"version": "0.30.3",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.3-alpha';
+	const PACKAGE_VERSION = '0.30.3';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+
+### Fixed
+- Minor change in method response [#35336]
+
 ## [0.15.0] - 2024-01-18
 ### Added
 - Adding support for IDC when site URL is an IP address. [#34753]
@@ -473,6 +480,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.15.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.13.0...v0.14.0

--- a/projects/packages/identity-crisis/changelog/fix-ip_requester_response
+++ b/projects/packages/identity-crisis/changelog/fix-ip_requester_response
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Minor change in method response

--- a/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.15.1-alpha",
+	"version": "0.15.1",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.15.1-alpha';
+	const PACKAGE_VERSION = '0.15.1';
 
 	/**
 	 * Persistent WPCOM blog ID that stays in the options after disconnect.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.12.0] - 2024-02-05
+### Added
+- Adds the completion logic for the Install the mobile app task to Atomic sites" [#35261]
+- Import: adds a banner to wp-admin linking to the Calypso import tool [#35351]
+- Register wp_block patterns from Dotcompatterns with blockTypes [#35337]
+
+### Changed
+- Updated package dependencies. [#35384]
+- Updated Readme to include Verbum issue board and clarify code syncing steps [#35318]
+- Verbum: Minify dynamic-loader script. [#35323]
+- Verbum: Use jetpack-assets package to register scripts using `.asset.php` file data. [#35323]
+- Verbum Comments blocks rollout to 50% of sites [#35446]
+
+### Fixed
+- Esnsure the submit event is fired by the comments form [#35388]
+- Verbum: Avoid copying PHP files into `src/build/verbum-comments/`. [#35323]
+
 ## [5.11.0] - 2024-01-29
 ### Security
 - Allow users to post HTML when blocks are enabled [#35276]
@@ -556,6 +573,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.12.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.11.0...v5.12.0
 [5.11.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.10.0...v5.11.0
 [5.10.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.9.0...v5.10.0
 [5.9.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.8.2...v5.9.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-import-admin-customizations
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-import-admin-customizations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Import: adds a banner to wp-admin linking to the Calypso import tool

--- a/projects/packages/jetpack-mu-wpcom/changelog/chore-register-wp-block-pattern-block-types
+++ b/projects/packages/jetpack-mu-wpcom/changelog/chore-register-wp-block-pattern-block-types
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Register wp_block patterns from Dotcompatterns with blockTypes

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Verbum: Avoid copying PHP files into `src/build/verbum-comments/`.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build#2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Verbum: Minify dynamic-loader script.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build#3
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-build#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Verbum: Use jetpack-assets package to register scripts using `.asset.php` file data.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-comment-reply-text
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-comment-reply-text
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-submit-akismet
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-submit-akismet
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Esnsure the submit event is fired by the comments form

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-subscription-options-no-email
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-subscription-options-no-email
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-request-last-seen-app-from-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-request-last-seen-app-from-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Adds the completion logic for the Install the mobile app task to Atomic sites"

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-verbum-blocks-rollout-50%
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-verbum-blocks-rollout-50%
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Verbum Comments blocks rollout to 50% of sites

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-verbum-readme-sync-step
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-verbum-readme-sync-step
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated Readme to include Verbum issue board and clarify code syncing steps

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.12.0-alpha",
+	"version": "5.12.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.12.0-alpha';
+	const PACKAGE_VERSION = '5.12.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+
 ## [3.0.2] - 2024-01-04
 ### Changed
 - Updated package dependencies. [#34815]
@@ -662,6 +666,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.0.3]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/Automattic/jetpack-jitm/compare/v2.5.3...v3.0.0

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.0.3-alpha';
+	const PACKAGE_VERSION = '3.0.3';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.0] - 2024-02-05
+### Added
+- Add tracking info to the Jetpack Manage Banner CTA [#35378]
+- My Jetpack: support redirect_to parameter on the product interstitial. [#35263]
+
+### Changed
+- Update CTA copy on the connection banner to make it clear which type of connection we are going to request [#35401]
+- Updated package dependencies.
+- Update product cards on My Jetpack to always display the status indidicator. [#35377]
+
+### Fixed
+- Fix issue where most products are not installing their standalone product upon purchase [#35399]
+
 ## [4.7.0] - 2024-01-29
 ### Changed
 - Update the UpsellBanner to use the Card component from WP components. [#35223]
@@ -1214,6 +1227,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.8.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.7.0...4.8.0
 [4.7.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.6.2...4.7.0
 [4.6.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.6.1...4.6.2
 [4.6.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.6.0...4.6.1

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add tracking info to the Jetpack Manage Banner CTA

--- a/projects/packages/my-jetpack/changelog/always-show-status-indicator-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/always-show-status-indicator-my-jetpack
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update product cards on My Jetpack to always display the status indidicator.

--- a/projects/packages/my-jetpack/changelog/fix-standalone-installation-for-all-products
+++ b/projects/packages/my-jetpack/changelog/fix-standalone-installation-for-all-products
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Fix issue where most products are not installing their standalone product upon purchase

--- a/projects/packages/my-jetpack/changelog/fix-welcome-banner-cta-copy
+++ b/projects/packages/my-jetpack/changelog/fix-welcome-banner-cta-copy
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update CTA copy on the connection banner to make it clear which type of connection we are going to request

--- a/projects/packages/my-jetpack/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/my-jetpack/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/update-discount-price-presentation
+++ b/projects/packages/my-jetpack/changelog/update-discount-price-presentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Small visual change
-
-

--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-card-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-card-my-jetpack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Just a title change
-
-

--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-fix-post-purchase-redirect
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-fix-post-purchase-redirect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-My Jetpack: support redirect_to parameter on the product interstitial.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.8.0-alpha",
+	"version": "4.8.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -34,7 +34,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.8.0-alpha';
+	const PACKAGE_VERSION = '4.8.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.0] - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+- Use Blog ID in links to WPCOM instead of site slug. [#35006]
+
 ## [0.40.0] - 2024-01-18
 ### Changed
 - Changed dismissed notices endpoint to be a core endpoint [#34544]
@@ -458,6 +463,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.41.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.3...v0.39.0
 [0.38.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.38.2...v0.38.3

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/changelog/update-social-wpcom-links-blog-id
+++ b/projects/packages/publicize/changelog/update-social-wpcom-links-blog-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Use Blog ID in links to WPCOM instead of site slug.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.41.0-alpha",
+	"version": "0.41.0",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.0] - 2024-02-05
+### Changed
+- Updated package dependencies. [#35384]
+- Updated package dependencies. [#35385]
+- Use blog ID instead of site slug in checkout links. [#35000]
+
 ## [0.42.1] - 2024-01-29
 ### Changed
 - Update dependencies. [#35170]
@@ -884,6 +890,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.43.0]: https://github.com/Automattic/jetpack-search/compare/v0.42.1...v0.43.0
 [0.42.1]: https://github.com/Automattic/jetpack-search/compare/v0.42.0...v0.42.1
 [0.42.0]: https://github.com/Automattic/jetpack-search/compare/v0.41.1...v0.42.0
 [0.41.1]: https://github.com/Automattic/jetpack-search/compare/v0.41.0...v0.41.1

--- a/projects/packages/search/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/search/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/update-protect-wpcom-links-blog-id
+++ b/projects/packages/search/changelog/update-protect-wpcom-links-blog-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Use blog ID instead of site slug in checkout links.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.43.0-alpha",
+	"version": "0.43.0",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.43.0-alpha';
+	const VERSION = '0.43.0';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.2 - 2024-02-05
+### Changed
+- Update dependencies.
+
 ## 0.15.1 - 2023-12-25
 ### Changed
 - Update dependencies.

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.15.1",
+	"version": "0.15.2",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.15.1';
+	const VERSION = '0.15.2';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2024-02-05
+### Added
+- Stats fetching mechanism: add filter allowing one to customize how long we cache results. [#35421]
+
+### Changed
+- Permit overriding cache when retrieving post views. [#34557]
+- Remove pre-6.3 asset enqueuing method, and relying on WordPress Core method instead. [#34072]
+
+### Removed
+- Stop requiring the Jetpack Assets Composer package. [#34072]
+
 ## [0.9.0] - 2023-12-25
 ### Added
 - Stats: added passing select UTM parameters to Tracking Pixel requests. [#34431]
@@ -118,6 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.10.0]: https://github.com/Automattic/jetpack-stats/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Automattic/jetpack-stats/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Automattic/jetpack-stats/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/Automattic/jetpack-stats/compare/v0.7.1...v0.7.2

--- a/projects/packages/stats/changelog/add-blog-stats-block
+++ b/projects/packages/stats/changelog/add-blog-stats-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Permit overriding cache when retrieving post views.

--- a/projects/packages/stats/changelog/add-script-strategy-support
+++ b/projects/packages/stats/changelog/add-script-strategy-support
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Remove pre-6.3 asset enqueuing method, and relying on WordPress Core method instead.

--- a/projects/packages/stats/changelog/add-script-strategy-support#2
+++ b/projects/packages/stats/changelog/add-script-strategy-support#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Stop requiring the Jetpack Assets Composer package.

--- a/projects/packages/stats/changelog/update-stats-pulling-jetpack-filter
+++ b/projects/packages/stats/changelog/update-stats-pulling-jetpack-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Stats fetching mechanism: add filter allowing one to customize how long we cache results.

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -404,7 +404,7 @@ class WPCOM_Stats {
 		 *
 		 * @module stats
 		 *
-		 * @since $$next-version$$
+		 * @since 0.10.0
 		 *
 		 * @param int $expiration The expiration time in minutes.
 		 */

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2024-02-05
+### Changed
+- Jetpack Connection: Add jetpack_package_versions to Sync [#35409]
+- Jetpack Sync: Disable Sync sending while a Pull is in progress [#35339]
+
 ## [2.4.2] - 2024-01-18
 ### Changed
 - Update dependencies.
@@ -1030,6 +1035,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.5.0]: https://github.com/Automattic/jetpack-sync/compare/v2.4.2...v2.5.0
 [2.4.2]: https://github.com/Automattic/jetpack-sync/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/Automattic/jetpack-sync/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/Automattic/jetpack-sync/compare/v2.3.0...v2.4.0

--- a/projects/packages/sync/changelog/update-jetpack-package-versions-add-to-sync
+++ b/projects/packages/sync/changelog/update-jetpack-package-versions-add-to-sync
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Jetpack Connection: Add jetpack_package_versions to Sync

--- a/projects/packages/sync/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/packages/sync/changelog/update-sync-disable-sending-while-pulling
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Jetpack Sync: Disable Sync sending while a Pull is in progress

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.5.0-alpha';
+	const PACKAGE_VERSION = '2.5.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] - 2024-02-05
+### Changed
+- Updated package dependencies.
+- Use blog ID instead of site slug in checkout URL. [#34996]
+
 ## [0.22.4] - 2024-01-29
 ### Changed
 - Update dependencies.
@@ -1246,6 +1251,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.4...v0.23.0
 [0.22.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.3...v0.22.4
 [0.22.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.2...v0.22.3
 [0.22.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.1...v0.22.2

--- a/projects/packages/videopress/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/videopress/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/update-videopress-wpcom-links-blog-id
+++ b/projects/packages/videopress/changelog/update-videopress-wpcom-links-blog-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Use blog ID instead of site slug in checkout URL.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.0-alpha",
+	"version": "0.23.0",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.0-alpha';
+	const PACKAGE_VERSION = '0.23.0';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2024-02-05
+### Added
+- Run the WAF on JN environments [#35341]
+
 ## [0.12.4] - 2024-01-18
 ### Fixed
 - Optimize how the web application firewall checks for updates on admin screens. [#34820]
@@ -257,6 +261,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.13.0]: https://github.com/Automattic/jetpack-waf/compare/v0.12.4...v0.13.0
 [0.12.4]: https://github.com/Automattic/jetpack-waf/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/Automattic/jetpack-waf/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/Automattic/jetpack-waf/compare/v0.12.1...v0.12.2

--- a/projects/packages/waf/changelog/add-run-waf-on-jn
+++ b/projects/packages/waf/changelog/add-run-waf-on-jn
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Run the WAF on JN environments

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7] - 2024-02-05
+### Changed
+- Updated package dependencies.
+
 ## [0.3.6] - 2024-01-29
 ### Changed
 - Update dependencies. [#35170]
@@ -299,6 +303,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.7]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.3...v0.3.4

--- a/projects/packages/wordads/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/wordads/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.7-alpha",
+	"version": "0.3.7",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.7-alpha';
+	const VERSION = '0.3.7';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.1-beta - 2024-02-05
+### Enhancements
+- Blog Stats Block: allow transforming the Legacy Widget into the new block. [#35408]
+- Gutenberg: Add Blog Stats block. [#34557]
+- Making sharing buttons block visible to all users [#34553]
+- Social: Added recommendation card for the advanced plan [#35244]
+- Top Posts & Pages block: allow transforming the Legacy Widget into the new block. [#34717]
+- Top Posts & Pages block: Remove unnecessary parameters from endpoint. [#34614]
+
+### Improved compatibility
+- Performance: improve script enqueuing strategies to rely on methods introduced in WordPress 6.3. [#34072]
+- Sitemaps: Use wp_loaded filter hook instead of init filter hook to load the permalinks for the sitemaps, Which will allow plugins and other hooks to load. [#34269]
+
+### Bug fixes
+- Dashboard: update the Support card to display the right contents depending on the plan or product used on the site. [#35364]
+- WordPress.com REST API: avoid fatal error when receiving error in API response. [#35389]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add Jetpack Manage banner in the Dashboard [#35283]
+- Admin Interface: remove exception for Import screen on Classic style [#35258]
+- AI Proofread plugin: add feature to the event props [#35370]
+- Fix issue where there are two Jetpack menu items that link users to Jetpack Backup [#35387]
+- Jetpack AI: add loading state to the usage panel. [#35352]
+- Jetpack AI: Build a Calypso URL as the redirect destination for Simple sites after upgrade. [#35376]
+- Jetpack AI: move error handling from top of block to closer the AI Control input. [#35322]
+- Jetpack AI: Use the editor URL as the redirect destination for after-purchase redirect. [#35263]
+- Jetpack Sync: Make media extraction more consistent with regards to getting alt text and image size information [#35369]
+- Remove sharing buttons on Print view. If multiple sharing buttons on the page they all should work. [#35382]
+- Revert the Tools menu to the one in core for the wp-admin interface. [#35212]
+- Sharing: update block markup to simplify output and escape as late as possible. [#35390]
+- Subscriber Login: Allow to add it to the Navigation block [#35410]
+- Subscriber Login: Fix log in URL for simple sites [#35371]
+- Subscriber Login: Move Subscriber Login block to production [#35332]
+- tiled gallery: carousel-image-args.php: Fix PHP warnings from nested arrays in image meta [#35317]
+- Updated package dependencies. [#35384]
+- Updated package dependencies. [#35385]
+- Update the Jetpack Manage Banner trackEvent target name [#35378]
+- Updating sharing buttons control with color styles settings [#35354]
+- Wordpress.com Tools Menu: Add Github Deployments submenu and gate behind a constant [#35350]
+- wpcom_restapi_copy_theme_plugin_actions: Fix PHP 8.1 fatals related to static calls on non-static [#35383]
+
 ## 13.1-a.9 - 2024-01-29
 ### Enhancements
 - Subject: A new way to upload media via the Jetpack App [#34179]

--- a/projects/plugins/jetpack/changelog/add-ai-proofread-event-prop
+++ b/projects/plugins/jetpack/changelog/add-ai-proofread-event-prop
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Proofread plugin: add feature to the event props

--- a/projects/plugins/jetpack/changelog/add-blog-stats-transform
+++ b/projects/plugins/jetpack/changelog/add-blog-stats-transform
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Blog Stats Block: allow transforming the Legacy Widget into the new block.

--- a/projects/plugins/jetpack/changelog/add-github-deployments-menu
+++ b/projects/plugins/jetpack/changelog/add-github-deployments-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Wordpress.com Tools Menu: Add Github Deployments submenu and gate behind a constant

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-manage-banner-tracking-info
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-manage-banner-tracking-info
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-run-waf-on-jn
+++ b/projects/plugins/jetpack/changelog/add-run-waf-on-jn
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-script-strategy-support
+++ b/projects/plugins/jetpack/changelog/add-script-strategy-support
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Performance: improve script enqueuing strategies to rely on methods introduced in WordPress 6.3.

--- a/projects/plugins/jetpack/changelog/add-script-strategy-support#2
+++ b/projects/plugins/jetpack/changelog/add-script-strategy-support#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-social-advanced-recommendation-card
+++ b/projects/plugins/jetpack/changelog/add-social-advanced-recommendation-card
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Social: Added recommendation card for the advanced plan

--- a/projects/plugins/jetpack/changelog/add-stats-block
+++ b/projects/plugins/jetpack/changelog/add-stats-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Gutenberg: Add Blog Stats block.

--- a/projects/plugins/jetpack/changelog/add-top-posts-transform
+++ b/projects/plugins/jetpack/changelog/add-top-posts-transform
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Top Posts & Pages block: allow transforming the Legacy Widget into the new block.

--- a/projects/plugins/jetpack/changelog/fix-action-hook-for-news-sitemap
+++ b/projects/plugins/jetpack/changelog/fix-action-hook-for-news-sitemap
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Sitemaps: Use wp_loaded filter hook instead of init filter hook to load the permalinks for the sitemaps, Which will allow plugins and other hooks to load.

--- a/projects/plugins/jetpack/changelog/fix-admin-menu-jetpack-backup-duplicate
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-jetpack-backup-duplicate
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix issue where there are two Jetpack menu items that link users to Jetpack Backup

--- a/projects/plugins/jetpack/changelog/fix-always-show-status-indicator-my-jetpack
+++ b/projects/plugins/jetpack/changelog/fix-always-show-status-indicator-my-jetpack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-cpt-nova
+++ b/projects/plugins/jetpack/changelog/fix-cpt-nova
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Nova Custom Content Type: avoid PHP notice.
-
-

--- a/projects/plugins/jetpack/changelog/fix-fatal-json-api
+++ b/projects/plugins/jetpack/changelog/fix-fatal-json-api
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-WordPress.com REST API: avoid fatal error when receiving error in API response.

--- a/projects/plugins/jetpack/changelog/fix-make-jetpack-media-extraction-more-consistent
+++ b/projects/plugins/jetpack/changelog/fix-make-jetpack-media-extraction-more-consistent
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack Sync: Make media extraction more consistent with regards to getting alt text and image size information

--- a/projects/plugins/jetpack/changelog/fix-standalone-installation-for-all-products
+++ b/projects/plugins/jetpack/changelog/fix-standalone-installation-for-all-products
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-subscriber-login-login-url
+++ b/projects/plugins/jetpack/changelog/fix-subscriber-login-login-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriber Login: Fix log in URL for simple sites

--- a/projects/plugins/jetpack/changelog/fix-welcome-banner-cta-copy
+++ b/projects/plugins/jetpack/changelog/fix-welcome-banner-cta-copy
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/hide-sharing-buttons-from-print
+++ b/projects/plugins/jetpack/changelog/hide-sharing-buttons-from-print
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Remove sharing buttons on Print view. If multiple sharing buttons on the page they all should work.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.2-a.0
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.1-a.10
-
-

--- a/projects/plugins/jetpack/changelog/make-sharing-block-prod
+++ b/projects/plugins/jetpack/changelog/make-sharing-block-prod
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Making sharing buttons block visible to all users

--- a/projects/plugins/jetpack/changelog/remove-classic-view-import-screen-exception
+++ b/projects/plugins/jetpack/changelog/remove-classic-view-import-screen-exception
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Admin Interface: remove exception for Import screen on Classic style

--- a/projects/plugins/jetpack/changelog/renovate-js-unit-testing-packages
+++ b/projects/plugins/jetpack/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/sharing-buttons-style-improvements
+++ b/projects/plugins/jetpack/changelog/sharing-buttons-style-improvements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updating sharing buttons control with color styles settings

--- a/projects/plugins/jetpack/changelog/update-improve-sharing-buttons-margin
+++ b/projects/plugins/jetpack/changelog/update-improve-sharing-buttons-margin
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Just updating margin styles for button. Change is very insignificant.
-
-

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-post-purchase-redirect
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-post-purchase-redirect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: Use the editor URL as the redirect destination for after-purchase redirect.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-improve-simple-site-redirect-after-upgrade-behavior
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-improve-simple-site-redirect-after-upgrade-behavior
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: Build a Calypso URL as the redirect destination for Simple sites after upgrade.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-move-error-closer-to-assistant-input
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-move-error-closer-to-assistant-input
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: move error handling from top of block to closer the AI Control input.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-usage-panel-loading-state
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-usage-panel-loading-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: add loading state to the usage panel.

--- a/projects/plugins/jetpack/changelog/update-jetpack-manage-banner-cta-tracking-info
+++ b/projects/plugins/jetpack/changelog/update-jetpack-manage-banner-cta-tracking-info
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Update the Jetpack Manage Banner trackEvent target name

--- a/projects/plugins/jetpack/changelog/update-jetpack-package-versions-add-to-sync
+++ b/projects/plugins/jetpack/changelog/update-jetpack-package-versions-add-to-sync
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update Sync related unit tests
-
-

--- a/projects/plugins/jetpack/changelog/update-jp-to-test-v13.1
+++ b/projects/plugins/jetpack/changelog/update-jp-to-test-v13.1
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Jetpack 13.1 to-test.md
-
-

--- a/projects/plugins/jetpack/changelog/update-manage-banner-in-jp-dashboard-and-use-upsellbanner
+++ b/projects/plugins/jetpack/changelog/update-manage-banner-in-jp-dashboard-and-use-upsellbanner
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add Jetpack Manage banner in the Dashboard

--- a/projects/plugins/jetpack/changelog/update-protect-2-wpcom-links-blog-id
+++ b/projects/plugins/jetpack/changelog/update-protect-2-wpcom-links-blog-id
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-protect-wpcom-links-blog-id
+++ b/projects/plugins/jetpack/changelog/update-protect-wpcom-links-blog-id
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-search-wpcom-links-blog-id
+++ b/projects/plugins/jetpack/changelog/update-search-wpcom-links-blog-id
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-sharing-block-markup
+++ b/projects/plugins/jetpack/changelog/update-sharing-block-markup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Sharing: update block markup to simplify output and escape as late as possible.

--- a/projects/plugins/jetpack/changelog/update-social-wpcom-links-blog-id
+++ b/projects/plugins/jetpack/changelog/update-social-wpcom-links-blog-id
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-subscriber-login-allow-in-nav
+++ b/projects/plugins/jetpack/changelog/update-subscriber-login-allow-in-nav
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriber Login: Allow to add it to the Navigation block

--- a/projects/plugins/jetpack/changelog/update-subscriber-login-no-longer-beta
+++ b/projects/plugins/jetpack/changelog/update-subscriber-login-no-longer-beta
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriber Login: Move Subscriber Login block to production

--- a/projects/plugins/jetpack/changelog/update-support-card-products
+++ b/projects/plugins/jetpack/changelog/update-support-card-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Dashboard: update the Support card to display the right contents depending on the plan or product used on the site.

--- a/projects/plugins/jetpack/changelog/update-sync-disable-sending-while-pulling
+++ b/projects/plugins/jetpack/changelog/update-sync-disable-sending-while-pulling
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-tidy-top-posts-endpoint
+++ b/projects/plugins/jetpack/changelog/update-tidy-top-posts-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Top Posts & Pages block: Remove unnecessary parameters from endpoint.

--- a/projects/plugins/jetpack/changelog/update-tiled-gallery-images
+++ b/projects/plugins/jetpack/changelog/update-tiled-gallery-images
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-tiled gallery: carousel-image-args.php: Fix PHP warnings from nested arrays in image meta

--- a/projects/plugins/jetpack/changelog/update-untangle-tools-menu
+++ b/projects/plugins/jetpack/changelog/update-untangle-tools-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Revert the Tools menu to the one in core for the wp-admin interface.

--- a/projects/plugins/jetpack/changelog/update-videopress-wpcom-links-blog-id
+++ b/projects/plugins/jetpack/changelog/update-videopress-wpcom-links-blog-id
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-wpcom_restapi_copy_theme
+++ b/projects/plugins/jetpack/changelog/update-wpcom_restapi_copy_theme
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-wpcom_restapi_copy_theme_plugin_actions: Fix PHP 8.1 fatals related to static calls on non-static

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_a_10",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_beta",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_1_beta",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-a.10
+ * Version: 13.1-beta
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-a.10' );
+define( 'JETPACK__VERSION', '13.1-beta' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.1-beta
+ * Version: 13.2-a.0
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.1-beta' );
+define( 'JETPACK__VERSION', '13.2-a.0' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-a.10",
+	"version": "13.1.0-beta",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.1.0-beta",
+	"version": "13.2.0-a.0",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,12 +293,22 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.1-a.9 - 2024-01-29
+### 13.1-beta - 2024-02-05
 #### Enhancements
-- Subject: A new way to upload media via the Jetpack App
+- Blog Stats Block: allow transforming the Legacy Widget into the new block.
+- Gutenberg: Add Blog Stats block.
+- Making sharing buttons block visible to all users
+- Social: Added recommendation card for the advanced plan
+- Top Posts & Pages block: allow transforming the Legacy Widget into the new block.
+- Top Posts & Pages block: Remove unnecessary parameters from endpoint.
 
 #### Improved compatibility
-- RNMobile: Disable Story block
+- Performance: improve script enqueuing strategies to rely on methods introduced in WordPress 6.3.
+- Sitemaps: Use wp_loaded filter hook instead of init filter hook to load the permalinks for the sitemaps, Which will allow plugins and other hooks to load.
+
+#### Bug fixes
+- Dashboard: update the Support card to display the right contents depending on the plan or product used on the site.
+- WordPress.com REST API: avoid fatal error when receiving error in API response.
 
 --------
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -295,19 +295,45 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 == Changelog ==
 ### 13.1-beta - 2024-02-05
 #### Enhancements
+- Add support for WooCommerce HPOS to the Google Analytics module.
 - Blog Stats Block: allow transforming the Legacy Widget into the new block.
+- Changed dismissed notices endpoint to be a core endpoint
+- GIF Block: Accept Giphy shortlinks as a valid embed.
+- GIF Block: fix styling of the search bar input.
 - Gutenberg: Add Blog Stats block.
+- Jetpack Search: Add 'price' as the default sorting option.
+- Like block: Move the block from beta to production
 - Making sharing buttons block visible to all users
+- Related Posts: Get the related posts only when the option is turned on and the current post contains a Related Posts block
 - Social: Added recommendation card for the advanced plan
+- Subject: A new way to upload media via the Jetpack App
+- Subscribe block: add buttons transform
+- Subscribe block: don't allow editing the email for subscribing for logged-in members.
+- Subscribe Block: Don't include social followers on counts by default.
 - Top Posts & Pages block: allow transforming the Legacy Widget into the new block.
 - Top Posts & Pages block: Remove unnecessary parameters from endpoint.
 
 #### Improved compatibility
+- Likes: Flip likers popup when overflowing viewport.
 - Performance: improve script enqueuing strategies to rely on methods introduced in WordPress 6.3.
+- Post Images: avoid PHP warnings on sites using PHP 8.1+, when a post image has a malformed URL.
+- RNMobile: Disable Story block
 - Sitemaps: Use wp_loaded filter hook instead of init filter hook to load the permalinks for the sitemaps, Which will allow plugins and other hooks to load.
 
 #### Bug fixes
+- AI Assistant: avoid deprecation notices when using a development version of WordPress.
+- AI Assistant: do not attempt to display the AI Excerpt assistant in the site editor and the widget editor.
 - Dashboard: update the Support card to display the right contents depending on the plan or product used on the site.
+- Enhanced WordPress.com API compatibility with third party plugin data.
+- Fixes recurring payments buttons multiple plan support.
+- iCalendarReader: Support BYDAY recurrence rules for last, second-to-last, or third-to-last weekdays
+- Subscribe block: fix spacing of "pending email confirmation" message in some themes
+- Subscribe modal: Don't show in Elementor editor
+- Subscriptions: do not display subscription checkboxes in comment forms displayed on Custom Post Type pages.
+- Subscriptions: Fix broken subscribe button in email
+- Subscriptions: Fix page scrolling up after the subscription modal is dismissed
+- Subscriptions: Fix subscribtion modal appear right after subscribing
+- Theme Tools: Ensure that Content Options does not override the Featured Images options set within blocks.
 - WordPress.com REST API: avoid fatal error when receiving error in API response.
 
 --------

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.18 - 2024-02-05
+### Changed
+- Internal updates.
+
 ## 2.0.17 - 2024-01-29
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-script-strategy-support
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-script-strategy-support
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/chore-register-wp-block-pattern-block-types
+++ b/projects/plugins/mu-wpcom-plugin/changelog/chore-register-wp-block-pattern-block-types
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-verbum-build
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-verbum-build
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-verbum-readme-sync-step
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-verbum-readme-sync-step
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_18_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_18"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.18-alpha
+ * Version: 2.0.18
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.18-alpha",
+	"version": "2.0.18",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.18, jetpack 13.1-beta

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.