### PR TITLE
jetpack-mu-wpcom: Add new WordPRess.com site menu

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-site-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-site-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+jetpack-mu-wpcom: Added the wpcom-site-menu feature to add a WordPress.com sidebar menu item.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.12.2",
+	"version": "5.12.3-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -76,6 +76,8 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/media/heif-support.php';
 
 		require_once __DIR__ . '/features/block-patterns/block-patterns.php';
+
+		require_once __DIR__ . '/features/wpcom-site-menu/wpcom-site-menu.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.12.2';
+	const PACKAGE_VERSION = '5.12.3-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * WordPress.com Site Menu
+ *
+ * Add's a WordPress.com menu item to the admin menu linking back to the sites WordPress.com home page.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Add a WordPress.com menu item to the wp-admin sidebar menu.
+ */
+function wpcom_add_wpcom_menu_item() {
+	if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
+		add_menu_page(
+			esc_attr__( 'WordPress.com', 'jetpack-mu-wpcom' ),
+			esc_attr__( 'WordPress.com', 'jetpack-mu-wpcom' ),
+			'manage_options',
+			"https://wordpress.com/home/$domain",
+			null,
+			'dashicons-arrow-left-alt2',
+			0
+		);
+
+		// Position a separator below the WordPress.com menu item.
+		// Inspired by https://github.com/Automattic/jetpack/blob/b6b6e86c5491869782857141ca48168dfa195635/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php#L239
+		global $menu;
+		$separator = array(
+			'',                                  // Menu title (ignored).
+			'manage_options',                    // Required capability.
+			wp_unique_id( 'separator-custom-' ), // URL or file (ignored, but must be unique).
+			'',                                  // Page title (ignored).
+			'wp-menu-separator',                 // CSS class. Identifies this item as a separator.
+		);
+		$position  = 0;
+		if ( isset( $menu[ "$position" ] ) ) {
+			$position            = $position + substr( base_convert( md5( $separator[2] . $separator[0] ), 16, 10 ), -5 ) * 0.00001;
+			$menu[ "$position" ] = $separator; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} else {
+			$menu[ "$position" ] = $separator; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+	}
+}
+add_action( 'admin_menu', 'wpcom_add_wpcom_menu_item' );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5567

## Proposed changes:

Part of the untangling calypso project fsHM7-p2

This PR adds a WordPress.com/home/:site link to the sidebar menu when the nav redesign is enabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/dotcom-forge/issues/5567

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Atomic testing:
* Using a woa dev blog
* Ensure wpcomsh is updated as this requires the feature flag function recently merged: https://github.com/Automattic/wpcomsh/pull/1681/
* Enable wp-admin classic view interface option under the hosting configuration settings page.
* jetpack rsync the wpcom mu plugin (ping for details if this is new to you)
* While proxied:
  * The new wordpress.com link should be shown, and it should point to wordpress.com/home/:sitedomain
* While not proxied:
  * There should be no link shown and nav unification should be present.
* Repeat with / without classic view enabled. It should only show when classic view is enabled and we're behind the proxy.

Simple site testing:
* Sync the mu-wpcom plugin to a sandboxed site
* The new menu item should not be present on wpcom or wp-admin for that site.
Before

![Screenshot(119)](https://github.com/Automattic/jetpack/assets/811776/ab406208-0b5c-4fd4-a78e-8ad07faaebd7)

After

![Screenshot(118)](https://github.com/Automattic/jetpack/assets/811776/8e96e434-3a97-4948-a29d-cf0008f7c0d4)