### PR TITLE
Blaze: hide Post Links in the Jetpack plugin while still leaving them in other environments

### DIFF
--- a/projects/packages/blaze/changelog/remove-blaze-link-from-post-and-page-items
+++ b/projects/packages/blaze/changelog/remove-blaze-link-from-post-and-page-items
@@ -1,4 +1,4 @@
-Significance: patch
-Type: changed
+Significance: minor
+Type: added
 
-Removing 'Promote with Blaze' link from posts and pages
+Quick Action Links: introduce new filter allowing to disable quick links in the Posts screen.

--- a/projects/packages/blaze/composer.json
+++ b/projects/packages/blaze/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.15.x-dev"
+			"dev-trunk": "0.16.x-dev"
 		},
 		"textdomain": "jetpack-blaze",
 		"version-constants": {

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.15.4-alpha",
+	"version": "0.16.0-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.15.4-alpha';
+	const PACKAGE_VERSION = '0.16.0-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -122,6 +122,39 @@ class Test_Blaze extends BaseTestCase {
 	}
 
 	/**
+	 * Tests if the post_row action is added for admins when we force Blaze to be enabled.
+	 *
+	 * @covers Automattic\Jetpack\Blaze::add_post_links_actions
+	 */
+	public function test_post_row_added() {
+		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
+
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+		Blaze::add_post_links_actions();
+
+		$this->assertNotFalse( has_action( 'post_row_actions' ) );
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+	}
+
+	/**
+	 * Tests whether Post row actions can be disabled via a filter.
+	 *
+	 * @covers Automattic\Jetpack\Blaze::add_post_links_actions
+	 */
+	public function test_post_row_removed_filter() {
+		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
+
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_blaze_post_row_actions_enable', '__return_false' );
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+		Blaze::add_post_links_actions();
+
+		$this->assertFalse( has_action( 'post_row_actions' ) );
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+	}
+
+	/**
 	 * Test if the admin menu is added for admins when we force Blaze to be enabled.
 	 *
 	 * @covers Automattic\Jetpack\Blaze::enable_blaze_menu

--- a/projects/plugins/jetpack/changelog/remove-blaze-link-from-post-and-page-items
+++ b/projects/plugins/jetpack/changelog/remove-blaze-link-from-post-and-page-items
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Blaze: remove "Promote with Blaze" links appearing in the Posts list when the Blaze feature is enabled. You can still go to Tools > Advertising to create and manage Blaze campaigns on your site.

--- a/projects/plugins/jetpack/changelog/remove-blaze-link-on-posts-and-pages
+++ b/projects/plugins/jetpack/changelog/remove-blaze-link-on-posts-and-pages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -456,7 +456,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/blaze",
-				"reference": "a5c46dc3b1d15cf3ed299f1b7021b9fed418173e"
+				"reference": "8eb5301f37af61edc86a39ec129eac85d3f0d779"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -484,7 +484,7 @@
 					"link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.15.x-dev"
+					"dev-trunk": "0.16.x-dev"
 				},
 				"textdomain": "jetpack-blaze",
 				"version-constants": {

--- a/projects/plugins/jetpack/modules/blaze.php
+++ b/projects/plugins/jetpack/modules/blaze.php
@@ -16,3 +16,6 @@
 use Automattic\Jetpack\Blaze;
 
 Blaze::init();
+
+// Remove post row Blaze actions in the Jetpack plugin.
+add_filter( 'jetpack_blaze_post_row_actions_enable', '__return_false' );


### PR DESCRIPTION
> [!IMPORTANT]
> This is an alternative approach to #35586. The PR is against that branch, and shouldn't be merged by anyone but @CodeyGuyDylan once he gets the chance to review this different approach.

## Proposed changes:

#35586 removes the quick action post links appearing in the Posts list when the Blaze module is enabled. This PR does the same, but keeps the post link feature in the package so it can still be used by other consumers of the package. The links can now be disabled in the Jetpack plugin via a new filter, `jetpack_blaze_post_row_actions_enable`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/pull/35586#pullrequestreview-1874953949

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a Jetpack site that's connected to WordPress.com.
* Go to Jetpack > Settings > Traffic and enable the Blaze feature
* Go to Posts > All Posts
* You should not see any "Promote with Blaze" links when moving your mouse hover published posts
* You should still see a "Tools > Advertising" menu in the admin navigation.

Now test this patch on a WordPress.com Simple site.

* Go to Posts > All Posts on a public, launched site.
* You should see a "Promote with Blaze" link when moving your mouse hover published posts.

