### PR TITLE
CRM: Resolves 3426 - PHP fatal if WooSync order is deleted

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3426-fatal_if_deleted_order
+++ b/projects/plugins/crm/changelog/fix-crm-3426-fatal_if_deleted_order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Client Portal: Catch error if Woo order associated with invoice is deleted.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3426 - PHP fatal if WooSync order is deleted

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If one visits the Client Portal for an invoice whose original Woo order has been deleted, they'll get an error. This PR catches that case, and restructures the code around it a bit.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure WooSync is set to create invoices, and changes invoice statuses to "Deleted" if the order is deleted.
2. Create an order, then delete it completely (empty trash).
3. Go to the invoice and preview it in Client Portal.

In `trunk`, one gets a PHP fatal.

In the `fix/crm/3426-fatal_if_deleted_order` branch, one gets an admin notice if logged in with Invoice permissions; otherwise the section "Pay Now" is blank.