### PR TITLE
Social: Add archive page support to social notes

### DIFF
--- a/projects/plugins/social/changelog/add-social-note-archive
+++ b/projects/plugins/social/changelog/add-social-note-archive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Social: Added archive page support to notes

--- a/projects/plugins/social/src/class-note.php
+++ b/projects/plugins/social/src/class-note.php
@@ -74,6 +74,7 @@ class Note {
 				'items_list'            => esc_html__( 'Notes list', 'jetpack-social' ),
 			),
 			'show_in_rest' => true,
+			'has_archive'  => true,
 			'supports'     => array( 'editor', 'thumbnail', 'publicize', 'activitypub' ),
 			'menu_icon'    => 'dashicons-welcome-write-blog',
 			'rewrite'      => array( 'slug' => 'sn' ),


### PR DESCRIPTION
The custom post type for Social Notes needs to have the archive option set, so a page displaying a list of notes is added by default.

### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
* On this branch, run `jetpack docker wp option update jetpack-social-note true` to enable social notes.
* Also run `jetpack docker wp option delete jetpack_socia_rewrite_rules_flushed` to make sure we flush the rewrite rules
* Head to https://yoursite.com/sn/
* You should see an archive of your notes. Without this change it will be a 404
