### PR TITLE
Boost: cache the _COOKIE and _GET arrays for later use in the cache_filename

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache.php
@@ -25,11 +25,31 @@ abstract class Boost_Cache {
 	 */
 	protected $request_uri = false;
 
+	/*
+	 * @var array - The cookies for the current request.
+	 */
+	protected $cookies;
+
+	/*
+	 * @var array - The get parameters for the current request.
+	 */
+	protected $get;
+
 	public function __construct() {
 		$this->settings    = Boost_Cache_Settings::get_instance();
 		$this->request_uri = isset( $_SERVER['REQUEST_URI'] )
 			? $this->normalize_request_uri( $_SERVER['REQUEST_URI'] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			: false;
+
+		/*
+		 * Set the cookies and get parameters for the current request.
+		 * Sometimes these arrays are modified by WordPress or other plugins.
+		 * We need to cache them here so they can be used for the cache key
+		 * later.
+		 * We don't need to sanitize them, as they are only used for comparison.
+		 */
+		$this->cookies = $_COOKIE; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$this->get     = $_GET; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 	}
 
 	/*
@@ -156,8 +176,8 @@ abstract class Boost_Cache {
 
 		$defaults = array(
 			'request_uri' => $this->request_uri,
-			'cookies'     => $_COOKIE, // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			'get'         => $_GET, // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+			'cookies'     => $this->cookies, // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			'get'         => $this->get, // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		);
 		$args     = array_merge( $defaults, $args );
 

--- a/projects/plugins/boost/app/modules/cache/Boost_File_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_File_Cache.php
@@ -46,8 +46,8 @@ class Boost_File_Cache extends Boost_Cache {
 	private function cache_filename( $args = array() ) {
 		$defaults = array(
 			'request_uri' => $this->request_uri,
-			'cookies'     => $_COOKIE, // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			'get'         => $_GET, // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+			'cookies'     => $this->cookies, // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			'get'         => $this->get, // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		);
 		$args     = array_merge( $defaults, $args );
 

--- a/projects/plugins/boost/changelog/boost-cache-cache_globals
+++ b/projects/plugins/boost/changelog/boost-cache-cache_globals
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Boost: cache the COOKIE and GET arrays for later use.
+
+


### PR DESCRIPTION
The cache filename is partly generated from the _COOKIE and _GET arrays, but sometimes WordPress or another plugin will modify those arrays. I noticed the values of some _COOKIE elements were slashed in the browser but on reload they were not which resulted in the cache filename not being found on reload.
This PR caches that data and uses that cached data to generate the cache_filename when saving the cached page.

Fixes [#35394](https://github.com/Automattic/jetpack/issues/35394)

## Proposed changes:
* Cache _GET and _COOKIE in the Boost_Cache constructor.
* Use that data in the get() and set() functions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR
* Define a "BOOST_CACHE" constant in wp-config.php
* Browse around your test site and check that you're being served cached pages.