### PR TITLE
Fix default styling on sharing buttons

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-default-styling-on-sharing-buttons
+++ b/projects/plugins/jetpack/changelog/fix-default-styling-on-sharing-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Small adjustments to default Sharing Buttons styles

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/style.scss
@@ -31,6 +31,11 @@
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22), 0 0 0 1px rgba(0, 0, 0, 0.22);
 	}
 
+	&.components-button {
+		font-size: inherit;
+		padding: 4px 11px 3px 9px;
+	}
+
 	&.style-icon {
 		border-radius: 50%;
 		border: 0;

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/style.scss
@@ -30,7 +30,7 @@
 
 .editor-styles-wrapper .wp-block-jetpack-sharing-buttons {
 	gap: 0;
-	padding-left: 0;
+	padding-inline-start: 0;
 }
 
 ul.jetpack-sharing-buttons__services-list.has-background {

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/style.scss
@@ -28,6 +28,11 @@
 	}
 }
 
+.editor-styles-wrapper .wp-block-jetpack-sharing-buttons {
+	gap: 0;
+	padding-left: 0;
+}
+
 ul.jetpack-sharing-buttons__services-list.has-background {
     padding: 1.25em 2.375em;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35519

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
While spinning a fresh JN site and adding a sharing buttons additional default styles are applied which make block appear differently. 
- Gap between blocks is too big.
- Big margin on the start of the block
- Buttons size can't be changed.
This PR addresses it

| Before | After |
| ------- | -------- |
| <img width="480" alt="Screenshot 2024-02-07 at 11 58 44 AM" src="https://github.com/Automattic/jetpack/assets/60262784/8d312d0c-92c6-439b-bc18-00e18623551f"> | <img width="499" alt="Screenshot 2024-02-07 at 11 55 08 AM" src="https://github.com/Automattic/jetpack/assets/60262784/d16feb89-c5d1-4bd2-9d14-7d98b14d25c5"> |


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up the branch locally and `build plugins/jetpack`
* Spin a fresh JN site
* Add a new post. Add sharing buttons. Verify that margins are off and size can't be changed.
* `rsync` local changes to JN site.
* Observe on the post that Sharing Buttons act normally.