### PR TITLE
Social: Fix (no title) from showing up in OG:tag for titleless posts

### DIFF
--- a/projects/plugins/social/changelog/fix-no-title-og-tags
+++ b/projects/plugins/social/changelog/fix-no-title-og-tags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed no title from showing up in og:title

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -255,7 +255,11 @@ class Meta_Tags {
 		$tags = array();
 
 		if ( empty( $data->post_title ) ) {
-			$tags['og:title'] = __( '(no title)', 'jetpack-social' );
+			if ( $data->post_type === Note::JETPACK_SOCIAL_NOTE_CPT ) {
+				$tags['og:title'] = substr( get_the_excerpt(), 0, 50 );
+			} else {
+				$tags['og:title'] = __( '(no title)', 'jetpack-social' );
+			}
 		} else {
 			/** This filter is documented in core/src/wp-includes/post-template.php */
 			$tags['og:title'] = wp_kses( apply_filters( 'the_title', $data->post_title, $data->ID ), array() );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set a substring of the excerpt as the title for Social Notes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1707825832158189/1707821204.375989-slack-C02JJ910CNL
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On the bleeding edge, with just social active, publish a Social Note with featured image and share it to Facebook or Mastodon or Nextdoor. In the link preview, you will (no title) showing up. 
<img width="792" alt="Screenshot 2024-02-13 at 5 36 59 PM" src="https://github.com/Automattic/jetpack/assets/6594561/d0659899-b57a-4a6e-ba11-395dcbeb4ba9">

* Do the same on this branch and see that the excerpt shows up instead of no title

<img width="764" alt="Screenshot 2024-02-13 at 5 37 06 PM" src="https://github.com/Automattic/jetpack/assets/6594561/6e9852e7-575b-4f8f-a0cc-a26800e65945">

