### PR TITLE
Forms: fix multiple and single choice fields button style

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-radio-button-block-variation
+++ b/projects/packages/forms/changelog/fix-contact-form-radio-button-block-variation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix multiple and single choice fields button style

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.3",
+	"version": "0.30.4-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.3';
+	const PACKAGE_VERSION = '0.30.4-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -611,23 +611,56 @@ on production builds, the attributes are being reordered, causing side-effects
 	width: calc(var(--jetpack--contact-form--font-size) / 2);
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-checkbox-multiple-label,
+.contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-radio-label {
-	color: var(--jetpack--contact-form--button-outline--text-color);
-	border: var(--jetpack--contact-form--button-outline--border);
-	border-color: transparent;
-	border-radius: unset;
+	display: inline-flex;
+  align-items: center;
+
 	padding: var(--jetpack--contact-form--button-outline--padding);
+
+	background: var(--jetpack--contact-form--button-outline--background-color);
+	border: var(--jetpack--contact-form--button-outline--border);
+	border-radius: var(--jetpack--contact-form--button-outline--border-radius);
+	color: var(--jetpack--contact-form--button-outline--text-color);
+
 	line-height: var(--jetpack--contact-form--button-outline--line-height);
-	cursor: pointer;
-	position: relative;
-	z-index: 0;
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-radio-label {
-	position: relative;
-	flex-direction: row-reverse;
-	gap: 16px;
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button {
+	/* visually-hidden */
+	clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked + .grunion-radio-label {
+	display: inline-flex;
+	gap: 0.5em;
+}
+
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked + .grunion-radio-label:before {
+	content: "\2713";
+}
+
+.contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field:focus-within,
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:focus + .grunion-radio-label {
+	outline: var(--jetpack--contact-form--button-outline--border);
+	outline-offset: 2px;
+}
+
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple.is-style-button {
+	border-radius: var(--jetpack--contact-form--button-outline--border-radius);
+	color: var(--jetpack--contact-form--button-outline--text-color);
+
+	font-family: var(--wp--preset--font-family--body);
+}
+
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple.is-style-button:focus {
+	outline-width: 0; /* focus style defined on parent */
 }
 
 .contact-form input.grunion-field.is-style-button + .grunion-field-text::before {
@@ -650,7 +683,6 @@ on production builds, the attributes are being reordered, causing side-effects
 	color: var(--jetpack--contact-form--button-outline--color);
 }
 
-
 .contact-form input.grunion-field.is-style-button:checked,
 .contact-form input.grunion-field.is-style-button:checked + .grunion-field-text {
 	color: var(--jetpack--contact-form--button-outline--background-color-fallback);
@@ -659,42 +691,6 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form input.grunion-field.is-style-button:checked + .grunion-field-text::before {
 	background: var(--jetpack--contact-form--button-outline--text-color);
 	border-color: var(--jetpack--contact-form--button-outline--text-color);
-}
-
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio {
-	align-items: center;
-	border: none;
-	display: flex;
-	height: auto;
-	margin: 0;
-	position: absolute;
-	padding: 0;
-	visibility: hidden;
-	width: auto;
-}
-
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio:checked {
-	position: relative;
-	visibility: visible;
-}
-
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio::before {
-	display: none;
-}
-
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio::after {
-	background: unset;
-	content: "✓";
-	display: block;
-	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
-	font-weight: 400;
-	font-size: 1em;
-	height: auto;
-	margin: -0.2em 0 0;
-	position: relative;
-	transform: unset;
-	visibility: inherit;
-	width: auto;
 }
 
 .contact-form__error,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35089

## Proposed changes:
This PR fixes the _Button_ style of the multiple and single choice fields on the front end (see linked issue). It also makes sure the fields are usable with a keyboard.

| Before | After |
| - | - |
|<img width="189" alt="Screenshot 2024-02-05 at 3 46 35 PM" src="https://github.com/Automattic/jetpack/assets/1620183/9179432b-11af-496b-85cb-81391294cdff">|<img width="190" alt="Screenshot 2024-02-05 at 3 41 56 PM" src="https://github.com/Automattic/jetpack/assets/1620183/e49a947a-7a71-4748-a293-a93512feba00">|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Build the package: `cd projects/packages/forms && npm run build`
- Create a new post
- Add a _Contact Form_ block
- Add a _Single Choice_ and _Multiple Choice_ fields to the form
- Open the preview and check they look and behave normally
- Back in the editor, update their style to _Button_
<img width="280" alt="Screenshot 2024-02-05 at 2 35 05 PM" src="https://github.com/Automattic/jetpack/assets/1620183/51197de6-648d-499d-9664-a95075388ada">

- In the preview, check that the style is the same as in the editor and that the form behaves normally


