### PR TITLE
Revert "CRM: Making sure invoice total count factors in credit notes and refunds correctly in invoice editor, preview and pdf view"

### DIFF
--- a/projects/plugins/crm/changelog/revert-34211-fix-crm-invoice-total-credit-refund
+++ b/projects/plugins/crm/changelog/revert-34211-fix-crm-invoice-total-credit-refund
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Invoices: Changing total amount calculation in preview and pdf when refunds or credit notes are applied, back to pre 6.4.0 implementation.

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
@@ -2753,49 +2753,52 @@ class zbsDAL_invoices extends zbsDAL_ObjectLayer {
 
                 // get total due
                 $invoiceTotalValue = 0.0; if (isset($invoice['total'])) $invoiceTotalValue = (float)$invoice['total'];
+                // this one'll be a rolling sum
+                $transactionsTotalValue = 0.0;
 
-						// this one'll be a rolling sum
-						$transactions_total_value = 0.0;
+                // cycle through trans + calc existing balance
+                if (isset($invoice['transactions']) && is_array($invoice['transactions'])){
 
-						// cycle through trans + calc existing balance
-						if ( isset( $invoice['transactions'] ) && is_array( $invoice['transactions'] ) ) {
+                    // got trans
+                    foreach ($invoice['transactions'] as $transaction){
 
-							// got trans
-							foreach ( $invoice['transactions'] as $transaction ) {
+                        // should we also check for status=completed/succeeded? (leaving for now, will let check all):
 
-								// should we also check for status=completed/succeeded? (leaving for now, will let check all):
+                        // get amount
+                        $transactionAmount = 0.0; if (isset($transaction['total'])) $transactionAmount = (float)$transaction['total'];
 
-								// get amount
-								$transaction_amount = 0.0;
+                        if ($transactionAmount > 0){
 
-								if ( isset( $transaction['total'] ) ) {
-									$transaction_amount = (float) $transaction['total'];
-								}
+                            switch ($transaction['type']){
 
-								switch ( $transaction['type'] ) {
+                                case __('Sale','zero-bs-crm'):
 
-									case __( 'Sale', 'zero-bs-crm' ):
-										// these count as debits against invoice.
-										$transactions_total_value -= $transaction_amount;
+                                    // these count as debits against invoice.
+                                    $transactionsTotalValue -= $transactionAmount;
 
-										break;
+                                    break;
 
-									case __( 'Refund', 'zero-bs-crm' ):
-									case __( 'Credit Note', 'zero-bs-crm' ):
-										// These count as credits against invoice, and should be added.
-										$transactions_total_value -= abs( (float) $transaction_amount );
+                                case __('Refund','zero-bs-crm'):
+                                case __('Credit Note','zero-bs-crm'):
 
-										break;
+                                    // these count as credits against invoice.
+                                    $transactionsTotalValue += $transactionAmount;
 
-								} // / switch on type (sale/refund)
+                                    break;
 
-							} // / each trans
 
-							// should now have $transactionsTotalValue & $invoiceTotalValue
-							// ... so we sum + return.
-							return $invoiceTotalValue + $transactions_total_value; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
-						} // / if has trans
+                            } // / switch on type (sale/refund)
+
+                        } // / if trans > 0
+
+                    } // / each trans
+
+                    // should now have $transactionsTotalValue & $invoiceTotalValue
+                    // ... so we sum + return.
+                    return $invoiceTotalValue + $transactionsTotalValue;
+
+                } // / if has trans
 
             } // / if retrieved inv
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
@@ -2752,55 +2752,58 @@ class zbsDAL_invoices extends zbsDAL_ObjectLayer {
             if (is_array($invoice)){
 
                 // get total due
-                $invoiceTotalValue = 0.0; if (isset($invoice['total'])) $invoiceTotalValue = (float)$invoice['total'];
-                // this one'll be a rolling sum
-                $transactionsTotalValue = 0.0;
+						$invoice_total_value = 0.0;
+						if ( isset( $invoice['total'] ) ) {
+							$invoice_total_value = (float) $invoice['total'];
+							// this one'll be a rolling sum
+							$transactions_total_value = 0.0;
 
-                // cycle through trans + calc existing balance
-                if (isset($invoice['transactions']) && is_array($invoice['transactions'])){
+							// cycle through trans + calc existing balance
+							if ( isset( $invoice['transactions'] ) && is_array( $invoice['transactions'] ) ) {
 
-                    // got trans
-                    foreach ($invoice['transactions'] as $transaction){
+								// got trans
+								foreach ( $invoice['transactions'] as $transaction ) {
 
-                        // should we also check for status=completed/succeeded? (leaving for now, will let check all):
+									// should we also check for status=completed/succeeded? (leaving for now, will let check all):
 
-                        // get amount
-                        $transactionAmount = 0.0; if (isset($transaction['total'])) $transactionAmount = (float)$transaction['total'];
+									// get amount
+									$transaction_amount = 0.0;
 
-                        if ($transactionAmount > 0){
+									if ( isset( $transaction['total'] ) ) {
+										$transaction_amount = (float) $transaction['total'];
 
-                            switch ($transaction['type']){
+										if ( $transaction_amount > 0 ) {
 
-                                case __('Sale','zero-bs-crm'):
+											switch ( $transaction['type'] ) {
+												case __( 'Sale', 'zero-bs-crm' ):
+													// these count as debits against invoice.
+													$transactions_total_value -= $transaction_amount;
 
-                                    // these count as debits against invoice.
-                                    $transactionsTotalValue -= $transactionAmount;
+													break;
 
-                                    break;
+												case __( 'Refund', 'zero-bs-crm' ):
+												case __( 'Credit Note', 'zero-bs-crm' ):
+													// these count as credits against invoice.
+													$transactions_total_value += $transaction_amount;
 
-                                case __('Refund','zero-bs-crm'):
-                                case __('Credit Note','zero-bs-crm'):
+													break;
 
-                                    // these count as credits against invoice.
-                                    $transactionsTotalValue += $transactionAmount;
+											} // / switch on type (sale/refund)
 
-                                    break;
+										} // / if trans > 0
 
+									} // / if isset
 
+								} // / each trans
 
-                            } // / switch on type (sale/refund)
+								// should now have $transactions_total_value & $invoice_total_value
+								// ... so we sum + return.
+								return $invoice_total_value + $transactions_total_value;
 
-                        } // / if trans > 0
+							} // / if has trans
+						} //  if isset invoice total
 
-                    } // / each trans
-
-                    // should now have $transactionsTotalValue & $invoiceTotalValue
-                    // ... so we sum + return.
-                    return $invoiceTotalValue + $transactionsTotalValue;
-
-                } // / if has trans
-
-            } // / if retrieved inv
+					} // / if retrieved inv
 
         } // / if invoice_id > 0
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -1569,10 +1569,8 @@ function zbscrm_JS_calc_amount_due() {
 			// get
 			var v = jQuery( '.zbs-partial-value', ele ).text();
 
-			var label = jQuery( '.zlabel', ele ).text();
-
 			// detect +-
-			var multiplier = 1; // gets turned to -1 if negative ()
+			var multiplier = 1; // gets turned to -1 if negotive ()
 
 			// got -?
 			if ( v.includes( '(' ) ) {
@@ -1581,11 +1579,10 @@ function zbscrm_JS_calc_amount_due() {
 			}
 			v = parseFloat( v ) * multiplier;
 
-			if (  label.includes( 'Refund' ) || label.includes( 'Credit' ) ) {
-				amount_due -= Math.abs( v );
-			} else {
-				amount_due -= v;
-			}
+			// debug console.log('amount:',[jQuery('.zbs-partial-value',ele).text(),amount_due,v]);
+
+			// do it :)
+			amount_due -= v;
 		} );
 
 		jQuery( '#inv-amount-due' ).html( amount_due.toFixed( zbs_root.currencyOptions.noOfDecimals ) );


### PR DESCRIPTION
Reverts Automattic/jetpack#34211

This PR was include in CRM 6.4.0, and after some discussion (Slack ref - p1707313986371539-slack-CTXBP902X) we've decided to revert this change for the next release.

The reasoning is that while the change does make the credit / refund display more consistent (the editor / preview / portal displays will be the same), the additional change to make sure credits and refunds behave the same whether positive or negative in value may (and has in one known case) disrupt existing workflows (using negative value invoices for example).

As a long-term solution would likely require migrations and more accountancy input, we decided the best solution for now would be to go back to the previous implementation.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

While this is a revert, test-wise we can confirm that any new manually added transactions linked to invoices don't return unexpected results.