### PR TITLE
SSO: Users page, change column text and add tooltip

### DIFF
--- a/projects/plugins/jetpack/changelog/Add column tooltip
+++ b/projects/plugins/jetpack/changelog/Add column tooltip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Rename status column to sso status and add tooltip

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -555,9 +555,9 @@ class Jetpack_SSO {
 	 */
 	public function jetpack_user_connected_th( $columns ) {
 		$columns['user_jetpack'] = sprintf(
-			'<span title="%1$s">%2$s</span>',
-			esc_attr__( 'Connected users can log-in to this site using their WordPress.com account.', 'jetpack' ),
-			esc_html__( 'Status', 'jetpack' )
+			'<span title="%1$s">%2$s <span class="tooltip">?</span></span>',
+			esc_attr__( 'Jetpack SSO is required for a seamless and secure experience on WordPress.com. Join millions of WordPress users who trust us to keep their accounts safe.', 'jetpack' ),
+			esc_html__( 'SSO Status', 'jetpack' )
 		);
 		return $columns;
 	}
@@ -678,6 +678,16 @@ class Jetpack_SSO {
 			.jetpack-sso-invitation.sso-disconnected-user:focus,
 			.jetpack-sso-invitation.sso-disconnected-user:active {
 				color: #0096dd;
+			}
+			.tooltip {
+				background: #aaaaaa;
+				width: 20px;
+				display: inline-block;
+				border-radius: 10px;
+				height: 20px;
+				text-align: center;
+				color: white;
+				cursor: pointer;
 			}
 		</style>
 		<?php


### PR DESCRIPTION
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/87302

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes column name from Status to SSO Status and add a tooltip explaining the column.
More details https://github.com/Automattic/wp-calypso/issues/87302


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Pull and run this branch
* Sync with your atomic site
* Navigate to `/wp-admin/users.php`
* Check the column and hover over the "?"

<img width="304" alt="image" src="https://github.com/Automattic/jetpack/assets/2653810/63bf7e28-57d7-47d0-91a9-95ff24527f4c">

<img width="160" alt="image" src="https://github.com/Automattic/jetpack/assets/2653810/711f463f-457b-429a-a925-a62a6bf81073">