### PR TITLE
Boost: Fix sometimes not correctly adding WP_CACHE to wp-config.php

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -91,7 +91,7 @@ require_once( \'' . $boost_cache_filename . '\');
 	 */
 	private static function add_wp_cache_define() {
 		$content = file_get_contents( ABSPATH . 'wp-config.php' );
-		if ( preg_match( '#define\s*\(\s*[\'"]WP_CACHE[\'"]#', $content ) === 1 ) {
+		if ( preg_match( '#^\s*define\s*\(\s*[\'"]WP_CACHE[\'"]#m', $content ) === 1 ) {
 			/*
 			 * wp-settings.php checks "if ( WP_CACHE )" so it may be truthy and
 			 * not === true to pass that check.
@@ -105,8 +105,8 @@ require_once( \'' . $boost_cache_filename . '\');
 
 			return true; // WP_CACHE already added.
 		}
-		$content = str_replace(
-			'<?php',
+		$content = preg_replace(
+			'#^<\?php#',
 			'<?php
 define( \'WP_CACHE\', true );',
 			$content

--- a/projects/plugins/boost/changelog/fix-cache-setup-wp-config-constant
+++ b/projects/plugins/boost/changelog/fix-cache-setup-wp-config-constant
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix not adding WP_CACHE to wp-config.php in some cases.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35628

# Merge after https://github.com/Automattic/jetpack/pull/35568.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix case where WP_CACHE isn't added if there's already a commented out WP_CACHE define.
* Fix adding multiple WP_CACHE defines if there's a commented out `<?php` block. People do all sorts of crazy things in their wp-config.php (I know I have 😅).

### Note

It is still possible to break this if a multi-line comment is used and there's a define inside that block.

Example:

```php
<?php

/*

define( 'WP_CACHE', false );

*/
```

I considered this an edge-case and decided to leave it out of this fix.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add either a commented or uncommented define (`define( 'WP_CACHE', true );` and variations of it with quotes, single quotes, false, 'false', etc, to `wp-config.php` and check if setup works without a problem.