### PR TITLE
Revert "Untangle: Do not add the dashboard switcher for the wp-admin interface"

### DIFF
--- a/projects/plugins/jetpack/changelog/revert-35210-update-untangle-dashboard-switcher
+++ b/projects/plugins/jetpack/changelog/revert-35210-update-untangle-dashboard-switcher
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Revert: Untangle: Do not add the dashboard switcher for the wp-admin interface

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -576,16 +576,4 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			parent::add_appearance_menu();
 		}
 	}
-
-	/**
-	 * Adds a dashboard switcher to the list of screen meta links of the current page.
-	 */
-	public function add_dashboard_switcher() {
-		// When the interface is set to wp-admin, do not show the dashboard switcher.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
-			return;
-		}
-
-		parent::add_dashboard_switcher();
-	}
 }


### PR DESCRIPTION
Reverts Automattic/jetpack#35210 

Context p1707422522583409-slack-C06DN6QQVAQ

The early application of this change is causing some problems for HE's, lets revert for now and ship it again later if we need it.

Fixes https://github.com/Automattic/dotcom-forge/issues/5525