### PR TITLE
Contact Form: deprecate old temporary filter

### DIFF
--- a/projects/packages/forms/changelog/remove-old-filter-contact-form
+++ b/projects/packages/forms/changelog/remove-old-filter-contact-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: deprecated
+
+Deprecate the temporary tmp_grunion_allow_editor_view filter.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.5",
+	"version": "0.30.6-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.5';
+	const PACKAGE_VERSION = '0.30.6-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -30,7 +30,7 @@ class Jetpack_Forms {
 			$dashboard->init();
 		}
 
-		if ( is_admin() && apply_filters( 'tmp_grunion_allow_editor_view', true ) ) {
+		if ( is_admin() && apply_filters_deprecated( 'tmp_grunion_allow_editor_view', array( true ), '0.30.5', '', 'This functionality will be removed in an upcoming version.' ) ) {
 			add_action( 'current_screen', '\Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
 		}
 

--- a/projects/plugins/jetpack/changelog/remove-old-filter-contact-form
+++ b/projects/plugins/jetpack/changelog/remove-old-filter-contact-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Contact Form: deprecate temporary tmp_grunion_allow_editor_view filter.

--- a/projects/plugins/jetpack/modules/contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form.php
@@ -45,10 +45,11 @@ require_once __DIR__ . '/contact-form/grunion-contact-form.php';
  * Expected to be removed in Jetpack 5.8 or if a security issue merits removing the old code sooner.
  *
  * @since 5.2.0
+ * @deprecated 13.2.0
  *
  * @param boolean $view Use new Editor View. Default true.
  */
-if ( is_admin() && apply_filters( 'tmp_grunion_allow_editor_view', true ) ) {
+if ( is_admin() && apply_filters_deprecated( 'tmp_grunion_allow_editor_view', array( true ), '13.2.0', '', 'This functionality will be removed in an upcoming version.' ) ) {
 	require_once __DIR__ . '/contact-form/grunion-editor-view.php';
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When looking through the code for something else, I found this undocumented filter (in the package) and the documentioned version in the module. It was always marked as temporary and noted that it would be removed around Jetpack 5.8, some 73 or so releases ago.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Mark the filter as officially deprecated so we can remove it later.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None needed, but make sure the admin view still works if you want to!

