### PR TITLE
Backport mu-wpcom-plugin 2.0.20, jetpack 13.2-a.3 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.6.0] - 2024-02-05
 ### Added
 - Jetpack AI: Support floating error messaging on the AI Control component. [#35322]
@@ -206,6 +210,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.6.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.4.1...v0.5.0

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.6.1-alpha",
+	"version": "0.6.1",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.16.10] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.16.9] - 2024-02-05
 ### Changed
 - Updated package dependencies. [#35384]
@@ -294,6 +298,7 @@
 - Add the API methods left behind by the previous PR.
 - Initial release of jetpack-api package
 
+[0.16.10]: https://github.com/Automattic/jetpack-api/compare/v0.16.9...v0.16.10
 [0.16.9]: https://github.com/Automattic/jetpack-api/compare/v0.16.8...v0.16.9
 [0.16.8]: https://github.com/Automattic/jetpack-api/compare/v0.16.7...v0.16.8
 [0.16.7]: https://github.com/Automattic/jetpack-api/compare/v0.16.6...v0.16.7

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.16.10-alpha",
+	"version": "0.16.10",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.17] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.6.16] - 2024-02-05
 ### Changed
 - Updated package dependencies. [#35384]
@@ -246,6 +250,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.17]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.16...0.6.17
 [0.6.16]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.15...0.6.16
 [0.6.15]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.14...0.6.15
 [0.6.14]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.13...0.6.14

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.17-alpha",
+	"version": "0.6.17",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.22] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.1.21] - 2024-02-05
 ### Changed
 - Updated package dependencies. [#35384]
@@ -99,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.22]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.19...v0.1.20
 [0.1.19]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.18...v0.1.19

--- a/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.22-alpha",
+	"version": "0.1.22",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.48.2] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.48.1] - 2024-02-05
 ### Changed
 - Update clicking an icon tooltip to cause the tooltip to show/hide instead of always showing. [#35312]
@@ -937,6 +941,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.48.2]: https://github.com/Automattic/jetpack-components/compare/0.48.1...0.48.2
 [0.48.1]: https://github.com/Automattic/jetpack-components/compare/0.48.0...0.48.1
 [0.48.0]: https://github.com/Automattic/jetpack-components/compare/0.47.0...0.48.0
 [0.47.0]: https://github.com/Automattic/jetpack-components/compare/0.46.0...0.47.0

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.48.2-alpha",
+	"version": "0.48.2",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.32.1] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.32.0] - 2024-02-05
 ### Changed
 - Allow using blog ID instead of site suffix in checkout URL. [#34996]
@@ -698,6 +702,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.32.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.2...v0.32.0
 [0.31.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.0...v0.31.1

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.32.1-alpha",
+	"version": "0.32.1",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.45] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [2.0.44] - 2024-02-05
 ### Changed
 - Updated package dependencies. [#35384]
@@ -205,6 +209,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.45]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.44...v2.0.45
 [2.0.44]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.43...v2.0.44
 [2.0.43]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.42...v2.0.43
 [2.0.42]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.41...v2.0.42

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.45-alpha",
+	"version": "2.0.45",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.61 - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## 0.10.60 - 2024-02-05
 ### Changed
 - Updated package dependencies. [#35384]

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.61-alpha",
+	"version": "0.10.61",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.1 - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## 0.12.0 - 2024-02-05
 ### Added
 - Added social specific success card on Jetpack Social license activation. [#35224]

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.12.1-alpha",
+	"version": "0.12.1",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.69 - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## 0.2.68 - 2024-02-05
 ### Changed
 - Updated package dependencies.

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.69-alpha",
+	"version": "0.2.69",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.47.1] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.47.0] - 2024-02-12
 ### Changed
 - Change editor layout for social notes [#35536]
@@ -586,6 +590,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.47.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.47.0...v0.47.1
 [0.47.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.45.2...v0.46.0
 [0.45.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.45.1...v0.45.2

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.47.1-alpha",
+	"version": "0.47.1",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.2] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.14.1] - 2024-02-05
 ### Changed
 - Updated package dependencies.
@@ -336,6 +340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.14.2]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.1...0.14.2
 [0.14.1]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.0...0.14.1
 [0.14.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.10...0.14.0
 [0.13.10]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.13.9...0.13.10

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.14.2-alpha",
+	"version": "0.14.2",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.2 - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## 3.1.1 - 2024-02-05
 ### Changed
 - Updated package dependencies. [#35384]

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.1.2-alpha",
+	"version": "3.1.2",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [2.1.0] - 2024-02-05
 ### Added
 - Add support for script enqueuing strategies implemented in WordPress 6.3 [#34072]
@@ -403,6 +407,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[2.1.1]: https://github.com/Automattic/jetpack-assets/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/Automattic/jetpack-assets/compare/v2.0.4...v2.1.0
 [2.0.4]: https://github.com/Automattic/jetpack-assets/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/Automattic/jetpack-assets/compare/v2.0.2...v2.0.3

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.5] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [3.1.4] - 2024-02-08
 ### Fixed
 - Write helper script to ABSPATH by default, just like we did before [#35508]
@@ -558,6 +562,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.1.5]: https://github.com/Automattic/jetpack-backup/compare/v3.1.4...v3.1.5
 [3.1.4]: https://github.com/Automattic/jetpack-backup/compare/v3.1.3...v3.1.4
 [3.1.3]: https://github.com/Automattic/jetpack-backup/compare/v3.1.2...v3.1.3
 [3.1.2]: https://github.com/Automattic/jetpack-backup/compare/v3.1.1...v3.1.2

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.1.5-alpha';
+	const PACKAGE_VERSION = '3.1.5';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2024-02-13
+### Added
+- Blaze: Whiteliste /media/new WPCOM REST API call for image uploading [#34790]
+- Quick Action Links: introduce new filter allowing to disable quick links in the Posts screen. [#35586]
+
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.15.3] - 2024-02-05
 ### Changed
 - Updated package dependencies. [#35384]
@@ -277,6 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.16.0]: https://github.com/automattic/jetpack-blaze/compare/v0.15.3...v0.16.0
 [0.15.3]: https://github.com/automattic/jetpack-blaze/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/automattic/jetpack-blaze/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/automattic/jetpack-blaze/compare/v0.15.0...v0.15.1

--- a/projects/packages/blaze/changelog/remove-blaze-link-from-post-and-page-items
+++ b/projects/packages/blaze/changelog/remove-blaze-link-from-post-and-page-items
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Quick Action Links: introduce new filter allowing to disable quick links in the Posts screen.

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/changelog/whitelist-image-uploading-to-wpcom
+++ b/projects/packages/blaze/changelog/whitelist-image-uploading-to-wpcom
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Blaze: Whiteliste /media/new WPCOM REST API call for image uploading

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.16.0-alpha",
+	"version": "0.16.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -65,7 +65,7 @@ class Blaze {
 			/**
 			 * Allow third-party plugins to disable Blaze row actions.
 			 *
-			 * @since $$next-version$$
+			 * @since 0.16.0
 			 *
 			 * @param bool $blaze_post_actions_enabled Should Blaze row actions be enabled?
 			 */

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.16.0-alpha';
+	const PACKAGE_VERSION = '0.16.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/boost-speed-score/CHANGELOG.md
+++ b/projects/packages/boost-speed-score/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2024-02-13
+### Fixed
+- Speed Score: Do not return no-boost score if no boost modules are active [#35327]
+
 ## [0.3.3] - 2024-01-22
 ### Added
 - Send current boost version with API requests to handle requests accordingly [#35132]
@@ -46,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new package for Boost Speed Score [#30914]
 - Add a new argument to `Speed_Score` to identify where the request was made from (e.g. 'boost-plugin', 'jetpack-dashboard', etc). [#31012]
 
+[0.3.4]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.0...v0.3.1

--- a/projects/packages/boost-speed-score/changelog/fix-initial-score
+++ b/projects/packages/boost-speed-score/changelog/fix-initial-score
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Speed Score: Do not return no-boost score if no boost modules are active

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -23,7 +23,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.3.4-alpha';
+	const PACKAGE_VERSION = '0.3.4';
 
 	/**
 	 * An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup passed to the constructor

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [2.3.0] - 2024-02-05
 ### Added
 - Add rate limiter to the package versions endpoint calls. [#35379]
@@ -960,6 +964,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.3.1]: https://github.com/Automattic/jetpack-connection/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/Automattic/jetpack-connection/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/Automattic/jetpack-connection/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/Automattic/jetpack-connection/compare/v2.1.0...v2.1.1

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.3.1-alpha';
+	const PACKAGE_VERSION = '2.3.1';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.5] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.30.4] - 2024-02-12
 ### Fixed
 - Dashboard: improve the display of the dashboard to non-admins. [#35571]
@@ -486,6 +490,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.5]: https://github.com/automattic/jetpack-forms/compare/v0.30.4...v0.30.5
 [0.30.4]: https://github.com/automattic/jetpack-forms/compare/v0.30.3...v0.30.4
 [0.30.3]: https://github.com/automattic/jetpack-forms/compare/v0.30.2...v0.30.3
 [0.30.2]: https://github.com/automattic/jetpack-forms/compare/v0.30.1...v0.30.2

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.5-alpha",
+	"version": "0.30.5",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.5-alpha';
+	const PACKAGE_VERSION = '0.30.5';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
+### Deprecated
+- Deprecating unused methods for IDC handling [#35444]
+
 ## [0.16.0] - 2024-02-07
 ### Deprecated
 - Removing old and previously deprecated code. [#35048]
@@ -484,6 +491,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.17.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.14.1...v0.15.0

--- a/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/changelog/update-deprecate-idc-methods-2
+++ b/projects/packages/identity-crisis/changelog/update-deprecate-idc-methods-2
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Deprecating unused methods for IDC handling

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.17.0-alpha",
+	"version": "0.17.0",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.17.0-alpha';
+	const PACKAGE_VERSION = '0.17.0';
 
 	/**
 	 * Persistent WPCOM blog ID that stays in the options after disconnect.
@@ -141,11 +141,11 @@ class Identity_Crisis {
 	/**
 	 * Gets the link to the support document used to explain Safe Mode to users.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public static function get_safe_mod_doc_url() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		return Redirect::get_url( 'jetpack-support-safe-mode' );
 	}
 
@@ -357,13 +357,13 @@ class Identity_Crisis {
 	/**
 	 * Prepare URL for display.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @param string $url URL to display.
 	 *
 	 * @return string
 	 */
 	public static function prepare_url_for_display( $url ) {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		return untrailingslashit( self::normalize_url_protocol_agnostic( $url ) );
 	}
 
@@ -575,11 +575,11 @@ class Identity_Crisis {
 	 * Is a container for the error notices.
 	 * Will be shown/controlled by jQuery in idc-notice.js.
 	 *
-	 * @deprecated  $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated  0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return void
 	 */
 	public function render_error_notice() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		?>
 		<div class="jp-idc-error__notice dops-notice is-error">
 			<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" viewBox="0 0 24 24">
@@ -605,11 +605,11 @@ class Identity_Crisis {
 	/**
 	 * Renders the first step notice.
 	 *
-	 * @deprecated  $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated  0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return void
 	 */
 	public function render_notice_first_step() {
-		_deprecated_function( __METHOD__, ' $$next-version$$' );
+		_deprecated_function( __METHOD__, ' 0.17.0' );
 		?>
 		<div class="jp-idc-notice__first-step">
 			<div class="jp-idc-notice__content-header">
@@ -650,12 +650,12 @@ class Identity_Crisis {
 	/**
 	 * Renders the second step notice.
 	 *
-	 * @deprecated  $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated  0.17.0 Use `@automattic/jetpack-idc` instead.
 	 *
 	 * @return void
 	 */
 	public function render_notice_second_step() {
-		_deprecated_function( __METHOD__, ' $$next-version$$' );
+		_deprecated_function( __METHOD__, ' 0.17.0' );
 		?>
 		<div class="jp-idc-notice__second-step">
 			<div class="jp-idc-notice__content-header">
@@ -697,12 +697,12 @@ class Identity_Crisis {
 	/**
 	 * Returns the first step header lead.
 	 *
-	 * @deprecated  $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated  0.17.0 Use `@automattic/jetpack-idc` instead.
 	 *
 	 * @return string
 	 */
 	public function get_first_step_header_lead() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$html = wp_kses(
 			sprintf(
 			/* translators: %s: Safe mode docs URL and site URL. */
@@ -728,12 +728,12 @@ class Identity_Crisis {
 	/**
 	 * Returns the first step header explanation.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 *
 	 * @return string
 	 */
 	public function get_first_step_header_explanation() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$html = wp_kses(
 			sprintf(
 			/* translators: %s: Safe mode docs URL. */
@@ -757,11 +757,11 @@ class Identity_Crisis {
 	/**
 	 * Returns the confirm safe mode explanation.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public function get_confirm_safe_mode_action_explanation() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$html = wp_kses(
 			sprintf(
 			/* translators: %s: Site URL. */
@@ -786,11 +786,11 @@ class Identity_Crisis {
 	/**
 	 * Returns the confirm safe mode button text.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public function get_confirm_safe_mode_button_text() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$string = esc_html__( 'Confirm Safe Mode', 'jetpack-idc' );
 
 		/**
@@ -807,11 +807,11 @@ class Identity_Crisis {
 	/**
 	 * Returns the first step fix connection action explanation.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public function get_first_step_fix_connection_action_explanation() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$html = wp_kses(
 			sprintf(
 			/* translators: %s: Site URL. */
@@ -836,11 +836,11 @@ class Identity_Crisis {
 	/**
 	 * Returns the first step fix connection button text.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public function get_first_step_fix_connection_button_text() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$string = esc_html__( "Fix Jetpack's Connection", 'jetpack-idc' );
 
 		/**
@@ -857,11 +857,11 @@ class Identity_Crisis {
 	/**
 	 * Returns the second step header lead.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public function get_second_step_header_lead() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$string = sprintf(
 		/* translators: %s: Site URL. */
 			esc_html__( 'Is %1$s the new home of %2$s?', 'jetpack-idc' ),
@@ -883,11 +883,11 @@ class Identity_Crisis {
 	/**
 	 * Returns the site action explanation.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public function get_migrate_site_action_explanation() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$html = wp_kses(
 			sprintf(
 			/* translators: %s: Site URL. */
@@ -914,11 +914,11 @@ class Identity_Crisis {
 	/**
 	 * Returns the migrate site button text.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public function get_migrate_site_button_text() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$string = esc_html__( 'Migrate Stats &amp; Subscribers', 'jetpack-idc' );
 
 		/**
@@ -935,11 +935,11 @@ class Identity_Crisis {
 	/**
 	 * Returns the start fresh explanation.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public function get_start_fresh_action_explanation() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$html = wp_kses(
 			sprintf(
 			/* translators: %s: Site URL. */
@@ -966,11 +966,11 @@ class Identity_Crisis {
 	/**
 	 * Returns the start fresh button text.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public function get_start_fresh_button_text() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$string = esc_html__( 'Start Fresh &amp; Create New Connection', 'jetpack-idc' );
 
 		/**
@@ -987,11 +987,11 @@ class Identity_Crisis {
 	/**
 	 * Returns the unsure prompt text.
 	 *
-	 * @deprecated since $$next-version$$ Use `@automattic/jetpack-idc` instead.
+	 * @deprecated since 0.17.0 Use `@automattic/jetpack-idc` instead.
 	 * @return string
 	 */
 	public function get_unsure_prompt() {
-		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'package-0.17.0' );
 		$html = wp_kses(
 			sprintf(
 			/* translators: %s: Safe mode docs URL. */

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.12.2] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [5.12.1] - 2024-02-12
 ### Changed
 - Make the 'Install the mobile app' task visible to Simple and Atomic. [#35465]
@@ -577,6 +581,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.12.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.12.1...v5.12.2
 [5.12.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.12.0...v5.12.1
 [5.12.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.11.0...v5.12.0
 [5.11.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.10.0...v5.11.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.12.2-alpha",
+	"version": "5.12.2",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.12.2-alpha';
+	const PACKAGE_VERSION = '5.12.2';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.4] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [3.0.3] - 2024-02-05
 ### Changed
 - Updated package dependencies. [#35384]
@@ -666,6 +670,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.0.4]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.3...v3.0.4
 [3.0.3]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.0...v3.0.1

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.0.4-alpha';
+	const PACKAGE_VERSION = '3.0.4';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.2] - 2024-02-13
+### Changed
+- My Jetpack: various improvements to the Stats card. [#35355]
+- Updated package dependencies. [#35608]
+
 ## [4.9.1] - 2024-02-12
 ### Added
 - Add My Jetpack link to standalone plugins missing it [#35523]
@@ -1239,6 +1244,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.9.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.9.1...4.9.2
 [4.9.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.9.0...4.9.1
 [4.9.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.8.0...4.9.0
 [4.8.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.7.0...4.8.0

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-stats-section
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-stats-section
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: various improvements to the Stats card.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.9.2-alpha",
+	"version": "4.9.2",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -34,7 +34,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.9.2-alpha';
+	const PACKAGE_VERSION = '4.9.2';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.1] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.42.0] - 2024-02-12
 ### Changed
 - Change editor layout for social notes [#35536]
@@ -472,6 +476,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.42.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.0...v0.42.1
 [0.42.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.39.0...v0.40.0

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.1-alpha",
+	"version": "0.42.1",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.1] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.43.0] - 2024-02-05
 ### Changed
 - Updated package dependencies. [#35384]
@@ -890,6 +894,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.43.1]: https://github.com/Automattic/jetpack-search/compare/v0.43.0...v0.43.1
 [0.43.0]: https://github.com/Automattic/jetpack-search/compare/v0.42.1...v0.43.0
 [0.42.1]: https://github.com/Automattic/jetpack-search/compare/v0.42.0...v0.42.1
 [0.42.0]: https://github.com/Automattic/jetpack-search/compare/v0.41.1...v0.42.0

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.43.1-alpha",
+	"version": "0.43.1",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.43.1-alpha';
+	const VERSION = '0.43.1';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1] - 2024-02-13
+### Changed
+- Internal updates.
+
 ## [2.6.0] - 2024-02-12
 ### Added
 - Added a new site setting option for opting out of research partners using your site's content. [#35509]
@@ -1043,6 +1047,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.6.1]: https://github.com/Automattic/jetpack-sync/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/Automattic/jetpack-sync/compare/v2.5.1...v2.6.0
 [2.5.1]: https://github.com/Automattic/jetpack-sync/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/Automattic/jetpack-sync/compare/v2.4.2...v2.5.0

--- a/projects/packages/sync/changelog/add-coupons-blacklist
+++ b/projects/packages/sync/changelog/add-coupons-blacklist
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.6.1-alpha';
+	const PACKAGE_VERSION = '2.6.1';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.2] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.23.1] - 2024-02-12
 ### Fixed
 - Fixed various PHP warnings in PHP 8.1+ [#35551]
@@ -1255,6 +1259,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.1...v0.23.2
 [0.23.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.4...v0.23.0
 [0.22.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.3...v0.22.4

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.2-alpha",
+	"version": "0.23.2",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.2-alpha';
+	const PACKAGE_VERSION = '0.23.2';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2024-02-13
+### Changed
+- Updated package dependencies. [#35608]
+
 ## [0.3.7] - 2024-02-05
 ### Changed
 - Updated package dependencies.
@@ -303,6 +307,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.8]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.4...v0.3.5

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.8-alpha",
+	"version": "0.3.8",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.8-alpha';
+	const VERSION = '0.3.8';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.2-a.3 - 2024-02-13
+### Enhancements
+- Blaze: remove "Promote with Blaze" links appearing in the Posts list when the Blaze feature is enabled. You can still go to Tools > Advertising to create and manage Blaze campaigns on your site. [#35586]
+
+### Bug fixes
+- Disable scroll to top when memberships subscribe popup is opened. [#35553]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Create with voice: Rename feature to Voice to content [#35645]
+- Jetpack AI Voice to content: Enable on P2 [#35610]
+- Related Posts: fix too few arguments error [#35646]
+- Update "Earn" to "Monetize" navigation item  on Jetpack sites managed in Calypso/WP.com. [#35633]
+- Updated package dependencies.
+
 ## 13.2-a.1 - 2024-02-12
 ### Enhancements
 - Additional CSS: Use the correct plan name in the WordPress.com nudge. [#35495]

--- a/projects/plugins/jetpack/changelog/add-whitelist-wpcom-image-uploading-for-blaze
+++ b/projects/plugins/jetpack/changelog/add-whitelist-wpcom-image-uploading-for-blaze
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-related-post-arg-count-error
+++ b/projects/plugins/jetpack/changelog/fix-related-post-arg-count-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Related Posts: fix too few arguments error

--- a/projects/plugins/jetpack/changelog/fix-tokensubscriptionservice
+++ b/projects/plugins/jetpack/changelog/fix-tokensubscriptionservice
@@ -1,3 +1,0 @@
-Significance: patch
-Type: other
-Comment: In token_from_request() make sure $_GET['token'] is a string

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.2-a.2
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.2-a.4
+
+

--- a/projects/plugins/jetpack/changelog/remove-blaze-link-from-post-and-page-items
+++ b/projects/plugins/jetpack/changelog/remove-blaze-link-from-post-and-page-items
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Blaze: remove "Promote with Blaze" links appearing in the Posts list when the Blaze feature is enabled. You can still go to Tools > Advertising to create and manage Blaze campaigns on your site.

--- a/projects/plugins/jetpack/changelog/remove-blaze-link-on-posts-and-pages
+++ b/projects/plugins/jetpack/changelog/remove-blaze-link-on-posts-and-pages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/subscribe-popup-disable-scroll
+++ b/projects/plugins/jetpack/changelog/subscribe-popup-disable-scroll
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Disable scroll to top when memberships subscribe popup is opened.

--- a/projects/plugins/jetpack/changelog/update-atomic-navi-earn-rename
+++ b/projects/plugins/jetpack/changelog/update-atomic-navi-earn-rename
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update "Earn" to "Monetize" navigation item  on Jetpack sites managed in Calypso/WP.com.

--- a/projects/plugins/jetpack/changelog/update-deprecate-idc-methods-2
+++ b/projects/plugins/jetpack/changelog/update-deprecate-idc-methods-2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-deprecate-idc-methods-2#2
+++ b/projects/plugins/jetpack/changelog/update-deprecate-idc-methods-2#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-create-with-voice-p2
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-create-with-voice-p2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI Voice to content: Enable on P2

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-rename-create-with-voice
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-rename-create-with-voice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Create with voice: Rename feature to Voice to content

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_2",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_3",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_4",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.2-a.2
+ * Version: 13.2-a.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.2-a.2' );
+define( 'JETPACK__VERSION', '13.2-a.3' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.2-a.3
+ * Version: 13.2-a.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.2-a.3' );
+define( 'JETPACK__VERSION', '13.2-a.4' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.2.0-a.2",
+	"version": "13.2.0-a.3",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.2.0-a.3",
+	"version": "13.2.0-a.4",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,19 +293,12 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.2-a.1 - 2024-02-12
+### 13.2-a.3 - 2024-02-13
 #### Enhancements
-- Additional CSS: Use the correct plan name in the WordPress.com nudge.
-- Admin Bar: link Stats item to WordPress.com.
-- Blog Stats Block: allow displaying site's number of visitors.
-- Change editor layout for social notes
-- Remove Support link from Jetpack on plugins page
-- Remove the My Mailboxes menu from the classic view
+- Blaze: remove "Promote with Blaze" links appearing in the Posts list when the Blaze feature is enabled. You can still go to Tools > Advertising to create and manage Blaze campaigns on your site.
 
 #### Bug fixes
-- Don't include Dash cards on Admin UI if module is not available, which fixes positioning.
-- Small adjustments to default Sharing Buttons styles
-- WooCommerce Analytics: avoid error when trying to pay for a deleted product.
+- Disable scroll to top when memberships subscribe popup is opened.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.20 - 2024-02-13
+### Changed
+- Updated package dependencies. [#35591]
+
 ## 2.0.19 - 2024-02-12
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_20_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_20"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.20-alpha
+ * Version: 2.0.20
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.20-alpha",
+	"version": "2.0.20",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.20, jetpack 13.2-a.3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.