### PR TITLE
Update masterbar on WOA for wp-admin centric design.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-masterbar-for-developers-initiative
+++ b/projects/plugins/jetpack/changelog/update-masterbar-for-developers-initiative
@@ -1,0 +1,3 @@
+Significance: minor
+Type: enhancement
+Comment: Updates the admin bar for WoA sites to better reflect core when a specific user flag is present.

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -132,8 +132,7 @@ class Masterbar {
 		$this->is_rtl          = isset( $this->user_data['text_direction'] ) && 'rtl' === $this->user_data['text_direction'];
 		$this->user_locale     = isset( $this->user_data['user_locale'] ) ? $this->user_data['user_locale'] : '';
 		$this->site_woa        = ( new Host() )->is_woa_site();
-		// update true to check user meta. true -> get_user_meta( $this->user_data['ID'], 'wpcom-global-nav-enabled', true ); or get_user_option( 'wpcom-global-nav-enabled', $this->user_id )
-		$this->use_dev_nav = $this->site_woa && true;
+		$this->use_dev_nav     = $this->site_woa && ( isset( $this->user_data['wpcom_global_nav_enabled'] ) ? $this->user_data['wpcom_global_nav_enabled'] : false );
 
 		// Store part of the connected user data as user options so it can be used
 		// by other files of the masterbar module without making another XMLRPC


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to pe7F0s-1Dj-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the masterbar for atomic sites to show the core wp-admin version with the "W" button leading to the sites page on WordPress.com. This keeps the help center and notifications panels in place as well.
* Conditions the changes behind private variable `$this->use_dev_nav` which is populated by a user_meta value added to user data here. D137411-code is required for this meta to be accessible here.

Also note - The "W" logo has extra right padding still. This will have to be updated from the css file loaded from wpcom in a separate patch. D137303-code. This is linked in the last bit of testing instructions as well.

![Screenshot 2024-02-06 at 2 00 55 PM](https://github.com/Automattic/jetpack/assets/28742426/17e56e90-c3a6-4220-a6e1-92dd5cf659b1)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
These changes are restricted to WoA sites, related to pe7F0s-1Dj-p2 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### With D137411-code to support the meta check.
* Setup a WoA dev blog on the atomic dev servers.
* Be sure to define BOTH `define( 'JETPACK_AUTOLOAD_DEV', true );` and `define( 'JETPACK__SANDBOX_DOMAIN', '$your_sandbox_hostname' )' in the wp-config.php file for the site.
* Load this branch of the jetpack repo.
* Update [this line of code](https://github.com/Automattic/jetpack/blob/96450fad7be369e308975431e84710115e47810b/projects/packages/connection/src/class-manager.php#L754) to comment out the cached return.
* Build and sync these changes to your WoA dev blog.
* Patch D137411-code on your sandbox.
* update your user meta value for `wpcom_global_nav_enabled` to be `true`. I do this on my sandbox through wpsh: `return add_user_meta( '$user_id', 'wpcom_global_nav_enabled', true );` (similarly, you can use the  `update_user_meta` function to change this back to false in testing).
* Reload your WoA site in wp-admin.
* Verify the admin bar reflects core now. The "W" logo should link to the sites page in calypso. Help center and notifications links should still be present.
* This should happen regardless of the selected interface setting in hosting config under Settings-> Hosting Options:
![Screenshot 2024-02-06 at 2 42 42 PM](https://github.com/Automattic/jetpack/assets/28742426/07330ff4-07c8-4b95-9954-270974677d2a)
* Update the user meta to be false, verify this goes back to previous behavior.

### (optional) With D137303-code for the fixed "W" logo margin
* After the above is set up and you can see the changes, patch this diff on your sandbox.
* Follow instructions on this diff, links to a previous diff with instructions and my troubleshooting in slack also exist here and may be helpful.
* Once this is properly applied, you should see a balanced margin on the "W" logo

![Screenshot 2024-02-06 at 5 14 39 PM](https://github.com/Automattic/jetpack/assets/28742426/254bed92-f41d-40c2-87d9-ee7990a6a18f)