### PR TITLE
My Jetpack: Show in multisite installations

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-enable-my-jetpack-on-multisite
+++ b/projects/packages/my-jetpack/changelog/update-enable-my-jetpack-on-multisite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Made My Jetpack be available on multisite installations

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -372,10 +372,6 @@ class Initializer {
 	public static function should_initialize() {
 		$should = true;
 
-		if ( is_multisite() ) {
-			$should = false;
-		}
-
 		/**
 		 * Allows filtering whether My Jetpack should be initialized.
 		 *


### PR DESCRIPTION
Fixes #35555

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the check for multisite that was making My Jetpack not load in subsites of multisite installations.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions

* Launch a multisite. Create a subsite
* Network activate Jetpack
  * Expect to see the error reported in #35557 but Jetpack will be network activated
* Visit the subsite. 
* Activate Jetpack
* Expect to be redirected to My Jetpack
* Expect to see the My Jetpack menu item
