### PR TITLE
[Boost] Add the hostname to the cache path for multisite installs

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache.php
@@ -35,7 +35,8 @@ class Boost_Cache {
 	 */
 	public function __construct( $storage = null ) {
 		$this->settings = Boost_Cache_Settings::get_instance();
-		$this->storage  = $storage ?? new Storage\File_Storage( WP_CONTENT_DIR . '/boost-cache/cache/' );
+		$home           = isset( $_SERVER['HTTP_HOST'] ) ? strtolower( $_SERVER['HTTP_HOST'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		$this->storage  = $storage ?? new Storage\File_Storage( WP_CONTENT_DIR . '/boost-cache/cache/' . $home );
 
 		$this->request_uri = isset( $_SERVER['REQUEST_URI'] )
 			? $this->normalize_request_uri( $_SERVER['REQUEST_URI'] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash

--- a/projects/plugins/boost/app/modules/cache/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache.php
@@ -36,7 +36,7 @@ class Boost_Cache {
 	public function __construct( $storage = null ) {
 		$this->settings = Boost_Cache_Settings::get_instance();
 		$home           = isset( $_SERVER['HTTP_HOST'] ) ? strtolower( $_SERVER['HTTP_HOST'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$this->storage  = $storage ?? new Storage\File_Storage( WP_CONTENT_DIR . '/boost-cache/cache/' . $home );
+		$this->storage  = $storage ?? new Storage\File_Storage( $home );
 
 		$this->request_uri = isset( $_SERVER['REQUEST_URI'] )
 			? $this->normalize_request_uri( $_SERVER['REQUEST_URI'] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash

--- a/projects/plugins/boost/app/modules/cache/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/storage/File_Storage.php
@@ -19,7 +19,7 @@ class File_Storage implements Storage {
 	private $root_path;
 
 	public function __construct( $root_path ) {
-		$this->root_path = Boost_Cache_Utils::sanitize_file_path( Boost_Cache_Utils::trailingslashit( $root_path ) );
+		$this->root_path = WP_CONTENT_DIR . '/boost-cache/cache' . Boost_Cache_Utils::sanitize_file_path( Boost_Cache_Utils::trailingslashit( $root_path ) );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/storage/File_Storage.php
@@ -19,7 +19,7 @@ class File_Storage implements Storage {
 	private $root_path;
 
 	public function __construct( $root_path ) {
-		$this->root_path = Boost_Cache_Utils::trailingslashit( $root_path );
+		$this->root_path = Boost_Cache_Utils::sanitize_file_path( Boost_Cache_Utils::trailingslashit( $root_path ) );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/boost-cache-add-hostname-to-cache-path
+++ b/projects/plugins/boost/changelog/boost-cache-add-hostname-to-cache-path
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+[Boost] add the hostname to the cache path.


### PR DESCRIPTION
If a WordPress multisite uses this cache the cached files for all the sites on the server will be mixed up.
This PR adds the hostname to the cache path so this doesn't happen.

Fixes #35643

## Proposed changes:
* Add the HTTP_HOST to the path passed to File_Storage in Boost_Cache.php
* Sanitize the path in the File_Storage constructor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Apply the patch
Visit the test site as an anonymous user
Check that the cache files are created in a directory with the hostname in it.