### PR TITLE
VaultPress plugin: use autotagger and autorelease

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -277,15 +277,7 @@ If `.extra.autotagger` is set to an object with falsey value for `v` (i.e. if `.
 
 Note that, for this to work, you'll need to create a secret `API_TOKEN_GITHUB` in the mirror repo. The value of the secret must be a GitHub access token. See PCYsg-xsv-p2#mirror-repo-secrets for details.
 
-This is intended to work in combination with [Changelogger](#jetpack-changelogger): When any change files are present in the project, a `-alpha` version entry will be written to the changelog so the autotagging will not be triggered. To release a new version, you'd do the following:
-
-1. (optional) Activate the "Release Lock" (see PCYsg-zQS-p2#generating-a-new-changelog).
-2. Use `tools/changelogger-release.sh` to create a PR rolling the change files into a new changelog entry.
-3. Push and merge that PR.
-4. If you used the Release Lock in step 1, go turn it off. If you didn't, check that no one merged any PRs in between steps 2 and 3 that added change files to the projects being released.
-   * If they did, you'll likely have to create a release branch in the affected projects' mirror repos and manually tag.
-5. Verify that the Build workflow run for your PR's merge to trunk succeeded. [This search](https://github.com/Automattic/jetpack/actions/workflows/build.yml?query=branch%3Atrunk) will show the runs of that workflow for all merges to trunk.
-   * If it failed, you can try re-running it as long as no other PRs were merged. If some were merged, you'll have to manually tag the affected projects.
+This is intended to work in combination with [Changelogger](#jetpack-changelogger): When any change files are present in the project, a `-alpha` version entry will be written to the changelog so the autotagging will not be triggered. To release a new plugin version, see: PCYsg-SU8-p2
 
 ### Auto-release
 

--- a/projects/plugins/vaultpress/changelog/update-vaultpress-plugin-use-autotag
+++ b/projects/plugins/vaultpress/changelog/update-vaultpress-plugin-use-autotag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use autotagger and autorelease in composer.json
+
+

--- a/projects/plugins/vaultpress/composer.json
+++ b/projects/plugins/vaultpress/composer.json
@@ -41,6 +41,10 @@
 		}
 	},
 	"extra": {
+		"autorelease": true,
+		"autotagger": {
+			"v": false
+		},
 		"mirror-repo": "Automattic/vaultpress",
 		"release-branch-prefix": "vaultpress",
 		"version-constants": {

--- a/projects/plugins/vaultpress/composer.lock
+++ b/projects/plugins/vaultpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4af54d0b802692d27e52ee465a30d16c",
+    "content-hash": "012b22c1aede0d5b5b64a5858ae5efe3",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",


### PR DESCRIPTION
## Proposed changes:

* VaultPress plugin: use autotagger and autorelease
* Update some outdated plugin release instructions in monorepo docs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1707345219083679-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Jetpack release lead should be able to see this work next time there is a plugin release.

**Related Todos:**

- [x] Add secrets to VaultPress mirror [repo](https://github.com/Automattic/vaultpress)
- [x] Document secrets at PCYsg-xsv-p2#mirror-repo-secrets
- [x] SVN user has commit access to plugin