### PR TITLE
Like block: Update block's Learn more link logic

### DIFF
--- a/projects/plugins/jetpack/changelog/update-like-block-learn-more-link-logic
+++ b/projects/plugins/jetpack/changelog/update-like-block-learn-more-link-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Like block: Update block's Learn more link logic

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -18,10 +18,7 @@ function LikeEdit( { attributes, setAttributes } ) {
 		} );
 	};
 
-	const learnMoreUrl =
-		isAtomicSite() || isSimpleSite()
-			? 'https://wordpress.com/support/likes/'
-			: 'https://jetpack.com/support/likes/';
+	const isJetpackSite = ! isAtomicSite() && ! isSimpleSite();
 
 	const avatars = [ avatar1, avatar2, avatar3 ];
 
@@ -30,9 +27,13 @@ function LikeEdit( { attributes, setAttributes } ) {
 	return (
 		<div { ...blockProps }>
 			<InspectorControls key="like-inspector">
-				<div className="wp-block-jetpack-like__learn-more">
-					<ExternalLink href={ learnMoreUrl }>{ __( 'Learn more', 'jetpack' ) }</ExternalLink>
-				</div>
+				{ isJetpackSite && (
+					<div className="wp-block-jetpack-like__learn-more">
+						<ExternalLink href={ 'https://jetpack.com/support/likes/' }>
+							{ __( 'Learn more', 'jetpack' ) }
+						</ExternalLink>
+					</div>
+				) }
 				{ isSimpleSite() && (
 					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 						<ToggleControl


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/87340.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* display the "Learn more" link only for self-hosted Jetpack sites; otherwise (for Simple and WoA sites, the Help Center link will be displayed instead (introduced in https://github.com/Automattic/wp-calypso/pull/87419).

| self-hosted Jetpack site | Simple / WoA |
|--------|--------|
| ![Markup on 2024-02-13 at 17:27:13](https://github.com/Automattic/jetpack/assets/25105483/535b2c69-7485-45e7-92cc-6514e4c99439) | ![Markup on 2024-02-13 at 17:33:15](https://github.com/Automattic/jetpack/assets/25105483/c89e544c-3054-473f-8388-6432f31dd2f2) | 




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Related issue: https://github.com/Automattic/wp-calypso/issues/87340

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:

1. Add the Like block to a post.
2. When you click on it in the block editor, the sidebar should display the "Learn more" link only for self-hosted Jetpack sites.

