### PR TITLE
[Boost] Fix missing minify step for CSS and JS

### DIFF
--- a/projects/plugins/boost/app/lib/class-minify.php
+++ b/projects/plugins/boost/app/lib/class-minify.php
@@ -9,12 +9,18 @@
 
 namespace Automattic\Jetpack_Boost\Lib;
 
-use JShrink\Minifier;
+use JShrink\Minifier as JSMinifier;
+use tubalmartin\CssMin\Minifier as CSSMinifier;
 
 /**
  * Class Minify
  */
 class Minify {
+
+	/**
+	 * @var Minify - Holds the CssMin\Minifier instance, for reuse on subsequent calls.
+	 */
+	private static $css_minifier;
 
 	/**
 	 * Strips whitespace from JavaScript scripts.
@@ -27,11 +33,22 @@ class Minify {
 		require_once JETPACK_BOOST_DIR_PATH . '/vendor/tedivm/jshrink/src/JShrink/Minifier.php';
 
 		try {
-			$minified_js = Minifier::minify( $js );
+			$minified_js = JSMinifier::minify( $js );
 		} catch ( \Exception $e ) {
 			return $js;
 		}
 
 		return $minified_js;
+	}
+
+	/**
+	 * Minifies the supplied CSS code, returning its minified form.
+	 */
+	public static function css( $css ) {
+		if ( ! self::$css_minifier ) {
+			self::$css_minifier = new CSSMinifier();
+		}
+
+		return self::$css_minifier->run( $css );
 	}
 }

--- a/projects/plugins/boost/app/lib/minify/Config.php
+++ b/projects/plugins/boost/app/lib/minify/Config.php
@@ -18,16 +18,6 @@ class Config {
 		return $path;
 	}
 
-	public static function is_css_minify_enabled() {
-		if ( defined( 'PAGE_OPTIMIZE_CSS_MINIFY' ) ) {
-			$enabled = (bool) PAGE_OPTIMIZE_CSS_MINIFY;
-		} else {
-			$enabled = false;
-		}
-
-		return $enabled;
-	}
-
 	public static function get_abspath() {
 		if ( defined( 'PAGE_OPTIMIZE_ABSPATH' ) ) {
 			$path = PAGE_OPTIMIZE_ABSPATH;

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -1,9 +1,9 @@
 <?php
 
+use Automattic\Jetpack_Boost\Lib\Minify;
 use Automattic\Jetpack_Boost\Lib\Minify\Config;
 use Automattic\Jetpack_Boost\Lib\Minify\Dependency_Path_Mapping;
 use Automattic\Jetpack_Boost\Lib\Minify\Utils;
-use tubalmartin\CssMin\Minifier;
 
 function jetpack_boost_page_optimize_types() {
 	return array(
@@ -133,7 +133,8 @@ function jetpack_boost_strip_parent_path( $parent_path, $path ) {
 }
 
 /**
- * Generate a combined and minified output for the current request.
+ * Generate a combined and minified output for the current request. This is run regardless of the
+ * type of content being fetched; JavaScript or CSS, so it must handle either.
  */
 function jetpack_boost_page_optimize_build_output() {
 	$use_wp = defined( 'JETPACK_BOOST_CONCAT_USE_WP' ) && JETPACK_BOOST_CONCAT_USE_WP;
@@ -208,8 +209,6 @@ function jetpack_boost_page_optimize_build_output() {
 	$last_modified = 0;
 	$pre_output    = '';
 	$output        = '';
-
-	$css_minify = new Minifier();
 
 	foreach ( $args as $uri ) {
 		$fullpath = jetpack_boost_page_optimize_get_path( $uri );
@@ -298,13 +297,13 @@ function jetpack_boost_page_optimize_build_output() {
 				);
 			}
 
-			$buf = $css_minify->run( $buf );
-		}
-
-		if ( $jetpack_boost_page_optimize_types['js'] === $mime_type ) {
-			$output .= "$buf;\n";
-		} else {
+			// Minify CSS.
+			$buf     = Minify::css( $buf );
 			$output .= "$buf";
+		} else {
+			// Minify JS
+			$buf     = Minify::js( $buf );
+			$output .= "$buf;\n";
 		}
 	}
 

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -3,7 +3,7 @@
 use Automattic\Jetpack_Boost\Lib\Minify\Config;
 use Automattic\Jetpack_Boost\Lib\Minify\Dependency_Path_Mapping;
 use Automattic\Jetpack_Boost\Lib\Minify\Utils;
-use tubalmartin\CssMin;
+use tubalmartin\CssMin\Minifier;
 
 function jetpack_boost_page_optimize_types() {
 	return array(
@@ -209,11 +209,7 @@ function jetpack_boost_page_optimize_build_output() {
 	$pre_output    = '';
 	$output        = '';
 
-	$should_minify_css = Config::is_css_minify_enabled();
-
-	if ( $should_minify_css ) {
-		$css_minify = new CssMin\Minifier();
-	}
+	$css_minify = new Minifier();
 
 	foreach ( $args as $uri ) {
 		$fullpath = jetpack_boost_page_optimize_get_path( $uri );
@@ -302,9 +298,7 @@ function jetpack_boost_page_optimize_build_output() {
 				);
 			}
 
-			if ( $should_minify_css ) {
-				$buf = $css_minify->run( $buf );
-			}
+			$buf = $css_minify->run( $buf );
 		}
 
 		if ( $jetpack_boost_page_optimize_types['js'] === $mime_type ) {

--- a/projects/plugins/boost/changelog/boost-fix-minify
+++ b/projects/plugins/boost/changelog/boost-fix-minify
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JS and CSS concat: Fix minification

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -61,25 +61,6 @@ if ( ! defined( 'JETPACK_BOOST_PLUGINS_DIR_URL' ) ) {
 }
 
 /**
- * Setup Minify service.
- */
-// Potential improvement: Make concat URL dir configurable
-// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	$request_path = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) )[0];
-
-	// Handling JETPACK_BOOST_STATIC_PREFIX constant inline to avoid loading the minify module until we know we want it.
-	$static_prefix = defined( 'JETPACK_BOOST_STATIC_PREFIX' ) ? JETPACK_BOOST_STATIC_PREFIX : '/_jb_static/';
-	if ( $static_prefix === substr( $request_path, -strlen( $static_prefix ) ) ) {
-		define( 'JETPACK_BOOST_CONCAT_USE_WP', true );
-
-		require_once JETPACK_BOOST_DIR_PATH . '/serve-minified-content.php';
-		exit;
-	}
-}
-
-/**
  * Setup autoloading
  */
 $boost_packages_path = JETPACK_BOOST_DIR_PATH . '/vendor/autoload_packages.php';
@@ -132,6 +113,25 @@ if ( is_readable( $boost_packages_path ) ) {
 
 	add_action( 'admin_notices', __NAMESPACE__ . '\\jetpack_boost_admin_missing_files' );
 	return;
+}
+
+/**
+ * Setup Minify service.
+ */
+// Potential improvement: Make concat URL dir configurable
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$request_path = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) )[0];
+
+	// Handling JETPACK_BOOST_STATIC_PREFIX constant inline to avoid loading the minify module until we know we want it.
+	$static_prefix = defined( 'JETPACK_BOOST_STATIC_PREFIX' ) ? JETPACK_BOOST_STATIC_PREFIX : '/_jb_static/';
+	if ( $static_prefix === substr( $request_path, -strlen( $static_prefix ) ) ) {
+		define( 'JETPACK_BOOST_CONCAT_USE_WP', true );
+
+		require_once JETPACK_BOOST_DIR_PATH . '/serve-minified-content.php';
+		exit;
+	}
 }
 
 require plugin_dir_path( __FILE__ ) . 'app/class-jetpack-boost.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #34201

We've had reports that sometimes we were not serving minified content when concatenation was turned on. I've investigated - it turns out that minifying was behind a feature flag it shouldn't have been.

## Proposed changes:
* Remove the feature flag around minifying content
* Ensure that the JavaScript output codepath also called a minify method
* Unify the way the two JS and CSS minifiers are wrapped / called.
* Ensure the autoload service is configured *before* the minify script runs, to ensure autoload behaves as expected.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Add some custom JavaSCript and CSS files to your test site which are explicitly not minified.
* Verify this handles minifying both gracefully.