### PR TITLE
blog-stats block: avoid "Undefined array key" warning

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blog-stats-label-warning
+++ b/projects/plugins/jetpack/changelog/fix-blog-stats-label-warning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Avoid blog-stats block warning for "Undefined array key label"
+
+

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
@@ -95,7 +95,7 @@ function load_assets( $attributes ) {
 		_n( 'hit', 'hits', $stats, 'jetpack' )
 	);
 
-	$label = $attributes['label'] ? $attributes['label'] : $fallback_label;
+	$label = isset( $attributes['label'] ) ? $attributes['label'] : $fallback_label;
 
 	$wrapper_attributes = \WP_Block_Supports::get_instance()->apply_block_supports();
 

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
@@ -95,7 +95,7 @@ function load_assets( $attributes ) {
 		_n( 'hit', 'hits', $stats, 'jetpack' )
 	);
 
-	$label = isset( $attributes['label'] ) ? $attributes['label'] : $fallback_label;
+	$label = $attributes['label'] ?? $fallback_label;
 
 	$wrapper_attributes = \WP_Block_Supports::get_instance()->apply_block_supports();
 

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
@@ -95,7 +95,7 @@ function load_assets( $attributes ) {
 		_n( 'hit', 'hits', $stats, 'jetpack' )
 	);
 
-	$label = $attributes['label'] ?? $fallback_label;
+	$label = empty( $attributes['label'] ) ? $fallback_label : $attributes['label'];
 
 	$wrapper_attributes = \WP_Block_Supports::get_instance()->apply_block_supports();
 


### PR DESCRIPTION
## Proposed changes:

Avoid warning:

```
[12-Feb-2024 22:22:58 UTC] PHP Warning:  Undefined array key "label" in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php on line 98
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
No.

## Testing instructions:

* `blog-stats` block is currently beta, so you must have beta blocks enabled. Also have WP_DEBUG logging enabled.
* pre-patch, add the `blog-stats` block to a test post.
* You should see the `Undefined array key` warning in your debug log while in the editor.
* Pull down changes and refresh saved post in the editor, the warning should no longer occur.