### PR TITLE
SSO: Update users table sso background colors

### DIFF
--- a/projects/plugins/jetpack/changelog/update-users-table-sso-background-colors
+++ b/projects/plugins/jetpack/changelog/update-users-table-sso-background-colors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update users table ssorow background colors

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -569,10 +569,10 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 			?>
 		<style>
 			#the-list tr:has(.sso-disconnected-user) {
-				background: #F5E6B3;
+				background: #F5F1E1;
 			}
 			#the-list tr:has(.sso-pending-invite) {
-				background: #ccedef;
+				background: #E9F0F5;
 			}
 			.fixed .column-user_jetpack {
 				width: 100px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update `pending invite` and disconnected user rows' background color:
Pending Invite: yellow-5 -> yellow-0
Disconnected: blue-5 -> blue-0

<img width="993" alt="CleanShot 2024-02-14 at 10 24 55@2x" src="https://github.com/Automattic/jetpack/assets/10482592/bd526f3c-03ff-4cdd-9c49-63014c2cb85b">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout branch and rsync to atomic site.
* Navigate to `/wp-admin/users.php` and verify the row background colors.

