### PR TITLE
Make sure $url is a string before calling str_contains().

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-oembedtimeoutoverride
+++ b/projects/plugins/jetpack/changelog/fix-oembedtimeoutoverride
@@ -1,3 +1,5 @@
 Significance: patch
-Type: fixed
-Comment: Make sure $url is a string before calling str_contains().
+Type: other
+Comment: Embeds: avoid notices caused by wrong data used in iCloud embeds
+
+

--- a/projects/plugins/jetpack/changelog/fix-oembedtimeoutoverride
+++ b/projects/plugins/jetpack/changelog/fix-oembedtimeoutoverride
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Make sure $url is a string before calling str_contains().

--- a/projects/plugins/jetpack/modules/shortcodes/others.php
+++ b/projects/plugins/jetpack/modules/shortcodes/others.php
@@ -27,7 +27,10 @@ wp_oembed_add_provider( '#https?://(www\.)?loom\.com/share/.*#i', 'https://www.l
  * @return int The timeout value in seconds.
  */
 function jetpack_oembed_timeout_override( $timeout, $url ) {
-	if ( str_contains( $url, 'iwmb.icloud.com' ) ) {
+	if (
+		is_string( $url )
+		&& str_contains( $url, 'iwmb.icloud.com' )
+	) {
 		return 10;
 	}
 	return $timeout;


### PR DESCRIPTION
The jetpack_oembed_timeout_override() filter expects to always get a URL as a string.  There are times where that is not the case, being given an array instead.  Defend against that condition.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

