### PR TITLE
Memberships: Prevent subscribe popup from scrolling underlying content

### DIFF
--- a/projects/plugins/jetpack/changelog/subscribe-popup-disable-scroll
+++ b/projects/plugins/jetpack/changelog/subscribe-popup-disable-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Disable scroll to top when memberships subscribe popup is opened.

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -62,9 +62,6 @@ export function showModal( url ) {
 
 	window.addEventListener( 'message', handleIframeResult, false );
 	dialog.showModal();
-
-	// This line has to come after the modal has opened otherwise Firefox doesn't scroll to the top.
-	window.scrollTo( 0, 0 );
 }
 
 function setUpModal( button ) {

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -28,8 +28,6 @@ export function handleIframeResult( eventFromIframe ) {
 }
 
 export function showModal( url ) {
-	window.scrollTo( 0, 0 );
-
 	// prevent double scroll bars. We use the entire viewport for the modal so we need to hide overflow on the body element.
 	document.body.classList.add( 'modal-open' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/317

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes a `scrollTo` call when the modal is launched
* Visit parent issue to see historical reason for the addition

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure store sandbox is disabled
* Visit the [payment button test page](https://devotedly-magical.jurassic.ninja/scrollilng-journey/), scroll to the bottom, and click "Help Fund this Story" to launch the subscribe modal
* Visit the [paywall test page](https://devotedly-magical.jurassic.ninja/2024/02/09/endless-scroll/), scroll to the bottom, enter an email, and press "Subscribe"
* In both cases, the scroll position of the underlying page should remain where it was
* In both cases, the modal displayed should be visible and functional