### PR TITLE
Jetpack Sync: Avoid detecting invalid image size

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-too-large-detected-image-size
+++ b/projects/plugins/jetpack/changelog/fix-too-large-detected-image-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack Sync: Avoid detecting invalid image size

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -519,7 +519,7 @@ class Jetpack_PostImages {
 			$width  = (int) $image_tag->getAttribute( 'width' );
 			$height = (int) $image_tag->getAttribute( 'height' );
 			if ( 0 === $width && 0 === $height ) {
-				preg_match( '/-([0-9]+)x([0-9]+)\.(?:jpg|jpeg|png|gif|webp)$/i', $img_src, $matches );
+				preg_match( '/-([0-9]{1,5})x([0-9]{1,5})\.(?:jpg|jpeg|png|gif|webp)$/i', $img_src, $matches );
 				if ( ! empty( $matches[1] ) ) {
 					$width = (int) $matches[1];
 				}

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
@@ -62,7 +62,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	 * @covers Jetpack_PostImages::from_html
 	 */
 	public function test_from_html_no_size() {
-		$s = "<img src='img-851958915511220-220.jpg' />";
+		$s = "<img src='img-851958915511220x220.jpg' />";
 
 		$result = Jetpack_PostImages::from_html( $s );
 

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
@@ -41,6 +41,35 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test image size extract in src filename
+	 *
+	 * @covers Jetpack_PostImages::from_html
+	 */
+	public function test_from_html_size() {
+		$s = "<img src='img-2300x1300.jpg' />";
+
+		$result = Jetpack_PostImages::from_html( $s );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
+		$this->assertEquals( 2300, $result[0]['src_width'] );
+		$this->assertEquals( 1300, $result[0]['src_height'] );
+	}
+
+	/**
+	 * Test ignoring unrealistic image sizes from src filename
+	 *
+	 * @covers Jetpack_PostImages::from_html
+	 */
+	public function test_from_html_no_size() {
+		$s = "<img src='img-851958915511220-220.jpg' />";
+
+		$result = Jetpack_PostImages::from_html( $s );
+
+		$this->assertEquals( array(), $result );
+	}
+
+	/**
 	 * @author scotchfield
 	 * @covers Jetpack_PostImages::from_slideshow
 	 * @since 3.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ignore image size inferred from media URL if it's longer than 5 characters.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

panfyZ-3dY-p2#comment-8279

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Run the updated unit tests

```
jetpack docker phpunit -- --filter=WP_Test_Jetpack_PostImages
```