### PR TITLE
Blogroll: Add appender image placeholder and fix image sizing issue

### DIFF
--- a/projects/plugins/jetpack/changelog/update-blogroll-site-appender-results-img-placeholder
+++ b/projects/plugins/jetpack/changelog/update-blogroll-site-appender-results-img-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix blogroll item image size and fix blogroll appender result image placeholder

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -75,7 +75,7 @@ function load_assets( $attr, $content, $block ) {
 
 	$placeholder_site_icon = '';
 	$site_icon_html        = <<<HTML
-	<img src="$icon" alt="$name_attr" onerror="this.parentNode.classList.add('empty-site-icon')">
+	<img id="blogroll-item-image" src="$icon" alt="$name_attr" onerror="this.parentNode.classList.add('empty-site-icon')">
 HTML;
 
 	if ( empty( $icon ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -75,7 +75,7 @@ function load_assets( $attr, $content, $block ) {
 
 	$placeholder_site_icon = '';
 	$site_icon_html        = <<<HTML
-	<img id="blogroll-item-image" src="$icon" alt="$name_attr" onerror="this.parentNode.classList.add('empty-site-icon')">
+	<img class="blogroll-item-image" src="$icon" alt="$name_attr" onerror="this.parentNode.classList.add('empty-site-icon')">
 HTML;
 
 	if ( empty( $icon ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/edit.js
@@ -18,7 +18,7 @@ function BlogrollItemEdit( { className, attributes, setAttributes } ) {
 					<Button variant="link" onClick={ open } style={ { padding: 0 } }>
 						<figure>
 							<img
-								id="blogroll-item-image"
+								class="blogroll-item-image"
 								onError={ event => {
 									event.target.parentNode.classList.add( 'empty-site-icon' );
 								} }

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/edit.js
@@ -18,6 +18,7 @@ function BlogrollItemEdit( { className, attributes, setAttributes } ) {
 					<Button variant="link" onClick={ open } style={ { padding: 0 } }>
 						<figure>
 							<img
+								id="blogroll-item-image"
 								onError={ event => {
 									event.target.parentNode.classList.add( 'empty-site-icon' );
 								} }

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/editor.scss
@@ -15,13 +15,13 @@
 				background: url('../placeholder-site-icon.svg');
 				background-size: cover;
 
-				#blogroll-item-image {
+				.blogroll-item-image {
 					display: none;
 				}
 			}
 		}
 
-	#blogroll-item-image {
+	.blogroll-item-image {
 		border-radius: 50%;
 		width: 48px;
 		height: 48px;

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/editor.scss
@@ -15,13 +15,13 @@
 				background: url('../placeholder-site-icon.svg');
 				background-size: cover;
 
-				img {
+				#blogroll-item-image {
 					display: none;
 				}
 			}
 		}
 
-	img {
+	#blogroll-item-image {
 		border-radius: 50%;
 		width: 48px;
 		height: 48px;

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/components/blogroll-appender-results/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/components/blogroll-appender-results/index.js
@@ -54,7 +54,15 @@ export default function BlogrollAppenderResults( { results, onSelect, searchInpu
 									onClick={ () => onSelect( result ) }
 								>
 									<div className="jetpack-blogroll__appender-result-image">
-										{ result.site_icon && <img src={ result.site_icon } alt={ result.name } /> }
+										{ result.site_icon && (
+											<img
+												src={ result.site_icon }
+												alt={ result.name }
+												onError={ event => {
+													event.target.parentNode.classList.add( 'empty-site-icon' );
+												} }
+											/>
+										) }
 									</div>
 									<div className="jetpack-blogroll__appender-result-text">
 										<span className="jetpack-blogroll__appender-result-title">{ result.name }</span>

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/components/blogroll-appender-results/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/components/blogroll-appender-results/style.scss
@@ -70,6 +70,15 @@
 				height: 40px;
 				flex-shrink: 0;
 
+				&.empty-site-icon {
+					background: url('../../placeholder-site-icon.svg');
+					background-size: cover;
+	
+					img {
+						display: none;
+					}
+				}
+
 				img {
 					border-radius: 50%;
 					width: 40px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/87241

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

### Add image placeholder for site appender results if there is an error loading the site icon.

| Before | After |
| ------------- | ------------- |
| <img width="314" alt="CleanShot 2024-02-06 at 17 25 09@2x" src="https://github.com/Automattic/jetpack/assets/10482592/846c99b6-17c5-473e-a33b-3c82c313599e">  | <img width="322" alt="CleanShot 2024-02-06 at 17 28 37@2x" src="https://github.com/Automattic/jetpack/assets/10482592/97754ba6-70a0-46d8-ba14-958656ab6aa5">  |


You can use `https://myphotoshootideas.wordpress.com/` to test the before and after behavior.

### Fixes and ensures blogroll item images have the correct height and width.

Subscribe to `https://rich.blog/`.

| Before | After |
| ------------- | ------------- |
| <img width="710" src="https://github-production-user-asset-6210df.s3.amazonaws.com/10482592/302793414-2871c3f9-3c6c-44d1-98f1-8c1a5365d91a.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240206T222334Z&X-Amz-Expires=300&X-Amz-Signature=b5072f014174a1a43ab98c4fa2b178682b44ceb86202eda5d7478b5df36f2166&X-Amz-SignedHeaders=host&actor_id=10482592&key_id=0&repo_id=15231212"> | <img width="710" alt="CleanShot 2024-02-06 at 17 18 27@2x" src="https://github.com/Automattic/jetpack/assets/10482592/305b2a16-eba0-4d50-bdf3-58ab79dd2e94"> |




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* Sync to sandbox and atomic site. You can use the `jetpack sync` command.
**Simple site**: `username@hostname:~/public_html/wp-content/mu-plugins/jetpack-plugin/production`
**Atomic**: `atomic_site_address@sftp.wp.com:~/htdocs/wp-content/plugins/jetpack`
* Navigate to site editor and add blogitem block.
* Verify the blogroll item images have the correct dimensions. You can use `https://myphotoshootideas.wordpress.com/` to test the before and after behavior.
* Open the site appender and verify all sites have a placeholder image. You can test this by subscribing to `https://rich.blog/`.


