### PR TITLE
Fix youtube shortcode parsing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-youtube-shortcode-parsing
+++ b/projects/plugins/jetpack/changelog/fix-youtube-shortcode-parsing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Shortcodes: Get rid of warnings when given invalid input to parsing youtube urls

--- a/projects/plugins/jetpack/functions.compat.php
+++ b/projects/plugins/jetpack/functions.compat.php
@@ -59,11 +59,14 @@ if ( ! function_exists( 'youtube_sanitize_url' ) ) :
 	 * Normalizes a YouTube URL to include a v= parameter and a query string free of encoded ampersands.
 	 *
 	 * @param string|array $url YouTube URL.
-	 * @return string The normalized URL
+	 * @return string|array The normalized URL or false if input is invalid.
 	 */
 	function youtube_sanitize_url( $url ) {
 		if ( is_array( $url ) && isset( $url['url'] ) ) {
 			$url = $url['url'];
+		}
+		if ( ! is_string( $url ) ) {
+			return false;
 		}
 
 		$url = trim( $url, ' "' );

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -133,7 +133,7 @@ function youtube_link_callback( $matches ) {
  * Normalizes a YouTube URL to include a v= parameter and a query string free of encoded ampersands.
  *
  * @param string|array $url Youtube URL.
- * @return string The normalized URL
+ * @return string|false The normalized URL or false if input is invalid.
  */
 if ( ! function_exists( 'youtube_sanitize_url' ) ) :
 	/**
@@ -144,6 +144,9 @@ if ( ! function_exists( 'youtube_sanitize_url' ) ) :
 	function youtube_sanitize_url( $url ) {
 		if ( is_array( $url ) && isset( $url['url'] ) ) {
 			$url = $url['url'];
+		}
+		if ( ! is_string( $url ) ) {
+			return false;
 		}
 
 		$url = trim( $url, ' "' );

--- a/projects/plugins/jetpack/tests/php/general/test-class.functions.compat.php
+++ b/projects/plugins/jetpack/tests/php/general/test-class.functions.compat.php
@@ -122,6 +122,40 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @author robfelty
+	 * @covers ::youtube_sanitize_url
+	 * @since 13.2
+	 */
+	public function test_youtube_sanitize_url_as_array() {
+
+		$url_array              = array(
+			'url' => 'http://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US',
+		);
+		$expected_sanitized_url = 'http://www.youtube.com/?v=9FhMMmqzbD8&fs=1&hl=en_US';
+
+		$sanitized_url = youtube_sanitize_url( $url_array );
+
+		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
+	}
+
+	/**
+	 * @author robfelty
+	 * @covers ::youtube_sanitize_url
+	 * @since 13.2
+	 */
+	public function test_youtube_sanitize_url_invalid_input() {
+
+		$invalid_url_array      = array(
+			'vv' => 'http://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US',
+		);
+		$expected_sanitized_url = false;
+
+		$sanitized_url = youtube_sanitize_url( $invalid_url_array );
+
+		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
+	}
+
+	/**
 	 * @author enkrates
 	 * @covers ::jetpack_get_youtube_id
 	 * @since 3.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I noticed some PHP warnings being generated when extracting youtube shortcodes recently, of the type
```
Warning: trim() expects parameter 1 to be string, array given in wp-content/plugins/jetpack/modules/shortcodes/youtube.php
```
This fix ensures that if the `$url` is not a string, then we simply return false. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Run the new unit tests - there is one with a valid url array and one with an invalid array.
```
$ jetpack docker phpunit -- --filter=WP_Test_Functions_Compat
```
