### PR TITLE
Scheduled Updates Scaffolding

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/try-jetpack-scheduled-updates
+++ b/projects/packages/jetpack-mu-wpcom/changelog/try-jetpack-scheduled-updates
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a way to manage update schedules and kick them off from wp-cron.php

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -32,7 +32,11 @@ class Jetpack_Mu_Wpcom {
 		// Coming Soon feature.
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_coming_soon' ) );
 
+		/*
+		 * Please use `load_features` to load features that don't need any special loading considerations.
+		 */
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_features' ) );
+
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_launchpad' ), 0 );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_block_theme_previews' ) );
@@ -43,7 +47,7 @@ class Jetpack_Mu_Wpcom {
 
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_first_posts_stream_helpers' ) );
 
-		// This feature runs only on simple sites
+		// This feature runs only on simple sites.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_comments' ) );
 		}
@@ -66,16 +70,20 @@ class Jetpack_Mu_Wpcom {
 
 	/**
 	 * Load features that don't need any special loading considerations.
+	 *
+	 * Please organize in alphabetical order, so they are easier to find.
 	 */
 	public static function load_features() {
 		require_once __DIR__ . '/features/100-year-plan/enhanced-ownership.php';
 		require_once __DIR__ . '/features/100-year-plan/locked-mode.php';
 
+		require_once __DIR__ . '/features/block-patterns/block-patterns.php';
+
 		require_once __DIR__ . '/features/error-reporting/error-reporting.php';
 
 		require_once __DIR__ . '/features/media/heif-support.php';
 
-		require_once __DIR__ . '/features/block-patterns/block-patterns.php';
+		require_once __DIR__ . '/features/scheduled-updates/scheduled-updates.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/scheduled-updates/scheduled-updates.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/scheduled-updates/scheduled-updates.php
@@ -16,7 +16,8 @@ function jetpack_run_scheduled_update( $plugins = array() ) {
 
 	foreach ( $plugins as $plugin ) {
 		if ( isset( $available_updates->response[ $plugin ] ) ) {
-			$plugins_to_update[] = $plugin;
+			$plugins_to_update[ $plugin ]              = $available_updates->response[ $plugin ];
+			$plugins_to_update[ $plugin ]->old_version = $available_updates->checked[ $plugin ];
 		}
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/scheduled-updates/scheduled-updates.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/scheduled-updates/scheduled-updates.php
@@ -71,6 +71,9 @@ function jetpack_managed_extension_field() {
 			/**
 			 * Populates the is_managed field.
 			 *
+			 * Users could have their own plugins folder with symlinks pointing to it, so we need to check if the
+			 * link target is within the `/wordpress` directory to determine if the plugin is managed.
+			 *
 			 * @see p9o2xV-3Nx-p2#comment-8728
 			 *
 			 * @param array $data Prepared response array.

--- a/projects/packages/jetpack-mu-wpcom/src/features/scheduled-updates/scheduled-updates.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/scheduled-updates/scheduled-updates.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Manages update schedules for plugins and themes.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Run the scheduled update.
+ *
+ * @param array $plugins List of plugins to update.
+ */
+function jetpack_run_scheduled_update( $plugins = array() ) {
+	$available_updates = get_site_transient( 'update_plugins' );
+	$plugins_to_update = array();
+
+	foreach ( $plugins as $plugin ) {
+		if ( isset( $available_updates->response[ $plugin ] ) ) {
+			$plugins_to_update[] = $plugin;
+		}
+	}
+
+	if ( ! empty( $plugins_to_update ) ) {
+		wp_remote_post(
+			'https://public-api.wordpress.com/wpcom/v2/scheduled-updates/update-plugins', // TODO: Create the endpoint.
+			array(
+				'body' => array(
+					'plugins' => $plugins_to_update,
+				),
+			)
+		);
+	}
+}
+add_action( 'jetpack_scheduled_update', 'jetpack_run_scheduled_update' );
+
+/**
+ * Allow plugins that are part of scheduled updates to be updated automatically.
+ *
+ * @param bool|null $update Whether to update. The value of null is internally used
+ *                          to detect whether nothing has hooked into this filter.
+ * @param object    $item   The update offer.
+ * @return bool
+ */
+function jetpack_allowlist_scheduled_plugins( $update, $item ) {
+	// TODO: Check if we're in a scheduled update request from Jetpack_Autoupdates.
+	$schedules = get_option( 'jetpack_update_schedules', array() );
+
+	foreach ( $schedules as $plugins ) {
+		if ( in_array( $item->slug, $plugins, true ) ) {
+			return true;
+		}
+	}
+
+	return $update;
+}
+add_filter( 'auto_update_plugin', 'jetpack_allowlist_scheduled_plugins', 10, 2 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * Endpoint to manage plugin and theme update schedules.
+ *
+ * Example: https://public-api.wordpress.com/wpcom/v2/update-schedules
+ *
+ * @package API_v2
+ */
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Update_Schedules
+ */
+class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
+	/**
+	 * The namespace of this controller's route.
+	 *
+	 * @var string
+	 */
+	public $namespace = 'wpcom/v2';
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	public $rest_base = 'update-schedules';
+
+	/**
+	 * Whether the endpoint is a site-specific endpoint.
+	 *
+	 * @var bool
+	 */
+	public $wpcom_is_site_specific_endpoint = true;
+
+	/**
+	 * WPCOM_REST_API_V2_Endpoint_Atomic_Hosting_Update_Schedule constructor.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_item' ),
+				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				'args'                => $this->get_object_params(),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<schedule_id>[\s]+)/',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				'args'                => array(
+					'schedule_id' => array(
+						'description' => 'ID of the schedule.',
+						'type'        => 'string',
+						'required'    => true,
+					),
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_item' ),
+				'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				'args'                => array_merge(
+					array(
+						'schedule_id' => array(
+							'description' => 'ID of the schedule.',
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
+					$this->get_object_params()
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'delete_item' ),
+				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+			)
+		);
+	}
+
+	/**
+	 * Permission check for retrieving schedules.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool
+	 */
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return current_user_can( 'update_plugins' );
+	}
+
+	/**
+	 * Returns a list of update schedules.
+	 *
+	 * Checks the jetpack_update_schedules option for saved schedule ids and retries scheduled events with the `jetpack_scheduled_update` hook.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$schedules = get_option( 'jetpack_update_schedules', array() );
+		$events    = array();
+
+		foreach ( $schedules as $timestamp => $schedule_args ) {
+			$events[] = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args, $timestamp );
+		}
+
+		return rest_ensure_response( $events );
+	}
+
+	/**
+	 * Permission check for creating a new schedule.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool|WP_Error
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( ! wpcom_site_has_feature( WPCOM_Features::SCHEDULED_UPDATES ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-mu-wpcom' ), array( 'status' => 403 ) );
+		}
+
+		$schedules = get_option( 'jetpack_update_schedules', array() );
+		if ( count( $schedules ) >= 2 ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create more than two schedules at this time.', 'jetpack-mu-wpcom' ), array( 'status' => 403 ) );
+		}
+
+		foreach ( $schedules as $timestamp => $schedule_args ) {
+			if ( strtotime( 'next ' . $request['schedule']['weekday'] . ' ' . $request['schedule']['time'] ) === $timestamp ) {
+				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same time as an existing schedule.', 'jetpack-mu-wpcom' ), array( 'status' => 403 ) );
+			}
+
+			if ( md5( serialize( $schedule_args ) ) === md5( serialize( $request['plugins'] ) ) ) { // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same plugins as an existing schedule.', 'jetpack-mu-wpcom' ), array( 'status' => 403 ) );
+			}
+		}
+
+		if ( ! empty( $request['themes'] ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not schedule theme updates at this time.', 'jetpack-mu-wpcom' ), array( 'status' => 403 ) );
+		}
+
+		return current_user_can( 'update_plugins' );
+	}
+
+	/**
+	 * Creates a new update schedule.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$schedule = $request['schedule'];
+		$plugins  = $request['plugins'];
+
+		$timestamp = strtotime( 'next ' . $schedule['weekday'] . ' ' . $schedule['time'] );
+		if ( false === $timestamp ) {
+			return new WP_Error( 'rest_invalid_schedule', __( 'The weekday and time provided could not be used to create a schedule.', 'jetpack-mu-wpcom' ), array( 'status' => 400 ) );
+		}
+
+		$event = wp_schedule_event( $timestamp, $schedule['interval'], 'jetpack_scheduled_update', $plugins, true );
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
+
+		$schedules               = get_option( 'jetpack_update_schedules', array() );
+		$schedules[ $timestamp ] = $plugins;
+		update_option( 'jetpack_update_schedules', $schedules );
+
+		return rest_ensure_response( md5( serialize( $plugins ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+	}
+
+	/**
+	 * Permission check for retrieving a specific schedule.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool
+	 */
+	public function get_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return current_user_can( 'update_plugins' );
+	}
+
+	/**
+	 * Returns information about an update schedule.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$schedules = get_option( 'jetpack_update_schedules', array() );
+		$event     = array();
+
+		foreach ( $schedules as $timestamp => $schedule_args ) {
+			if ( md5( serialize( $schedule_args ) ) === $request['schedule_id'] ) { // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+				$event = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args, $timestamp );
+				break;
+			}
+		}
+
+		return rest_ensure_response( $event );
+	}
+
+	/**
+	 * Permission check for updating a specific schedule.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool|WP_Error
+	 */
+	public function update_item_permissions_check( $request ) {
+		if ( ! wpcom_site_has_feature( WPCOM_Features::SCHEDULED_UPDATES ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-mu-wpcom' ), array( 'status' => 403 ) );
+		}
+
+		$schedules = get_option( 'jetpack_update_schedules', array() );
+		foreach ( $schedules as $timestamp => $schedule_args ) {
+			if ( strtotime( 'next ' . $request['schedule']['weekday'] . ' ' . $request['schedule']['time'] ) === $timestamp ) {
+				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same time as an existing schedule.', 'jetpack-mu-wpcom' ), array( 'status' => 403 ) );
+			}
+
+			if ( md5( serialize( $schedule_args ) ) === md5( serialize( $request['plugins'] ) ) ) { // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same plugins as an existing schedule.', 'jetpack-mu-wpcom' ), array( 'status' => 403 ) );
+			}
+		}
+
+		if ( ! empty( $request['themes'] ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not schedule theme updates at this time.', 'jetpack-mu-wpcom' ), array( 'status' => 403 ) );
+		}
+
+		return current_user_can( 'update_plugins' );
+	}
+
+	/**
+	 * Updates an existing update schedule.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$schedules = get_option( 'jetpack_update_schedules', array() );
+		$found     = array();
+
+		foreach ( $schedules as $timestamp => $schedule_args ) {
+			if ( md5( serialize( $schedule_args ) ) === $request['schedule_id'] ) { // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+				// We found the schedule to update.
+				$found = true;
+
+				$result = wp_unschedule_event( $timestamp, 'jetpack_scheduled_update', $schedule_args, true );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+
+				// Remove the old schedule.
+				unset( $schedules[ $timestamp ] );
+				break;
+			}
+		}
+
+		if ( ! $found ) {
+			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-mu-wpcom' ), array( 'status' => 400 ) );
+		}
+
+		return $this->create_item( $request );
+	}
+
+	/**
+	 * Permission check for deleting a specific schedule.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool
+	 */
+	public function delete_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return current_user_can( 'update_plugins' );
+	}
+
+	/**
+	 * Deletes an existing update schedule.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$schedules = get_option( 'jetpack_update_schedules', array() );
+		$found     = array();
+
+		foreach ( $schedules as $timestamp => $schedule_args ) {
+			if ( md5( serialize( $schedule_args ) ) === $request['schedule_id'] ) { // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+				// We found the schedule to delete.
+				$found = true;
+
+				$result = wp_unschedule_event( $timestamp, 'jetpack_scheduled_update', $schedule_args, true );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+
+				// Remove the old schedule.
+				unset( $schedules[ $timestamp ] );
+				break;
+			}
+		}
+
+		if ( ! $found ) {
+			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-mu-wpcom' ), array( 'status' => 400 ) );
+		}
+
+		update_option( 'jetpack_update_schedules', $schedules );
+
+		return rest_ensure_response( true );
+	}
+
+	/**
+	 * Retrieves the query params for scheduled updates.
+	 *
+	 * @return array[] Array of query parameters.
+	 */
+	public function get_object_params() {
+		return array(
+			'plugins'  => array(
+				'description' => 'List of plugin slugs to update.',
+				'type'        => 'array',
+				'required'    => false,
+			),
+			'themes'   => array(
+				'description' => 'List of theme slugs to update.',
+				'type'        => 'array',
+				'required'    => false,
+			),
+			'schedule' => array(
+				'description' => 'Update schedule.',
+				'type'        => 'object',
+				'required'    => true,
+				'properties'  => array(
+					'interval' => array(
+						'description' => 'Interval for the schedule.',
+						'type'        => 'string',
+						'enum'        => array( 'daily', 'weekly' ),
+					),
+					'weekday'  => array(
+						'description' => 'Weekday for the schedule.',
+						'type'        => 'string',
+						'enum'        => array( 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday' ),
+					),
+					'time'     => array(
+						'description' => 'Time for the schedule.',
+						'type'        => 'string',
+						'format'      => 'date-time',
+					),
+				),
+			),
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Update_Schedules' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -1,0 +1,393 @@
+<?php
+/**
+ * Test class for WPCOM_REST_API_V2_Endpoint_Update_Schedules.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+//phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php';
+
+/**
+ * Test class for WPCOM_REST_API_V2_Endpoint_Update_Schedules.
+ *
+ * @coversDefaultClass WPCOM_REST_API_V2_Endpoint_Update_Schedules
+ */
+class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	public $admin_id;
+
+	/**
+	 * Editor user ID.
+	 *
+	 * @var int
+	 */
+	public $editor_id;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id  = wp_insert_user(
+			array(
+				'user_login' => 'dummy_user',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+		$this->editor_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_editor',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( 0 );
+
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		delete_option( 'jetpack_update_schedules' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test get_items.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items() {
+		// Unauthenticated request.
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules' );
+		$result  = rest_do_request( $request );
+
+		$this->assertSame( 401, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+
+		// Not the right permissions.
+		wp_set_current_user( $this->editor_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 403, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+
+		// Successful request.
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		// No schedules.
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( array(), $result->get_data() );
+
+		// Set up some schedules.
+		$plugins = array(
+			'gutenberg/gutenberg.php',
+			'custom-plugin/custom-plugin.php',
+		);
+		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_update', array( 'hello-dolly/hello-dolly.php' ) );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		update_option( 'jetpack_update_schedules', array( array( 'hello-dolly/hello-dolly.php' ), $plugins ) );
+
+		// Successful request.
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'hook'      => 'jetpack_scheduled_update',
+					'args'      => array( 'hello-dolly/hello-dolly.php' ),
+					'timestamp' => strtotime( 'next Tuesday 9:00' ),
+					'schedule'  => 'daily',
+					'interval'  => DAY_IN_SECONDS,
+				),
+				(object) array(
+					'hook'      => 'jetpack_scheduled_update',
+					'args'      => $plugins,
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'schedule'  => 'weekly',
+					'interval'  => WEEK_IN_SECONDS,
+				),
+			),
+			$result->get_data()
+		);
+	}
+
+	/**
+	 * Test create item.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_create_item() {
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => array(
+					'gutenberg/gutenberg.php',
+					'custom-plugin/custom-plugin.php',
+				),
+				'schedule' => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
+				),
+			)
+		);
+		$schedule_id = md5( serialize( $request->get_body_params()['plugins'] ) );
+
+		// Unauthenticated request.
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 401, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+
+		// Not the right permissions.
+		wp_set_current_user( $this->editor_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 403, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+
+		// Successful request.
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( $schedule_id, $result->get_data() );
+
+		// Can't create a schedule for the same time again.
+		$request->set_body_params(
+			array(
+				'plugins'  => array(
+					'gutenberg/gutenberg.php',
+					'custom-plugin/custom-plugin.php',
+				),
+				'schedule' => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
+				),
+			)
+		);
+
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 403, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+	}
+
+	/**
+	 * Can't have multiple schedules for the same time.
+	 *
+	 * @covers ::create_item_permissions_check
+	 */
+	public function test_creating_schedules_for_same_time() {
+		$plugins = array(
+			'gutenberg/gutenberg.php',
+			'custom-plugin/custom-plugin.php',
+		);
+
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		update_option( 'jetpack_update_schedules', array( $plugins ) );
+
+		// Can't create a schedule for the same time again.
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => array(
+					'gutenberg/gutenberg.php',
+					'custom-plugin/custom-plugin.php',
+				),
+				'schedule' => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
+				),
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 403, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+	}
+
+	/**
+	 * Can't have more than two schedules.
+	 *
+	 * @covers ::create_item_permissions_check
+	 */
+	public function test_creating_more_than_two_schedules() {
+		$plugins = array(
+			'gutenberg/gutenberg.php',
+			'custom-plugin/custom-plugin.php',
+		);
+
+		// Create two schedules.
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_update', $plugins );
+		update_option( 'jetpack_update_schedules', array( $plugins, $plugins ) );
+
+		// Number 3.
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => array(
+					'gutenberg/gutenberg.php',
+					'custom-plugin/custom-plugin.php',
+				),
+				'schedule' => array(
+					'timestamp' => strtotime( 'next Wednesday 10:00' ),
+					'interval'  => 'daily',
+				),
+			)
+		);
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 403, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+	}
+
+	/**
+	 * Test get item.
+	 *
+	 * @covers ::get_item
+	 */
+	public function test_get_item() {
+		$plugins     = array(
+			'gutenberg/gutenberg.php',
+			'custom-plugin/custom-plugin.php',
+		);
+		$schedule_id = md5( serialize( $plugins ) );
+
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		update_option( 'jetpack_update_schedules', array( $plugins ) );
+
+		// Unauthenticated request.
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules/' . $schedule_id );
+		$result  = rest_do_request( $request );
+
+		$this->assertSame( 401, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+
+		// Not the right permissions.
+		wp_set_current_user( $this->editor_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 403, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+
+		// Successful request.
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertEquals(
+			(object) array(
+				'hook'      => 'jetpack_scheduled_update',
+				'args'      => $plugins,
+				'timestamp' => strtotime( 'next Monday 8:00' ),
+				'schedule'  => 'weekly',
+				'interval'  => WEEK_IN_SECONDS,
+			),
+			$result->get_data()
+		);
+	}
+
+	/**
+	 * Test update item.
+	 *
+	 * @covers ::update_item
+	 */
+	public function test_update_item() {
+		$plugins     = array(
+			'gutenberg/gutenberg.php',
+			'custom-plugin/custom-plugin.php',
+		);
+		$schedule_id = md5( serialize( $plugins ) );
+
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		update_option( 'jetpack_update_schedules', array( $plugins ) );
+
+		// Unauthenticated request.
+		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $schedule_id );
+		$request->set_body_params(
+			array(
+				'plugins'  => $plugins,
+				'schedule' => array(
+					'timestamp' => strtotime( 'next Tuesday 9:00' ),
+					'interval'  => 'daily',
+				),
+			)
+		);
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 401, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+
+		// Not the right permissions.
+		wp_set_current_user( $this->editor_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 403, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+
+		// Successful request.
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( $schedule_id, $result->get_data() );
+	}
+
+	/**
+	 * Test delete item.
+	 *
+	 * @covers ::delete_item
+	 */
+	public function test_delete_item() {
+		$plugins     = array(
+			'gutenberg/gutenberg.php',
+			'custom-plugin/custom-plugin.php',
+		);
+		$schedule_id = md5( serialize( $plugins ) );
+
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		update_option( 'jetpack_update_schedules', array( $plugins ) );
+
+		// Unauthenticated request.
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'DELETE', '/wpcom/v2/update-schedules/' . $schedule_id );
+		$result  = rest_do_request( $request );
+
+		$this->assertSame( 401, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+
+		// Not the right permissions.
+		wp_set_current_user( $this->editor_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 403, $result->get_status() );
+		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
+
+		// Successful request.
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertTrue( $result->get_data() );
+
+		$this->assertEmpty( get_option( 'jetpack_update_schedules' ) );
+		$this->assertFalse( wp_get_scheduled_event( 'jetpack_scheduled_update', $plugins ) );
+	}
+}


### PR DESCRIPTION
WIP

This is just a way to share some code. It might not stay in `jetpack-mu-wpcom`, but this is as good a place for it as any to get some eyes on it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions in the first comment to sync this PR to a WoA test site.
* Install the "Rest API Console" plugin and activate it: https://wordpress.org/plugins/rest-api-console/
* Go to Tools > Rest API console
* Test the endpoint by running requests against `/wpcom/v2/update-schedules`
* Send OPTION requests to find out about the the two endpoints, `/wpcom/v2/update-schedules` and `/wpcom/v2/update-schedules/{ID}`
* Run a POST request with the following information in the body: `plugins=rest-api-console%2Frest-api-console.php&schedule[weekday]=monday&schedule[time]=2024-03-12T07:10:50.52Z&schedule[interval]=weekly` (Until D138106-code is merged, you'll have to comment out the feature check)
* With the ID that gets returned, test individual schedule endpoint functionality.