### PR TITLE
Untangle: add admin notice to Dashboard about menu reorganization

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wpcom-menu
+++ b/projects/plugins/jetpack/changelog/update-wpcom-menu
@@ -6,3 +6,5 @@ Move the following items from Tools to the new WordPress.com menu for the calyps
 * Marketing
 * Site Monitoring
 * Hosting Configuration
+
+Added an admin notices that warns about the above menu reorganization.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -43,8 +43,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			0
 		);
 
-		// Add notices to the settings pages when there is a Calypso page available.
 		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+			// Add notice to the Dashboard page about the reorganized menus.
+			add_action( 'load-index.php', array( $this, 'add_reorganized_menus_notice' ) );
+
+			// Add notices to the settings pages when there is a Calypso page available.
 			add_action( 'current_screen', array( $this, 'add_settings_page_notice' ) );
 		}
 	}
@@ -573,6 +576,24 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			?>
 			<div class="notice notice-warning">
 				<p><?php echo wp_kses( sprintf( $notice, esc_url( $switch_url ) ), array( 'a' => array( 'href' => array() ) ) ); ?></p>
+			</div>
+			<?php
+		};
+
+		add_action( 'admin_notices', $admin_notices );
+	}
+
+	/**
+	 * Adds an admin notice about the menu reorganization.
+	 *
+	 * @return void
+	 */
+	public function add_reorganized_menus_notice() {
+		$admin_notices = function () {
+			$notice = __( 'We’re improving our menu organization to align with WordPress.org’s wp-admin. WordPress.com specific features are now in the new <b>WordPress.com</b> menu.', 'jetpack' );
+			?>
+			<div class="notice notice-warning is-dismissible">
+				<p><?php echo wp_kses( $notice, array( 'b' => array() ) ); ?></p>
 			</div>
 			<?php
 		};

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -590,10 +590,12 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_reorganized_menus_notice() {
 		$admin_notices = function () {
-			$notice = __( 'We’re improving our menu organization to align with WordPress.org’s wp-admin. WordPress.com specific features are now in the new <b>WordPress.com</b> menu.', 'jetpack' );
+			$menu_url = sprintf( 'https://wordpress.com/plans/%s', $this->domain );
+			// translators: %s is a link to the new WordPress.com menu.
+			$notice = __( 'We’re improving our menu organization to align with WordPress.org’s wp-admin. WordPress.com specific features are now in <a href="%s">the new WordPress.com menu</a>.', 'jetpack' );
 			?>
 			<div class="notice notice-warning is-dismissible">
-				<p><?php echo wp_kses( $notice, array( 'b' => array() ) ); ?></p>
+				<p><?php echo wp_kses( sprintf( $notice, esc_url( $menu_url ) ), array( 'a' => array( 'href' => array() ) ) ); ?></p>
 			</div>
 			<?php
 		};


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5503

## Proposed changes:

This PR adds an admin notice that warns the user about the menu reorganization for WordPress.com.

<img width="1325" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/52b4d67b-4de3-4d32-a6c1-4509d1100858">

## Questions

Should we also mention about some menus being moved to Jetpack?

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply this patch.
2. Go to `/wp-admin` and verify that you see the banner.

