### PR TITLE
Add the Welcome Email Message setting to Newsletter settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
@@ -17,12 +17,17 @@ export function withModuleSettingsFormHelpers( InnerComponent ) {
 		};
 
 		onOptionChange = event => {
-			const optionName = event.target.name;
+			let optionName = event.target.name;
 			let optionValue;
 			// Get the option value from the `checked` property if present.
 			if ( event.target.type === 'checkbox' ) {
 				optionValue =
 					typeof event.target.checked !== 'undefined' ? event.target.checked : event.target.value;
+			} else if ( optionName.includes( '.' ) ) {
+				// We define the use of an object in a form field name like "object.member", ie: "subscription_options.welcome".
+				// Then we create an object with the setting name and the subsetting name. This is useful for nested settings.
+				const [ settingName, subSettingName ] = optionName.split( '.' );
+				optionName = { [ settingName ]: { [ subSettingName ]: event.target.value } };
 			} else {
 				optionValue = event.target.value;
 			}

--- a/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
@@ -210,6 +210,7 @@ export function withModuleSettingsFormHelpers( InnerComponent ) {
 					isSavingAnyOption={ this.isSavingAnyOption }
 					isDirty={ this.isDirty }
 					resetFormStateOption={ this.resetFormStateOption }
+					optionsState={ this.state.options }
 					{ ...this.props }
 				/>
 			);

--- a/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
@@ -17,17 +17,12 @@ export function withModuleSettingsFormHelpers( InnerComponent ) {
 		};
 
 		onOptionChange = event => {
-			let optionName = event.target.name;
+			const optionName = event.target.name;
 			let optionValue;
 			// Get the option value from the `checked` property if present.
 			if ( event.target.type === 'checkbox' ) {
 				optionValue =
 					typeof event.target.checked !== 'undefined' ? event.target.checked : event.target.value;
-			} else if ( optionName.includes( '.' ) ) {
-				// We define the use of an object in a form field name like "object.member", ie: "subscription_options.welcome".
-				// Then we create an object with the setting name and the subsetting name. This is useful for nested settings.
-				const [ settingName, subSettingName ] = optionName.split( '.' );
-				optionName = { [ settingName ]: { [ subSettingName ]: event.target.value } };
 			} else {
 				optionValue = event.target.value;
 			}

--- a/projects/plugins/jetpack/_inc/client/components/settings-group/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-group/style.scss
@@ -10,18 +10,26 @@
 		&.jp-settings-card__blocks-description {
 			margin-bottom: 0;
 		}
+
+		&.jp-settings-card__email-settings {
+			margin-bottom: 0.7rem;
+		}
 	}
+
 	fieldset p:last-child {
 		margin-bottom: 8px;
 	}
+
 	.form-toggle__label {
 		margin-top: rem( 4px );
 		margin-bottom: rem( 4px );
 	}
+
 	.form-toggle__switch {
 		float: left;
 		margin-top: 2px;
 	}
+
 	.jp-form-setting-explanation {
 		color: $gray-text-min;
 		display: block;
@@ -43,10 +51,13 @@
 			text-decoration: underline;
 		}
 	}
+
 	.dops-foldable-card & {
 		/* padding-bottom: 16px; */
 	}
-	.dops-card  {
+
+	.dops-card {
+		padding-top: 0.7rem;
 		padding-right: rem( 48px );
 	}
 
@@ -57,6 +68,7 @@
 		& + p {
 			margin-top: 2px;
 		}
+
 		& + span {
 			padding-top: 2px;
 			display: block;
@@ -79,5 +91,9 @@
 
 	&.foldable-wrapper > .dops-card {
 		padding: 0;
+	}
+
+	.email-settings__title {
+		margin-bottom: 0.3rem;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -49,6 +49,7 @@ function SubscriptionsSettings( props ) {
 		siteAdminUrl,
 		themeStylesheet,
 		blogID,
+		onOptionChange,
 	} = props;
 
 	const welcomeMessage = props.getOptionValue( 'subscription_options' )?.welcome || '';
@@ -96,6 +97,16 @@ function SubscriptionsSettings( props ) {
 
 	const isDisabled =
 		! isSubscriptionsActive || unavailableInOfflineMode || isSavingAnyOption( [ 'subscriptions' ] );
+
+	const changeWelcomeMessageState = useCallback(
+		event => {
+			const subscriptionOptionEvent = {
+				target: { name: event.target.name, value: { welcome: event.target.value } },
+			};
+			onOptionChange( subscriptionOptionEvent );
+		},
+		[ onOptionChange ]
+	);
 
 	return (
 		<>
@@ -196,9 +207,9 @@ function SubscriptionsSettings( props ) {
 							{ __( 'Welcome email message', 'jetpack' ) }
 						</span>
 						<Textarea
-							name={ 'subscription_options.welcome' }
+							name={ 'subscription_options' }
 							value={ welcomeMessage }
-							onChange={ props.onOptionChange }
+							onChange={ changeWelcomeMessageState }
 						/>
 					</FormLabel>
 				</SettingsGroup>

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import Card from 'components/card';
 import ConnectUserBar from 'components/connect-user-bar';
-import { FormFieldset } from 'components/forms';
+import { FormLabel, FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
@@ -19,6 +19,7 @@ import {
 	getSiteAdminUrl,
 } from 'state/initial-state';
 import { getModule } from 'state/modules';
+import Textarea from '../components/textarea';
 
 const trackViewSubsClick = () => {
 	analytics.tracks.recordJetpackClick( 'manage-subscribers' );
@@ -50,6 +51,7 @@ function SubscriptionsSettings( props ) {
 		blogID,
 	} = props;
 
+	const welcomeMessage = props.getOptionValue( 'subscription_options' )?.welcome || '';
 	const subscribeModalEditorUrl =
 		siteAdminUrl && themeStylesheet
 			? addQueryArgs( `${ siteAdminUrl }site-editor.php`, {
@@ -96,85 +98,112 @@ function SubscriptionsSettings( props ) {
 		! isSubscriptionsActive || unavailableInOfflineMode || isSavingAnyOption( [ 'subscriptions' ] );
 
 	return (
-		<SettingsCard { ...props } hideButton module="subscriptions">
-			<SettingsGroup
-				hasChild
-				disableInOfflineMode
-				disableInSiteConnectionMode
-				module={ subscriptions }
-				support={ {
-					text: __(
-						'Allows readers to subscribe to your posts or comments, and receive notifications of new content by email.',
-						'jetpack'
-					),
-					link: getRedirectUrl( 'jetpack-support-subscriptions' ),
-				} }
-			>
-				<ModuleToggle
-					slug="subscriptions"
-					disabled={ unavailableInOfflineMode }
-					activated={ isSubscriptionsActive }
-					toggling={ isSavingAnyOption( 'subscriptions' ) }
-					toggleModule={ toggleModuleNow }
+		<>
+			<SettingsCard { ...props } hideButton module="subscriptions">
+				<SettingsGroup
+					hasChild
+					disableInOfflineMode
+					disableInSiteConnectionMode
+					module={ subscriptions }
+					support={ {
+						text: __(
+							'Allows readers to subscribe to your posts or comments, and receive notifications of new content by email.',
+							'jetpack'
+						),
+						link: getRedirectUrl( 'jetpack-support-subscriptions' ),
+					} }
 				>
-					<span className="jp-form-toggle-explanation">{ subscriptions.description }</span>
-				</ModuleToggle>
-				{
-					<FormFieldset>
-						<ToggleControl
-							checked={ isSubscriptionsActive && isStbEnabled }
-							disabled={ isDisabled }
-							toggling={ isSavingAnyOption( [ 'stb_enabled' ] ) }
-							onChange={ handleSubscribeToBlogToggleChange }
-							label={ __(
-								'Enable the “subscribe to site” option on your comment form',
-								'jetpack'
-							) }
-						/>
-						<ToggleControl
-							checked={ isSubscriptionsActive && isStcEnabled }
-							disabled={ isDisabled }
-							toggling={ isSavingAnyOption( [ 'stc_enabled' ] ) }
-							onChange={ handleSubscribeToCommentToggleChange }
-							label={ __(
-								'Enable the “subscribe to comments” option on your comment form',
-								'jetpack'
-							) }
-						/>
-						<ToggleControl
-							checked={ isSubscriptionsActive && isSmEnabled }
-							disabled={ isDisabled }
-							toggling={ isSavingAnyOption( [ 'sm_enabled' ] ) }
-							onChange={ handleSubscribeModalToggleChange }
-							label={ __( 'Enable subscription pop-up', 'jetpack' ) }
-						/>
-						<p className="jp-form-setting-explanation">
-							{ __(
-								'Automatically add a subscription form pop-up to every post and turn visitors into subscribers. It will appear as readers scroll through your posts.',
-								'jetpack'
-							) }
-							{ isBlockTheme && subscribeModalEditorUrl && (
-								<>
-									{ ' ' }
-									<ExternalLink href={ subscribeModalEditorUrl }>
-										{ __( 'Preview and edit the pop-up', 'jetpack' ) }
-									</ExternalLink>
-								</>
-							) }
-						</p>
-					</FormFieldset>
-				}
-			</SettingsGroup>
-			{ getSubClickableCard() }
+					<ModuleToggle
+						slug="subscriptions"
+						disabled={ unavailableInOfflineMode }
+						activated={ isSubscriptionsActive }
+						toggling={ isSavingAnyOption( 'subscriptions' ) }
+						toggleModule={ toggleModuleNow }
+					>
+						<span className="jp-form-toggle-explanation">{ subscriptions.description }</span>
+					</ModuleToggle>
+					{
+						<FormFieldset>
+							<ToggleControl
+								checked={ isSubscriptionsActive && isStbEnabled }
+								disabled={ isDisabled }
+								toggling={ isSavingAnyOption( [ 'stb_enabled' ] ) }
+								onChange={ handleSubscribeToBlogToggleChange }
+								label={ __(
+									'Enable the “subscribe to site” option on your comment form',
+									'jetpack'
+								) }
+							/>
+							<ToggleControl
+								checked={ isSubscriptionsActive && isStcEnabled }
+								disabled={ isDisabled }
+								toggling={ isSavingAnyOption( [ 'stc_enabled' ] ) }
+								onChange={ handleSubscribeToCommentToggleChange }
+								label={ __(
+									'Enable the “subscribe to comments” option on your comment form',
+									'jetpack'
+								) }
+							/>
+							<ToggleControl
+								checked={ isSubscriptionsActive && isSmEnabled }
+								disabled={ isDisabled }
+								toggling={ isSavingAnyOption( [ 'sm_enabled' ] ) }
+								onChange={ handleSubscribeModalToggleChange }
+								label={ __( 'Enable subscription pop-up', 'jetpack' ) }
+							/>
+							<p className="jp-form-setting-explanation">
+								{ __(
+									'Automatically add a subscription form pop-up to every post and turn visitors into subscribers. It will appear as readers scroll through your posts.',
+									'jetpack'
+								) }
+								{ isBlockTheme && subscribeModalEditorUrl && (
+									<>
+										{ ' ' }
+										<ExternalLink href={ subscribeModalEditorUrl }>
+											{ __( 'Preview and edit the pop-up', 'jetpack' ) }
+										</ExternalLink>
+									</>
+								) }
+							</p>
+						</FormFieldset>
+					}
+				</SettingsGroup>
+				{ getSubClickableCard() }
 
-			{ ! isLinked && ! isOffline && (
-				<ConnectUserBar
-					feature="subscriptions"
-					featureLabel={ __( 'Newsletter', 'jetpack' ) }
-					text={ __( 'Connect to manage your subscriptions settings.', 'jetpack' ) }
-				/>
-			) }
-		</SettingsCard>
+				{ ! isLinked && ! isOffline && (
+					<ConnectUserBar
+						feature="subscriptions"
+						featureLabel={ __( 'Newsletter', 'jetpack' ) }
+						text={ __( 'Connect to manage your subscriptions settings.', 'jetpack' ) }
+					/>
+				) }
+			</SettingsCard>
+			<SettingsCard
+				{ ...props }
+				header={ __( 'Messages', 'jetpack' ) }
+				module="subscriptions"
+				saveDisabled={ props.isSavingAnyOption( [ 'subscription_options' ] ) }
+			>
+				<SettingsGroup hasChild disableInOfflineMode module={ subscriptions }>
+					<p className="jp-settings-card__email-settings">
+						{ __(
+							'These settings change the emails sent from your site to your readers.',
+							'jetpack'
+						) }
+					</p>
+					<FormLabel>
+						<span className="jp-form-label-wide email-settings__title">
+							{ __( 'Welcome email message', 'jetpack' ) }
+						</span>
+						<Textarea
+							name={ 'subscription_options.welcome' }
+							value={ welcomeMessage }
+							onChange={ props.onOptionChange }
+						/>
+					</FormLabel>
+				</SettingsGroup>
+			</SettingsCard>
+		</>
 	);
 }
 

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2657,6 +2657,17 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
+			'subscription_options'                 => array(
+				'description'       => esc_html__( 'Three options used in subscription email templates: \'invitation\', \'welcome\' and \'comment_follow\'.', 'jetpack' ),
+				'type'              => 'object',
+				'default'           => array(
+					'invitation'     => '',
+					'welcome'        => '',
+					'comment_follow' => '',
+				),
+				'validate_callback' => __CLASS__ . '::validate_subscription_options',
+				'jp_group'          => 'subscriptions',
+			),
 
 			// Related Posts.
 			'show_headline'                        => array(
@@ -3559,6 +3570,37 @@ class Jetpack_Core_Json_Api_Endpoints {
 			$validate = self::validate_string( $array_item, $request, $param );
 			if ( is_wp_error( $validate ) ) {
 				return $validate;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validates the subscription_options parameter.
+	 *
+	 * @param array $values Value to check.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function validate_subscription_options( $values ) {
+		if ( is_object( $values ) ) {
+			return new WP_Error(
+				'invalid_param',
+				/* Translators: subscription_options is a variable name, and shouldn't be translated. */
+				esc_html__( 'subscription_options must be an object.', 'jetpack' )
+			);
+		}
+		foreach ( array_keys( $values ) as $key ) {
+			if ( ! in_array( $key, array( 'welcome', 'invitation', 'comment_follow' ), true ) ) {
+				return new WP_Error(
+					'invalid_param',
+					sprintf(
+						/* Translators: Placeholder is the invalid param being sent. */
+						esc_html__( '%s is not one of the allowed members of subscription_options.', 'jetpack' ),
+						$key
+					)
+				);
 			}
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -990,6 +990,46 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$updated = (bool) get_option( $option ) !== (bool) $value ? update_option( $option, (bool) $value ) : true;
 					break;
 
+				case 'subscription_options':
+					if ( ! is_array( $value ) ) {
+						break;
+					}
+
+					$allowed_keys   = array( 'invitation', 'comment_follow', 'welcome' );
+					$filtered_value = array_filter(
+						$value,
+						function ( $key ) use ( $allowed_keys ) {
+							return in_array( $key, $allowed_keys, true );
+						},
+						ARRAY_FILTER_USE_KEY
+					);
+
+					if ( empty( $filtered_value ) ) {
+						break;
+					}
+
+					array_walk_recursive(
+						$filtered_value,
+						function ( &$value ) {
+							$value = wp_kses(
+								$value,
+								array(
+									'a' => array(
+										'href' => array(),
+									),
+								)
+							);
+						}
+					);
+
+					$old_subscription_options = get_option( 'subscription_options' );
+					$new_subscription_options = array_merge( $old_subscription_options, $filtered_value );
+
+					if ( update_option( $option, $new_subscription_options ) ) {
+						$updated[ $option ] = true;
+					}
+					break;
+
 				default:
 					// Boolean values are stored as 1 or 0.
 					if ( isset( $options[ $option ]['type'] ) && 'boolean' === $options[ $option ]['type'] ) {

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1023,6 +1023,9 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					);
 
 					$old_subscription_options = get_option( 'subscription_options' );
+					if ( ! is_array( $old_subscription_options ) ) {
+						$old_subscription_options = array();
+					}
 					$new_subscription_options = array_merge( $old_subscription_options, $filtered_value );
 
 					if ( update_option( $option, $new_subscription_options ) ) {

--- a/projects/plugins/jetpack/changelog/add-welcome-email-message-setting
+++ b/projects/plugins/jetpack/changelog/add-welcome-email-message-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+We added the Welcome Email Message setting to Newsletter settings


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87265

## Proposed changes:
This PR adds the Welcome Email Message setting to the Newsletter settings in Jetpack.

### Why I'm not using `connect` to get the value of the Welcome Message

As you can see, we use connect from Redux to access the necessary state values, except for the Welcome message, which is retrieved differently.

This is because we're employing connect without a Redux Store. We modify the state within the higher-order component withModuleSettingsFormHelpers using setState. React recognizes a change when an object updated with setState gets a new reference (is recreated) during the state change. However, connect [requires the dispatching of actions](https://react-redux.js.org/troubleshooting#my-views-arent-updating) for updates to be detected. Since we're not using a Redux Store, we can't dispatch actions, leading connect to miss changes in the object.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1707239212354309/1707173087.804499-slack-C02NQ4HMJKV

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Go to Jetpack -> Settings -> Newsletter
<img width="1024" alt="Screenshot 2024-02-13 at 11 26 16" src="https://github.com/Automattic/jetpack/assets/3832570/d6bd550b-59d9-44da-99d3-d2b107ee38ae">
- Write something in the Welcome Email Message setting and press "Save settings". You should see the success toaster in the top right corner.
- Refresh the page. The new message should be loaded.
- Extra check: use the site explorer tool to check the option values of your jurassic site. It should be the same value for `subscription_options.welcome`.