### PR TITLE
Add: Jetack App upload media extension

### DIFF
--- a/projects/plugins/jetpack/changelog/add-app-upload-media-enabled
+++ b/projects/plugins/jetpack/changelog/add-app-upload-media-enabled
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add images while publishing on the web via the jetpack app

--- a/projects/plugins/jetpack/extensions/shared/external-media/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/index.js
@@ -1,10 +1,6 @@
-import {
-	isCurrentUserConnected,
-	getJetpackBlocksVariation,
-} from '@automattic/jetpack-shared-extension-utils';
+import { isCurrentUserConnected } from '@automattic/jetpack-shared-extension-utils';
 import { useBlockEditContext } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
-import { SOURCE_JETPACK_APP_MEDIA } from './constants';
 import MediaButton from './media-button';
 import { addPexelsToMediaInserter, addGooglePhotosToMediaInserter } from './media-service';
 import { mediaSources } from './sources';
@@ -14,15 +10,7 @@ function insertExternalMediaBlocks( settings, name ) {
 	if ( name !== 'core/image' ) {
 		return settings;
 	}
-	// Only add the Jetpack App Media button if we are in the beta variation.
-	if ( getJetpackBlocksVariation() !== 'beta' ) {
-		const index = mediaSources.findIndex(
-			mediaSource => mediaSource.id === SOURCE_JETPACK_APP_MEDIA
-		);
-		if ( index > -1 ) {
-			mediaSources.splice( index, 1 );
-		}
-	}
+
 	return {
 		...settings,
 		keywords: [ ...settings.keywords, ...mediaSources.map( source => source.keyword ) ],


### PR DESCRIPTION
This PR enables the Jetpack App media extension for all users. 

## Proposed changes:

* Enables the Jetpack App media extension for all users. 

Please merge this after - https://github.com/Automattic/jetpack/pull/35580 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Project Thread: pcdRpT-4N2-p2
Call for testing: p58i-gxT-p2


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Load up this PR. It should work always. Without the need for beta extensions. 