### PR TITLE
Subscribe block: disable batcache when user is logged in

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-batcache
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-batcache
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Subscribe block: avoid Batcache when logged in

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -660,6 +660,14 @@ function render_for_website( $data, $classes, $styles ) {
 	$is_subscribed      = Jetpack_Memberships::is_current_user_subscribed();
 	$button_text        = get_submit_button_text( $data );
 
+	// Prevent Batcache from caching views with subscribe block when user subscribed, or even just logged and aren't subscribed.
+	// Avoids user's emails or block's "subscribed" state getting cached.
+	if ( $is_subscribed || ! empty( $data['subscribe_email'] ) ) {
+		if ( function_exists( 'batcache_cancel' ) ) {
+			batcache_cancel();
+		}
+	}
+
 	ob_start();
 
 	Jetpack_Subscriptions_Widget::render_widget_status_messages(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In the spirit of https://github.com/Automattic/jetpack/pull/35372 and would be followed-up by some additional cache plugins in https://github.com/Automattic/jetpack/pull/35506

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a check in block's website rendering method to skip Batcache when:
  * User is logged in, even if they aren't subscribed and thus don't have the JWT auth token cookie set.
  * When user _is_ subscribed — this might be already covered by the token cookie done in https://github.com/Automattic/jetpack/pull/35372 so the only check we might need if user is logged in?

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See testing instructions from https://github.com/Automattic/jetpack/pull/35372

