### PR TITLE
Social: OG tags causing issues with old posts

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-og-tags-string-issue
+++ b/projects/packages/publicize/changelog/fix-social-og-tags-string-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue where on old sites og:image is an array that causes issues

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.1",
+	"version": "0.42.2-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1622,7 +1622,12 @@ abstract class Publicize_Base {
 	 */
 	public function get_remote_filesize( $image_url ) {
 		$response = wp_remote_get( $image_url, array( 'method' => 'HEAD' ) );
-		$size     = wp_remote_retrieve_header( $response, 'content-length' );
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$size = wp_remote_retrieve_header( $response, 'content-length' );
 
 		return ! empty( $size ) ? $size : null;
 	}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1726,7 +1726,7 @@ abstract class Publicize_Base {
 			$tags = $this->add_jetpack_social_og_image( $tags, $social_opengraph_image );
 		}
 
-		if ( empty( $tags['og:image'] ) || empty( $tags['og:image:width'] ) || empty( $tags['og:image:height'] ) ) {
+		if ( empty( $tags['og:image'] ) || ! is_string( $tags['og:image'] ) || empty( $tags['og:image:width'] ) || empty( $tags['og:image:height'] ) ) {
 			return $tags;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35038

Back before 2015 `og:image` could have been an array. Right now this causes issues with the new optimization logic we have

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed so we only optimize if `og:image` is a string

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1707922750914239-slack-C01U2KGS2PQ
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have Jetpack Social enabled on your site, and add `$tags['og:image'] = array( $tags['og:image'], $tags['og:image']);` to the start of `jetpack_social_open_graph_filter` function. On trunk this should cause the issue reported in the slack thread, while with this change it the post should load fine
`
*