### PR TITLE
CRM: Resolves 3420+3423 - WooSync fixes

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3420+3423-woosync_fixes
+++ b/projects/plugins/crm/changelog/fix-crm-3420+3423-woosync_fixes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+WooSync: Remove broken link from settings page.
+WooSync: Prevent addition of the same site more than once.

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/connections.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/connections.page.php
@@ -181,39 +181,38 @@ function jpcrm_settings_page_html_woosync_connections() {
 				<td>
 					<?php
 
-						// first up we want to pick any local connections out of the stack
-						if ( isset( $sync_sites['local'] ) ){
+					// first up we want to pick any local connections out of the stack
+					if ( isset( $sync_sites['local'] ) ) {
 
-							// draw it
-							jpcrm_woosync_connections_page_single_connection( 'local', $sync_sites['local'] );
+						// draw it
+						jpcrm_woosync_connections_page_single_connection( 'local', $sync_sites['local'] );
 
+					}
+
+					foreach ( $sync_sites as $site_key => $site_info ) {
+
+						// skip local as dealt with above
+						if ( $site_key === 'local' ) {
+							continue;
 						}
 
+						// draw it
+						jpcrm_woosync_connections_page_single_connection( $site_key, $site_info );
 
-						foreach ( $sync_sites as $site_key => $site_info ){
+					}
 
-							// skip local as dealt with above
-							if ( $site_key == 'local' ) continue;
+					// if no connections show message:
+					if ( count( $sync_sites ) === 0 ) {
 
-							// draw it
-							jpcrm_woosync_connections_page_single_connection( $site_key, $site_info );
+						echo zeroBSCRM_UI2_messageHTML( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							'info',
+							__( 'No WooCommerce connections', 'zero-bs-crm' ),
+							__( 'Connect to an external WooCommerce store or install WooCommerce to get started.', 'zero-bs-crm' ),
+							'',
+							'jpcrm-no-woo-connections-notice'
+						);
 
-						}
-
-
-
-						// if no connections show message:
-						if ( count( $sync_sites ) == 0 ){
-
-							echo zeroBSCRM_UI2_messageHTML( 
-								'info',
-								__( 'No WooCommerce connections', 'zero-bs-crm' ),
-								__( '<a href="%s">Connect to an external WooCommerce store</a> or install WooCommerce to get started.', 'zero-bs-crm' ),
-								'',
-								'jpcrm-no-woo-connections-notice'
-							);
-
-						}
+					}
 
 					?>
 				</td>
@@ -519,5 +518,4 @@ function jpcrm_woosync_connections_styles_scripts(){
 	global $zbs;	
 	wp_enqueue_script( 'jpcrm-woo-sync-connections-page', plugins_url( '/js/jpcrm-woo-sync-settings-connections'.wp_scripts_get_suffix().'.js', JPCRM_WOO_SYNC_ROOT_FILE ), array( 'jquery' ), $zbs->modules->woosync->version );
 	wp_enqueue_style( 'jpcrm-woo-sync-connections-page', plugins_url( '/css/jpcrm-woo-sync-settings-connections'.wp_scripts_get_suffix().'.css', JPCRM_WOO_SYNC_ROOT_FILE ) );
-
 }

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/connections.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/connections.page.php
@@ -158,7 +158,7 @@ function jpcrm_settings_page_html_woosync_connections() {
 						<?php _e('Are you sure?',"zero-bs-crm"); ?>
 					</div>
 					<p><?php echo sprintf( __( 'Are you sure you want to disconnect the connection to the store at <br><code>%s</code>?', 'zero-bs-crm' ), $sync_sites[ $site_key_to_disconnect ]['domain'] ); ?></p>
-					<p><?php esc_html_e( 'This will pernamently remove this connection. No new data will be synchronised from this external store unless you add a new connection to it at a later date. This will not remove any existing data.', 'zero-bs-crm' ); ?></p>
+					<p><?php esc_html_e( 'This will permanently remove this connection. No new data will be synchronised from this external store unless you add a new connection to it at a later date. This will not remove any existing data.', 'zero-bs-crm' ); ?></p>
 					<p><?php
 
 									// actions

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1853,19 +1853,20 @@ class Woo_Sync {
 
 		$this->skip_local_woo_check = $pre_state;
 
+		// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 		// basic validation
-		if ( ! in_array( $mode, array( JPCRM_WOO_SYNC_MODE_LOCAL, JPCRM_WOO_SYNC_MODE_API ), true ) ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+		if ( ! in_array( $mode, array( JPCRM_WOO_SYNC_MODE_LOCAL, JPCRM_WOO_SYNC_MODE_API ), true ) ) {
 			return false;
 		}
 
 		// if no site key, attempt to generate one:
 		if ( empty( $site_key ) ) {
 
-			if ( $mode === JPCRM_WOO_SYNC_MODE_LOCAL ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			if ( $mode === JPCRM_WOO_SYNC_MODE_LOCAL ) {
 				$site_key = 'local';
-			} elseif ( ! empty( $domain ) ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			} elseif ( ! empty( $domain ) ) {
 
-				$site_key = $this->generate_site_key( $domain ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+				$site_key = $this->generate_site_key( $domain );
 
 			} else {
 
@@ -1882,7 +1883,7 @@ class Woo_Sync {
 				// site key already exists
 				|| isset( $sync_sites[ $site_key ] )
 				// domain already exists
-				|| in_array( $domain, array_column( $sync_sites, 'domain' ), true ) // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+				|| in_array( $domain, array_column( $sync_sites, 'domain' ), true )
 				) {
 				return false;
 			}
@@ -1891,11 +1892,11 @@ class Woo_Sync {
 
 		// add
 		$sync_sites[ $site_key ] = array(
-			'mode'                  => $mode, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-			'domain'                => $domain, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-			'key'                   => $key, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-			'secret'                => $secret, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-			'prefix'                => $prefix, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			'mode'                  => $mode,
+			'domain'                => $domain,
+			'key'                   => $key,
+			'secret'                => $secret,
+			'prefix'                => $prefix,
 
 			// tracking
 			'last_sync_fired'       => -1,
@@ -1906,11 +1907,12 @@ class Woo_Sync {
 		);
 
 		// pause, if present
-		if ( $paused ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+		if ( $paused ) {
 
-			$sync_sites[ $site_key ]['paused'] = $paused; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$sync_sites[ $site_key ]['paused'] = $paused;
 
 		}
+		// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 		// save
 		$this->settings->update( 'sync_sites', $sync_sites );

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1874,8 +1874,14 @@ class Woo_Sync {
 
 			$sync_sites = $this->get_active_sync_sites( 'default' );
 
-			// Abort if site key wasn't generated or already exists.
-			if ( empty( $site_key ) || isset( $sync_sites[ $site_key ] ) ) {
+			if (
+				// error generating key
+				empty( $site_key )
+				// site key already exists
+				|| isset( $sync_sites[ $site_key ] )
+				// domain already exists
+				|| in_array( $domain, array_column( $sync_sites, 'domain' ), true ) // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+				) {
 				return false;
 			}
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1,4 +1,4 @@
-<?php 
+<?php // phpcs:disable
 /*!
  * Jetpack CRM
  * https://jetpackcrm.com
@@ -1507,7 +1507,9 @@ class Woo_Sync {
 							);
 
 							// add option to flag newly added to UI
-							set_transient( 'jpcrm_woo_newly_authenticated', $new_sync_site['site_key'], 600 );
+							if ( $new_sync_site ) {
+								set_transient( 'jpcrm_woo_newly_authenticated', $new_sync_site['site_key'], 600 );
+							}
 
 						} else {
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1495,16 +1495,16 @@ class Woo_Sync {
 
 							$log[] = 'connection verified';
 
-							// if legit, add as site							
-							$new_sync_site = $this->add_sync_site( array(
-			        			
-					            'mode'           => JPCRM_WOO_SYNC_MODE_API,
-					            'domain'         => $transient_check_domain,
-					            'key'            => $key,
-					            'secret'         => $secret,
-					            'prefix'         => ''
-
-					        ));
+							// if legit, add as site
+							$new_sync_site = $this->add_sync_site(
+								array(
+									'mode'   => JPCRM_WOO_SYNC_MODE_API,
+									'domain' => $transient_check_domain,
+									'key'    => $key,
+									'secret' => $secret,
+									'prefix' => '',
+								)
+							);
 
 							// add option to flag newly added to UI
 							set_transient( 'jpcrm_woo_newly_authenticated', $new_sync_site['site_key'], 600 );

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1848,7 +1848,6 @@ class Woo_Sync {
 		// get existing (but side-step the woo local check because that can cause an infinite loop)
 		$pre_state = $this->skip_local_woo_check;
 		$this->skip_local_woo_check = true;
-		$sync_sites = $this->get_active_sync_sites( 'default' );
 
 		$this->skip_local_woo_check = $pre_state;
 
@@ -1856,41 +1855,28 @@ class Woo_Sync {
 		if ( ! in_array( $mode, array( JPCRM_WOO_SYNC_MODE_LOCAL, JPCRM_WOO_SYNC_MODE_API ), true ) ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 			return false;
 		}
-		if ( isset( $sync_sites[ $site_key ] ) ) {
-			return false;
-		}
 
 		// if no site key, attempt to generate one:
 		if ( empty( $site_key ) ) {
 
 			if ( $mode === JPCRM_WOO_SYNC_MODE_LOCAL ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-
 				$site_key = 'local';
+			} elseif ( ! empty( $domain ) ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
-				// if local and already have a local, error?
-				if ( isset( $sync_sites[ $site_key ] ) ) {
-					return false;
-				}
+				$site_key = $this->generate_site_key( $domain ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
 			} else {
 
-				if ( ! empty( $domain ) ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-
-					$site_key = $this->generate_site_key( $domain );
-
-				} else {
-
-					// external site setup without a domain ¯\_(ツ)_/¯
-					$site_key = $this->generate_site_key( 'no_domain' );
-
-				}
+				// external site setup without a domain ¯\_(ツ)_/¯
+				$site_key = $this->generate_site_key( 'no_domain' );
 
 			}
 
-			// any luck?
-			if ( empty( $site_key ) ) {
+			$sync_sites = $this->get_active_sync_sites( 'default' );
 
+			// Abort if site key wasn't generated or already exists.
+			if ( empty( $site_key ) || isset( $sync_sites[ $site_key ] ) ) {
 				return false;
-
 			}
 
 		}

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -248,7 +248,6 @@
 	"projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-my-account-integration.php",
 	"projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-segment-conditions.php",
 	"projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php",
-	"projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php",
 	"projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php",
 	"projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-default-settings.php",
 	"projects/plugins/crm/modules/woo-sync/includes/segment-conditions/class-segment-condition-woo-customer.php",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3420 and Automattic/zero-bs-crm#3423 - WooSync fixes

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR:
1. Removes a broken (and redundant) link in the WooSync settings page.
2. Prevents duplicate WooCommerce sites from being added. This was happening because we never checked for a duplicate existing site domain when adding a site.
3. Catches a PHP notice in scenarios where adding a site fails.

I also did a slight rework/optimisation in the `add_sync_site()` function. I was forced to disable PHPCS on the file, as even a slight change was forcing checks on the entire file for some reason (which turned up thousands of violations).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a JN site with WooCommerce installed.
2. Create a JN site with CRM installed and WooSync enabled.
4. On the CRM site, go here: `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=woosync&subtab=connections`

In `trunk`, the "Connect to an external WooCommerce store" text has a broken link:
![image](https://github.com/Automattic/jetpack/assets/32492176/8c89172f-9ba3-40f2-95d1-45d2884f6a5d)

In the `fix/crm/3420+3423-woosync_fixes` branch, the link is removed (the correct link is in the subheading already).

5. Click "Connect a Store".
6. Put the Woo site's URL in, and click "Connect Store".
7. You'll be redirected to an OAuth screen on the Woo site.
8. Click approve many times.

In `trunk` the connections page will list several instances of the site.

In the `fix/crm/3420+3423-woosync_fixes` branch, only one instance of the site will show.