### PR TITLE
SSO/Improve row readability: Add icon and rename row item

### DIFF
--- a/projects/plugins/jetpack/changelog/Improve column
+++ b/projects/plugins/jetpack/changelog/Improve column
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Improve column by renaming and adding icon

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -630,7 +630,7 @@ class Jetpack_SSO {
 			$nonce           = wp_create_nonce( 'jetpack-sso-invite-user' );
 			$connection_html = sprintf(
 				// Using formmethod and formaction because we can't nest forms and have to submit using the main form.
-				'<a href="%s" class="jetpack-sso-invitation sso-disconnected-user" title="%s">%s</a>',
+				'<a href="%1$s" class="jetpack-sso-invitation sso-disconnected-user">%2$s</a><span title="%3$s" class="sso-disconnected-user-icon dashicons dashicons-warning"></span>',
 				add_query_arg(
 					array(
 						'user_id'      => $user_id,
@@ -639,8 +639,8 @@ class Jetpack_SSO {
 					),
 					admin_url( 'admin-post.php' )
 				),
-				esc_attr__( 'Invite the user to this site so they can login via SSO.', 'jetpack' ),
-				esc_html__( 'Invite', 'jetpack' )
+				esc_html__( 'Send invite', 'jetpack' ),
+				esc_attr__( 'This user doesn&#8217;t have a WP.com account and, with your current site settings, won&#8217;t be able to log in. Request them to create a WP.com to be able to function normally.', 'jetpack' )
 			);
 			return $connection_html;
 		}
@@ -678,6 +678,13 @@ class Jetpack_SSO {
 			.jetpack-sso-invitation.sso-disconnected-user:focus,
 			.jetpack-sso-invitation.sso-disconnected-user:active {
 				color: #0096dd;
+			}
+			.sso-disconnected-user-icon {
+				margin-left: 5px;
+				cursor: pointer;
+				background: black;
+				border-radius: 10px;
+				color: white;
 			}
 		</style>
 		<?php

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -637,7 +637,7 @@ class Jetpack_SSO {
 					admin_url( 'admin-post.php' )
 				),
 				esc_html__( 'Send invite', 'jetpack' ),
-				esc_attr__( 'This user doesn&#8217;t have a WP.com account and, with your current site settings, won&#8217;t be able to log in. Request them to create a WP.com to be able to function normally.', 'jetpack' )
+				esc_attr__( 'This user doesn&#8217;t have a WP.com account and, with your current site settings, won&#8217;t be able to log in. Request them to create a WP.com account to be able to function normally.', 'jetpack' )
 			);
 			return $connection_html;
 		}


### PR DESCRIPTION

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/87321

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Rename row item, `Invite`to `Send invite` and add a warning icon to help users with monochromacy  

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Pull and run this branch
* Sync with your atomic site
* Navigate to /wp-admin/users.php
* Check/hover the row and the warning icon.

<img width="1755" alt="image" src="https://github.com/Automattic/jetpack/assets/2653810/ccf00472-d35e-4d68-91ca-8df170bfabc9">

<img width="662" alt="image" src="https://github.com/Automattic/jetpack/assets/2653810/0d48b66d-572e-45eb-895c-c54649e5ae90">


