### PR TITLE
Boost: Cache UI tweaks - follow up of #35568

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/main/variables.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/variables.scss
@@ -41,6 +41,7 @@ $jetpack_green_100: #001c09;
 
 $red_50: #d63638;
 $orange_20: #faa754;
+$yellow_20: #DEB100;
 $jetpack_green: $jetpack_green_50;
 
 $padding: 48px;
@@ -84,4 +85,5 @@ $spacing-unit: 8px;
 	--jetpack-green-80: #{$jetpack_green_80};
 	--jetpack-green-90: #{$jetpack_green_90};
 	--jetpack-green-100: #{$jetpack_green_100};
+	--jp-yellow-20: #{$yellow_20};
 }

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/health/health.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/health/health.module.scss
@@ -1,3 +1,3 @@
-.underline {
-	text-decoration: underline;
+.nowrap {
+	white-space: nowrap;
 }

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/health/health.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/health/health.tsx
@@ -1,6 +1,7 @@
 import { Button, Notice } from '@automattic/jetpack-components';
 import { usePageCacheErrorDS, useRunPageCacheSetupAction } from '$lib/stores/page-cache';
 import getErrorData from './lib/get-error-data';
+import { __ } from '@wordpress/i18n';
 
 const Health = () => {
 	const pageCacheError = usePageCacheErrorDS();
@@ -17,14 +18,18 @@ const Health = () => {
 		const errorData = getErrorData( errorCode );
 		if ( errorData ) {
 			return (
-				<>
-					<Notice level="warning" hideCloseButton={ true } title={ errorData.title }>
-						{ errorData.message }
-					</Notice>
-					<Button size="small" weight="regular" onClick={ requestRunSetup }>
-						I`ve fixed the errors, run setup again.
-					</Button>
-				</>
+				<Notice
+					level="warning"
+					hideCloseButton={ true }
+					title={ errorData.title }
+					actions={ [
+						<Button size="small" weight="regular" onClick={ requestRunSetup } key="try-again">
+							{ __( 'Try again', 'jetpack-boost' ) }
+						</Button>,
+					] }
+				>
+					<p>{ errorData.message }</p>
+				</Notice>
 			);
 		}
 	}

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/health/lib/get-error-data.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/health/lib/get-error-data.tsx
@@ -6,34 +6,75 @@ const cacheIssuesLink = 'TBD'; // @todo - add proper link here.
 
 const messages: { [ key: string ]: { title: string; message: React.ReactNode } } = {
 	'wp-content-not-writable': {
-		title: 'wp-content-not-writable',
-		message: 'wp-content-not-writable',
-	},
-	'advanced-cache-incompatible': {
-		title: 'advanced-cache-incompatible',
-		message: 'advanced-cache-incompatible',
-	},
-	'unable-to-write-advanced-cache': {
-		title: 'unable-to-write-advanced-cache',
-		message: 'unable-to-write-advanced-cache',
-	},
-	'wp-cache-defined-not-true': {
-		title: 'wp-cache-defined-not-true',
-		message: 'wp-cache-defined-not-true',
-	},
-	'feature-disabled-advanced-cache-incompatible': {
-		title: __( 'Cache loader script already exists', 'jetpack-boost' ),
+		title: 'wp-content not writable',
 		message: createInterpolateElement(
 			sprintf(
-				// translators: %d refers to the path of the cache loader script.
+				// translators: %s refers to wp-content.
 				__(
-					`This feature cannot be enabled because <underline>%s</underline> was found on your site. It was created by another plugin, or your hosting provider. Please remove it to use this module. <link>Learn more.</link>`,
+					`This feature cannot be enabled because <code>%s</code> is not writable. <link>Learn more.</link>`,
+					'jetpack-boost'
+				),
+				'wp-content'
+			),
+			{
+				code: <code className={ styles.nowrap } />,
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				link: <a href={ cacheIssuesLink } target="_blank" rel="noopener noreferrer" />,
+			}
+		),
+	},
+	'advanced-cache-incompatible': {
+		title: __( 'Cache loader file already exists', 'jetpack-boost' ),
+		message: createInterpolateElement(
+			sprintf(
+				// translators: %s refers to the path of the cache loader file.
+				__(
+					`This feature cannot be enabled because <code>%s</code> was found on your site. It was created by another plugin, or your hosting provider. Please remove it to use this module. <link>Learn more.</link>`,
 					'jetpack-boost'
 				),
 				'wp-content/advanced-cache.php'
 			),
 			{
-				underline: <span className={ styles.underline } />,
+				code: <code className={ styles.nowrap } />,
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				link: <a href={ cacheIssuesLink } target="_blank" rel="noopener noreferrer" />,
+			}
+		),
+	},
+	'unable-to-write-to-advanced-cache': {
+		title: __( 'Could not write to cache loader file', 'jetpack-boost' ),
+		message: createInterpolateElement(
+			sprintf(
+				// translators: %s refers to the path of the cache loader file.
+				__(
+					`This feature cannot be enabled because <code>%s</code> is not writable. <link>Learn more.</link>`,
+					'jetpack-boost'
+				),
+				'wp-content/advanced-cache.php'
+			),
+			{
+				code: <code className={ styles.nowrap } />,
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				link: <a href={ cacheIssuesLink } target="_blank" rel="noopener noreferrer" />,
+			}
+		),
+	},
+	'wp-cache-defined-not-true': {
+		title: __( 'Cache constant not set to true', 'jetpack-boost' ),
+		message: createInterpolateElement(
+			sprintf(
+				// translators: %1$s refers to the cache constant (WP_CACHE), %2$s refers to what it isn't set to (true), %3$s refers to what the value should be set to (true).
+				__(
+					`<code>%1$s</code> has already been defined, but is not set to <code>%2$s</code>. To use caching, it needs to be set to <code>%3$s</code>. <link>Learn more.</link>`,
+					'jetpack-boost'
+				),
+				'WP_CACHE',
+				'true',
+				'true',
+				'wp-content/advanced-cache.php'
+			),
+			{
+				code: <code className={ styles.nowrap } />,
 				// eslint-disable-next-line jsx-a11y/anchor-has-content
 				link: <a href={ cacheIssuesLink } target="_blank" rel="noopener noreferrer" />,
 			}
@@ -45,13 +86,13 @@ const messages: { [ key: string ]: { title: string; message: React.ReactNode } }
 			sprintf(
 				// translators: %d refers to the path of the cache directory.
 				__(
-					`This feature cannot be enabled because the cache directory (<underline>%s</underline>) is not writable. This needs to be resolved before caching can be enabled.`,
+					`This feature cannot be enabled because the cache directory (<code>%s</code>) is not writable. This needs to be resolved before caching can be enabled.`,
 					'jetpack-boost'
 				),
 				'wp-content/boost-cache'
 			),
 			{
-				underline: <span className={ styles.underline } />,
+				code: <code className={ styles.nowrap } />,
 			}
 		),
 	},
@@ -61,13 +102,13 @@ const messages: { [ key: string ]: { title: string; message: React.ReactNode } }
 			sprintf(
 				// translators: %d refers to the path of wp-config.php.
 				__(
-					`This feature cannot be enabled because <underline>%s</underline> is not writable. This needs to be resolved before caching can be enabled.`,
+					`This feature cannot be enabled because <code>%s</code> is not writable. This needs to be resolved before caching can be enabled.`,
 					'jetpack-boost'
 				),
 				'wp-config.php'
 			),
 			{
-				underline: <span className={ styles.underline } />,
+				code: <code className={ styles.nowrap } />,
 			}
 		),
 	},

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
@@ -1,4 +1,8 @@
-import { useDataSync, useDataSyncAction } from '@automattic/jetpack-react-data-sync-client';
+import {
+	invalidateQuery,
+	useDataSync,
+	useDataSyncAction,
+} from '@automattic/jetpack-react-data-sync-client';
 import { z } from 'zod';
 
 export const PageCacheError = z.string();
@@ -32,4 +36,10 @@ function usePageCacheErrorAction<
 			action_response: responseSchema,
 		},
 	} );
+}
+
+// When page cache is enabled, page cache error needs to be invalidated,
+// so we can get the updated error message from the last setup run.
+export function invalidatePageCacheError() {
+	invalidateQuery( 'page_cache_error' );
 }

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -16,7 +16,7 @@ import { useRegenerateCriticalCssAction } from '$features/critical-css/lib/store
 import PremiumTooltip from '$features/premium-tooltip/premium-tooltip';
 import Upgraded from '$features/ui/upgraded/upgraded';
 import PageCacheHealth from '$features/page-cache/health/health';
-import { invalidateQuery } from '@automattic/jetpack-react-data-sync-client';
+import { invalidatePageCacheError } from '$lib/stores/page-cache';
 
 const Index = () => {
 	const criticalCssLink = getRedirectUrl( 'jetpack-boost-critical-css' );
@@ -32,12 +32,6 @@ const Index = () => {
 	const { canResizeImages } = Jetpack_Boost;
 
 	const premiumFeatures = usePremiumFeatures();
-
-	// When page cache is enabled, page cache error needs to be invalidated,
-	// so we can get the updated error message from the last setup run.
-	const invalidatePageCacheError = () => {
-		invalidateQuery( 'page_cache_error' );
-	};
 
 	return (
 		<div className="jb-container--narrow">

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -80,7 +80,7 @@ require_once( \'' . $boost_cache_filename . '\');
 
 		$write_advanced_cache = Boost_Cache_Utils::write_to_file( $advanced_cache_filename, $contents );
 		if ( is_wp_error( $write_advanced_cache ) ) {
-			return new \WP_Error( 'unable-to-write-advanced-cache', $write_advanced_cache->get_error_message() );
+			return new \WP_Error( 'unable-to-write-to-advanced-cache', $write_advanced_cache->get_error_message() );
 		}
 
 		return true;

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -10,7 +10,7 @@ class Page_Cache_Setup {
 	 */
 	public static function run_setup() {
 		$steps = array(
-			'is_wp_content_writable',
+			'verify_wp_content_writable',
 			'create_advanced_cache',
 			'add_wp_cache_define',
 		);
@@ -32,7 +32,7 @@ class Page_Cache_Setup {
 	/**
 	 * Returns true if the wp-content directory is writeable.
 	 */
-	private static function is_wp_content_writable() {
+	private static function verify_wp_content_writable() {
 		$filename = WP_CONTENT_DIR . '/' . uniqid() . '.txt';
 		$result   = file_put_contents( $filename, 'test' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		wp_delete_file( $filename );

--- a/projects/plugins/boost/changelog/update-cache-ui-tweaks
+++ b/projects/plugins/boost/changelog/update-cache-ui-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add content for setup errors. Update button layout in error notice.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35626.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add content for setup errors (screenshots for all below);
* Update error notice color (still doesn't match designs, but that's because the current RNA component is outdated - https://github.com/Automattic/jetpack/issues/35676);
* Update retry button text and position. Decided to make it a small button, as it stands out more than a link, which might be next to the "learn more" link in some cases;
* Replace underline with a `<code />`, to put more emphasis on the important aspects of the message and to avoid misleading users into thinking those are links.

## Error messages:

I'm not a 100% sure what the content for the error messages should be. Here's a complete list and what they look like:

<details><summary>wp-content directory is not writable</summary>

![CleanShot 2024-02-14 at 15 11 30](https://github.com/Automattic/jetpack/assets/11799079/27511d82-562f-41a7-916e-914b007eb6fb)

</details>

<details><summary>there's already a advanced-cache.php file</summary>

![image](https://github.com/Automattic/jetpack/assets/11799079/7921ea80-8685-4dbb-a2e9-e120b06f2443)

</details>

<details><summary>unable to write to advanced-cache.php file</summary>

![CleanShot 2024-02-14 at 15 12 55](https://github.com/Automattic/jetpack/assets/11799079/ea94583e-ada2-4951-af9a-dc460b9294b4)

</details>

<details><summary>WP_CACHE exists, but is not set to "true"</summary>

![CleanShot 2024-02-14 at 15 13 27](https://github.com/Automattic/jetpack/assets/11799079/a3b14ba8-1fa6-4666-b40e-f417aa92980a)

</details>

<details><summary>boost cache is not writable (not used atm)</summary>

![CleanShot 2024-02-14 at 15 14 11](https://github.com/Automattic/jetpack/assets/11799079/b3a32c69-ab6a-41c8-adb3-c6dc196bcb94)

</details>

<details><summary>wp-config.php is not writable</summary>

![CleanShot 2024-02-14 at 15 14 45](https://github.com/Automattic/jetpack/assets/11799079/b59f1be5-12ba-4be6-98a4-5d28a1eec2ed)

</details>

<details><summary>unknown error (shouldn't happen, but we have it just in case)</summary>

![image](https://github.com/Automattic/jetpack/assets/11799079/79b9e82f-1b70-44d2-9152-f5278466a444)

</details>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-2rA-p2

https://github.com/Automattic/jetpack/pull/35568

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the setup to see the various notices. Easiest way to do this, is to check the [list of error codes](https://github.com/Automattic/jetpack/blob/update/boost/cache-ui-tweaks/projects/plugins/boost/app/assets/src/js/features/page-cache/health/lib/get-error-data.tsx#L8) we have and update the option `jetpack_boost_ds_page_cache_error`.