### PR TITLE
Memberships: instruct WP Super cache to not cache membership posts

### DIFF
--- a/projects/plugins/jetpack/changelog/update-do-not-cache-plugins
+++ b/projects/plugins/jetpack/changelog/update-do-not-cache-plugins
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Memberships: instruct WP Super Cache plugin to not cache membership posts

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -39,6 +39,17 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	}
 
 	/**
+	 * Request common cache plugins to not cache this post
+	 *
+	 * @return void
+	 */
+	public function plugins_do_not_cache() {
+		// WP Super Cache
+		// https://jetpack.com/support/wp-super-cache/wp-super-cache-faq/
+		define( 'DONOTCACHEPAGE', true );
+	}
+
+	/**
 	 * Set the token from the Request to the cookie and retrieve the token.
 	 *
 	 * @return string|null

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -39,19 +39,6 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	}
 
 	/**
-	 * Request common cache plugins to not cache this post
-	 *
-	 * @return void
-	 */
-	public function plugins_do_not_cache() {
-		// WP Super Cache
-		// https://jetpack.com/support/wp-super-cache/wp-super-cache-faq/
-		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
-			define( 'DONOTCACHEPAGE', true );
-		}
-	}
-
-	/**
 	 * Set the token from the Request to the cookie and retrieve the token.
 	 *
 	 * @return string|null

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -46,7 +46,9 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	public function plugins_do_not_cache() {
 		// WP Super Cache
 		// https://jetpack.com/support/wp-super-cache/wp-super-cache-faq/
-		define( 'DONOTCACHEPAGE', true );
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -660,6 +660,12 @@ function render_for_website( $data, $classes, $styles ) {
 	$is_subscribed      = Jetpack_Memberships::is_current_user_subscribed();
 	$button_text        = get_submit_button_text( $data );
 
+	// Prevent Batcache from caching views with subscribe block when user subscribed, or even just logged and aren't subscribed.
+	// Avoids user's emails or block's "subscribed" state getting cached.
+	if ( $is_subscribed || ! empty( $data['subscribe_email'] ) ) {
+		Jetpack_Memberships::plugins_do_not_cache();
+	}
+
 	ob_start();
 
 	Jetpack_Subscriptions_Widget::render_widget_status_messages(

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -655,7 +655,7 @@ class Jetpack_Memberships {
 		// Request common cache plugins to not cache this post
 		// Batcache at WP.com is handled by JWT_AUTH_TOKEN_COOKIE_NAME being prefixed with `wp-` already.
 		if ( $can_view_post && $post_access_level !== Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY ) {
-			Abstract_Token_Subscription_Service::plugins_do_not_cache();
+			$paywall->plugins_do_not_cache();
 		}
 
 		self::$user_can_view_post_cache[ $cache_key ] = $can_view_post;

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -652,6 +652,12 @@ class Jetpack_Memberships {
 
 		$can_view_post = $paywall->visitor_can_view_content( $all_newsletters_plan_ids, $post_access_level );
 
+		// Request common cache plugins to not cache this post
+		// Batcache at WP.com is handled by JWT_AUTH_TOKEN_COOKIE_NAME being prefixed with `wp-` already.
+		if ( $can_view_post && $post_access_level !== Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY ) {
+			Abstract_Token_Subscription_Service::plugins_do_not_cache();
+		}
+
 		self::$user_can_view_post_cache[ $cache_key ] = $can_view_post;
 		return $can_view_post;
 	}

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -655,7 +655,7 @@ class Jetpack_Memberships {
 		// Request common cache plugins to not cache this post
 		// Batcache at WP.com is handled by JWT_AUTH_TOKEN_COOKIE_NAME being prefixed with `wp-` already.
 		if ( $can_view_post && $post_access_level !== Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY ) {
-			$paywall->plugins_do_not_cache();
+			self::plugins_do_not_cache();
 		}
 
 		self::$user_can_view_post_cache[ $cache_key ] = $can_view_post;
@@ -848,6 +848,20 @@ class Jetpack_Memberships {
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
 		return $subscription_service->is_current_user_subscribed();
+	}
+
+	/**
+	 * Request common cache plugins to not cache this post
+	 *
+	 * @return void
+	 */
+	public static function plugins_do_not_cache() {
+		// WP Super Cache
+		// Jetpack Boost Cache
+		// https://jetpack.com/support/wp-super-cache/wp-super-cache-faq/
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
+		}
 	}
 }
 Jetpack_Memberships::get_instance();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to https://github.com/Automattic/jetpack/pull/35372#discussion_r1473017981

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a method to bust cache with WP Super Cache plugin ([FAQ](https://jetpack.com/support/wp-super-cache/wp-super-cache-faq/))
    * Jetpack Boost Cache [is handled with this same constant](https://github.com/Automattic/jetpack/issues/35497#issuecomment-1931721738).
* Requests plugins not to cache when the page has either a paywall, or the subscribe block and:
   * User is a subscriber
   * User is logged in, even if they aren't subscribed and thus don't have the JWT auth token cookie set.
When user is subscribed 



Later on need to look also what other [common cache plugins](https://wordpress.org/plugins/search/cache/) require.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See https://github.com/Automattic/jetpack/pull/35372

