### PR TITLE
Repo gardening > Board triage: update team Zap's assignments

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-zap-assignment
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-zap-assignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Board triage: update team Zap's assignment settings.

--- a/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
@@ -21,12 +21,6 @@ export const automatticAssignments = {
 		slack_id: 'C01B6KEJ5GE',
 		board_id: 'https://github.com/orgs/Automattic/projects/718',
 	},
-	Newsletter: {
-		team: 'Zap',
-		labels: [ '[Block] Subscriptions', '[Block] Paywall', '[Feature] Subscriptions' ],
-		slack_id: 'C02NQ4HMJKV',
-		board_id: 'https://github.com/orgs/Automattic/projects/657',
-	},
 	Reader: {
 		team: 'Loop',
 		labels: [ '[Feature] Reader' ],
@@ -99,6 +93,12 @@ export const automatticAssignments = {
 		team: 'Agora',
 		labels: [ '[Package] My Jetpack' ],
 		slack_id: 'C02TQF5VAJD',
+	},
+	Newsletter: {
+		team: 'Zap',
+		labels: [ '[Block] Subscriptions', '[Block] Paywall' ],
+		slack_id: 'C02NQ4HMJKV',
+		board_id: 'https://github.com/orgs/Automattic/projects/657',
 	},
 	Protect: {
 		team: 'Scan',


### PR DESCRIPTION
## Proposed changes:

- The team is now part of the Jetpack division
- Let's not automate assignments for the "Subscriptions" label, since team Apex also works on a lot of things under that label.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* This can only be tested once that PR will have been merged.
* You can test in a fork, but that will require adjusting settings from the automattic org to your own.
* I would recommend checking that the new object makes sense, and is valid js.
