### PR TITLE
Newsletter Settings: Add Newsletter Categories settings card with a toggle

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/constants.js
+++ b/projects/plugins/jetpack/_inc/client/newsletter/constants.js
@@ -1,0 +1,1 @@
+export const SUBSCRIPTIONS_MODULE_NAME = 'subscriptions';

--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { getModule } from 'state/modules';
 import { isModuleFound as isModuleFoundSelector } from 'state/search';
+import NewsletterCategories from './newsletter-categories';
 import SubscriptionsSettings from './subscriptions-settings';
 
 /**
@@ -41,6 +42,7 @@ function Subscriptions( props ) {
 			{ foundSubscriptions && (
 				<SubscriptionsSettings siteRawUrl={ siteRawUrl } blogID={ blogID } />
 			) }
+			<NewsletterCategories />
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -7,6 +7,10 @@ import { isModuleFound as isModuleFoundSelector } from 'state/search';
 import NewsletterCategories from './newsletter-categories';
 import SubscriptionsSettings from './subscriptions-settings';
 
+//Check for feature flag
+const urlParams = new URLSearchParams( window.location.search );
+const isNewsletterCategoriesEnabled = urlParams.get( 'enable-newsletter-categories' ) === 'true';
+
 /**
  * Newsletter Section.
  *
@@ -42,7 +46,7 @@ function Subscriptions( props ) {
 			{ foundSubscriptions && (
 				<SubscriptionsSettings siteRawUrl={ siteRawUrl } blogID={ blogID } />
 			) }
-			<NewsletterCategories />
+			{ isNewsletterCategoriesEnabled && <NewsletterCategories /> }
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { getModule } from 'state/modules';
 import { isModuleFound as isModuleFoundSelector } from 'state/search';
+import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 import NewsletterCategories from './newsletter-categories';
 import SubscriptionsSettings from './subscriptions-settings';
 
@@ -20,7 +21,7 @@ const isNewsletterCategoriesEnabled = urlParams.get( 'enable-newsletter-categori
 function Subscriptions( props ) {
 	const { active, isModuleFound, searchTerm, siteRawUrl, blogID } = props;
 
-	const foundSubscriptions = isModuleFound( 'subscriptions' );
+	const foundSubscriptions = isModuleFound( SUBSCRIPTIONS_MODULE_NAME );
 
 	if ( ! searchTerm && ! active ) {
 		return null;

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -4,9 +4,16 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import React, { useCallback, useState } from 'react';
 import { connect } from 'react-redux';
+import {
+	isUnavailableInOfflineMode,
+	isUnavailableInSiteConnectionMode,
+	requiresConnection,
+} from 'state/connection';
 import { withModuleSettingsFormHelpers } from '../components/module-settings/with-module-settings-form-helpers';
 import TextInput from '../components/text-input';
 import Textarea from '../components/textarea';
+
+const SUBSCRIPTIONS_MODULE_NAME = 'subscriptions';
 
 const mapCategoriesIds = category => {
 	switch ( typeof category ) {
@@ -32,12 +39,14 @@ function NewsletterCategories( props ) {
 		newsletterCategories,
 		updateFormStateOptionValue,
 		categories,
+		isUnavailableDueOfflineMode,
+		isUnavailableDueSiteConnectionMode,
 	} = props;
 
 	const [ newCategories, setNewCategories ] = useState( '' );
 
 	const handleEnagleNewsletterCategoriesToggleChange = useCallback( () => {
-		updateFormStateModuleOption( 'subscriptions', 'wpcom_newsletter_categories_enabled' );
+		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, 'wpcom_newsletter_categories_enabled' );
 	}, [ updateFormStateModuleOption ] );
 
 	const categoriesValue = JSON.stringify( newsletterCategories.map( mapCategoriesIds ) );
@@ -55,8 +64,13 @@ function NewsletterCategories( props ) {
 
 	return (
 		<SettingsCard { ...props } module="subscriptions">
-			<SettingsGroup hasChild disableInOfflineMode disableInSiteConnectionMode>
+			<SettingsGroup
+				hasChild
+				disableInOfflineMode={ requiresConnection }
+				disableInSiteConnectionMode={ requiresConnection }
+			>
 				<ToggleControl
+					disabled={ isUnavailableDueOfflineMode || isUnavailableDueSiteConnectionMode }
 					checked={ isNewsletterCategoriesEnabled }
 					onChange={ handleEnagleNewsletterCategoriesToggleChange }
 					label={ __( 'Enable newsletter categories', 'jetpack' ) }
@@ -81,6 +95,12 @@ export default withModuleSettingsFormHelpers(
 			),
 			newsletterCategories: ownProps.getOptionValue( 'wpcom_newsletter_categories' ),
 			categories: ownProps.getOptionValue( 'categories' ),
+			requiresConnection: requiresConnection( state, SUBSCRIPTIONS_MODULE_NAME ),
+			isUnavailableDueOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
+			isUnavailableDueSiteConnectionMode: isUnavailableInSiteConnectionMode(
+				state,
+				SUBSCRIPTIONS_MODULE_NAME
+			),
 		};
 	} )( NewsletterCategories )
 );

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -8,14 +8,14 @@ import { withModuleSettingsFormHelpers } from '../components/module-settings/wit
 import TextInput from '../components/text-input';
 import Textarea from '../components/textarea';
 
-const mapCategoriesIds = categorie => {
-	switch ( typeof categorie ) {
+const mapCategoriesIds = category => {
+	switch ( typeof category ) {
 		case 'number':
-			return categorie;
+			return category;
 		case 'string':
-			return parseInt( categorie );
+			return parseInt( category );
 		case 'object':
-			return categorie.term_id;
+			return category.term_id;
 	}
 };
 

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -9,11 +9,11 @@ import {
 	isUnavailableInSiteConnectionMode,
 	requiresConnection,
 } from 'state/connection';
+import { getModule } from 'state/modules';
 import { withModuleSettingsFormHelpers } from '../components/module-settings/with-module-settings-form-helpers';
 import TextInput from '../components/text-input';
 import Textarea from '../components/textarea';
-
-const SUBSCRIPTIONS_MODULE_NAME = 'subscriptions';
+import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
 const mapCategoriesIds = category => {
 	switch ( typeof category ) {
@@ -41,6 +41,7 @@ function NewsletterCategories( props ) {
 		categories,
 		isUnavailableDueOfflineMode,
 		isUnavailableDueSiteConnectionMode,
+		subscriptionsModule,
 	} = props;
 
 	const [ newCategories, setNewCategories ] = useState( '' );
@@ -68,6 +69,7 @@ function NewsletterCategories( props ) {
 				hasChild
 				disableInOfflineMode={ requiresConnection }
 				disableInSiteConnectionMode={ requiresConnection }
+				module={ subscriptionsModule }
 			>
 				<ToggleControl
 					disabled={ isUnavailableDueOfflineMode || isUnavailableDueSiteConnectionMode }
@@ -90,6 +92,7 @@ function NewsletterCategories( props ) {
 export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
+			subscriptionsModule: getModule( state, 'subscriptions' ),
 			isNewsletterCategoriesEnabled: ownProps.getOptionValue(
 				'wpcom_newsletter_categories_enabled'
 			),

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -74,7 +74,7 @@ function NewsletterCategories( props ) {
 				<ToggleControl
 					disabled={ isUnavailableDueOfflineMode || isUnavailableDueSiteConnectionMode }
 					checked={ isNewsletterCategoriesEnabled }
-					onChange={ handleEnagleNewsletterCategoriesToggleChange }
+					onChange={ handleEnableNewsletterCategoriesToggleChange }
 					label={ __( 'Enable newsletter categories', 'jetpack' ) }
 				/>
 				All categories:

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -46,7 +46,7 @@ function NewsletterCategories( props ) {
 
 	const [ newCategories, setNewCategories ] = useState( '' );
 
-	const handleEnagleNewsletterCategoriesToggleChange = useCallback( () => {
+	const handleEnableNewsletterCategoriesToggleChange = useCallback( () => {
 		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, 'wpcom_newsletter_categories_enabled' );
 	}, [ updateFormStateModuleOption ] );
 

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -64,7 +64,12 @@ function NewsletterCategories( props ) {
 	}, [] );
 
 	return (
-		<SettingsCard { ...props } module="subscriptions">
+		<SettingsCard
+			{ ...props }
+			header={ __( 'Newsletter categories', 'jetpack' ) }
+			hideButton
+			module="subscriptions"
+		>
 			<SettingsGroup
 				hasChild
 				disableInOfflineMode={ requiresConnection }

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -6,6 +6,7 @@ import React, { useCallback, useState } from 'react';
 import { connect } from 'react-redux';
 import { withModuleSettingsFormHelpers } from '../components/module-settings/with-module-settings-form-helpers';
 import TextInput from '../components/text-input';
+import Textarea from '../components/textarea';
 
 const mapCategoriesIds = categorie => {
 	switch ( typeof categorie ) {
@@ -30,6 +31,7 @@ function NewsletterCategories( props ) {
 		isNewsletterCategoriesEnabled,
 		newsletterCategories,
 		updateFormStateOptionValue,
+		categories,
 	} = props;
 
 	const [ newCategories, setNewCategories ] = useState( '' );
@@ -59,9 +61,11 @@ function NewsletterCategories( props ) {
 					onChange={ handleEnagleNewsletterCategoriesToggleChange }
 					label={ __( 'Enable newsletter categories', 'jetpack' ) }
 				/>
-				Categories state:
+				All categories:
+				<Textarea disabled value={ JSON.stringify( categories ) } />
+				Checked categories (by ID):
 				<TextInput value={ categoriesValue } disabled />
-				New value:
+				New Checked categories value:
 				<TextInput value={ newCategories } onChange={ onCategoriesChange } />
 				<button onClick={ parseArray }>Parse array to state</button>
 			</SettingsGroup>
@@ -76,6 +80,7 @@ export default withModuleSettingsFormHelpers(
 				'wpcom_newsletter_categories_enabled'
 			),
 			newsletterCategories: ownProps.getOptionValue( 'wpcom_newsletter_categories' ),
+			categories: ownProps.getOptionValue( 'categories' ),
 		};
 	} )( NewsletterCategories )
 );

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -68,7 +68,7 @@ function NewsletterCategories( props ) {
 			{ ...props }
 			header={ __( 'Newsletter categories', 'jetpack' ) }
 			hideButton
-			module="subscriptions"
+			module={ SUBSCRIPTIONS_MODULE_NAME }
 		>
 			<SettingsGroup
 				hasChild
@@ -97,7 +97,7 @@ function NewsletterCategories( props ) {
 export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
-			subscriptionsModule: getModule( state, 'subscriptions' ),
+			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
 			isNewsletterCategoriesEnabled: ownProps.getOptionValue(
 				'wpcom_newsletter_categories_enabled'
 			),

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -1,0 +1,81 @@
+import { ToggleControl } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import React, { useCallback, useState } from 'react';
+import { connect } from 'react-redux';
+import { withModuleSettingsFormHelpers } from '../components/module-settings/with-module-settings-form-helpers';
+import TextInput from '../components/text-input';
+
+const mapCategoriesIds = categorie => {
+	switch ( typeof categorie ) {
+		case 'number':
+			return categorie;
+		case 'string':
+			return parseInt( categorie );
+		case 'object':
+			return categorie.term_id;
+	}
+};
+
+/**
+ * NewsletterCategories settings component.
+ *
+ * @param {object} props - Component props.
+ * @returns {React.Component} Subscription settings component.
+ */
+function NewsletterCategories( props ) {
+	const {
+		updateFormStateModuleOption,
+		isNewsletterCategoriesEnabled,
+		newsletterCategories,
+		updateFormStateOptionValue,
+	} = props;
+
+	const [ newCategories, setNewCategories ] = useState( '' );
+
+	const handleEnagleNewsletterCategoriesToggleChange = useCallback( () => {
+		updateFormStateModuleOption( 'subscriptions', 'wpcom_newsletter_categories_enabled' );
+	}, [ updateFormStateModuleOption ] );
+
+	const categoriesValue = JSON.stringify( newsletterCategories.map( mapCategoriesIds ) );
+	const parseArray = useCallback( () => {
+		try {
+			updateFormStateOptionValue( 'wpcom_newsletter_categories', JSON.parse( newCategories ) );
+		} catch ( error ) {
+			alert( 'Invalid JSON' );
+		}
+	}, [ newCategories, updateFormStateOptionValue ] );
+
+	const onCategoriesChange = useCallback( e => {
+		setNewCategories( e.target.value );
+	}, [] );
+
+	return (
+		<SettingsCard { ...props } module="subscriptions">
+			<SettingsGroup hasChild disableInOfflineMode disableInSiteConnectionMode>
+				<ToggleControl
+					checked={ isNewsletterCategoriesEnabled }
+					onChange={ handleEnagleNewsletterCategoriesToggleChange }
+					label={ __( 'Enable newsletter categories', 'jetpack' ) }
+				/>
+				Categories state:
+				<TextInput value={ categoriesValue } disabled />
+				New value:
+				<TextInput value={ newCategories } onChange={ onCategoriesChange } />
+				<button onClick={ parseArray }>Parse array to state</button>
+			</SettingsGroup>
+		</SettingsCard>
+	);
+}
+
+export default withModuleSettingsFormHelpers(
+	connect( ( state, ownProps ) => {
+		return {
+			isNewsletterCategoriesEnabled: ownProps.getOptionValue(
+				'wpcom_newsletter_categories_enabled'
+			),
+			newsletterCategories: ownProps.getOptionValue( 'wpcom_newsletter_categories' ),
+		};
+	} )( NewsletterCategories )
+);

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -113,7 +113,7 @@ function SubscriptionsSettings( props ) {
 
 	return (
 		<>
-			<SettingsCard { ...props } hideButton module="subscriptions">
+			<SettingsCard { ...props } hideButton module={ SUBSCRIPTIONS_MODULE_NAME }>
 				<SettingsGroup
 					hasChild
 					disableInOfflineMode

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -20,6 +20,7 @@ import {
 } from 'state/initial-state';
 import { getModule } from 'state/modules';
 import Textarea from '../components/textarea';
+import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
 const trackViewSubsClick = () => {
 	analytics.tracks.recordJetpackClick( 'manage-subscribers' );
@@ -63,15 +64,15 @@ function SubscriptionsSettings( props ) {
 			: null;
 
 	const handleSubscribeToBlogToggleChange = useCallback( () => {
-		updateFormStateModuleOption( 'subscriptions', 'stb_enabled' );
+		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, 'stb_enabled' );
 	}, [ updateFormStateModuleOption ] );
 
 	const handleSubscribeToCommentToggleChange = useCallback( () => {
-		updateFormStateModuleOption( 'subscriptions', 'stc_enabled' );
+		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, 'stc_enabled' );
 	}, [ updateFormStateModuleOption ] );
 
 	const handleSubscribeModalToggleChange = useCallback( () => {
-		updateFormStateModuleOption( 'subscriptions', 'sm_enabled' );
+		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, 'sm_enabled' );
 	}, [ updateFormStateModuleOption ] );
 
 	const getSubClickableCard = () => {
@@ -96,7 +97,9 @@ function SubscriptionsSettings( props ) {
 	};
 
 	const isDisabled =
-		! isSubscriptionsActive || unavailableInOfflineMode || isSavingAnyOption( [ 'subscriptions' ] );
+		! isSubscriptionsActive ||
+		unavailableInOfflineMode ||
+		isSavingAnyOption( [ SUBSCRIPTIONS_MODULE_NAME ] );
 
 	const changeWelcomeMessageState = useCallback(
 		event => {
@@ -128,7 +131,7 @@ function SubscriptionsSettings( props ) {
 						slug="subscriptions"
 						disabled={ unavailableInOfflineMode }
 						activated={ isSubscriptionsActive }
-						toggling={ isSavingAnyOption( 'subscriptions' ) }
+						toggling={ isSavingAnyOption( SUBSCRIPTIONS_MODULE_NAME ) }
 						toggleModule={ toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">{ subscriptions.description }</span>
@@ -223,9 +226,9 @@ export default withModuleSettingsFormHelpers(
 		return {
 			isLinked: isCurrentUserLinked( state ),
 			isOffline: isOfflineMode( state ),
-			isSubscriptionsActive: ownProps.getOptionValue( 'subscriptions' ),
-			unavailableInOfflineMode: isUnavailableInOfflineMode( state, 'subscriptions' ),
-			subscriptions: getModule( state, 'subscriptions' ),
+			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
+			unavailableInOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
+			subscriptions: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
 			isStbEnabled: ownProps.getOptionValue( 'stb_enabled' ),
 			isStcEnabled: ownProps.getOptionValue( 'stc_enabled' ),
 			isSmEnabled: ownProps.getOptionValue( 'sm_enabled' ),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2643,6 +2643,20 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
+			'wpcom_newsletter_categories'          => array(
+				'description'       => esc_html__( 'Array of post category ids that are marked as newsletter categories', 'jetpack' ),
+				'type'              => 'array',
+				'default'           => array(),
+				'validate_callback' => __CLASS__ . '::validate_array',
+				'jp_group'          => 'subscriptions',
+			),
+			'wpcom_newsletter_categories_enabled'  => array(
+				'description'       => esc_html__( 'Whether the newsletter categories are enabled or not', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 1,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'subscriptions',
+			),
 			'sm_enabled'                           => array(
 				'description'       => esc_html__( 'Show popup Subscribe modal to readers.', 'jetpack' ),
 				'type'              => 'boolean',
@@ -3603,7 +3617,29 @@ class Jetpack_Core_Json_Api_Endpoints {
 				);
 			}
 		}
+		return true;
+	}
 
+	/**
+	 * Validates that the parameter is an array.
+	 *
+	 * @param array           $values Value to check.
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 * @param string          $param Name of the parameter passed to the endpoint holding $value.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function validate_array( $values, $request, $param ) {
+		if ( ! is_array( $values ) ) {
+			return new WP_Error(
+				'invalid_param',
+				sprintf(
+					/* Translators: Placeholder is a parameter name. */
+					esc_html__( '%s must be a object.', 'jetpack' ),
+					$param
+				)
+			);
+		}
 		return true;
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2653,7 +2653,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'wpcom_newsletter_categories_enabled'  => array(
 				'description'       => esc_html__( 'Whether the newsletter categories are enabled or not', 'jetpack' ),
 				'type'              => 'boolean',
-				'default'           => 1,
+				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -981,6 +981,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				case 'stb_enabled':
 				case 'stc_enabled':
 				case 'sm_enabled':
+				case 'wpcom_newsletter_categories_enabled':
 					// Convert the false value to 0. This allows the option to be updated if it doesn't exist yet.
 					$sub_value = $value ? $value : 0;
 					$updated   = (string) get_option( $option ) !== (string) $sub_value ? update_option( $option, $sub_value ) : true;

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -454,6 +454,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
+		$response['categories'] = get_categories( array( 'get' => 'all' ) );
+
 		foreach ( $settings as $setting => $properties ) {
 			switch ( $setting ) {
 				case 'lang_id':

--- a/projects/plugins/jetpack/changelog/update-newsletter-categories-enabled-toggle
+++ b/projects/plugins/jetpack/changelog/update-newsletter-categories-enabled-toggle
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: Draft PR
+Comment: In progress, enables categories newsletter settings (under enable-newsletter-categories feature flag )
 
 

--- a/projects/plugins/jetpack/changelog/update-newsletter-categories-enabled-toggle
+++ b/projects/plugins/jetpack/changelog/update-newsletter-categories-enabled-toggle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Draft PR
+
+


### PR DESCRIPTION
At the Newsletter setting page, there is the **Newsletter categories** section.

As part of the effort to untangle calypso from wp-admin, we should recreate this section on Jetpack Newsletter setting page:
https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/_inc/client/newsletter/index.jsx

This PR is a work in progress under the `enable-newsletter-categories` feature flag, that allows us to toggle the categories on/off.
![image](https://github.com/Automattic/jetpack/assets/33497086/f6e3abc6-459b-4107-9bc2-b2f71ecdf986)

This also includes a raw text input for editing which categories the users checked. It is not meant for the final user, we use it only to test the connection of the interface with backend.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
To enable the feature flag navigate with **enable-newsletter-categories** query param:
`wp-admin/admin.php?enable-newsletter-categories=true&page=jetpack#/newsletter`

**Testing the toggle:**
- Toggle the setting on jetpack side.
- Check that the same option was toggle on wordpress.com for that site.

**Testing the raw input for categories check:**
![image](https://github.com/Automattic/jetpack/assets/33497086/70fc5af1-7608-4964-9892-cbc1a5441d73)

- On wordpress.com side, check about 3 categories and save the setting.
- On jetpack side, copy the array from `Categories state` field to `New value`, remove one of the ids from the array.
- Click on `Parse array to state `. It should save the new checked list.
- Refresh the wordpress.com page. It should reflect the new state in which one of the categories were unchecked.