### PR TITLE
WAF: Update "within" operator to be case sensitive.

### DIFF
--- a/projects/packages/waf/changelog/add-waf-case-sensitive-within
+++ b/projects/packages/waf/changelog/add-waf-case-sensitive-within
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update firewall "within" operator to be case sensitive.
+
+

--- a/projects/packages/waf/src/class-waf-operators.php
+++ b/projects/packages/waf/src/class-waf-operators.php
@@ -279,7 +279,7 @@ class Waf_Operators {
 			return false;
 		}
 
-		return stripos( $test, $input ) !== false
+		return strpos( $test, $input ) !== false
 		? $input
 		: false;
 	}

--- a/projects/packages/waf/tests/php/unit/test-waf-operators.php
+++ b/projects/packages/waf/tests/php/unit/test-waf-operators.php
@@ -524,6 +524,9 @@ final class WafOperatorsTest extends PHPUnit\Framework\TestCase {
 			'ghij',
 			'abcdefghi',
 			false,
+			'ABC',
+			'abcdefghi',
+			false,
 		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-scan-team/issues/503

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `strpos` instead of `stripos` in the `Waf_Operators::within()` method.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p2-pbuNQi-2VB

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run automated tests: `jetpack test packages/waf php`
* Smoke test the WAF on a JN site.

