### PR TITLE
[Boost] Skip any missing post type archive pages

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Archive_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Archive_Provider.php
@@ -32,7 +32,11 @@ class Archive_Provider extends Provider {
 			$post_types = array_intersect( $post_types, $context_post_types );
 		}
 		foreach ( $post_types as $post_type ) {
-			$links[ $post_type ][] = get_post_type_archive_link( $post_type );
+			$link = get_post_type_archive_link( $post_type );
+
+			if ( ! empty( $link ) ) {
+				$links[ $post_type ][] = $link;
+			}
 		}
 
 		return $links;

--- a/projects/plugins/boost/changelog/boost-fix-invalid-post-type
+++ b/projects/plugins/boost/changelog/boost-fix-invalid-post-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: Prevent missing archive pages from breaking generation process


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related: p1707398907914029-slack-C016BBAFHHS

Sometimes when there is something wrong with the archive page for a custom post type, `get_post_type_archive_link` can return `false` to indicate there is no valid archive page available. In such circumstances, we should not include the URL in the set of URLs to generate Critical CSS for, as it is not valid.

## Proposed changes:
* Skip any `false` URLs returned from `get_post_type_archive_link` when generating Critical CSS.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Set up a filter to break a custom post type. e.g.: `add_filter( 'post_type_archive_link', '__return_false' );`
* Make sure you can still generate Critical CSS locally.