### PR TITLE
Jetpack: redirect users to "My Jetpack" upon plugin activation

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-post-activation-redirect
+++ b/projects/plugins/jetpack/changelog/add-jetpack-post-activation-redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Plugin activation: redirect to My Jetpack once activated. 

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3332,6 +3332,9 @@ p {
 		/** Already documented in automattic/jetpack-connection::src/class-client.php */
 		$client_verify_ssl_certs = apply_filters( 'jetpack_client_verify_ssl_certs', false );
 
+		// Run post-activation actions if needed.
+		$this->plugin_post_activation();
+
 		if ( ( self::is_connection_ready() || $is_offline_mode ) && false === $fallback_no_verify_ssl_certs && ! $client_verify_ssl_certs ) {
 			// Upgrade: 1.1 -> 1.1.1
 			// Check and see if host can verify the Jetpack servers' SSL certificate.
@@ -6921,5 +6924,22 @@ endif;
 			. '</a>';
 
 		return $plugin_meta;
+	}
+
+	/**
+	 * Run plugin post-activation actions if we need to.
+	 *
+	 * @return void
+	 */
+	private function plugin_post_activation() {
+		if ( ( new Status() )->is_offline_mode() ) {
+			return;
+		}
+
+		if ( get_transient( 'activated_jetpack' ) ) {
+			delete_transient( 'activated_jetpack' );
+
+			wp_safe_redirect( static::admin_url( 'page=my-jetpack' ) );
+		}
 	}
 }


### PR DESCRIPTION
## Proposed changes:
* Redirect users to "My Jetpack" upon plugin activation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-qWK-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Go to "Plugins" and deactivate Jetpack and all standalone plugins.
2. Activate Jetpack.
3. Confirm you got redirected to the "My Jetpack" page.
4. If you're using a new site without any standalone plugins installed, "My Jetpack" should display the "Welcome to Jetpack!" banner.