### PR TITLE
Related Posts: fix SVG notice in block editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-notice-svg
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-notice-svg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Related Posts: fix SVG notice in block.

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/edit.js
@@ -45,7 +45,7 @@ function PlaceholderPostEdit( props ) {
 						viewBox="0 0 350 200"
 					>
 						<title>{ __( 'Grey square', 'jetpack' ) }</title>
-						<Path d="M0 0h350v200H0z" fill="#8B8B96" fill-opacity=".1" />
+						<Path d="M0 0h350v200H0z" fill="#8B8B96" fillOpacity=".1" />
 					</SVG>
 					<SVG
 						className="jp-related-posts-i2__post-image-placeholder-icon"


### PR DESCRIPTION
## Proposed changes:

Since we're not using native SVG, we must adapt syntax for SVG properties.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site connected to WordPress.com, and using a block-based theme like Twenty Twenty Four.
* Go to Appearance > Site Editor > Templates > Single posts
* Add a Related Posts block.
* Notice the following notice in your browser console:

```
Warning: Invalid DOM property `fill-opacity`. Did you mean `fillOpacity`?
```

* Apply this PR.
* Refresh the page.
* The notice should disappear.

