### PR TITLE
WooCommerce Analytics: check if product exists before we use it

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wc-product-fatal
+++ b/projects/plugins/jetpack/changelog/fix-wc-product-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WooCommerce Analytics: avoid error when trying to pay for a deleted product.

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -68,7 +68,13 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 			} else {
 				$product = $item['data'];
 			}
+
+			if ( ! $product || ! $product instanceof WC_Product ) {
+				continue;
+			}
+
 			$data = $this->get_product_details( $product );
+
 			if ( $item instanceof WC_Order_Item_Product ) {
 				$data['pq'] = $item->get_quantity();
 			} else {


### PR DESCRIPTION
Fixes #35562

## Proposed changes:

Account for all possible returns from `wc_get_product` when checking for the different items present in a cart. It should avoid issues like the one reported in #35562.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site connected to WordPress.com and where WooCommerce is installed and configured.
* Create a product A
* Make a purchase of product A until `/checkout/order-received/<order-id>/`—this fires `capture_order_confirmation_view` https://github.com/Automattic/jetpack/blob/e49db6b9261d36fad4dc1f49a5e4af3806c92db5/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php#L35-L37
* Delete product A
* Visit again `/checkout/order-received/<order-id>/`
    * It should not trigger anything in your logs.
