### PR TITLE
Maintenance releases after Jetpack 13.1.1

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/CHANGELOG.md
+++ b/projects/github-actions/pr-is-up-to-date/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2024-02-07
+### Changed
+- Update dependencies. [#34213]
+
 ## [2.0.2] - 2023-02-07
 ### Changed
 - Minor internal updates.
@@ -49,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.3]: https://github.com/Automattic/action-pr-is-up-to-date/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/action-pr-is-up-to-date/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/action-pr-is-up-to-date/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/action-pr-is-up-to-date/compare/v1.0.3...v2.0.0

--- a/projects/github-actions/pr-is-up-to-date/changelog/force-a-release
+++ b/projects/github-actions/pr-is-up-to-date/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/github-actions/push-to-mirrors/CHANGELOG.md
+++ b/projects/github-actions/push-to-mirrors/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2024-02-07
+### Added
+- Added support for GitHub Enterprise by replacing github.com with a dynamic variable [#32974]
+
+### Changed
+- Update example in readme to use `actions/checkout@v4`. [#35262]
+
 ## [2.0.0] - 2022-11-23
 ### Changed
 - It is now considered an error if the mirror repo does not exist. [#27523]
@@ -51,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[2.1.0]: https://github.com/Automattic/action-push-to-mirrors/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/Automattic/action-push-to-mirrors/compare/v1.0.5...v2.0.0
 [1.0.5]: https://github.com/Automattic/action-push-to-mirrors/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/Automattic/action-push-to-mirrors/compare/v1.0.3...v1.0.4

--- a/projects/github-actions/push-to-mirrors/changelog/add-support-for-github-enterprise
+++ b/projects/github-actions/push-to-mirrors/changelog/add-support-for-github-enterprise
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added support for GitHub Enterprise by replacing github.com with a dynamic variable

--- a/projects/github-actions/push-to-mirrors/changelog/update-actions-node20
+++ b/projects/github-actions/push-to-mirrors/changelog/update-actions-node20
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update example in readme to use `actions/checkout@v4`.

--- a/projects/github-actions/repo-gardening/CHANGELOG.md
+++ b/projects/github-actions/repo-gardening/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2024-02-07
+### Added
+- Auto-label features in the mu-wpcom package. [#32221]
+- Board triage: automate triage of Verbum-related issues. [#35326]
+- Board triage task: automatically add issues classified as bugs to the project board. [#33493]
+- Gather Support References task: automatically label issues that include support references. [#32398]
+- Label automations: mark revert PRs with a label. [#33472]
+- Label cleanup: Remove `[Status] Stale` from closed PRs. [#31743]
+- New task: updateBoard allows you to automate updates to a GitHub Project Board fields to match priority labels on an issue in your repo. [#33469]
+- Project Board automations: automatically update the status field based on the "Triaged" label. [#33482]
+- Project Board triage: automatically assign teams to an issue based on issue labels. [#34313]
+- Repo Gardening Action: Add add_labels input to addLabels task for setting custom path: label matching directly in the workflow. [#32306]
+
+### Changed
+- addMilestone task: if a milestone description contains a string with "Code Freeze: YYYY-MM-DD" or "Branch Cut: YYYY-MM-DD", and that date has elapsed, then don't add PRs to that milestone. This prevents merged PRs from being automatically added to milestones that have entered a code freeze. [#31973]
+- Board triage: update team Zap's assignment settings. [#35466]
+- Check description task: support different phrasing in milestone descriptiion. "Code Freeze" can also be "Branch cut". [#31987]
+- Description task: update milestone details to include information about the different release schedules. [#33675]
+- Gather Support References: also gather p2 comment references. [#33979]
+- Gather Support References: consider forum links to be a valid support reference. [#35148]
+- Issue Triage: update the "Escalated" status label to "Priority Review Triggered". [#33756]
+- Label cleanup: Task now runs for closed issues as well as PRs. [#31743]
+- Labelling: handle automatic labeling of Contact Form changes in the package. [#33864]
+- Labels: prefix module labels with [Feature], to match new bug reporting tool. [#32118]
+- Labels: update "Premium Content" to "Paid Content". [#33119]
+- Labels: update Stats's label name. [#32916]
+- Project Board triage: handle issues waiting on a third-party fix when auto-triaging. [#33876]
+- Updated package dependencies. [#33650]
+- Update the label used to mark issues that have reports from Happiness Engineers. [#32711]
+- Use the node20 runner instead of the deprecated node16 runner. [#35262]
+
+### Removed
+- Description task: remove reference to "Required review" check that was removed a while back. [#33683]
+- Status checks: remove commit verification status check. [#33075]
+
+### Fixed
+- Adds Woo Sync to GH label name exceptions. [#33713]
+- Automated Board triage: fix event reference to trigger the action. [#34482]
+- Board triage: ensure the task works when the organization name is capitalized [#34980]
+- Don't crash on milestones with null description. [#32599]
+- Issue references: avoid changing capitalization of p2 shortlinks. [#34426]
+- Issue references: do not gather support references in Pull Requests, only in issues. [#34426]
+- Project Board automations: do not run any automation on closed issues. [#33539]
+
 ## [4.0.0] - 2023-06-06
 ### Added
 - Add new task to notify Quality team of important issues
@@ -166,6 +210,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[5.0.0]: https://github.com/Automattic/action-repo-gardening/compare/v4.0.0...v5.0.0
 [4.0.0]: https://github.com/Automattic/action-repo-gardening/compare/v3.1.1...v4.0.0
 [3.1.1]: https://github.com/Automattic/action-repo-gardening/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/Automattic/action-repo-gardening/compare/v3.0.0...v3.1.0

--- a/projects/github-actions/repo-gardening/changelog/add-happiness-request-labelling
+++ b/projects/github-actions/repo-gardening/changelog/add-happiness-request-labelling
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Gather Support References task: automatically label issues that include support references.

--- a/projects/github-actions/repo-gardening/changelog/add-mu-wpcom-feature-labeling
+++ b/projects/github-actions/repo-gardening/changelog/add-mu-wpcom-feature-labeling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Auto-label features in the mu-wpcom package.

--- a/projects/github-actions/repo-gardening/changelog/add-repo-gardening-project-priority-automation
+++ b/projects/github-actions/repo-gardening/changelog/add-repo-gardening-project-priority-automation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-New task: updateBoard allows you to automate updates to a GitHub Project Board fields to match priority labels on an issue in your repo.

--- a/projects/github-actions/repo-gardening/changelog/add-repo-gardening-revert-flag
+++ b/projects/github-actions/repo-gardening/changelog/add-repo-gardening-revert-flag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Label automations: mark revert PRs with a label.

--- a/projects/github-actions/repo-gardening/changelog/add-triaged-board-update
+++ b/projects/github-actions/repo-gardening/changelog/add-triaged-board-update
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Project Board automations: automatically update the status field based on the "Triaged" label.

--- a/projects/github-actions/repo-gardening/changelog/add-update-board-bug-board
+++ b/projects/github-actions/repo-gardening/changelog/add-update-board-bug-board
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Board triage task: automatically add issues classified as bugs to the project board.

--- a/projects/github-actions/repo-gardening/changelog/change-repo-gardening-crm-next-release-date
+++ b/projects/github-actions/repo-gardening/changelog/change-repo-gardening-crm-next-release-date
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Only affects PR creation
-
-

--- a/projects/github-actions/repo-gardening/changelog/fix-auto-assignment-capitalization
+++ b/projects/github-actions/repo-gardening/changelog/fix-auto-assignment-capitalization
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Board triage: ensure the task works when the organization name is capitalized

--- a/projects/github-actions/repo-gardening/changelog/fix-gather-issue-references-pr
+++ b/projects/github-actions/repo-gardening/changelog/fix-gather-issue-references-pr
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Issue references: do not gather support references in Pull Requests, only in issues.

--- a/projects/github-actions/repo-gardening/changelog/fix-gather-issue-references-pr#2
+++ b/projects/github-actions/repo-gardening/changelog/fix-gather-issue-references-pr#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Issue references: avoid changing capitalization of p2 shortlinks.

--- a/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-null-description
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-null-description
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Don't crash on milestones with null description.

--- a/projects/github-actions/repo-gardening/changelog/fix-repo_gardening_label_tweaks
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo_gardening_label_tweaks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Adds Woo Sync to GH label name exceptions.

--- a/projects/github-actions/repo-gardening/changelog/fix-update-board-trigger-reference
+++ b/projects/github-actions/repo-gardening/changelog/fix-update-board-trigger-reference
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Automated Board triage: fix event reference to trigger the action.

--- a/projects/github-actions/repo-gardening/changelog/remove-doc-refs-to-required-review
+++ b/projects/github-actions/repo-gardening/changelog/remove-doc-refs-to-required-review
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Description task: remove reference to "Required review" check that was removed a while back.

--- a/projects/github-actions/repo-gardening/changelog/remove-not-verified-git-hook
+++ b/projects/github-actions/repo-gardening/changelog/remove-not-verified-git-hook
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Status checks: remove commit verification status check.

--- a/projects/github-actions/repo-gardening/changelog/renovate-github-api-packages
+++ b/projects/github-actions/repo-gardening/changelog/renovate-github-api-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/repo-gardening/changelog/update-actions-node20
+++ b/projects/github-actions/repo-gardening/changelog/update-actions-node20
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-Use the node20 runner instead of the deprecated node16 runner.

--- a/projects/github-actions/repo-gardening/changelog/update-add-milestone-consider-code-freeze
+++ b/projects/github-actions/repo-gardening/changelog/update-add-milestone-consider-code-freeze
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-addMilestone task: if a milestone description contains a string with "Code Freeze: YYYY-MM-DD" or "Branch Cut: YYYY-MM-DD", and that date has elapsed, then don't add PRs to that milestone. This prevents merged PRs from being automatically added to milestones that have entered a code freeze.

--- a/projects/github-actions/repo-gardening/changelog/update-cleanup-docs-from-32306
+++ b/projects/github-actions/repo-gardening/changelog/update-cleanup-docs-from-32306
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update docs from #32306. No need for a separate changelog entry.
-
-

--- a/projects/github-actions/repo-gardening/changelog/update-description-release-process
+++ b/projects/github-actions/repo-gardening/changelog/update-description-release-process
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Description task: update milestone details to include information about the different release schedules.

--- a/projects/github-actions/repo-gardening/changelog/update-description-task-code-freeze
+++ b/projects/github-actions/repo-gardening/changelog/update-description-task-code-freeze
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Check description task: support different phrasing in milestone descriptiion. "Code Freeze" can also be "Branch cut".

--- a/projects/github-actions/repo-gardening/changelog/update-escalated-label
+++ b/projects/github-actions/repo-gardening/changelog/update-escalated-label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Issue Triage: update the "Escalated" status label to "Priority Review Triggered".

--- a/projects/github-actions/repo-gardening/changelog/update-gardening-actions-meteorite
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-actions-meteorite
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: It is just a change to a repo automation
-
-

--- a/projects/github-actions/repo-gardening/changelog/update-gardening-contact-form-label
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-contact-form-label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Labelling: handle automatic labeling of Contact Form changes in the package.

--- a/projects/github-actions/repo-gardening/changelog/update-gardening-remove-stale-from-closed
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-remove-stale-from-closed
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Label cleanup: Remove `[Status] Stale` from closed PRs.

--- a/projects/github-actions/repo-gardening/changelog/update-gardening-remove-stale-from-closed#2
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-remove-stale-from-closed#2
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Label cleanup: Task now runs for closed issues as well as PRs.

--- a/projects/github-actions/repo-gardening/changelog/update-gather-forum-links
+++ b/projects/github-actions/repo-gardening/changelog/update-gather-forum-links
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Gather Support References: consider forum links to be a valid support reference.

--- a/projects/github-actions/repo-gardening/changelog/update-gather-support-p2s-too
+++ b/projects/github-actions/repo-gardening/changelog/update-gather-support-p2s-too
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Gather Support References: also gather p2 comment references.

--- a/projects/github-actions/repo-gardening/changelog/update-label-happiness-request
+++ b/projects/github-actions/repo-gardening/changelog/update-label-happiness-request
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update the label used to mark issues that have reports from Happiness Engineers.

--- a/projects/github-actions/repo-gardening/changelog/update-labels-prefixes
+++ b/projects/github-actions/repo-gardening/changelog/update-labels-prefixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Labels: prefix module labels with [Feature], to match new bug reporting tool.

--- a/projects/github-actions/repo-gardening/changelog/update-node-20
+++ b/projects/github-actions/repo-gardening/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/github-actions/repo-gardening/changelog/update-premium-content
+++ b/projects/github-actions/repo-gardening/changelog/update-premium-content
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Labels: update "Premium Content" to "Paid Content".

--- a/projects/github-actions/repo-gardening/changelog/update-quality-messages
+++ b/projects/github-actions/repo-gardening/changelog/update-quality-messages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Slack Messages: remove mentions of Kitkat.
-
-

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-add-labels
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-add-labels
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Repo Gardening Action: Add add_labels input to addLabels task for setting custom path: label matching directly in the workflow.

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-update-board-team
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-update-board-team
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Project Board triage: automatically assign teams to an issue based on issue labels.

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-verbum-board
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-verbum-board
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Board triage: automate triage of Verbum-related issues.

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-zap-assignment
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-zap-assignment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Board triage: update team Zap's assignment settings.

--- a/projects/github-actions/repo-gardening/changelog/update-stats-module-label-name
+++ b/projects/github-actions/repo-gardening/changelog/update-stats-module-label-name
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Labels: update Stats's label name.

--- a/projects/github-actions/repo-gardening/changelog/update-support-reference-matches
+++ b/projects/github-actions/repo-gardening/changelog/update-support-reference-matches
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Issue references triage: update matching for p2 comments
-
-

--- a/projects/github-actions/repo-gardening/changelog/update-update-board-closed-issue
+++ b/projects/github-actions/repo-gardening/changelog/update-update-board-closed-issue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Project Board automations: do not run any automation on closed issues.

--- a/projects/github-actions/repo-gardening/changelog/update-update-board-triaged-3rd-party-fix
+++ b/projects/github-actions/repo-gardening/changelog/update-update-board-triaged-3rd-party-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Project Board triage: handle issues waiting on a third-party fix when auto-triaging.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "5.0.0-alpha",
+	"version": "5.0.0",
 	"description": "Manage Pull Requests and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/required-review/CHANGELOG.md
+++ b/projects/github-actions/required-review/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2024-02-07
+### Added
+- Added support for GitHub Enterprise by replacing github.com with a dynamic variable [#32974]
+
+### Changed
+- Updated package dependencies. [#33650]
+- Use the node20 runner instead of the deprecated node16 runner. [#35262]
+
 ## [3.1.0] - 2023-07-06
 ### Added
 - Added `consume` option for requirements. [#29317]
@@ -75,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[4.0.0]: https://github.com/Automattic/action-required-review/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/Automattic/action-required-review/compare/v3.0.2...v3.1.0
 [3.0.2]: https://github.com/Automattic/action-required-review/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/Automattic/action-required-review/compare/v3.0.0...v3.0.1

--- a/projects/github-actions/required-review/changelog/add-support-for-github-enterprise
+++ b/projects/github-actions/required-review/changelog/add-support-for-github-enterprise
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added support for GitHub Enterprise by replacing github.com with a dynamic variable

--- a/projects/github-actions/required-review/changelog/renovate-github-api-packages
+++ b/projects/github-actions/required-review/changelog/renovate-github-api-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/required-review/changelog/update-actions-node20
+++ b/projects/github-actions/required-review/changelog/update-actions-node20
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-Use the node20 runner instead of the deprecated node16 runner.

--- a/projects/github-actions/required-review/changelog/update-node-20
+++ b/projects/github-actions/required-review/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/github-actions/required-review/package.json
+++ b/projects/github-actions/required-review/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "required-review",
-	"version": "4.0.0-alpha",
+	"version": "4.0.0",
 	"description": "Check that a Pull Request has reviews from required teams.",
 	"main": "index.js",
 	"author": "Automattic",

--- a/projects/github-actions/test-results-to-slack/CHANGELOG.md
+++ b/projects/github-actions/test-results-to-slack/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2024-02-07
+### Changed
+- Update doc example to use `actions/upload-artifact@v4`. [#34997]
+- Updated package dependencies. [#33650]
+- Updated package dependencies. [#34193]
+- Updated package dependencies. [#34427]
+- Updated package dependencies. [#35385]
+- Use the node20 runner instead of the deprecated node16 runner. [#35262]
+
 ## [0.2.1] - 2023-04-07
 ### Changed
 - Updated package dependencies.
@@ -46,5 +55,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove duplicated last run button for scheduled event notification
 - Remove duplicated last run button for workflow_run events
 
+[0.3.0]: https://github.com/Automattic/action-test-results-to-slack/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Automattic/action-test-results-to-slack/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/action-test-results-to-slack/compare/v0.1.0...v0.2.0

--- a/projects/github-actions/test-results-to-slack/changelog/renovate-actions-download-artifact-4.x
+++ b/projects/github-actions/test-results-to-slack/changelog/renovate-actions-download-artifact-4.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update doc example to use `actions/upload-artifact@v4`.

--- a/projects/github-actions/test-results-to-slack/changelog/renovate-github-api-packages
+++ b/projects/github-actions/test-results-to-slack/changelog/renovate-github-api-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/test-results-to-slack/changelog/renovate-js-unit-testing-packages
+++ b/projects/github-actions/test-results-to-slack/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/test-results-to-slack/changelog/renovate-js-unit-testing-packages#2
+++ b/projects/github-actions/test-results-to-slack/changelog/renovate-js-unit-testing-packages#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/test-results-to-slack/changelog/renovate-major-eslint-packages
+++ b/projects/github-actions/test-results-to-slack/changelog/renovate-major-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix new JS lints. No change in functionality.
-
-

--- a/projects/github-actions/test-results-to-slack/changelog/renovate-slack-web-api-6.x
+++ b/projects/github-actions/test-results-to-slack/changelog/renovate-slack-web-api-6.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/test-results-to-slack/changelog/update-actions-node20
+++ b/projects/github-actions/test-results-to-slack/changelog/update-actions-node20
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-Use the node20 runner instead of the deprecated node16 runner.

--- a/projects/github-actions/test-results-to-slack/changelog/update-convert-e2e-tests-to-esm
+++ b/projects/github-actions/test-results-to-slack/changelog/update-convert-e2e-tests-to-esm
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Convert E2E configs to ESM. No change to the plugin itself.
-
-

--- a/projects/github-actions/test-results-to-slack/changelog/update-node-20
+++ b/projects/github-actions/test-results-to-slack/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/github-actions/test-results-to-slack/package.json
+++ b/projects/github-actions/test-results-to-slack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "test-results-to-slack",
-	"version": "0.3.0-alpha",
+	"version": "0.3.0",
 	"description": "GitHub Action to send Slack notifications with test results",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/eslint-changed/CHANGELOG.md
+++ b/projects/js-packages/eslint-changed/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.8] - 2024-02-07
+### Changed
+- Updated package dependencies. [#34427]
+
 ## [2.0.7] - 2023-07-12
 ### Fixed
 - Fix package name in readme. [#31844]
@@ -75,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Created as a tool within the monorepo.
 
+[2.0.8]: https://github.com/Automattic/eslint-changed/compare/2.0.7...2.0.8
 [2.0.7]: https://github.com/Automattic/eslint-changed/compare/2.0.6...2.0.7
 [2.0.6]: https://github.com/Automattic/eslint-changed/compare/2.0.5...2.0.6
 [2.0.5]: https://github.com/Automattic/eslint-changed/compare/2.0.4...2.0.5

--- a/projects/js-packages/eslint-changed/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/eslint-changed/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-changed/changelog/update-node-20
+++ b/projects/js-packages/eslint-changed/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/eslint-changed/package.json
+++ b/projects/js-packages/eslint-changed/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/eslint-changed",
-	"version": "2.0.8-alpha",
+	"version": "2.0.8",
 	"description": "Run eslint on files, but only report warnings and errors from lines that were changed.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/eslint-changed/#readme",
 	"type": "module",

--- a/projects/js-packages/eslint-changed/src/cli.js
+++ b/projects/js-packages/eslint-changed/src/cli.js
@@ -6,7 +6,7 @@ import { Command } from 'commander';
 import { ESLint } from 'eslint';
 import parseDiff from 'parse-diff';
 
-const APP_VERSION = '2.0.8-alpha';
+const APP_VERSION = '2.0.8';
 
 /**
  * Create a Commander instance.

--- a/projects/js-packages/eslint-config-target-es/CHANGELOG.md
+++ b/projects/js-packages/eslint-config-target-es/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2024-02-07
+### Added
+- All versions indicated by browserslist are now checked, not just the lowest. Added `getAllBrowsers` function to support this. [#31658]
+- Support for more complex MDN data:
+  * Multiple support statements are now all checked. Previously only the first (most recent) was, which may have missed cases where support was backported.
+  * `version_removed` is now checked.
+  * Ranged versions (≤) are now handled.
+  * `prefix`, `alternative_name`, and `flags` now indicate (possible) lack of support. [#31658]
+
+### Changed
+- Updated package dependencies.
+
+### Deprecated
+- Deprecated `getBrowsers` function in favor of the new `getAllBrowsers`. [#31658]
+
+### Fixed
+- Apparently MDN data considers "preview" a version, but didn't think that worth documenting. Handle it. [#31816]
+
 ## [2.0.0] - 2023-06-26
 ### Changed
 - As `eslint-plugin-es` appears to be abandoned, change to using `eslint-plugin-es-x`. [#31556]
@@ -41,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.1.0]: https://github.com/Automattic/eslint-config-target-es/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/Automattic/eslint-config-target-es/compare/1.0.6...2.0.0
 [1.0.6]: https://github.com/Automattic/eslint-config-target-es/compare/1.0.5...1.0.6
 [1.0.5]: https://github.com/Automattic/eslint-config-target-es/compare/1.0.4...1.0.5

--- a/projects/js-packages/eslint-config-target-es/changelog/add-eslint-config-target-es-more-mdn-support
+++ b/projects/js-packages/eslint-config-target-es/changelog/add-eslint-config-target-es-more-mdn-support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Deprecated `getBrowsers` function in favor of the new `getAllBrowsers`.

--- a/projects/js-packages/eslint-config-target-es/changelog/add-eslint-config-target-es-more-mdn-support#3
+++ b/projects/js-packages/eslint-config-target-es/changelog/add-eslint-config-target-es-more-mdn-support#3
@@ -1,8 +1,0 @@
-Significance: minor
-Type: added
-
-Support for more complex MDN data:
-* Multiple support statements are now all checked. Previously only the first (most recent) was, which may have missed cases where support was backported.
-* `version_removed` is now checked.
-* Ranged versions (≤) are now handled.
-* `prefix`, `alternative_name`, and `flags` now indicate (possible) lack of support.

--- a/projects/js-packages/eslint-config-target-es/changelog/add-eslint-config-target-es-more-mdn-support#4
+++ b/projects/js-packages/eslint-config-target-es/changelog/add-eslint-config-target-es-more-mdn-support#4
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-All versions indicated by browserslist are now checked, not just the lowest. Added `getAllBrowsers` function to support this.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-eslint-packages
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-eslint-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-eslint-packages#2
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-eslint-packages#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-eslint-packages#3
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-eslint-packages#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-major-eslint-packages
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-major-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Make new version of prettier happy. No functional change.
-
-

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-5.x
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-5.x#2
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-5.x#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Apparently MDN data considers "preview" a version, but didn't think that worth documenting. Handle it.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-5.x#3
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-5.x#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-5.x#4
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-5.x#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#10
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#10
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#3
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#4
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#5
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#6
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#7
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#8
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#9
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-wordpress-monorepo#9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/update-node-20
+++ b/projects/js-packages/eslint-config-target-es/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/eslint-config-target-es/package.json
+++ b/projects/js-packages/eslint-config-target-es/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/eslint-config-target-es",
-	"version": "2.1.0-alpha",
+	"version": "2.1.0",
 	"description": "ESLint sharable config to activate eslint-plugin-es checks based on browserslist targets.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/eslint-config-target-es/README.md#readme",
 	"bugs": {

--- a/projects/js-packages/eslint-config-target-es/src/funcs.js
+++ b/projects/js-packages/eslint-config-target-es/src/funcs.js
@@ -41,7 +41,7 @@ function getAllBrowsers( options = {} ) {
 /**
  * Get the list of supported browsers.
  *
- * @deprecated since $$next-version$$. Use getAllBrowsers instead.
+ * @deprecated since 2.1.0. Use getAllBrowsers instead.
  * @param {object} options - Options.
  * @param {string} options.query - Browserslist query.
  * @returns {object} Browsers mapped to minimum versions.

--- a/projects/js-packages/storybook/CHANGELOG.md
+++ b/projects/js-packages/storybook/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 - 2024-02-07
+### Added
+- Add AI Client icon components [#32079]
+- Added boost back to storybook [#34180]
+- Storybook: register ./extensions folder of the Jetpack plugin project [#33771]
+
+### Changed
+- Boost: Updated storybook configuration to allow scss imports in boost stories. [#32690]
+- Jetpack Boost: Remove Jetpack Boost stories while in the React refactor [#34103]
+- Updated package dependencies.
+
+### Fixed
+- Storybook: remove Jetpack plugin from deps to fix builds in trunk [#33784]
+
 ## 0.4.0 - 2023-07-06
 ### Added
 - Import root styles from js-packages to load root variables used by components [#30037]

--- a/projects/js-packages/storybook/changelog/add-i18n-mock
+++ b/projects/js-packages/storybook/changelog/add-i18n-mock
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Added a mock for window.wp.i18n for storybook component
-
-

--- a/projects/js-packages/storybook/changelog/add-new-boost-path-aliases
+++ b/projects/js-packages/storybook/changelog/add-new-boost-path-aliases
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add latest Boost path aliases.
-
-

--- a/projects/js-packages/storybook/changelog/boost-react-refactor-structure
+++ b/projects/js-packages/storybook/changelog/boost-react-refactor-structure
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Jetpack Boost: Remove Jetpack Boost stories while in the React refactor

--- a/projects/js-packages/storybook/changelog/fix-boost-storybook
+++ b/projects/js-packages/storybook/changelog/fix-boost-storybook
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added boost back to storybook

--- a/projects/js-packages/storybook/changelog/remove-unused-js-deps
+++ b/projects/js-packages/storybook/changelog/remove-unused-js-deps
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unused JS deps. No change to the project itself.
-
-

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#4
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#5
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/storybook/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-npm-postcss-vulnerability
+++ b/projects/js-packages/storybook/changelog/renovate-npm-postcss-vulnerability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-sass-1.x
+++ b/projects/js-packages/storybook/changelog/renovate-sass-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-storybook-addon-mock-4.x
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-addon-mock-4.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#4
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#5
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#6
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#7
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#8
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#9
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/js-packages/storybook/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-ai-client-add-ai-icon
+++ b/projects/js-packages/storybook/changelog/update-ai-client-add-ai-icon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add AI Client icon components

--- a/projects/js-packages/storybook/changelog/update-jetpack-add-usage-panel-story
+++ b/projects/js-packages/storybook/changelog/update-jetpack-add-usage-panel-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Storybook: register ./extensions folder of the Jetpack plugin project

--- a/projects/js-packages/storybook/changelog/update-node-20
+++ b/projects/js-packages/storybook/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/storybook/changelog/update-storybook-config
+++ b/projects/js-packages/storybook/changelog/update-storybook-config
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Boost: Updated storybook configuration to allow scss imports in boost stories.

--- a/projects/js-packages/storybook/changelog/update-storybook-remove-jetpack-plugin
+++ b/projects/js-packages/storybook/changelog/update-storybook-remove-jetpack-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Storybook: remove Jetpack plugin from deps to fix builds in trunk

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-storybook",
-	"version": "0.4.1-alpha",
+	"version": "0.4.1",
 	"description": "Jetpack components storybook",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/storybook/#readme",
 	"bugs": {

--- a/projects/js-packages/svelte-data-sync-client/CHANGELOG.md
+++ b/projects/js-packages/svelte-data-sync-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2024-02-07
+### Changed
+- Updated package dependencies. [#34427]
+
 ## [0.3.4] - 2023-10-26
 ### Changed
 - DataSync: Refactor the datasync interface [#33538]
@@ -54,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#29471]
 - Updated to use Abort Controller to allow cancelling requests mid-stream. [#29122]
 
+[0.3.5]: https://github.com/Automattic/jetpack-svelte-data-sync-client/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Automattic/jetpack-svelte-data-sync-client/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Automattic/jetpack-svelte-data-sync-client/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Automattic/jetpack-svelte-data-sync-client/compare/v0.3.1...v0.3.2

--- a/projects/js-packages/svelte-data-sync-client/changelog/add-lint-only-one-of-jsconfig-tsconfig
+++ b/projects/js-packages/svelte-data-sync-client/changelog/add-lint-only-one-of-jsconfig-tsconfig
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove redundant jsconfig.json file (tsconfig.json already exists).
-
-

--- a/projects/js-packages/svelte-data-sync-client/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/svelte-data-sync-client/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/svelte-data-sync-client/changelog/update-node-20
+++ b/projects/js-packages/svelte-data-sync-client/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/js-packages/svelte-data-sync-client/changelog/update-standardize-on-devtool-source-map
+++ b/projects/js-packages/svelte-data-sync-client/changelog/update-standardize-on-devtool-source-map
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use default devtool from js-packages/webpack-config now that it matches what was being used here already.
-
-

--- a/projects/js-packages/svelte-data-sync-client/package.json
+++ b/projects/js-packages/svelte-data-sync-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-svelte-data-sync-client",
-	"version": "0.3.5-alpha",
+	"version": "0.3.5",
 	"description": "A Svelte.js client for the wp-js-data-sync package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/svelte-data-sync-client/#readme",
 	"type": "module",

--- a/projects/packages/analyzer/CHANGELOG.md
+++ b/projects/packages/analyzer/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2024-02-07
+### Added
+- Set keywords to have `composer require` prompt for `--dev` on installation. [#30756]
+
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.7.3] - 2023-02-07
 ### Changed
 - Minor internal updates.
@@ -94,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jetpack code analyzer
 
+[2.0.0]: https://github.com/Automattic/jetpack-analyzer/compare/v1.7.3...v2.0.0
 [1.7.3]: https://github.com/Automattic/jetpack-analyzer/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/Automattic/jetpack-analyzer/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/Automattic/jetpack-analyzer/compare/v1.7.0...v1.7.1

--- a/projects/packages/analyzer/changelog/add-composer-dev-keywords
+++ b/projects/packages/analyzer/changelog/add-composer-dev-keywords
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Set keywords to have `composer require` prompt for `--dev` on installation.

--- a/projects/packages/analyzer/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/analyzer/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/analyzer/changelog/fix-phpcompatibility-dev-wp
+++ b/projects/packages/analyzer/changelog/fix-phpcompatibility-dev-wp
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unnecessary `phpcs:ignore`
-
-

--- a/projects/packages/codesniffer/CHANGELOG.md
+++ b/projects/packages/codesniffer/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2024-02-07
+### Added
+- Add "Jetpack-NoWP" ruleset. [#33287]
+- Added rulesets `Jetpack-Compat-*` to disable PHPCompatibility rules that trigger with `testVersion` 5.6 but don't apply to various later PHP versions. [#31711]
+- Add `Jetpack-Compat-83` ruleset. [#34346]
+- Add `Jetpack-Compat-NoWP` ruleset. [#33287]
+- Declare requirement of PHP >= 7.4. [#34192]
+- Enable `MediaWiki.AlternativeSyntax.UnicodeEscape` sniff. [#34194]
+- Enable `MediaWiki.PHPUnit.MockBoilerplate` sniff. [#34338]
+- Enable `Modernize.FunctionCalls.Dirname.Nested` sniff that is currently being disabled by WordPress-Extra. [#34218]
+
+### Changed
+- BREAKING: Drop support for PHP 5.6. `testVersion` should be set to `7.0-`. [#34126]
+- Updated package dependencies. [#31609]
+- Updated package dependencies. [#32605]
+- Updated package dependencies. [#34338]
+- Update to WordPress-Coding-Standards 3.0. [#32608]
+- Update `Jetpack-Compat-*` rulesets against PHPCompatibility develop branch. [#33112]
+
+### Removed
+- Exclude new `WordPress.Security.EscapeOutput.ExceptionNotEscaped` sniff. https://core.trac.wordpress.org/ticket/59282 is the correct way to fix the underlying issue it's trying to avoid, this would cause other problems. [#32608]
+- Remove `MediaWiki.WhiteSpace.SpaceAfterClosure`, as `Squiz.Functions.MultiLineFunctionDeclaration` now catches the same thing and more. [#32608]
+
 ## [2.8.0] - 2023-06-06
 ### Added
 - Added MediaWiki.Usage.ForbiddenFunctions rule to use preferred functions
@@ -124,6 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Codesniffer: Add a package to hold our coding standard
 
+[3.0.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.8.0...v3.0.0
 [2.8.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.6.1...v2.7.0
 [2.6.1]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.6.0...v2.6.1

--- a/projects/packages/codesniffer/changelog/add-codesniffer-8.3-support
+++ b/projects/packages/codesniffer/changelog/add-codesniffer-8.3-support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add `Jetpack-Compat-83` ruleset.

--- a/projects/packages/codesniffer/changelog/add-codesniffer-MediaWiki.AlternativeSyntax.UnicodeEscape-sniff
+++ b/projects/packages/codesniffer/changelog/add-codesniffer-MediaWiki.AlternativeSyntax.UnicodeEscape-sniff
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Enable `MediaWiki.AlternativeSyntax.UnicodeEscape` sniff.

--- a/projects/packages/codesniffer/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
+++ b/projects/packages/codesniffer/changelog/add-codesniffer-Modernize.FunctionCalls.Dirname.Nested-sniff
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Enable `Modernize.FunctionCalls.Dirname.Nested` sniff that is currently being disabled by WordPress-Extra.

--- a/projects/packages/codesniffer/changelog/add-codesniffer-compat-rulesets
+++ b/projects/packages/codesniffer/changelog/add-codesniffer-compat-rulesets
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added rulesets `Jetpack-Compat-*` to disable PHPCompatibility rules that trigger with `testVersion` 5.6 but don't apply to various later PHP versions.

--- a/projects/packages/codesniffer/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/codesniffer/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Declare requirement of PHP >= 7.4.

--- a/projects/packages/codesniffer/changelog/fix-phpcompatibility-dev-wp
+++ b/projects/packages/codesniffer/changelog/fix-phpcompatibility-dev-wp
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add `Jetpack-Compat-NoWP` ruleset.

--- a/projects/packages/codesniffer/changelog/fix-phpcompatibility-dev-wp#2
+++ b/projects/packages/codesniffer/changelog/fix-phpcompatibility-dev-wp#2
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add "Jetpack-NoWP" ruleset.

--- a/projects/packages/codesniffer/changelog/renovate-dealerdirect-phpcodesniffer-composer-installer-1.x
+++ b/projects/packages/codesniffer/changelog/renovate-dealerdirect-phpcodesniffer-composer-installer-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-42.x
+++ b/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-42.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-42.x#2
+++ b/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-42.x#2
@@ -1,4 +1,0 @@
-Significance: major
-Type: added
-
-Enable `MediaWiki.PHPUnit.MockBoilerplate` sniff.

--- a/projects/packages/codesniffer/changelog/renovate-wp-coding-standards-wpcs-3.x
+++ b/projects/packages/codesniffer/changelog/renovate-wp-coding-standards-wpcs-3.x
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-Update to WordPress-Coding-Standards 3.0.

--- a/projects/packages/codesniffer/changelog/renovate-wp-coding-standards-wpcs-3.x#2
+++ b/projects/packages/codesniffer/changelog/renovate-wp-coding-standards-wpcs-3.x#2
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Remove `MediaWiki.WhiteSpace.SpaceAfterClosure`, as `Squiz.Functions.MultiLineFunctionDeclaration` now catches the same thing and more.

--- a/projects/packages/codesniffer/changelog/renovate-wp-coding-standards-wpcs-3.x#3
+++ b/projects/packages/codesniffer/changelog/renovate-wp-coding-standards-wpcs-3.x#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Exclude new `WordPress.Security.EscapeOutput.ExceptionNotEscaped` sniff. https://core.trac.wordpress.org/ticket/59282 is the correct way to fix the underlying issue it's trying to avoid, this would cause other problems.

--- a/projects/packages/codesniffer/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/packages/codesniffer/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/codesniffer/changelog/update-codesniffer-compat-rulesets
+++ b/projects/packages/codesniffer/changelog/update-codesniffer-compat-rulesets
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update `Jetpack-Compat-*` rulesets against PHPCompatibility develop branch.

--- a/projects/packages/codesniffer/changelog/update-php-requirements
+++ b/projects/packages/codesniffer/changelog/update-php-requirements
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-BREAKING: Drop support for PHP 5.6. `testVersion` should be set to `7.0-`.

--- a/projects/packages/heartbeat/CHANGELOG.md
+++ b/projects/packages/heartbeat/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2024-02-07
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.5.3] - 2023-07-06
 ### Added
 - Add Jetpack Autoloader package suggestion. [#29988]
@@ -124,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use new heartbeat package
 - Creates the Jetpack Heartbeat package
 
+[2.0.0]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.5.3...v2.0.0
 [1.5.3]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.5.0...v1.5.1

--- a/projects/packages/heartbeat/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/heartbeat/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/ignorefile/CHANGELOG.md
+++ b/projects/packages/ignorefile/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2024-02-07
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+- Updated package dependencies. [#32605]
+
+### Removed
+- Remove use of deprecated `wikimedia/at-ease` package. PHP 7 improved error handling so `@` is ok to use now. [#34217]
+
 ## [1.0.5] - 2023-06-06
 ### Changed
 - Minor internal updates.
@@ -31,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.0]: https://github.com/Automattic/ignorefile/compare/v1.0.5...v2.0.0
 [1.0.5]: https://github.com/Automattic/ignorefile/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/Automattic/ignorefile/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/Automattic/ignorefile/compare/v1.0.2...v1.0.3

--- a/projects/packages/ignorefile/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/ignorefile/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/ignorefile/changelog/fix-phpcompatibility-dev-wp
+++ b/projects/packages/ignorefile/changelog/fix-phpcompatibility-dev-wp
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update phpcs config.
-
-

--- a/projects/packages/ignorefile/changelog/remove-old-composer-deps
+++ b/projects/packages/ignorefile/changelog/remove-old-composer-deps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Remove use of deprecated `wikimedia/at-ease` package. PHP 7 improved error handling so `@` is ok to use now.

--- a/projects/packages/ignorefile/changelog/renovate-wp-coding-standards-wpcs-3.x
+++ b/projects/packages/ignorefile/changelog/renovate-wp-coding-standards-wpcs-3.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix new phpcs sniffs from WPCS v3. No changes to functionality.
-
-

--- a/projects/packages/ignorefile/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/packages/ignorefile/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/lazy-images/CHANGELOG.md
+++ b/projects/packages/lazy-images/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2024-02-07
+### Changed
+- Code Modernization: Replace usage of strpos() with str_contains() [#34137]
+- The package now requires PHP >= 7.0. [#34192]
+- Update dependencies. [#33946]
+- Updated package dependencies.
+
 ## [2.3.2] - 2023-10-23
 ### Changed
 - Updated package dependencies. [#33687]
@@ -368,6 +375,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lazy Images: Move into a package
 
+[3.0.0]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.3.2...v3.0.0
 [2.3.2]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.2.0...v2.3.0

--- a/projects/packages/lazy-images/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/lazy-images/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/lazy-images/changelog/fix-hack-fix-lazy-images-tests
+++ b/projects/packages/lazy-images/changelog/fix-hack-fix-lazy-images-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Hack tests to pass by avoiding calling `Modules::disable()` from packages/status, which has an undeclared dependency on `Jetpack_Options` which is currently in packages/connection.
-
-

--- a/projects/packages/lazy-images/changelog/force-a-release
+++ b/projects/packages/lazy-images/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo#3
+++ b/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo#4
+++ b/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/lazy-images/changelog/update-node-20
+++ b/projects/packages/lazy-images/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/lazy-images/changelog/update-strpos-str-contains
+++ b/projects/packages/lazy-images/changelog/update-strpos-str-contains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Code Modernization: Replace usage of strpos() with str_contains()

--- a/projects/packages/options/CHANGELOG.md
+++ b/projects/packages/options/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2024-02-07
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+- Updated package dependencies. [#32605]
+
 ## [1.16.6] - 2023-04-10
 ### Added
 - Add Jetpack Autoloader package suggestion. [#29988]
@@ -190,6 +195,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[2.0.0]: https://github.com/Automattic/jetpack-options/compare/v1.16.6...v2.0.0
 [1.16.6]: https://github.com/Automattic/jetpack-options/compare/v1.16.5...v1.16.6
 [1.16.5]: https://github.com/Automattic/jetpack-options/compare/v1.16.4...v1.16.5
 [1.16.4]: https://github.com/Automattic/jetpack-options/compare/v1.16.3...v1.16.4

--- a/projects/packages/options/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/options/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/options/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/packages/options/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/partner/CHANGELOG.md
+++ b/projects/packages/partner/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2024-02-07
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
+### Deprecated
+- This package is now deprecated. Find Partner classes in the automattic/jetpack-connection package from now on. You can now remove this package from your project's dependencies. [#33832]
+
 ## [1.7.25] - 2023-09-19
+
 - Minor internal updates.
 
 ## [1.7.24] - 2023-08-23
@@ -223,6 +231,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add partner subsidiary id to upgrade URLs.
 
+[2.0.0]: https://github.com/Automattic/jetpack-partner/compare/v1.7.25...v2.0.0
 [1.7.25]: https://github.com/Automattic/jetpack-partner/compare/v1.7.24...v1.7.25
 [1.7.24]: https://github.com/Automattic/jetpack-partner/compare/v1.7.23...v1.7.24
 [1.7.23]: https://github.com/Automattic/jetpack-partner/compare/v1.7.22...v1.7.23

--- a/projects/packages/partner/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/partner/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/partner/changelog/fix-connection-partner-standalone-sites
+++ b/projects/packages/partner/changelog/fix-connection-partner-standalone-sites
@@ -1,4 +1,0 @@
-Significance: major
-Type: deprecated
-
-This package is now deprecated. Find Partner classes in the automattic/jetpack-connection package from now on. You can now remove this package from your project's dependencies.

--- a/projects/packages/partner/src/class-partner-coupon.php
+++ b/projects/packages/partner/src/class-partner-coupon.php
@@ -2,7 +2,7 @@
 /**
  * Class for the Jetpack partner coupon logic.
  *
- * @deprecated $$next-version$$
+ * @deprecated 2.0.0
  * @see automattic/jetpack-connection
  *
  * @package automattic/jetpack-partner

--- a/projects/packages/partner/src/class-partner.php
+++ b/projects/packages/partner/src/class-partner.php
@@ -2,7 +2,7 @@
 /**
  * Jetpack Partner utilities.
  *
- * @deprecated $$next-version$$
+ * @deprecated 2.0.0
  * @see automattic/jetpack-connection
  *
  * @package automattic/jetpack-partner

--- a/projects/packages/phpcs-filter/CHANGELOG.md
+++ b/projects/packages/phpcs-filter/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2024-02-07
+### Added
+- Support the old PHPCS 2.x "phpcs_input_file:path" method for specifying the stdin filename. [#33545]
+
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+- Updated package dependencies. [#32605]
+
+### Fixed
+- Ignore `--basepath` command line option. It doesn't mean what we thought it means. [#33508]
+
 ## 1.0.5 - 2023-06-06
 ### Added
 - Set keywords to have `composer require` prompt for `--dev` on installation.

--- a/projects/packages/phpcs-filter/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/phpcs-filter/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/phpcs-filter/changelog/add-phpcs-filter-old-phpcs_input_file-syntax
+++ b/projects/packages/phpcs-filter/changelog/add-phpcs-filter-old-phpcs_input_file-syntax
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Support the old PHPCS 2.x "phpcs_input_file:path" method for specifying the stdin filename.

--- a/projects/packages/phpcs-filter/changelog/fix-phpcompatibility-dev-wp
+++ b/projects/packages/phpcs-filter/changelog/fix-phpcompatibility-dev-wp
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update phpcs config.
-
-

--- a/projects/packages/phpcs-filter/changelog/fix-phpcs-filter-ignore-basepath
+++ b/projects/packages/phpcs-filter/changelog/fix-phpcs-filter-ignore-basepath
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Ignore `--basepath` command line option. It doesn't mean what we thought it means.

--- a/projects/packages/phpcs-filter/changelog/renovate-wp-coding-standards-wpcs-3.x
+++ b/projects/packages/phpcs-filter/changelog/renovate-wp-coding-standards-wpcs-3.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix new phpcs sniffs from WPCS v3. No changes to functionality.
-
-

--- a/projects/packages/phpcs-filter/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/packages/phpcs-filter/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/tracking/CHANGELOG.md
+++ b/projects/packages/tracking/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2024-02-07
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+
 ## [1.14.13] - 2023-07-06
 ### Added
 - Add Jetpack Autoloader package suggestion. [#29988]
@@ -262,6 +266,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create package for Jetpack Tracking
 
+[2.0.0]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.13...v2.0.0
 [1.14.13]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.12...v1.14.13
 [1.14.12]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.11...v1.14.12
 [1.14.11]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.10...v1.14.11

--- a/projects/packages/tracking/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/tracking/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/yoast-promo/CHANGELOG.md
+++ b/projects/packages/yoast-promo/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2024-02-07
+### Changed
+- The package now requires PHP >= 7.0. [#34192]
+- Updated package dependencies.
+
 ## [0.1.2] - 2023-07-06
 ### Changed
 - Updated package dependencies.
@@ -22,5 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generate initial package for Yoast promo components [#29627]
 - Initialize yoast promo package in jetpack plugin [#29641]
 
+[0.2.0]: https://github.com/automattic/jetpack-yoast-promo/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/automattic/jetpack-yoast-promo/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/automattic/jetpack-yoast-promo/compare/v0.1.0...v0.1.1

--- a/projects/packages/yoast-promo/changelog/add-declare-php-version-for-all-composer-packages
+++ b/projects/packages/yoast-promo/changelog/add-declare-php-version-for-all-composer-packages
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The package now requires PHP >= 7.0.

--- a/projects/packages/yoast-promo/changelog/remove-unused-js-deps
+++ b/projects/packages/yoast-promo/changelog/remove-unused-js-deps
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unused JS deps. No change to the project itself.
-
-

--- a/projects/packages/yoast-promo/changelog/renovate-babel-monorepo
+++ b/projects/packages/yoast-promo/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-babel-monorepo#2
+++ b/projects/packages/yoast-promo/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-babel-monorepo#3
+++ b/projects/packages/yoast-promo/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-babel-monorepo#4
+++ b/projects/packages/yoast-promo/changelog/renovate-babel-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-babel-monorepo#5
+++ b/projects/packages/yoast-promo/changelog/renovate-babel-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-sass-1.x
+++ b/projects/packages/yoast-promo/changelog/renovate-sass-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#3
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#4
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#5
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#6
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#7
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#8
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#9
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/packages/yoast-promo/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/update-node-20
+++ b/projects/packages/yoast-promo/changelog/update-node-20
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove "engines" from package.json. No change to the project itself; note the build formerly removed this before mirroring.
-
-

--- a/projects/packages/yoast-promo/package.json
+++ b/projects/packages/yoast-promo/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-yoast-promo",
-	"version": "0.2.0-alpha",
+	"version": "0.2.0",
 	"description": "Components used to promote Yoast as part of our collaboration",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/yoast-promo/#readme",
 	"bugs": {

--- a/projects/packages/yoast-promo/src/class-yoast-promo.php
+++ b/projects/packages/yoast-promo/src/class-yoast-promo.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack;
  */
 class Yoast_Promo {
 
-	const PACKAGE_VERSION = '0.2.0-alpha';
+	const PACKAGE_VERSION = '0.2.0';
 
 	/**
 	 * Script handle for the JS file we enqueue in the post editor.


### PR DESCRIPTION
## Proposed changes:

Package maintenance releases after shipping Jetpack 13.1.1

Will handle plugins separately. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Proofread.

