### PR TITLE
Add/waf get basename method

### DIFF
--- a/projects/packages/waf/changelog/add-waf-get-basename-method
+++ b/projects/packages/waf/changelog/add-waf-get-basename-method
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Added a method to the WAF package for parsing basenames.
+
+

--- a/projects/packages/waf/src/class-waf-request.php
+++ b/projects/packages/waf/src/class-waf-request.php
@@ -254,6 +254,24 @@ class Waf_Request {
 	}
 
 	/**
+	 * Return the basename part of the request
+	 *
+	 * @example for 'https://wordpress.com/some/page.php?id=5', return 'page.php'
+	 * @return string
+	 */
+	public function get_basename() {
+		// Get the filename part of the request
+		$filename = $this->get_filename();
+		// Normalize slashes
+		$filename = str_replace( '\\', '/', $filename );
+		// Remove trailing slashes
+		$filename = rtrim( $filename, '/' );
+		// Return the basename
+		$offset = strrpos( $filename, '/' );
+		return $offset !== false ? substr( $filename, $offset + 1 ) : $filename;
+	}
+
+	/**
 	 * Return the query string. If present, it will be prefixed with '?'. Otherwise, it will be an empty string.
 	 *
 	 * @return string

--- a/projects/packages/waf/src/class-waf-runtime.php
+++ b/projects/packages/waf/src/class-waf-runtime.php
@@ -495,7 +495,7 @@ class Waf_Runtime {
 					);
 					break;
 				case 'request_basename':
-					$value = basename( $this->request->get_filename() );
+					$value = $this->request->get_basename();
 					break;
 				case 'request_body':
 					$value = $this->request->get_body();

--- a/projects/packages/waf/tests/php/unit/test-waf-request.php
+++ b/projects/packages/waf/tests/php/unit/test-waf-request.php
@@ -213,6 +213,35 @@ class WafRequestTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * Test Waf_Request::get_basename()
+	 */
+	public function testGetBasename() {
+		$_SERVER['REQUEST_URI'] = 'https://wordpress.com/some/file?test';
+		$request                = new Waf_Request();
+		$this->assertSame( 'file', $request->get_basename() );
+		// test with a root path request
+		$_SERVER['REQUEST_URI'] = 'https://wordpress.com/';
+		$request                = new Waf_Request();
+		$this->assertSame( '', $request->get_basename() );
+		// test with a relative root path request
+		$_SERVER['REQUEST_URI'] = '/';
+		$request                = new Waf_Request();
+		$this->assertSame( '', $request->get_basename() );
+		// test with encoded characters
+		$_SERVER['REQUEST_URI'] = 'https://wordpress.com/some/filé.php?test';
+		$request                = new Waf_Request();
+		$this->assertSame( 'filé.php', $request->get_basename() );
+		// test with trailing slash
+		$_SERVER['REQUEST_URI'] = 'https://wordpress.com/some/file/?test';
+		$request                = new Waf_Request();
+		$this->assertSame( 'file', $request->get_basename() );
+		// test with single period
+		$_SERVER['REQUEST_URI'] = 'https://wordpress.com/.';
+		$request                = new Waf_Request();
+		$this->assertSame( '.', $request->get_basename() );
+	}
+
+	/**
 	 * Test Waf_Request::get_query_string()
 	 */
 	public function testGetQueryString() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-scan-team/issues/504

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a new `get_basename()` method to `Waf_Request`, to mirror ModSecurity's approach.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p2-peb6dq-2ap

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check automated tests: `jetpack test packages/waf php`
* Smoke test the firewall blocking on a JN site. Insert SQL as the basename, validate you are blocked. Test that other valid requests are not blocked.

