### PR TITLE
Untangle: Remove WooCommerce menu (2nd try)

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-woocommerce-installation-menu
+++ b/projects/plugins/jetpack/changelog/update-remove-woocommerce-installation-menu
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Remove calls to add_woocommerce_installation_menu from WPcom_Admin_Menu and Atomic_Admin_Menu.
+Remove calls to `add_woocommerce_installation_menu()` from `WPcom_Admin_Menu` and `Atomic_Admin_Menu`.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -86,7 +86,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$this->add_new_site_link();
 		}
 
-		if ( $this->use_wp_admin_interface() ) {
+		if ( ! $this->use_wp_admin_interface() ) {
 			$this->add_woocommerce_installation_menu();
 		}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -54,7 +54,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 			$this->add_new_site_link();
 		}
 
-		if ( $this->use_wp_admin_interface() ) {
+		if ( ! $this->use_wp_admin_interface() ) {
 			$this->add_woocommerce_installation_menu();
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5534

## Proposed changes:

This is a fix to https://github.com/Automattic/jetpack/pull/35095. It had a flipped logic during a rebase. This PR fixed that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR
2. Observe that WooCommerce menu is no longer there on a Atomic classic style site.