### PR TITLE
Board triage: update owners of the My Jetpack feature

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-my-jetpack-assignment
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-my-jetpack-assignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Board triage management: update My Jetpack owners.

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-vulcan-assignment
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-vulcan-assignment
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Board triage: update Slack channel used for Vulcan issues, from jetpack-crew to jetpack-vulcan.
+
+

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "5.0.0",
+	"version": "5.0.1-alpha",
 	"description": "Manage Pull Requests and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
@@ -90,9 +90,10 @@ export const automatticAssignments = {
 		board_id: 'https://github.com/orgs/Automattic/projects/599',
 	},
 	'My Jetpack': {
-		team: 'Agora',
+		team: 'Jetpack MarTech',
 		labels: [ '[Package] My Jetpack' ],
-		slack_id: 'C02TQF5VAJD',
+		slack_id: 'C06CVN9QVFY',
+		board_id: 'https://github.com/orgs/Automattic/projects/724',
 	},
 	Newsletter: {
 		team: 'Zap',

--- a/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
@@ -68,13 +68,13 @@ export const automatticAssignments = {
 	'Blocks infrastructure': {
 		team: 'Vulcan',
 		labels: [ '[Package] Blocks', '[Focus] FSE', '[Focus] Blocks' ],
-		slack_id: 'CBG1CP4EN',
+		slack_id: 'C05PV073SG3',
 		board_id: 'https://github.com/orgs/Automattic/projects/778',
 	},
 	Connection: {
 		team: 'Vulcan',
 		labels: [ '[Package] Connection', '[Package] Identity Crisis', '[Package] Sync' ],
-		slack_id: 'CBG1CP4EN',
+		slack_id: 'C05PV073SG3',
 		board_id: 'https://github.com/orgs/Automattic/projects/778',
 	},
 	CRM: {
@@ -110,7 +110,7 @@ export const automatticAssignments = {
 	'React Dashboard': {
 		team: 'Vulcan',
 		labels: [ 'Admin Page' ],
-		slack_id: 'CBG1CP4EN',
+		slack_id: 'C05PV073SG3',
 		board_id: 'https://github.com/orgs/Automattic/projects/778',
 	},
 	Search: {


### PR DESCRIPTION
## Proposed changes:

My Jetpack has new owners (See p1707752160403739/1707692575.049899-slack-C0299DMPG )
Let's update our automation accordingly.

I also took the opportunity to update the slack channel ID used for Vulcan-related issues, from the jetpack-crew channel to the jetpack-vulcan channel.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* This can only be tested once that PR will have been merged.
* You can test in a fork, but that will require adjusting settings from the automattic org to your own.
* I would recommend checking that the new object makes sense, and is valid js.
