### PR TITLE
Related Posts: fix too few arguments error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-post-arg-count-error
+++ b/projects/plugins/jetpack/changelog/fix-related-post-arg-count-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Related Posts: fix too few arguments error

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -453,7 +453,7 @@ EOT;
 	 * @param WP_Block $block    The block object.
 	 * @return string
 	 */
-	public function render_block( $attributes, $content, $block ) {
+	public function render_block( $attributes, $content, $block = null ) {
 		if ( ! jetpack_is_frontend() ) {
 			return $content;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35353

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes the following PHP error, occurring with Related Posts
```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Jetpack_RelatedPosts::render_block()
``` 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See p1707841639941599-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I haven't been able to reproduce the issue, but the only place where `get_server_rendered_html` (see stack race)  is called is in [filter_add_target_to_dom](https://github.com/Automattic/jetpack/blob/e17687b5205ccae1e836303eb289659f122e213e/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php#L223). Commenting out the conditions, I could reproduce the issue locally on a page with related posts and confirm this PR fixed it.