### PR TITLE
Endpoint: update post endpoint to fail if the last modefied timestamp doesn't match.

### DIFF
--- a/projects/plugins/jetpack/changelog/try-update-post-endpoint-to-fail-on-old-revision
+++ b/projects/plugins/jetpack/changelog/try-update-post-endpoint-to-fail-on-old-revision
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Add 'if_not_modified_since' to the update post endpoints this will help clients fails if the post has been updated since last retrieved 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -106,15 +106,15 @@ new WPCOM_JSON_API_Update_Post_v1_2_Endpoint(
 		),
 
 		'request_format'       => array(
-			'date'              => "(ISO 8601 datetime) The post's creation time.",
-			'title'             => '(HTML) The post title.',
-			'content'           => '(HTML) The post content.',
-			'excerpt'           => '(HTML) An optional post excerpt.',
-			'slug'              => '(string) The name (slug) for the post, used in URLs.',
-			'author'            => '(string) The username or ID for the user to assign the post to.',
-			'publicize'         => '(array|bool) True or false if the post be shared to external services. An array of services if we only want to share to a select few. Defaults to true.',
-			'publicize_message' => '(string) Custom message to be shared to external services.',
-			'status'            => array(
+			'date'                  => "(ISO 8601 datetime) The post's creation time.",
+			'title'                 => '(HTML) The post title.',
+			'content'               => '(HTML) The post content.',
+			'excerpt'               => '(HTML) An optional post excerpt.',
+			'slug'                  => '(string) The name (slug) for the post, used in URLs.',
+			'author'                => '(string) The username or ID for the user to assign the post to.',
+			'publicize'             => '(array|bool) True or false if the post be shared to external services. An array of services if we only want to share to a select few. Defaults to true.',
+			'publicize_message'     => '(string) Custom message to be shared to external services.',
+			'status'                => array(
 				'publish' => 'Publish the post.',
 				'private' => 'Privately publish the post.',
 				'draft'   => 'Save the post as a draft.',
@@ -122,29 +122,30 @@ new WPCOM_JSON_API_Update_Post_v1_2_Endpoint(
 				'pending' => 'Mark the post as pending editorial approval.',
 				'trash'   => 'Set the post as trashed.',
 			),
-			'sticky'            => array(
+			'sticky'                => array(
 				'false' => 'Post is not marked as sticky.',
 				'true'  => 'Stick the post to the front page.',
 			),
-			'password'          => '(string) The plaintext password protecting the post, or, more likely, the empty string if the post is not password protected.',
-			'parent'            => "(int) The post ID of the new post's parent.",
-			'terms'             => '(object) Mapping of taxonomy to comma-separated list or array of term names',
-			'terms_by_id'       => '(object) Mapping of taxonomy to comma-separated list or array of term IDs',
-			'categories'        => '(array|string) Comma-separated list or array of category names',
-			'categories_by_id'  => '(array|string) Comma-separated list or array of category IDs',
-			'tags'              => '(array|string) Comma-separated list or array of tag names',
-			'tags_by_id'        => '(array|string) Comma-separated list or array of tag IDs',
-			'format'            => array_merge( array( 'default' => 'Use default post format' ), get_post_format_strings() ),
-			'discussion'        => '(object) A hash containing one or more of the following boolean values, which default to the blog\'s discussion preferences: `comments_open`, `pings_open`',
-			'likes_enabled'     => '(bool) Should the post be open to likes?',
-			'menu_order'        => '(int) (Pages only) the order pages should appear in. Use 0 to maintain alphabetical order.',
-			'page_template'     => '(string) (Pages Only) The page template this page should use.',
-			'sharing_enabled'   => '(bool) Should sharing buttons show on this post?',
-			'featured_image'    => '(string) The post ID of an existing attachment to set as the featured image. Pass an empty string to delete the existing image.',
-			'media'             => '(media) An array of files to attach to the post. To upload media, the entire request should be multipart/form-data encoded. Multiple media items will be displayed in a gallery. Accepts  jpg, jpeg, png, gif, pdf, doc, ppt, odt, pptx, docx, pps, ppsx, xls, xlsx, key. Audio and Video may also be available. See <code>allowed_file_types</code> in the options resposne of the site endpoint. <br /><br /><strong>Example</strong>:<br />' .
+			'password'              => '(string) The plaintext password protecting the post, or, more likely, the empty string if the post is not password protected.',
+			'parent'                => "(int) The post ID of the new post's parent.",
+			'terms'                 => '(object) Mapping of taxonomy to comma-separated list or array of term names',
+			'terms_by_id'           => '(object) Mapping of taxonomy to comma-separated list or array of term IDs',
+			'categories'            => '(array|string) Comma-separated list or array of category names',
+			'categories_by_id'      => '(array|string) Comma-separated list or array of category IDs',
+			'tags'                  => '(array|string) Comma-separated list or array of tag names',
+			'tags_by_id'            => '(array|string) Comma-separated list or array of tag IDs',
+			'format'                => array_merge( array( 'default' => 'Use default post format' ), get_post_format_strings() ),
+			'discussion'            => '(object) A hash containing one or more of the following boolean values, which default to the blog\'s discussion preferences: `comments_open`, `pings_open`',
+			'likes_enabled'         => '(bool) Should the post be open to likes?',
+			'menu_order'            => '(int) (Pages only) the order pages should appear in. Use 0 to maintain alphabetical order.',
+			'page_template'         => '(string) (Pages Only) The page template this page should use.',
+			'sharing_enabled'       => '(bool) Should sharing buttons show on this post?',
+			'featured_image'        => '(string) The post ID of an existing attachment to set as the featured image. Pass an empty string to delete the existing image.',
+			'media'                 => '(media) An array of files to attach to the post. To upload media, the entire request should be multipart/form-data encoded. Multiple media items will be displayed in a gallery. Accepts  jpg, jpeg, png, gif, pdf, doc, ppt, odt, pptx, docx, pps, ppsx, xls, xlsx, key. Audio and Video may also be available. See <code>allowed_file_types</code> in the options resposne of the site endpoint. <br /><br /><strong>Example</strong>:<br />' .
 							"<code>curl \<br />--form 'title=Image' \<br />--form 'media[]=@/path/to/file.jpg' \<br />-H 'Authorization: BEARER your-token' \<br />'https://public-api.wordpress.com/rest/v1/sites/123/posts/new'</code>",
-			'media_urls'        => '(array) An array of URLs for images to attach to a post. Sideloads the media in for a post.',
-			'metadata'          => '(array) Array of metadata objects containing the following properties: `key` (metadata key), `id` (meta ID), `previous_value` (if set, the action will only occur for the provided previous value), `value` (the new value to set the meta to), `operation` (the operation to perform: `update` or `add`; defaults to `update`). All unprotected meta keys are available by default for read requests. Both unprotected and protected meta keys are available for authenticated requests with proper capabilities. Protected meta keys can be made available with the <code>rest_api_allowed_public_metadata</code> filter.',
+			'media_urls'            => '(array) An array of URLs for images to attach to a post. Sideloads the media in for a post.',
+			'metadata'              => '(array) Array of metadata objects containing the following properties: `key` (metadata key), `id` (meta ID), `previous_value` (if set, the action will only occur for the provided previous value), `value` (the new value to set the meta to), `operation` (the operation to perform: `update` or `add`; defaults to `update`). All unprotected meta keys are available by default for read requests. Both unprotected and protected meta keys are available for authenticated requests with proper capabilities. Protected meta keys can be made available with the <code>rest_api_allowed_public_metadata</code> filter.',
+			'if_not_modified_since' => '(ISO 8601 datetime) If the post has been modified since this time, the post will not be updated.',
 		),
 
 		'example_request'      => 'https://public-api.wordpress.com/rest/v1.2/sites/82974409/posts/881',
@@ -276,6 +277,12 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 
 			if ( ! current_user_can( 'edit_post', $post->ID ) ) {
 				return new WP_Error( 'unauthorized', 'User cannot edit post', 403 );
+			}
+
+			if ( ! empty( $input['if_not_modified_since'] ) ) {
+				if ( mysql2date( 'U', $post->post_modified_gmt ) > mysql2date( 'U', $input['if_not_modified_since'] ) ) {
+					return new WP_Error( 'old-revision', 'There is a revision of this post that is more recent.', 409 );
+				}
 			}
 
 			if ( ! empty( $input['author'] ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds a new parameter that checks if the post has had any updates on the server that have not been retried by the client. 

## Proposed changes:

* Adds a new query parameter `if_not_modified_since` that helps to make sure that post don't get overwritten if the client is trying to update the post based on an stale version of the post. 

The error `old-revision` is returned instead. The client should then fetch the latest version and resolve the conflict present the user with a choice how they want to proceed. This will help ensure that the client is always trying udpate the latest version of the post.

This check also exists in core XMLRPC endpoint. See https://github.com/WordPress/WordPress/blob/d0800765800c3614924a6eaac1d52921c327e9f5/wp-includes/class-wp-xmlrpc-server.php#L1756 

This change is being done as part of the Better Offline experience int he mobile apps. See pcdRpT-5ID-p2

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make an api request to https://public-api.wordpress.com/rest/v1.2/sites/$site_id/posts/1
with the parameter `if_not_modified_since` and notice that you pass in the last post modified timestamp that the post updates as expected. 
but if you pass in the previous version of the post that

 we returns the error  `error:"old-revision"` 

<img width="607" alt="Screenshot 2024-02-16 at 9 12 56 AM" src="https://github.com/Automattic/jetpack/assets/115071/4f56fed3-92e5-4a8a-832f-4b43dbd9e8af">