### PR TITLE
Add/my jetpack link to all jetpack plugins on plugins page

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-link-to-all-jetpack-plugins-on-plugins-page
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-link-to-all-jetpack-plugins-on-plugins-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add My Jetpack link to standalone plugins missing it

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.9.0",
+	"version": "4.9.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -34,7 +34,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.9.0';
+	const PACKAGE_VERSION = '4.9.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -179,7 +179,11 @@ class Products {
 			'protect',
 			'crm',
 		);
+
+		// Add plugin action links for the core Jetpack plugin.
 		Product::extend_core_plugin_action_links();
+
+		// Add plugin action links to standalone products.
 		foreach ( $products as $product ) {
 			$class_name = self::get_product_class( $product );
 			$class_name::extend_plugin_action_links();

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -174,8 +174,12 @@ class Products {
 			'backup',
 			'boost',
 			'crm',
-			'videopress', // we use videopress here to add the plugin action to the Jetpack plugin itself
+			'videopress',
+			'social',
+			'protect',
+			'crm',
 		);
+		Product::extend_core_plugin_action_links();
 		foreach ( $products as $product ) {
 			$class_name = self::get_product_class( $product );
 			$class_name::extend_plugin_action_links();

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -178,6 +178,7 @@ class Products {
 			'social',
 			'protect',
 			'crm',
+			'search',
 		);
 
 		// Add plugin action links for the core Jetpack plugin.

--- a/projects/packages/my-jetpack/src/products/class-crm.php
+++ b/projects/packages/my-jetpack/src/products/class-crm.php
@@ -27,7 +27,10 @@ class Crm extends Product {
 	 *
 	 * @var string
 	 */
-	public static $plugin_filename = 'zero-bs-crm/ZeroBSCRM.php';
+	public static $plugin_filename = array(
+		'zero-bs-crm/ZeroBSCRM.php',
+		'crm/ZeroBSCRM.php',
+	);
 
 	/**
 	 * The slug of the plugin associated with this product. If not defined, it will default to the Jetpack plugin

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -47,7 +47,7 @@ abstract class Product {
 	/**
 	 * The Jetpack plugin filename
 	 *
-	 * @var string
+	 * @var array
 	 */
 	const JETPACK_PLUGIN_FILENAME = array(
 		'jetpack/jetpack.php',
@@ -537,15 +537,11 @@ abstract class Product {
 	}
 
 	/**
-	 * Extend the plugin action links.
+	 * Filter the action links for the plugins specified.
+	 *
+	 * @param string|string[] $filenames The plugin filename(s) to filter the action links for.
 	 */
-	public static function extend_plugin_action_links() {
-
-		$filenames = static::get_plugin_filename();
-		if ( ! is_array( $filenames ) ) {
-			$filenames = array( $filenames );
-		}
-
+	private static function filter_action_links( $filenames ) {
 		foreach ( $filenames as $filename ) {
 			$hook     = 'plugin_action_links_' . $filename;
 			$callback = array( static::class, 'get_plugin_actions_links' );
@@ -553,5 +549,26 @@ abstract class Product {
 				add_filter( $hook, $callback, 20, 2 );
 			}
 		}
+	}
+
+	/**
+	 * Extend the plugin action links.
+	 */
+	public static function extend_plugin_action_links() {
+		$filenames = static::get_plugin_filename();
+		if ( ! is_array( $filenames ) ) {
+			$filenames = array( $filenames );
+		}
+
+		self::filter_action_links( $filenames );
+	}
+
+	/**
+	 * Extend the Jetpack plugin action links.
+	 */
+	public static function extend_core_plugin_action_links() {
+		$filenames = self::JETPACK_PLUGIN_FILENAME;
+
+		self::filter_action_links( $filenames );
 	}
 }

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-link-to-all-jetpack-plugins-on-plugins-page
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-link-to-all-jetpack-plugins-on-plugins-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Remove Support link from Jetpack on plugins page

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3772,12 +3772,9 @@ p {
 	 * @return array
 	 */
 	public function plugin_action_links( $actions ) {
-		$support_link = ( new Host() )->is_woa_site() ? 'https://wordpress.com/help/contact/' : self::admin_url( 'page=jetpack-debugger' );
-
 		if ( current_user_can( 'jetpack_manage_modules' ) && ( self::is_connection_ready() || ( new Status() )->is_offline_mode() ) ) {
 			return array_merge(
 				array( 'settings' => sprintf( '<a href="%s">%s</a>', esc_url( self::admin_url( 'page=jetpack#/settings' ) ), __( 'Settings', 'jetpack' ) ) ),
-				array( 'support' => sprintf( '<a href="%s">%s</a>', esc_url( $support_link ), __( 'Support', 'jetpack' ) ) ),
 				$actions
 			);
 		}

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -879,8 +879,9 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 				'fun 😀' => admin_url( 'fun.php' ),
 			),
 			'jetpack/jetpack.php' => array(
-				'settings' => admin_url( 'settings.php' ),
-				'support'  => 'https://jetpack.com/support',
+				'settings'   => admin_url( 'settings.php' ),
+				'support'    => 'https://jetpack.com/support',
+				'My Jetpack' => admin_url( 'admin.php?page=my-jetpack' ),
 			),
 		);
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -874,16 +874,28 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
 
-		$expected_array = array(
-			'hello.php'           => array(
-				'fun 😀' => admin_url( 'fun.php' ),
-			),
-			'jetpack/jetpack.php' => array(
-				'settings'   => admin_url( 'settings.php' ),
-				'support'    => 'https://jetpack.com/support',
-				'My Jetpack' => admin_url( 'admin.php?page=my-jetpack' ),
-			),
-		);
+		if ( ! is_multisite() ) {
+			$expected_array = array(
+				'hello.php'           => array(
+					'fun 😀' => admin_url( 'fun.php' ),
+				),
+				'jetpack/jetpack.php' => array(
+					'settings'   => admin_url( 'settings.php' ),
+					'support'    => 'https://jetpack.com/support',
+					'My Jetpack' => admin_url( 'admin.php?page=my-jetpack' ),
+				),
+			);
+		} else {
+			$expected_array = array(
+				'hello.php'           => array(
+					'fun 😀' => admin_url( 'fun.php' ),
+				),
+				'jetpack/jetpack.php' => array(
+					'settings' => admin_url( 'settings.php' ),
+					'support'  => 'https://jetpack.com/support',
+				),
+			);
+		}
 
 		$this->assertEquals( $expected_array, $this->extract_plugins_we_are_testing( $plugins_action_links ) );
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -879,7 +879,9 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 				'fun 😀' => admin_url( 'fun.php' ),
 			),
 			'jetpack/jetpack.php' => array(
-				'settings' => admin_url( 'settings.php' ),
+				'settings'   => admin_url( 'settings.php' ),
+				'My Jetpack' => admin_url( 'admin.php?page=my-jetpack' ),
+				'support'    => 'https://jetpack.com/support',
 			),
 		);
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -880,7 +880,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			),
 			'jetpack/jetpack.php' => array(
 				'settings' => admin_url( 'settings.php' ),
-				'support'  => 'https://jetpack.com/support',
 			),
 		);
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -879,9 +879,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 				'fun 😀' => admin_url( 'fun.php' ),
 			),
 			'jetpack/jetpack.php' => array(
-				'settings'   => admin_url( 'settings.php' ),
-				'My Jetpack' => admin_url( 'admin.php?page=my-jetpack' ),
-				'support'    => 'https://jetpack.com/support',
+				'settings' => admin_url( 'settings.php' ),
+				'support'  => 'https://jetpack.com/support',
 			),
 		);
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -874,27 +874,18 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
 
+		$expected_array = array(
+			'hello.php'           => array(
+				'fun 😀' => admin_url( 'fun.php' ),
+			),
+			'jetpack/jetpack.php' => array(
+				'settings' => admin_url( 'settings.php' ),
+				'support'  => 'https://jetpack.com/support',
+			),
+		);
+
 		if ( ! is_multisite() ) {
-			$expected_array = array(
-				'hello.php'           => array(
-					'fun 😀' => admin_url( 'fun.php' ),
-				),
-				'jetpack/jetpack.php' => array(
-					'settings'   => admin_url( 'settings.php' ),
-					'support'    => 'https://jetpack.com/support',
-					'My Jetpack' => admin_url( 'admin.php?page=my-jetpack' ),
-				),
-			);
-		} else {
-			$expected_array = array(
-				'hello.php'           => array(
-					'fun 😀' => admin_url( 'fun.php' ),
-				),
-				'jetpack/jetpack.php' => array(
-					'settings' => admin_url( 'settings.php' ),
-					'support'  => 'https://jetpack.com/support',
-				),
-			);
+			$expected_array['jetpack/jetpack.php']['My Jetpack'] = admin_url( 'admin.php?page=my-jetpack' );
 		}
 
 		$this->assertEquals( $expected_array, $this->extract_plugins_we_are_testing( $plugins_action_links ) );

--- a/projects/plugins/search/changelog/add-my-jetpack-link-to-all-jetpack-plugins-on-plugins-page
+++ b/projects/plugins/search/changelog/add-my-jetpack-link-to-all-jetpack-plugins-on-plugins-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Showing My Jetpack link on plugins page even if the plugin is not installed

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -64,7 +64,7 @@
 	},
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ2_0_0",
+		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ2_0_1_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: Easily add cloud-powered instant search and filters to your website or WooCommerce store with advanced algorithms that boost your search results based on traffic to your site.
- * Version: 2.0.0
+ * Version: 2.0.1-alpha
  * Author: Automattic - Jetpack Search team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '2.0.0' );
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '2.0.1-alpha' );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 

--- a/projects/plugins/search/src/class-jetpack-search-plugin.php
+++ b/projects/plugins/search/src/class-jetpack-search-plugin.php
@@ -49,12 +49,6 @@ class Jetpack_Search_Plugin {
 		$settings_link = '<a href="' . admin_url( 'admin.php?page=jetpack-search' ) . '">' . esc_html__( 'Settings', 'jetpack-search' ) . '</a>';
 		array_unshift( $links, $settings_link );
 
-		// Add the My Jetpack link only if Jetpack is connected
-		if ( ( new Connection_Manager() )->is_connected() ) {
-			$my_jetpack_link = '<a href="' . admin_url( 'admin.php?page=my-jetpack' ) . '">' . esc_html__( 'My Jetpack', 'jetpack-search' ) . '</a>';
-			array_unshift( $links, $my_jetpack_link );
-		}
-
 		return $links;
 	}
 


### PR DESCRIPTION
## Proposed changes:

* The core Jetpack plugin as well as Social, Protect, and CRM were missing the My Jetpack link on the plugins page
* This PR adds the My Jetpack link to those to ensure all plugins have it
* It also removes the Support link from the Jetpack core plugin (this might be changed back, won't merge until I know for sure)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Activate the Jetpack plugin as well as all the standalone plugins (CRM, Social, Search, Boost, Protect, and VideoPress) and make sure all of them have the My Jetpack link
![image](https://github.com/Automattic/jetpack/assets/65001528/8df7bd0c-abe1-440c-9dbc-3d5f49728caa)
![image](https://github.com/Automattic/jetpack/assets/65001528/09d5d707-40ad-44aa-aa67-0473fc055ef6)
3. Make sure the Support link is also missing from the Jetpack plugin
![image](https://github.com/Automattic/jetpack/assets/65001528/f4942261-adcf-4e85-a8a9-3d327a0463c6)



