### PR TITLE
Jetpack: Fix woocommerce-analytics script enqueuing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-woocommerce-analytics-script-enqueue
+++ b/projects/plugins/jetpack/changelog/fix-woocommerce-analytics-script-enqueue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WooCommerce Analytics: Resolve warning when enqueuing analytics script.

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
@@ -5,8 +5,6 @@
  * @package automattic/jetpack
  */
 
-use Automattic\Jetpack\Assets;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -114,19 +112,19 @@ class Jetpack_WooCommerce_Analytics {
 	 * Place script to call s.js, Store Analytics.
 	 */
 	public function enqueue_tracking_script() {
-		$filename = sprintf(
+		$url = sprintf(
 			'https://stats.wp.com/s-%d.js',
 			gmdate( 'YW' )
 		);
 
-		Assets::register_script(
+		wp_enqueue_script(
 			'woocommerce-analytics',
-			esc_url( $filename ),
-			__FILE__,
+			$url,
+			array(),
+			null, // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- The version is set in the URL.
 			array(
 				'in_footer' => false,
 				'strategy'  => 'defer',
-				'enqueue'   => true,
 			)
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #34072 we replaced a call to the being-deprecated `Assets::enqueue_async_script()` method, which is ok with being passed a URL, with `Assets::register_script()`, which requires a pathname. This results in a PHP warning about filemtime and an incorrect script being enqueued.

Switch it to calling WP Core's `wp_enqueue_script()` instead. And name the variable correctly for good measure.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1707237842852709-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Kind of, in that #34072 accidentally broke a tracking thing and this fixes it.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a site with Jetpack trunk and WooCommerce.
* Visit the WooCommerce shop page. Observe the warning logged, and that the page has a tag like this in it: `<script src="https://example.com/wp-content/plugins/jetpack/modules/woocommerce-analytics/https:/stats.wp.com/s-202406.js?minify=false&amp;ver=6.4.3" id="woocommerce-analytics-js" defer data-wp-strategy="defer"></script>`
* Apply this commit. Warning should no longer be generated, and the script tag should be like `<script src="https://stats.wp.com/s-202406.js" id="woocommerce-analytics-js" defer data-wp-strategy="defer"></script>`