### PR TITLE
Social: Implement the fix for the title-less post

### DIFF
--- a/projects/plugins/social/changelog/fix-support-for-titless-posts
+++ b/projects/plugins/social/changelog/fix-support-for-titless-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Implemented titless permalink fixes. 

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -87,6 +87,7 @@ if ( is_readable( $jetpack_autoloader ) ) {
 }
 
 register_activation_hook( JETPACK_SOCIAL_PLUGIN_ROOT_FILE_RELATIVE_PATH, array( 'Jetpack_Social', 'plugin_activation' ) );
+register_deactivation_hook( JETPACK_SOCIAL_PLUGIN_ROOT_FILE_RELATIVE_PATH, array( 'Jetpack_Social', 'plugin_deactivation' ) );
 
 // Main plugin class.
 new Jetpack_Social();

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -87,7 +87,6 @@ if ( is_readable( $jetpack_autoloader ) ) {
 }
 
 register_activation_hook( JETPACK_SOCIAL_PLUGIN_ROOT_FILE_RELATIVE_PATH, array( 'Jetpack_Social', 'plugin_activation' ) );
-register_deactivation_hook( JETPACK_SOCIAL_PLUGIN_ROOT_FILE_RELATIVE_PATH, array( 'Jetpack_Social', 'plugin_deactivation' ) );
 
 // Main plugin class.
 new Jetpack_Social();

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -104,7 +104,7 @@ class Jetpack_Social {
 				My_Jetpack_Initializer::init();
 			}
 		);
-		add_action( 'init', array( new Automattic\Jetpack\Social\Note(), 'register' ) );
+		add_action( 'init', array( new Automattic\Jetpack\Social\Note(), 'init' ) );
 
 		$this->manager = $connection_manager ? $connection_manager : new Connection_Manager();
 

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -396,15 +396,6 @@ class Jetpack_Social {
 	}
 
 	/**
-	 * Plugin deactivation actions to take.
-	 *
-	 * @static
-	 */
-	public static function plugin_deactivation() {
-		Automattic\Jetpack\Social\Note::delete_rewrite_rules_option();
-	}
-
-	/**
 	 * Helper to check that we have a Jetpack connection.
 	 */
 	private function is_connected() {

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -396,6 +396,15 @@ class Jetpack_Social {
 	}
 
 	/**
+	 * Plugin deactivation actions to take.
+	 *
+	 * @static
+	 */
+	public static function plugin_deactivation() {
+		Automattic\Jetpack\Social\Note::delete_rewrite_rules_option();
+	}
+
+	/**
 	 * Helper to check that we have a Jetpack connection.
 	 */
 	private function is_connected() {

--- a/projects/plugins/social/src/class-note.php
+++ b/projects/plugins/social/src/class-note.php
@@ -76,6 +76,7 @@ class Note {
 			'show_in_rest' => true,
 			'supports'     => array( 'editor', 'thumbnail', 'publicize', 'activitypub' ),
 			'menu_icon'    => 'dashicons-welcome-write-blog',
+			'rewrite'      => array( 'slug' => 'sn' ),
 		);
 		register_post_type( self::JETPACK_SOCIAL_NOTE_CPT, $args );
 		static::maybe_flush_rewrite_rules();

--- a/projects/plugins/social/src/class-note.php
+++ b/projects/plugins/social/src/class-note.php
@@ -83,7 +83,7 @@ class Note {
 			'menu_icon'    => 'dashicons-welcome-write-blog',
 		);
 		register_post_type( self::JETPACK_SOCIAL_NOTE_CPT, $args );
-		static::may_be_flush_rewrite_rules( true );
+		static::may_be_flush_rewrite_rules();
 	}
 
 	/**
@@ -92,9 +92,16 @@ class Note {
 	 * @param boolean $force Force flush the rewrite rules.
 	 */
 	public static function may_be_flush_rewrite_rules( $force = false ) {
-		if ( ! empty( get_option( self::JETPACK_SOCIAL_REWRITE_RULES_LAST_FLUSHED_AT ) ) || $force ) {
+		if ( empty( get_option( self::JETPACK_SOCIAL_REWRITE_RULES_LAST_FLUSHED_AT ) ) || $force ) {
 			flush_rewrite_rules();
 			update_option( self::JETPACK_SOCIAL_REWRITE_RULES_LAST_FLUSHED_AT, time() );
 		}
+	}
+
+	/**
+	 * Delete the JETPACK_SOCIAL_REWRITE_RULES_LAST_FLUSHED_AT option when plugin is deactivated.
+	 */
+	public static function delete_rewrite_rules_option() {
+		delete_option( self::JETPACK_SOCIAL_REWRITE_RULES_LAST_FLUSHED_AT );
 	}
 }

--- a/projects/plugins/social/src/class-note.php
+++ b/projects/plugins/social/src/class-note.php
@@ -12,23 +12,23 @@ namespace Automattic\Jetpack\Social;
  */
 class Note {
 	const JETPACK_SOCIAL_NOTE_CPT     = 'jetpack-social-note';
-	const FLUSH_REWRITE_RULES_FLUSHED = 'jetpack_socia_rewrite_rules_flushed';
+	const FLUSH_REWRITE_RULES_FLUSHED = 'jetpack_social_rewrite_rules_flushed';
 
 	/**
 	 * Check if the feature is enabled.
 	 */
-	public static function enabled() {
+	public function enabled() {
 		return get_option( self::JETPACK_SOCIAL_NOTE_CPT );
 	}
 
 	/**
 	 * Initialize the Jetpack Social Note custom post type.
 	 */
-	public static function init() {
-		if ( ! static::enabled() ) {
+	public function init() {
+		if ( ! self::enabled() ) {
 			return;
 		}
-		static::register_cpt();
+		self::register_cpt();
 		add_action( 'wp_insert_post_data', array( new Note(), 'set_empty_title' ), 10, 2 );
 	}
 
@@ -38,7 +38,7 @@ class Note {
 	 * @param array $data The Post Data.
 	 * @param array $post The Post.
 	 */
-	public static function set_empty_title( $data, $post ) {
+	public function set_empty_title( $data, $post ) {
 		if ( self::JETPACK_SOCIAL_NOTE_CPT === $post['post_type'] && 'auto-draft' === $post['post_status'] ) {
 			$data['post_title'] = '';
 		}
@@ -48,7 +48,7 @@ class Note {
 	/**
 	 * Register the Jetpack Social Note custom post type.
 	 */
-	public static function register_cpt() {
+	public function register_cpt() {
 		$args = array(
 			'public'       => true,
 			'labels'       => array(
@@ -79,7 +79,7 @@ class Note {
 			'rewrite'      => array( 'slug' => 'sn' ),
 		);
 		register_post_type( self::JETPACK_SOCIAL_NOTE_CPT, $args );
-		static::maybe_flush_rewrite_rules();
+		self::maybe_flush_rewrite_rules();
 	}
 
 	/**
@@ -87,7 +87,7 @@ class Note {
 	 *
 	 * @param boolean $force Force flush the rewrite rules.
 	 */
-	public static function maybe_flush_rewrite_rules( $force = false ) {
+	public function maybe_flush_rewrite_rules( $force = false ) {
 		if ( empty( get_option( self::FLUSH_REWRITE_RULES_FLUSHED ) ) || $force ) {
 			flush_rewrite_rules( false );
 			update_option( self::FLUSH_REWRITE_RULES_FLUSHED, true );
@@ -97,8 +97,8 @@ class Note {
 	/**
 	 * Toggle whether or not the Notes feature is enabled.
 	 */
-	public static function toggle_enabled_status() {
-		if ( ! static::enabled() ) {
+	public function toggle_enabled_status() {
+		if ( ! self::enabled() ) {
 			update_option( self::JETPACK_SOCIAL_NOTE_CPT, true );
 		} else {
 			delete_option( self::JETPACK_SOCIAL_NOTE_CPT );

--- a/projects/plugins/social/tests/php/test-class-jetpack-social.php
+++ b/projects/plugins/social/tests/php/test-class-jetpack-social.php
@@ -77,17 +77,18 @@ class Jetpack_Social_Test extends BaseTestCase {
 	 * Test the social notes feature.
 	 */
 	public function test_social_notes() {
-		Note::init();
+		$note = new Note();
+		$note->init();
 		$this->assertEmpty( get_option( Note::FLUSH_REWRITE_RULES_FLUSHED ) );
 		update_option( Note::JETPACK_SOCIAL_NOTE_CPT, true );
-		Note::init();
+		$note->init();
 		$this->assertTrue( get_option( Note::FLUSH_REWRITE_RULES_FLUSHED ) );
-		Note::toggle_enabled_status();
-		$this->assertFalse( Note::enabled() );
-		Note::init();
+		$note->toggle_enabled_status();
+		$this->assertFalse( $note->enabled() );
+		$note->init();
 		$this->assertEmpty( get_option( Note::FLUSH_REWRITE_RULES_FLUSHED ) );
-		Note::toggle_enabled_status();
-		Note::init();
+		$note->toggle_enabled_status();
+		$note->init();
 		$this->assertTrue( get_option( Note::FLUSH_REWRITE_RULES_FLUSHED ) );
 	}
 }

--- a/projects/plugins/social/tests/php/test-class-jetpack-social.php
+++ b/projects/plugins/social/tests/php/test-class-jetpack-social.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Social\Note;
 use WorDBless\BaseTestCase;
 
 /**
@@ -56,7 +57,7 @@ class Jetpack_Social_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Testh that the Publicize package isn't ensured without a user connection
+	 * Test that the Publicize package isn't ensured without a user connection
 	 */
 	public function test_publicize_not_configured() {
 		$connection_manager = $this->createMock( Connection_Manager::class );
@@ -70,5 +71,23 @@ class Jetpack_Social_Test extends BaseTestCase {
 		do_action( 'plugins_loaded' );
 
 		$this->assertSame( 0, did_action( 'jetpack_feature_publicize_enabled' ) );
+	}
+
+	/**
+	 * Test the social notes feature.
+	 */
+	public function test_social_notes() {
+		Note::init();
+		$this->assertEmpty( get_option( Note::FLUSH_REWRITE_RULES_FLUSHED ) );
+		update_option( Note::JETPACK_SOCIAL_NOTE_CPT, true );
+		Note::init();
+		$this->assertTrue( get_option( Note::FLUSH_REWRITE_RULES_FLUSHED ) );
+		Note::toggle_enabled_status();
+		$this->assertFalse( Note::enabled() );
+		Note::init();
+		$this->assertEmpty( get_option( Note::FLUSH_REWRITE_RULES_FLUSHED ) );
+		Note::toggle_enabled_status();
+		Note::init();
+		$this->assertTrue( get_option( Note::FLUSH_REWRITE_RULES_FLUSHED ) );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

There is a problem when you register a post type without support for title where the title is set to 'Auto Draft' and the permalink also has auto-draft. This means the post's permalink takes you to a 404 page. 

Also, we need to flush the rewrite rules when creating new post types. Ref: https://developer.wordpress.org/reference/functions/flush_rewrite_rules/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hooked on to `wp_insert_post_data` to set the title to be an empty string. 
* Flush rewrite rules if it has not been flushed. 
* Flushing rewrite rules is expensive, so we are doing it only if it hasn't been done before using an option.
* Set the slug to be 'sn' for Social Notes in the permalink, so the permalink will look like this https://your-site.com/sn/36/
* Change the feature check to use the options instead of the constant 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On the bleeding edge, boot up a JN site and ensure you have this constant `define( 'JETPACK_SOCIAL_NOTES_ENABLED', true );`
* Create a Socia Note and go to the social notes list view and you will see that if you click on the view button, you will see a 404 error. 
* On this branch, run `jetpack docker wp option update jetpack-social-note true` to enable social notes. If you are on JN, use the code snippets plugin and run `update_option('jetpack-social-note', true)` and execute it once.
* Run this branch on your site and try the above step again, you will be taken to the post correctly. 
* Run `jetpack docker wp option delete jetpack-social-note` to see that Social Notes have disappeared from your admin menu. If you are on JN, use the code snippets plugin and run `delete_option('jetpack-social-note', true)` and execute it once.
* Run `composer phpunit` from the plugin's directory to make sure the tests run correctly. 
