### PR TITLE
Verbum: Bypass subscription modal for WordPress subdomains

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-wordpress-subdomain-comment-post
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-wordpress-subdomain-comment-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Bypass subscription modal if wordpress subdomain

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -78,7 +78,6 @@ class Verbum_Comments {
 	 * Get the comment form action url
 	 */
 	public function get_form_action() {
-		l( 'site_url: ', site_url() );
 		return is_jetpack_comments() ?
 			wp_json_encode( esc_url_raw( http() . '://' . JETPACK_SERVER__DOMAIN . '/jetpack-comment/' ) ) : site_url( '/wp-comments-post.php' );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -78,6 +78,7 @@ class Verbum_Comments {
 	 * Get the comment form action url
 	 */
 	public function get_form_action() {
+		l( 'site_url: ', site_url() );
 		return is_jetpack_comments() ?
 			wp_json_encode( esc_url_raw( http() . '://' . JETPACK_SERVER__DOMAIN . '/jetpack-comment/' ) ) : site_url( '/wp-comments-post.php' );
 	}
@@ -585,6 +586,15 @@ HTML;
 	 * Check if we should show the subscription modal.
 	 */
 	public function should_show_subscription_modal() {
+		// Do not display subscription modal for WordPress.com subdomain sites.
+		if ( defined( 'WPCOM_SUBDIR_SUBDOMAIN_BLOG_IDS_TO_REDIRECT' ) && defined( 'JETPACKCOM_BLOG_BLOG_IDS' ) ) {
+			$blogs_to_redirect = array_merge( WPCOM_SUBDIR_SUBDOMAIN_BLOG_IDS_TO_REDIRECT, JETPACKCOM_BLOG_BLOG_IDS );
+
+			if ( in_array( get_current_blog_id(), $blogs_to_redirect, true ) ) {
+				return false;
+			}
+		}
+
 		$modal_enabled = get_option( 'jetpack_verbum_subscription_modal', true );
 		return ! is_user_member_of_blog( '', $this->blog_id ) && $modal_enabled;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Regular users (non super-admin/A8C users) are having issues posting comments on learn.wordpress.com.
These changes skip the subscription modal if a non-super-admin/A8C user is posting on wordpress.com subdomain redirected site. For example, wordpress.com/learn (learn.wordpress.com).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync to sandbox
* Verify its not breaking Verbum on atomic and simple sites
* Sandbox `wordpress.com` and `learn.wordpress.com`. Test comment post with a new user / regular user on `https://wordpress.com/learn/courses/unlocking-the-power-of-ai/feedback-discussion/#comment-8428` (non A8C wordpress account).

