### PR TITLE
Boost: mirror the REQUEST_URI when storing cache files

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache.php
@@ -16,11 +16,6 @@ abstract class Boost_Cache {
 	private $settings;
 
 	/*
-	 * @var string - The path key used to identify the cache directory for the current request. MD5 of the request uri.
-	 */
-	protected $path_key = false;
-
-	/*
 	 * @var string - The normalized path for the current request. This is not sanitized. Only to be used for comparison purposes.
 	 */
 	protected $request_uri = false;

--- a/projects/plugins/boost/app/modules/cache/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache.php
@@ -28,7 +28,7 @@ abstract class Boost_Cache {
 	public function __construct() {
 		$this->settings    = Boost_Cache_Settings::get_instance();
 		$this->request_uri = isset( $_SERVER['REQUEST_URI'] )
-			? $this->normalize_request_uri( $_SERVER['REQUEST_URI'] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+			? Boost_Cache_Utils::sanitize_file_path( $this->normalize_request_uri( $_SERVER['REQUEST_URI'] ) ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			: false;
 	}
 
@@ -167,28 +167,6 @@ abstract class Boost_Cache {
 		);
 
 		return md5( json_encode( $key_components ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
-	}
-
-	/*
-	 * Returns a key to identify the path to the visitor's cache file.
-	 * Without a parameter it uses the current request uri, and caches that in
-	 * $this->path_key.
-	 * A URL like "/2024/01/01/hello-world/" on your site will have one path_key,
-	 * but the cache_filename to identify the cache file for a visitor is based
-	 * on the path_key + cache_key. Can have multiple cache files for one path_key.
-	 *
-	 * @param string $request_uri (optional) The sanitized request uri to calculate the path key. Defaults to the current request uri.
-	 * @return string
-	 */
-	public function path_key( $request_uri = '' ) {
-		if ( $request_uri !== '' ) {
-			return md5( $request_uri );
-		}
-
-		if ( ! $this->path_key ) {
-			$this->path_key = md5( $this->request_uri );
-		}
-		return $this->path_key;
 	}
 
 	abstract public function get();

--- a/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache_Utils.php
@@ -31,15 +31,42 @@ class Boost_Cache_Utils {
 		return @rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
 	}
 
+	/**
+	 * Performs a deep string replace operation to ensure the values in $search are no longer present.
+	 * Copied from wp-includes/formatting.php
+	 *
+	 * Repeats the replacement operation until it no longer replaces anything to remove "nested" values
+	 * e.g. $subject = '%0%0%0DDD', $search ='%0D', $result ='' rather than the '%0%0DD' that
+	 * str_replace would return
+	 *
+	 * @param string|array $search  The value being searched for, otherwise known as the needle.
+	 *                              An array may be used to designate multiple needles.
+	 * @param string       $subject The string being searched and replaced on, otherwise known as the haystack.
+	 * @return string The string with the replaced values.
+	 */
+	private static function deep_replace( $search, $subject ) {
+		$subject = (string) $subject;
+
+		$count = 1;
+		while ( $count ) {
+				$subject = str_replace( $search, '', $subject, $count );
+		}
+
+		return $subject;
+	}
+
+	public static function trailingslashit( $string ) {
+		return rtrim( $string, '/' ) . '/';
+	}
+
 	/*
 	 * Returns a sanitized directory path.
 	 * @param string $path - The path to sanitize.
 	 * @return string
 	 */
 	public static function sanitize_file_path( $path ) {
-		$path = trailingslashit( $path );
-
-		$path = _deep_replace(
+		$path = self::trailingslashit( $path );
+		$path = self::deep_replace(
 			array( '..', '\\' ),
 			preg_replace(
 				'/[ <>\'\"\r\n\t\(\)]/',

--- a/projects/plugins/boost/app/modules/cache/Boost_File_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_File_Cache.php
@@ -17,22 +17,12 @@ class Boost_File_Cache extends Boost_Cache {
 	 */
 	private function path( $request_uri = false ) {
 		if ( $request_uri !== false ) {
-			$request_uri = $this->normalize_request_uri( $request_uri );
+			$request_uri = Boost_Cache_Utils::sanitize_file_path( $this->normalize_request_uri( $request_uri ) );
 		} else {
 			$request_uri = $this->request_uri;
 		}
 
-		$key  = $this->path_key( $request_uri );
-		$path = WP_CONTENT_DIR . '/boost-cache/cache/';
-
-		/*
-		 * The cache directory is split into 5 levels of subdirectories.
-		 * 2 characters of the md5 hash of the request uri are used for each level.
-		 * This is done to prevent having too many files in a single directory.
-		 */
-		for ( $i = 0; $i < 10; $i += 2 ) {
-			$path .= substr( $key, $i, 2 ) . '/';
-		}
+		$path = Boost_Cache_Utils::trailingslashit( WP_CONTENT_DIR . '/boost-cache/cache/' . $request_uri );
 
 		return $path;
 	}

--- a/projects/plugins/boost/changelog/boost-cache-mirror-the-uri
+++ b/projects/plugins/boost/changelog/boost-cache-mirror-the-uri
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Boost: mirror the REQUEST_URI when storing cache files.


### PR DESCRIPTION
We are currently using an MD5 of the REQUEST_URI to store the cache files. However this makes invalidating the cache more difficult because the hash of every requested URI must be calculated to delete a cache file. It's not known in advance if the cache file exists or not.

Mirroring the URI makes things much easier, especially when deleting paged content. Simply deleting the parent directory recursively will remove any paged data.

Fixes [#35513](https://github.com/Automattic/jetpack/issues/35513)

## Proposed changes:
* The path() function will return the sanitized REQUEST_URI instead of calculating the MD5 of it and breaking it up into 5 directories.
* $this->request_uri will be sanitized by using deep_replace to remove unwanted characters.
* _deep_replace() is copied from formatting.php.
* Any mention of path_key is removed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Load this PR
* Set BOOST_CACHE constant in wp-config.php
* Visit the Boost settings page to set things up. No interaction required.
* Visit a page and then look in wp-content/boost-cache/cache/ and you'll see the URL of that page replicated there.
* Reload and view source. Look to the bottom of the page for the text "cached".