### PR TITLE
Feature Hints: add sharing block to the list of suggestions

### DIFF
--- a/projects/packages/plans/changelog/update-plugin-search-sharing-block
+++ b/projects/packages/plans/changelog/update-plugin-search-sharing-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Plan features: add "sharing block" to the list of features supported in the free plan.

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.4.1",
+	"version": "0.4.2-alpha",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -45,6 +45,7 @@ class Current_Plan {
 				'opentable',
 				'calendly',
 				'send-a-message',
+				'sharing-block',
 				'whatsapp-button',
 				'social-previews',
 				'videopress',

--- a/projects/plugins/jetpack/changelog/update-plugin-search-sharing-block
+++ b/projects/plugins/jetpack/changelog/update-plugin-search-sharing-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Feature Hints: add the sharing block to the list of suggested features when the site uses a block-based theme.

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -300,7 +300,7 @@ class Jetpack_Plugin_Search {
 	 */
 	public function get_extra_features() {
 		return array(
-			'akismet' => array(
+			'akismet'       => array(
 				'name'                => 'Akismet',
 				'search_terms'        => 'akismet, anti-spam, antispam, comments, spam, spam protection, form spam, captcha, no captcha, nocaptcha, recaptcha, phising, google',
 				'short_description'   => esc_html__( 'Keep your visitors and search engines happy by stopping comment and contact form spam with Akismet.', 'jetpack' ),
@@ -309,6 +309,16 @@ class Jetpack_Plugin_Search {
 				'sort'                => '16',
 				'learn_more_button'   => Redirect::get_url( 'plugin-hint-upgrade-akismet' ),
 				'configure_url'       => admin_url( 'admin.php?page=akismet-key-config' ),
+			),
+			'sharing-block' => array(
+				'name'                => esc_html__( 'Sharing buttons block', 'jetpack' ),
+				'search_terms'        => 'share, sharing, sharing block, sharing button, social buttons, buttons, share facebook, share twitter, social share, icons, email, facebook, twitter, x, linkedin, pinterest, pocket, social media',
+				'short_description'   => esc_html__( 'Add sharing buttons blocks anywhere on your website to help your visitors share your content.', 'jetpack' ),
+				'requires_connection' => false,
+				'module'              => 'sharing-block',
+				'sort'                => '13',
+				'learn_more_button'   => Redirect::get_url( 'jetpack-support-sharing-block' ),
+				'configure_url'       => admin_url( 'site-editor.php?path=%2Fwp_template' ),
 			),
 		);
 	}
@@ -331,26 +341,36 @@ class Jetpack_Plugin_Search {
 
 		// Looks like a search query; it's matching time.
 		if ( ! empty( $args->search ) ) {
+			$searchable_modules = array(
+				'contact-form',
+				'monitor',
+				'photon',
+				'photon-cdn',
+				'protect',
+				'publicize',
+				'related-posts',
+				'akismet',
+				'vaultpress',
+				'videopress',
+				'search',
+			);
+
+			/*
+			 * Let's handle the Sharing feature differently.
+			 * If we're using a block-based theme, we should suggest the sharing block.
+			 * If using a classic theme, we should suggest the old sharing module.
+			 */
+			if ( wp_is_block_theme() ) {
+				$searchable_modules[] = 'sharing-block';
+			} else {
+				$searchable_modules[] = 'sharedaddy';
+			}
+
 			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
 			$tracking             = new Tracking();
 			$jetpack_modules_list = array_intersect_key(
 				array_merge( $this->get_extra_features(), Jetpack_Admin::init()->get_modules() ),
-				array_flip(
-					array(
-						'contact-form',
-						'monitor',
-						'photon',
-						'photon-cdn',
-						'protect',
-						'publicize',
-						'related-posts',
-						'sharedaddy',
-						'akismet',
-						'vaultpress',
-						'videopress',
-						'search',
-					)
-				)
+				array_flip( $searchable_modules )
 			);
 			uasort( $jetpack_modules_list, array( $this, 'by_sorting_option' ) );
 
@@ -533,7 +553,15 @@ class Jetpack_Plugin_Search {
 
 		$links = array();
 
-		if ( 'akismet' === $plugin['module'] || 'vaultpress' === $plugin['module'] ) {
+		if ( 'sharing-block' === $plugin['module'] ) {
+			$links['jp_get_started'] = '<a
+				id="plugin-select-settings"
+				class="jetpack-plugin-search__primary jetpack-plugin-search__get-started button"
+				href="' . esc_url( admin_url( 'site-editor.php?path=%2Fwp_template' ) ) . '"
+				data-module="' . esc_attr( $plugin['module'] ) . '"
+				data-track="get_started"
+				>' . esc_html__( 'Add block', 'jetpack' ) . '</a>';
+		} elseif ( 'akismet' === $plugin['module'] || 'vaultpress' === $plugin['module'] ) {
 			$links['jp_get_started'] = '<a
 				id="plugin-select-settings"
 				class="jetpack-plugin-search__primary jetpack-plugin-search__get-started button"


### PR DESCRIPTION
## Proposed changes:

Feature Hints suggest the legacy sharing module whenever someone looks for sharing buttons in the plugin search. It is useful, but on block-based themes we can now suggest a better solution: the new sharing buttons block.
This adds logic so we suggest a different solution based on the theme in use on your site.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's connected to WordPress.com.
* Go to Plugins > Add New
* Search for "twitter"
    * If you use a block-based theme, you should see an invitation to add the sharing block to your site. The CTA link ("Add block") should lead you to the site editor.
    * If you use a classic theme, you should see a suggestion to use Jetpack's sharing buttons.

| Block theme | Classic theme |
|--------|--------|
| <img width="823" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/1ad4692f-191e-4606-812a-73b6d204b4a4"> | <img width="697" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/c633b64e-f94b-4413-be6d-7fd0f34f69ae"> |