### PR TITLE
Boost: only cache pages for logged out visitors

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache.php
@@ -100,6 +100,10 @@ abstract class Boost_Cache {
 			return false;
 		}
 
+		if ( function_exists( 'is_user_logged_in' ) && is_user_logged_in() ) {
+			return false;
+		}
+
 		if ( function_exists( 'is_404' ) && is_404() ) {
 			return false;
 		}

--- a/projects/plugins/boost/changelog/boost-cache-no-cache-for-logged-in-users
+++ b/projects/plugins/boost/changelog/boost-cache-no-cache-for-logged-in-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Boost: do not cache pages for logged in users.


### PR DESCRIPTION
This PR disables caching for logged in visitors to a site. The vast majority of visitors to most sites are anonymous and that's where page caching works best.

Since is_logged_in() isn't available when it's first needed, it will be run when the output buffer is saved, and that will stop it being saved.

Fixes #35301

## Proposed changes:
* Add a is_logged_in() check to the is_cacheable() function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR.
* In a logged in window visit the website and make sure pages aren't cached by looking at the page source.
* In a private window, make sure those visits are cached.
* Leave a comment on a post and note that a new cached page is made.
