### PR TITLE
Launchpad: Make the 'Install the mobile app' task visible to Simple and Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-show-mobile-app-installed-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-show-mobile-app-installed-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make the 'Install the mobile app' task visibile to Simple and Atomic.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.12.0",
+	"version": "5.12.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.12.0';
+	const PACKAGE_VERSION = '5.12.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -580,7 +580,6 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Install the mobile app', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_mobile_app_installed',
-			'is_visible_callback'  => 'wpcom_launchpad_is_mobile_app_installed_visible',
 			'get_calypso_path'     => function () {
 				return '/me/get-apps';
 			},
@@ -955,18 +954,6 @@ function wpcom_launchpad_is_domain_upsell_task_visible() {
 	);
 
 	return empty( $bundle_purchases );
-}
-
-/**
- * Determines whether or not the Install the mobile app task should be visible.
- *
- * @return bool True if the Install the mobile app task should be visible.
- */
-function wpcom_launchpad_is_mobile_app_installed_visible() {
-	// TODO: We are hidding the task for now because we the completion logic
-	// is not fully implemented yet. We should make it return true for simple sites
-	// once we get the completion logic in place.
-	return false;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/87097

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR makes the "Install the mobile app" task visible since we shipped D136776-code, and it will now work on the full cycle. 
* The task was hidden because the changes on the endpoint were not ready when we shipped it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Testing on Simple

* Apply this PR to your sandbox using the following command:
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/show-mobile-app-installed-task
```
* Make sure you close the Jetpack on your phone
* Clean the `jp_mobile_app_last_seen` user attribute through `wpsh`:
```
return delete_user_attribute(USER_ID, 'jp_mobile_app_last_seen');
```
* Create a new site through the `/setup/free` flow
* Launch your site once you reach the fullscreen Launchpad step
* Once you reach the Customer Home page, click on the `Show site setup` button on the banner
* You should see the "Install the mobile app" task
* Open up the Jetpack mobile app on your phone.
* Now go back to the Customer Home page and refresh it. The "Install the mobile app" should be marked as complete.

### Testing on Atomic

* Make sure you close the Jetpack on your phone
* Clean the `jp_mobile_app_last_seen` user attribute through `wpsh`:
```
return delete_user_attribute(USER_ID, 'jp_mobile_app_last_seen');
```
* Create a new site through the `/setup/free` flow
* Launch your site once you reach the fullscreen Launchpad step
* Now, add your site to the WoA Developer list.
* Transfer it to Atomic by navigating to `/hosting-config/:siteSlug` and activating the SSH. You'll need to add the Creator plan to your site.
* Once your site is Atomic, use the credentials on `/hosting-config/:siteSlug` to access the SSH
* Use the Jetpack Beta plugin to apply this PR to your site(You may have to update the files manually, as the plugin doesn't seem to work on my end)
* On the Customer Home, make sure you can see the "Install the mobile app" task
* Open up the Jetpack mobile app on your phone.
* Now go back to the Customer Home page and refresh it. The "Install the mobile app" should be marked as complete.