### PR TITLE
Fix: simple sites tiled gallery qr code upload

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-app-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-app-media.php
@@ -178,7 +178,7 @@ class WPCOM_REST_API_V2_Endpoint_App_Media extends WP_REST_Controller {
 			'caption'    => '',
 			'thumbnails' => array(
 				'thumbnail' => wp_get_attachment_image_url( $item->ID, 'thumbnail' ),
-				'large'     => wp_get_attachment_image_url( $item->ID, 'full' ),
+				'large'     => wp_get_attachment_image_url( $item->ID, 'large' ),
 			),
 		);
 	}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-app-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-app-media.php
@@ -151,7 +151,10 @@ class WPCOM_REST_API_V2_Endpoint_App_Media extends WP_REST_Controller {
 		$response['media'] = array();
 		while ( $media_query->have_posts() ) {
 			$media_query->the_post();
-			$response['media'][] = $this->format_item( $media_query->post );
+			// only include images.
+			if ( wp_attachment_is_image( $media_query->post->ID ) ) {
+				$response['media'][] = $this->format_item( $media_query->post );
+			}
 		}
 		$response['found'] = $media_query->found_posts;
 		$response['meta']  = array( 'next_page' => $media_query->paged + 1 );
@@ -165,10 +168,10 @@ class WPCOM_REST_API_V2_Endpoint_App_Media extends WP_REST_Controller {
 	private function format_item( $item ) {
 		return array(
 			'ID'         => $item->ID,
-			'url'        => wp_get_attachment_image_url( $item->ID ),
+			'url'        => wp_get_attachment_image_url( $item->ID, 'full', true ),
 			'date'       => get_date_from_gmt( $item->post_date_gmt ),
 			'name'       => get_the_title( $item ),
-			'file'       => basename( wp_get_attachment_image_url( $item->ID, 'full' ) ),
+			'file'       => basename( wp_get_attachment_url( $item->ID ) ),
 			'title'      => get_the_title( $item ),
 			'guid'       => get_the_guid( $item ),
 			'type'       => get_post_mime_type( $item ),

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-app-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-app-media.php
@@ -165,7 +165,7 @@ class WPCOM_REST_API_V2_Endpoint_App_Media extends WP_REST_Controller {
 	private function format_item( $item ) {
 		return array(
 			'ID'         => $item->ID,
-			'url'        => get_permalink( $item ),
+			'url'        => wp_get_attachment_image_url( $item->ID ),
 			'date'       => get_date_from_gmt( $item->post_date_gmt ),
 			'name'       => get_the_title( $item ),
 			'file'       => basename( wp_get_attachment_image_url( $item->ID, 'full' ) ),

--- a/projects/plugins/jetpack/changelog/fix-simple-sites-tiled-gallery-qr-code-upload
+++ b/projects/plugins/jetpack/changelog/fix-simple-sites-tiled-gallery-qr-code-upload
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: this fixes bugs that were never released yet so not important externally
+
+

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/jetpack-app-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/jetpack-app-media.js
@@ -32,7 +32,9 @@ function JetpackAppMedia( props ) {
 		[ insertMedia ]
 	);
 	useEffect( () => {
-		if ( media.length === 1 && ! multiple ) {
+		// In most cases media.length here should === 1, but when that is not the case the first image gets inserted.
+		// Since otherwise we end up in a situation where the user is presented with multiple images and they can only insert one.
+		if ( media.length && ! multiple ) {
 			// replace the media right away if there's only one item and we're not in multiple mode.
 			onCopy( media );
 		}

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
@@ -250,7 +250,7 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 						caption: image.caption,
 						id: image.ID,
 						type: 'image',
-						url: image.guid,
+						url: image.url,
 					} ) );
 				} else {
 					result = [
@@ -259,7 +259,7 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 							caption: items.caption,
 							id: items.ID,
 							type: 'image',
-							url: items.guid,
+							url: items.url,
 						},
 					];
 				}

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
@@ -233,6 +233,18 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 					.catch( this.handleApiError );
 			};
 
+			mapImageToResult = image => ( {
+				alt: image.name,
+				caption: image.caption,
+				id: image.ID,
+				type: 'image',
+				url: image.url,
+				sizes: {
+					thumbnail: { url: image.thumbnails.thumbnail },
+					large: { url: image.thumbnails.large },
+				},
+			} );
+
 			insertMedia = items => {
 				this.setState( { isCopying: items } );
 				this.props.noticeOperations.removeAllNotices();
@@ -243,25 +255,12 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 					this.modalElement.focus();
 				}
 				let result = [];
+
 				// insert media
 				if ( items.length !== 0 ) {
-					result = items.map( image => ( {
-						alt: image.name,
-						caption: image.caption,
-						id: image.ID,
-						type: 'image',
-						url: image.url,
-					} ) );
+					result = items.map( this.mapImageToResult );
 				} else {
-					result = [
-						{
-							alt: items.name,
-							caption: items.caption,
-							id: items.ID,
-							type: 'image',
-							url: items.url,
-						},
-					];
+					result = [ this.mapImageToResult( items ) ];
 				}
 
 				const { value, multiple, addToGallery } = this.props;


### PR DESCRIPTION
This PR fixes issues found during the call for testing of the jetpack app as a new media uploader.
See p58i-gxT-p2 this PR fixes 2 issues. 
1. tiled gallery. On simple sites the guid was returning an http url. Which was failing to redirect to the https url in the editor because the editor has a cross domain restriction. 
2. There could be a case where the users images upload really fast and then the user would be presented with multiple images but they could only add one. Which was a frustrating experience. 

Related https://github.com/Automattic/jetpack/pull/34179 


## Proposed changes:
* Update url to use the full image url.
* Update the insertion to accept any numeber of media to copy but only ever insert one. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this Patch to .com. 
2. Sandbox your testing domain to load up the site from .com 
3. Notice that tiled gallery works as expected. 
4. Notice that everything else works as expected. 