### PR TITLE
Additional CSS Nudge: Premium Plan -> Explorer Plan

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-css-nudge-plan
+++ b/projects/plugins/jetpack/changelog/fix-css-nudge-plan
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Additional CSS: Use the correct plan name in the WordPress.com nudge.

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-atomic-additional-css-manager.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-atomic-additional-css-manager.php
@@ -39,16 +39,7 @@ class Atomic_Additional_CSS_Manager {
 	 */
 	public function register_nudge( \WP_Customize_Manager $wp_customize_manager ) {
 		$nudge_url  = $this->get_nudge_url();
-		$nudge_text = __( 'Purchase a Business Plan to<br> activate CSS customization', 'jetpack' );
-
-		if (
-			( defined( 'ENABLE_PRO_PLAN' ) && ENABLE_PRO_PLAN ) ||
-			! empty( $_GET['enable_pro_plan'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only used to customize output.
-			! empty( $_COOKIE['enable_pro_plan'] )
-		) {
-			$nudge_text = __( 'Purchase a Pro Plan to<br> activate CSS customization', 'jetpack' );
-			$nudge_url  = preg_replace( '/premium$/', 'pro', $nudge_url );
-		}
+		$nudge_text = __( 'Purchase the Creator plan to<br> activate CSS customization', 'jetpack' );
 
 		$nudge = new CSS_Customizer_Nudge(
 			$nudge_url,

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-css-nudge-customize-control.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-css-nudge-customize-control.php
@@ -42,7 +42,7 @@ class CSS_Nudge_Customize_Control extends \WP_Customize_Control {
 	public function render_content() {
 		$cta_url           = $this->cta_url;
 		$nudge_copy        = $this->nudge_copy;
-		$nudge_button_copy = __( 'Upgrade Now', 'jetpack' );
+		$nudge_button_copy = __( 'Upgrade now', 'jetpack' );
 
 		echo '<div class="nudge-container">
 				<p>

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-wpcom-additional-css-manager.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-wpcom-additional-css-manager.php
@@ -39,7 +39,7 @@ class WPCOM_Additional_CSS_Manager {
 	 */
 	public function register_nudge( \WP_Customize_Manager $wp_customize_manager ) {
 		$nudge_url  = $this->get_nudge_url();
-		$nudge_text = __( 'Purchase a Premium Plan to<br> activate CSS customization', 'jetpack' );
+		$nudge_text = __( 'Purchase an Explorer plan to<br> activate CSS customization', 'jetpack' );
 
 		if (
 			( defined( 'ENABLE_PRO_PLAN' ) && ENABLE_PRO_PLAN ) ||

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-wpcom-additional-css-manager.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-wpcom-additional-css-manager.php
@@ -39,7 +39,7 @@ class WPCOM_Additional_CSS_Manager {
 	 */
 	public function register_nudge( \WP_Customize_Manager $wp_customize_manager ) {
 		$nudge_url  = $this->get_nudge_url();
-		$nudge_text = __( 'Purchase an Explorer plan to<br> activate CSS customization', 'jetpack' );
+		$nudge_text = __( 'Purchase the Explorer plan to<br> activate CSS customization', 'jetpack' );
 
 		if (
 			( defined( 'ENABLE_PRO_PLAN' ) && ENABLE_PRO_PLAN ) ||

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-wpcom-additional-css-manager.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-wpcom-additional-css-manager.php
@@ -41,15 +41,6 @@ class WPCOM_Additional_CSS_Manager {
 		$nudge_url  = $this->get_nudge_url();
 		$nudge_text = __( 'Purchase the Explorer plan to<br> activate CSS customization', 'jetpack' );
 
-		if (
-			( defined( 'ENABLE_PRO_PLAN' ) && ENABLE_PRO_PLAN ) ||
-			! empty( $_GET['enable_pro_plan'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only used to customize output.
-			! empty( $_COOKIE['enable_pro_plan'] )
-		) {
-			$nudge_text = __( 'Purchase a Pro Plan to<br> activate CSS customization', 'jetpack' );
-			$nudge_url  = preg_replace( '/premium$/', 'pro', $nudge_url );
-		}
-
 		$nudge = new CSS_Customizer_Nudge(
 			$nudge_url,
 			$nudge_text,

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-additional-css-manager.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-additional-css-manager.php
@@ -46,22 +46,14 @@ class Test_Atomic_Additional_CSS_Manager extends \WP_UnitTestCase {
 
 		$manager->register_nudge( $this->wp_customize );
 
-		$cta_urls = array(
-			'/checkout/foo.com/pro',
+		$this->assertEquals(
 			'/checkout/foo.com/business',
+			$this->wp_customize->controls()['custom_css_control']->cta_url
 		);
 
-		$cta_url = $this->wp_customize->controls()['custom_css_control']->cta_url;
-
-		$this->assertContains( $cta_url, $cta_urls );
-
-		$cta_copys = array(
-			'Purchase a Pro Plan to<br> activate CSS customization',
-			'Purchase a Business Plan to<br> activate CSS customization',
+		$this->assertEquals(
+			'Purchase the Creator plan to<br> activate CSS customization',
+			$this->wp_customize->controls()['custom_css_control']->nudge_copy
 		);
-
-		$cta_copy = $this->wp_customize->controls()['custom_css_control']->nudge_copy;
-
-		$this->assertContains( $cta_copy, $cta_copys );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-css-nudge-customize-control.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-css-nudge-customize-control.php
@@ -45,7 +45,7 @@ class Test_CSS_Nudge_Customize_Control extends \WP_UnitTestCase {
 					foo
 				</p>
 				<div class="button-container">
-					<button type="button" class="button-primary navigate-to" data-navigate-to-page="https://wordpress.com">Upgrade Now</button>
+					<button type="button" class="button-primary navigate-to" data-navigate-to-page="https://wordpress.com">Upgrade now</button>
 				</div>
 			</div>';
 		$this->assertEquals( $expected_output, $content );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-additional-css-manager.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-additional-css-manager.php
@@ -58,7 +58,7 @@ class Test_WPCOM_Additional_Css_Manager extends \WP_UnitTestCase {
 
 		$cta_copys = array(
 			'Purchase a Pro Plan to<br> activate CSS customization',
-			'Purchase an Explorer plan to<br> activate CSS customization',
+			'Purchase the Explorer plan to<br> activate CSS customization',
 		);
 
 		$cta_copy = $this->wp_customize->controls()['jetpack_custom_css_control']->nudge_copy;

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-additional-css-manager.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-additional-css-manager.php
@@ -46,23 +46,13 @@ class Test_WPCOM_Additional_Css_Manager extends \WP_UnitTestCase {
 		$manager = new WPCOM_Additional_CSS_Manager( 'foo.com' );
 
 		$manager->register_nudge( $this->wp_customize );
-
-		$cta_urls = array(
-			'/checkout/foo.com/pro',
+		$this->assertEquals(
 			'/checkout/foo.com/premium',
+			$this->wp_customize->controls()['jetpack_custom_css_control']->cta_url
 		);
-
-		$cta_url = $this->wp_customize->controls()['jetpack_custom_css_control']->cta_url;
-
-		$this->assertContains( $cta_url, $cta_urls );
-
-		$cta_copys = array(
-			'Purchase a Pro Plan to<br> activate CSS customization',
+		$this->assertEquals(
 			'Purchase the Explorer plan to<br> activate CSS customization',
+			$this->wp_customize->controls()['jetpack_custom_css_control']->nudge_copy
 		);
-
-		$cta_copy = $this->wp_customize->controls()['jetpack_custom_css_control']->nudge_copy;
-
-		$this->assertContains( $cta_copy, $cta_copys );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-additional-css-manager.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-additional-css-manager.php
@@ -58,7 +58,7 @@ class Test_WPCOM_Additional_Css_Manager extends \WP_UnitTestCase {
 
 		$cta_copys = array(
 			'Purchase a Pro Plan to<br> activate CSS customization',
-			'Purchase a Premium Plan to<br> activate CSS customization',
+			'Purchase an Explorer plan to<br> activate CSS customization',
 		);
 
 		$cta_copy = $this->wp_customize->controls()['jetpack_custom_css_control']->nudge_copy;


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses the term "Explorer plan" instead of "Premium Plan" in the CSS nudge (plan names should no longer be capitalised, as happens in the rest of Calypso) 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

Absolutely no idea if this works for certain - I don't think that I can test changes on WP.com! But it seems logical based on the code that this should work.

You can test this under "Additional CSS" in the Customizer on a Free/Starter plan site.

<img width="1119" alt="Screenshot 2024-02-06 at 22 41 08" src="https://github.com/Automattic/jetpack/assets/43215253/4bbed73a-7a69-40e0-8afc-40f6ca53ab7e">

