### PR TITLE
Odyssey Stats: Add API support for Email Stats

### DIFF
--- a/projects/packages/stats-admin/changelog/update-enable-email-stats-for-odyssey
+++ b/projects/packages/stats-admin/changelog/update-enable-email-stats-for-odyssey
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: added support for Email stats

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -52,7 +52,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.15.x-dev"
+			"dev-trunk": "0.16.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.15.3",
+	"version": "0.16.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.15.3';
+	const VERSION = '0.16.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -323,6 +323,17 @@ class REST_Controller {
 				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
+
+		// Get dashboard module settings.
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/stats/emails/(?P<resource>[\-\w]+)', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_email_stats' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+			)
+		);
 	}
 
 	/**
@@ -666,6 +677,32 @@ class REST_Controller {
 			'v1.1',
 			array( 'timeout' => 5 )
 		);
+	}
+
+	/**
+	 * Get Email stats as a list.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function get_email_stats( $req ) {
+		switch ( $req->get_param( 'resource' ) ) {
+			case 'summary':
+				return WPCOM_Client::request_as_blog_cached(
+					sprintf(
+						'/sites/%d/stats/emails/%s?%s',
+						Jetpack_Options::get_option( 'id' ),
+						$req->get_param( 'resource' ),
+						$this->filter_and_build_query_string(
+							$req->get_params()
+						)
+					),
+					'v1.1',
+					array( 'timeout' => 5 )
+				);
+			default:
+				return $this->get_forbidden_error();
+		}
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -937,8 +937,7 @@ class REST_Controller {
 			),
 			null,
 			'wpcom',
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			! isset( $_GET['force_refresh'] ) && ! isset( $_GET['statsPurchaseSuccess'] ),
+			true,
 			static::JETPACK_STATS_DASHBOARD_MODULES_CACHE_KEY
 		);
 	}
@@ -992,8 +991,7 @@ class REST_Controller {
 			),
 			null,
 			'wpcom',
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			! isset( $_GET['force_refresh'] ) && ! isset( $_GET['statsPurchaseSuccess'] ),
+			true,
 			static::JETPACK_STATS_DASHBOARD_MODULE_SETTINGS_CACHE_KEY
 		);
 	}

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -335,6 +335,7 @@ class REST_Controller {
 			)
 		);
 
+		// Get Email opens stats for a single post.
 		register_rest_route(
 			static::$namespace,
 			sprintf( '/sites/%d/stats/opens/emails/(?P<post_id>[\d]+)/(?P<resource>[\-\w]+)', Jetpack_Options::get_option( 'id' ) ),
@@ -345,6 +346,7 @@ class REST_Controller {
 			)
 		);
 
+		// Get Email clicks stats for a single post.
 		register_rest_route(
 			static::$namespace,
 			sprintf( '/sites/%d/stats/clicks/emails/(?P<post_id>[\d]+)/(?P<resource>[\-\w]+)', Jetpack_Options::get_option( 'id' ) ),
@@ -355,6 +357,7 @@ class REST_Controller {
 			)
 		);
 
+		// Get Email stats time series.
 		register_rest_route(
 			static::$namespace,
 			sprintf( '/sites/%d/stats/(?P<resource>[\-\w]+)/emails/(?P<post_id>[\d]+)', Jetpack_Options::get_option( 'id' ) ),
@@ -764,7 +767,7 @@ class REST_Controller {
 	}
 
 	/**
-	 * Get Email opens stats for a single post.
+	 * Get Email clicks stats for a single post.
 	 *
 	 * @param WP_REST_Request $req The request object.
 	 * @return array

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -641,9 +641,7 @@ class REST_Controller {
 			'v2',
 			array( 'timeout' => 5 ),
 			null,
-			'wpcom',
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			! isset( $_GET['force_refresh'] ) && ! isset( $_GET['statsPurchaseSuccess'] )
+			'wpcom'
 		);
 	}
 

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -324,13 +324,43 @@ class REST_Controller {
 			)
 		);
 
-		// Get dashboard module settings.
+		// Get email stats as a list.
 		register_rest_route(
 			static::$namespace,
-			sprintf( '/sites/%d/stats/emails/(?P<resource>[\-\w]+)', Jetpack_Options::get_option( 'id' ) ),
+			sprintf( '/sites/%d/stats/emails/(?P<resource>[\-\w\d]+)', Jetpack_Options::get_option( 'id' ) ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_email_stats' ),
+				'callback'            => array( $this, 'get_email_stats_list' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+			)
+		);
+
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/stats/opens/emails/(?P<post_id>[\d]+)/(?P<resource>[\-\w]+)', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_email_opens_stats_single' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+			)
+		);
+
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/stats/clicks/emails/(?P<post_id>[\d]+)/(?P<resource>[\-\w]+)', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_email_clicks_stats_single' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+			)
+		);
+
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/stats/(?P<resource>[\-\w]+)/emails/(?P<post_id>[\d]+)', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_email_stats_time_series' ),
 				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
@@ -685,7 +715,7 @@ class REST_Controller {
 	 * @param WP_REST_Request $req The request object.
 	 * @return array
 	 */
-	public function get_email_stats( $req ) {
+	public function get_email_stats_list( $req ) {
 		switch ( $req->get_param( 'resource' ) ) {
 			case 'summary':
 				return WPCOM_Client::request_as_blog_cached(
@@ -693,6 +723,96 @@ class REST_Controller {
 						'/sites/%d/stats/emails/%s?%s',
 						Jetpack_Options::get_option( 'id' ),
 						$req->get_param( 'resource' ),
+						$this->filter_and_build_query_string(
+							$req->get_params()
+						)
+					),
+					'v1.1',
+					array( 'timeout' => 5 )
+				);
+			default:
+				return $this->get_forbidden_error();
+		}
+	}
+
+	/**
+	 * Get Email opens stats for a single post.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function get_email_opens_stats_single( $req ) {
+		switch ( $req->get_param( 'resource' ) ) {
+			case 'client':
+			case 'device':
+			case 'country':
+			case 'rate':
+				return WPCOM_Client::request_as_blog_cached(
+					sprintf(
+						'/sites/%d/stats/opens/emails/%d/%s?%s',
+						Jetpack_Options::get_option( 'id' ),
+						$req->get_param( 'post_id' ),
+						$req->get_param( 'resource' ),
+						$this->filter_and_build_query_string(
+							$req->get_params()
+						)
+					),
+					'v1.1',
+					array( 'timeout' => 5 )
+				);
+			default:
+				return $this->get_forbidden_error();
+		}
+	}
+
+	/**
+	 * Get Email opens stats for a single post.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function get_email_clicks_stats_single( $req ) {
+		switch ( $req->get_param( 'resource' ) ) {
+			case 'client':
+			case 'device':
+			case 'country':
+			case 'rate':
+			case 'link':
+			case 'user-content-link':
+				return WPCOM_Client::request_as_blog_cached(
+					sprintf(
+						'/sites/%d/stats/clicks/emails/%d/%s?%s',
+						Jetpack_Options::get_option( 'id' ),
+						$req->get_param( 'post_id' ),
+						$req->get_param( 'resource' ),
+						$this->filter_and_build_query_string(
+							$req->get_params()
+						)
+					),
+					'v1.1',
+					array( 'timeout' => 5 )
+				);
+			default:
+				return $this->get_forbidden_error();
+		}
+	}
+
+	/**
+	 * Get Email stats time series.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function get_email_stats_time_series( $req ) {
+		switch ( $req->get_param( 'resource' ) ) {
+			case 'opens':
+			case 'clicks':
+				return WPCOM_Client::request_as_blog_cached(
+					sprintf(
+						'/sites/%d/stats/%s/emails/%d?%s',
+						Jetpack_Options::get_option( 'id' ),
+						$req->get_param( 'resource' ),
+						$req->get_param( 'post_id' ),
 						$this->filter_and_build_query_string(
 							$req->get_params()
 						)

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -600,7 +600,9 @@ class REST_Controller {
 			'v2',
 			array( 'timeout' => 5 ),
 			null,
-			'wpcom'
+			'wpcom',
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			! isset( $_GET['force_refresh'] ) && ! isset( $_GET['statsPurchaseSuccess'] )
 		);
 	}
 
@@ -780,7 +782,8 @@ class REST_Controller {
 			),
 			null,
 			'wpcom',
-			true,
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			! isset( $_GET['force_refresh'] ) && ! isset( $_GET['statsPurchaseSuccess'] ),
 			static::JETPACK_STATS_DASHBOARD_MODULES_CACHE_KEY
 		);
 	}
@@ -834,7 +837,8 @@ class REST_Controller {
 			),
 			null,
 			'wpcom',
-			true,
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			! isset( $_GET['force_refresh'] ) && ! isset( $_GET['statsPurchaseSuccess'] ),
 			static::JETPACK_STATS_DASHBOARD_MODULE_SETTINGS_CACHE_KEY
 		);
 	}

--- a/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey
+++ b/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add support for Email stats

--- a/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey
+++ b/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix a undefined key warning

--- a/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey
+++ b/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix a undefined key warning

--- a/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey#2
+++ b/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey#2
+++ b/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2333,7 +2333,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/stats-admin",
-				"reference": "f2d897fbcde16661701f7bfb4c78a34660cc731d"
+				"reference": "79533974543122e5051069845596cf08c15ad021"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2357,7 +2357,7 @@
 				"autotagger": true,
 				"mirror-repo": "Automattic/jetpack-stats-admin",
 				"branch-alias": {
-					"dev-trunk": "0.15.x-dev"
+					"dev-trunk": "0.16.x-dev"
 				},
 				"textdomain": "jetpack-stats-admin",
 				"version-constants": {


### PR DESCRIPTION
Fixes #35668

## Proposed changes:

Added Click and Open stats API for Emails.

We are having more and more routes, so it might be a good idea to group them into different files for clarity in the future.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Follow the instructions at https://github.com/Automattic/wp-calypso/pull/87442

