### PR TITLE
SSO: Automatically revoke invited users upon deletion

### DIFF
--- a/projects/plugins/jetpack/changelog/revoke-deleted-users
+++ b/projects/plugins/jetpack/changelog/revoke-deleted-users
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/changelog/revoke-deleted-users
+++ b/projects/plugins/jetpack/changelog/revoke-deleted-users
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-
+SSO: revoke invites sent to users upon users deletion

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -110,7 +110,7 @@ class Jetpack_SSO {
 		try {
 			$has_pending_invite = self::has_pending_wpcom_invite( $user_id );
 			if ( $has_pending_invite ) {
-				return self::revoke_deleted_users_invites( $has_pending_invite );
+				return self::revoke_wpcom_invite( $has_pending_invite );
 			}
 		} catch ( Exception $e ) {
 			return false;
@@ -235,7 +235,7 @@ class Jetpack_SSO {
 	 *
 	 * @param string $invite_id The ID of the invite to revoke.
 	 */
-	public function revoke_deleted_users_invites( $invite_id ) {
+	public function revoke_wpcom_invite( $invite_id ) {
 		$blog_id = Jetpack_Options::get_option( 'id' );
 
 		$url      = '/sites/' . $blog_id . '/invites/delete';
@@ -294,7 +294,7 @@ class Jetpack_SSO {
 			}
 
 			$invite_id    = sanitize_text_field( wp_unslash( $_GET['invite_id'] ) );
-			$body         = self::revoke_deleted_users_invites( $invite_id );
+			$body         = self::revoke_wpcom_invite( $invite_id );
 			$query_params = array(
 				'jetpack-sso-invite-user' => $body->deleted ? 'successful-revoke' : 'failed',
 				'_wpnonce'                => $nonce,

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -405,7 +405,7 @@ class Jetpack_SSO {
 		$users_with_invites = array_filter(
 			$user_ids,
 			function ( $user_id ) {
-				return self::has_pending_wpcom_invite( $user_id );
+				return $user_id !== null && self::has_pending_wpcom_invite( $user_id );
 			}
 		);
 
@@ -417,13 +417,16 @@ class Jetpack_SSO {
 			$users_with_invites
 		);
 
-		if ( count( $users_with_invites ) ) {
+		$invites_count = count( $users_with_invites );
+		if ( $invites_count > 0 ) {
 			$users_with_invites = implode( ', ', $users_with_invites );
 			$message            = wp_kses(
 				sprintf(
 					/* translators: %s is a comma-separated list of user logins. */
-					__(
+					_n(
+						'WordPress.com invitation will be automatically revoked for user: <strong>%s</strong>.',
 						'WordPress.com invitations will be automatically revoked for users: <strong>%s</strong>.',
+						$invites_count,
 						'jetpack'
 					),
 					$users_with_invites


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/pull/35277#issuecomment-1929350962.

## Proposed changes:
On the deletion confirmation screen, this will inform the user about WordPress.com invitations being automatically revoked when the user is deleted. 

![image](https://github.com/Automattic/jetpack/assets/17054134/92107f48-5712-44e8-aef4-b6a9615adc45)

**If it's multiple users**
Note that only invited users will be revoked:

![image](https://github.com/Automattic/jetpack/assets/17054134/802a0f29-3d03-42f9-b744-6ba70a6aca92)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Add a user, they will be automatically invited to wp.com.
2. Delete the user, the invitation should be revoked. Verify that by visiting the invitation in the email.
3. Select multiple users, some invited, some not, and bulk delete them.
4. Verify that the deletion screen will only inform you about users with pending invitations.
5. Verify that the invitations are gone for invited users in Calypso. 