### PR TITLE
Untangle: introduce use_untangled_interface() toggle

### DIFF
--- a/projects/plugins/jetpack/changelog/use-untangled-interface-toggle
+++ b/projects/plugins/jetpack/changelog/use-untangled-interface-toggle
@@ -1,0 +1,5 @@
+Significance: minor
+Type: other
+
+Introduce a new "use_untangled_interface()" toggle in the masterbar module, as a flag whether we should show the "untangled" menus.
+Untangled menus are those matching Core structure as similar as possible.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -392,7 +392,7 @@ class Admin_Menu extends Base_Admin_Menu {
 	 * @param int  $position  Menu position.
 	 * @param bool $separator Whether to add a separator before the menu.
 	 */
-	public function create_jetpack_menu( $position = 50, $separator = true ) {
+	public function create_jetpack_menu( $position, $separator ) {
 		if ( $separator ) {
 			$this->add_admin_menu_separator( $position, 'manage_options' );
 			++$position;
@@ -424,7 +424,12 @@ class Admin_Menu extends Base_Admin_Menu {
 	 * Adds Jetpack menu.
 	 */
 	public function add_jetpack_menu() {
-		$this->create_jetpack_menu();
+		if ( $this->use_untangled_interface() ) {
+			// Use a different position for the Jetpack menu.
+			$this->create_jetpack_menu( 2, false );
+		} else {
+			$this->create_jetpack_menu( 50, true );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -75,9 +75,13 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$this->add_my_home_menu();
 		$this->remove_gutenberg_menu();
 
-		// We don't need the `My Mailboxes` when the interface is set to wp-admin or the site is a staging site,
-		if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' && ! get_option( 'wpcom_is_staging_site' ) ) {
-			$this->add_my_mailboxes_menu();
+		if ( ! get_option( 'wpcom_is_staging_site' ) ) {
+			if ( ! $this->use_untangled_interface() ) {
+				// Only show the My Mailbox submenu when not in the untangled interface.
+				// The functionalites are already present in Upgrades -> Emails.
+
+				$this->add_my_mailboxes_menu();
+			}
 		}
 
 		// Not needed outside of wp-admin.
@@ -334,12 +338,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds Jetpack menu.
 	 */
 	public function add_jetpack_menu() {
-		// This is supposed to be the same as class-admin-menu but with a different position specified for the Jetpack menu.
-		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
-			parent::create_jetpack_menu( 2, false );
-		} else {
-			parent::add_jetpack_menu();
-		}
+		parent::add_jetpack_menu();
 
 		/**
 		 * Prevent duplicate menu items that link to Jetpack Backup.
@@ -431,9 +430,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// performance settings already have a link to Page Optimize settings page.
 		$this->hide_submenu_page( 'options-general.php', 'page-optimize' );
 
-		// Hide Settings > Performance when the interface is set to wp-admin.
-		// This is due to these settings are mostly also available in Jetpack > Settings, in the Performance tab.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		if ( $this->use_untangled_interface() ) {
+			// Hide Settings -> Performance submenu.
+			// These settings are mostly also available in Jetpack -> Settings, in the Performance tab.
 			$this->hide_submenu_page( 'options-general.php', 'https://wordpress.com/settings/performance/' . $this->domain );
 		}
 	}
@@ -444,8 +443,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_tools_menu() {
 		parent::add_tools_menu();
 
-		// Link the Tools menu to Available Tools when the interface is set to wp-admin.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		if ( $this->use_untangled_interface() ) {
+			// Link the Tools menu to Available Tools.
 			add_submenu_page( 'tools.php', esc_attr__( 'Available Tools', 'jetpack' ), __( 'Available Tools', 'jetpack' ), 'edit_posts', 'tools.php', null, 0 );
 		}
 
@@ -566,10 +565,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds Appearance menu.
 	 */
 	public function add_appearance_menu() {
-		// When the interface is set to wp-admin, we need to add a link to the Marketplace and rest of the menu keeps like core.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		if ( $this->use_wp_admin_interface() ) {
+			// Show Core submenus, then re-add Theme Showcase submenu pointing to the Calypso page.
 			add_submenu_page( 'themes.php', esc_attr__( 'Theme Showcase', 'jetpack' ), __( 'Theme Showcase', 'jetpack' ), 'read', 'https://wordpress.com/themes/' . $this->domain );
 		} else {
+			// Show Theme Showcase submenu as Calypso page.
 			parent::add_appearance_menu();
 		}
 	}
@@ -578,8 +578,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds a dashboard switcher to the list of screen meta links of the current page.
 	 */
 	public function add_dashboard_switcher() {
-		// When the interface is set to wp-admin, do not show the dashboard switcher.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		if ( $this->use_wp_admin_interface() ) {
+			// Do not show the dashboard switcher.
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -786,6 +786,16 @@ abstract class Base_Admin_Menu {
 	}
 
 	/**
+	 * Whether to show the untangled interface; i.e., matching Core's menus as similar as possible.
+	 *
+	 * @return bool
+	 */
+	public function use_untangled_interface() {
+		// Temporarily reuse the admin interface style toggle for now.
+		return $this->use_wp_admin_interface();
+	}
+
+	/**
 	 * Create the desired menu output.
 	 */
 	abstract public function reregister_menu_items();


### PR DESCRIPTION
## Proposed changes:

Currently, we're using the "if the current admin interface style is classic" check as a flag on whether we should show the untangled menus: both the structure (where should a menu lives) and the content (for a menu, if the classic view is set, show the wp-admin version).

However, now we want to be able to release the new structure for all users. Therefore the above conditions will need to be independent. This PR splits the check into one of the following independent checks:

- `use_wp_admin_interface()` -- whether the admin interface style is set to classic
- `use_untangled_interface()` -- whether we should show the new menus IA; the "untangled" ones matching Core's structure as similar as possible.

I categorized the merged PRs are as follows:

Should use `use_wp_admin_interface()` check:

- https://github.com/Automattic/jetpack/pull/35145
- https://github.com/Automattic/jetpack/pull/35210

Should use `use_untangled_interface()` check:

- https://github.com/Automattic/jetpack/pull/35154
- https://github.com/Automattic/jetpack/pull/35212
- https://github.com/Automattic/jetpack/pull/35217
- https://github.com/Automattic/jetpack/pull/35439

Let me know if I mis-categorized anything.

While I'm modifying the changes, I also improved the comments a little bit.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Re-test the above linked PRs.
