### PR TITLE
Woo Analytics: do not track store if Usage Tracking is disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-woocommerce-analytics-tracking-enabled
+++ b/projects/plugins/jetpack/changelog/fix-woocommerce-analytics-tracking-enabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+WooCommerce Analytics: disable feature when Usage Tracking is disabled.

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
@@ -76,6 +76,12 @@ class Jetpack_WooCommerce_Analytics {
 		if ( ! $minimum_woocommerce_active ) {
 			return false;
 		}
+
+		// Do not track if the user has opted out of tracking.
+		if ( 'yes' !== get_option( 'woocommerce_allow_tracking', 'no' ) ) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
@@ -78,7 +78,7 @@ class Jetpack_WooCommerce_Analytics {
 		}
 
 		// Do not track if the user has opted out of tracking.
-		if ( 'yes' !== get_option( 'woocommerce_allow_tracking', 'no' ) ) {
+		if ( 'yes' !== get_option( 'woocommerce_allow_tracking' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
> [!CAUTION]
> This PR should not be merged until the discussion in p1707240843845259-slack-C0299DMPG concludes, following a p2 post by @ralucaStan.

## Proposed changes:

When a Woo Site owner has explicitely disabled usage tracking in their Woo store settings, we should also disable WooCommerce Analytics.

With this change, we do not change the module status logic; the module will remain enabled if it was enabled. However, no analytics will be tracked if the option is off:

![Screenshot 2024-02-07 at 11 00 30](https://github.com/Automattic/jetpack/assets/426388/12a8b3bd-01a8-4835-98a2-71a297e9390f)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1707240843845259-slack-C0299DMPG

## Does this pull request change what data or activity we track or use?

* Yes, it stops enqueuing JavaScript on the frontend of stores, and stops setting up cookies, if the Usage Tracking feature is disabled in woo settings.

## Testing instructions:

* Start with a site running the most recent version of Jetpack and WooCommerce.
* Connect the site to your WordPress.com account.
* Go to Jetpack > Settings > Modules and confirm that the WooCommerce Analytics module is enabled.
* Go to the frontend of the site, and confirm that `https://stats.wp.com/s-xxxx.js` is enabled, `xxxx` being the year and month.
* Go to WooCommerce > Settings > Advanced > Woo.com
* Disable tracking
* Confirm that the js file above is still enqueued on the frontend.
* Apply this patch.
* Confirm that the js file is not available on the frontend anymore.
* Go back to  WooCommerce > Settings > Advanced > Woo.com and enable tracking back.
* Conform that the js file is now enqueued again.
