### PR TITLE
Blog Privacy [jetpack-mu-wpcom]: Add AI User Agents to robots.txt depending on blog setting

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-mu-wpcom-ai-robots-txt-blocks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-mu-wpcom-ai-robots-txt-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blog Privacy: Add AI User Agents to robots.txt depending on blog setting.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -50,7 +50,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.12.x-dev"
+			"dev-trunk": "5.13.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.12.3-alpha",
+	"version": "5.13.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -78,6 +78,8 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/block-patterns/block-patterns.php';
 
 		require_once __DIR__ . '/features/wpcom-site-menu/wpcom-site-menu.php';
+
+		require_once __DIR__ . '/features/blog-privacy/blog-privacy.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.12.3-alpha';
+	const PACKAGE_VERSION = '5.13.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Blog Privacy Settings
+ *
+ * Controls for Blog Privacy are spread out over several different places.
+ * * WordPress Core (all sites: `blog_privacy_selector`, `blog_public`)
+ * * wpcomsh (WoA: Private Site feature)
+ * * WP.com (simple: `blog_public`)
+ * * This jetpack-mu-wpcom feature (WoA, simple: robots.text user agent blocks)
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Blog_Privacy;
+
+/**
+ * Filters the robots.txt contents based on the value of the wpcom_data_sharing_opt_out option.
+ *
+ * @param string     $output The contents of robots.txt.
+ * @param int|string $public The value of the blog_public option.
+ * @return string
+ */
+function robots_txt( string $output, $public ): string {
+	// If the site is completely private, don't bother with the additional restrictions.
+	if ( -1 === (int) $public ) {
+		return $output;
+	}
+
+	// An option oddly named because of history.
+	if ( get_option( 'wpcom_data_sharing_opt_out' ) ) {
+		$ai_bots = array(
+			'CCBot',
+			'SentiBot',
+			'sentibot',
+			'Google-Extended',
+			'FacebookBot',
+			'omgili',
+			'omgilibot',
+			'Amazonbot',
+			'Bingbot',
+		);
+
+		foreach ( $ai_bots as $ai_bot ) {
+			$output .= "\nUser-agent: {$ai_bot}\n";
+			$output .= "Disallow: /\n";
+		}
+	}
+
+	return $output;
+}
+
+add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 20, 2 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -31,15 +31,15 @@ function robots_txt( string $output, $public ): string {
 	// An option oddly named because of history.
 	if ( get_option( 'wpcom_data_sharing_opt_out' ) ) {
 		$ai_bots = array(
+			'Amazonbot',
 			'CCBot',
-			'SentiBot',
-			'sentibot',
-			'Google-Extended',
 			'FacebookBot',
+			'Google-Extended',
+			'GPTBot',
 			'omgili',
 			'omgilibot',
-			'Amazonbot',
-			'Bingbot',
+			'SentiBot',
+			'sentibot',
 		);
 
 		foreach ( $ai_bots as $ai_bot ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -23,13 +23,15 @@ namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Blog_Privacy;
  * @return string
  */
 function robots_txt( string $output, $public ): string {
+	$public = (int) $public;
+
 	// If the site is completely private, don't bother with the additional restrictions.
-	if ( -1 === (int) $public ) {
+	if ( -1 === $public ) {
 		return $output;
 	}
 
 	// An option oddly named because of history.
-	if ( get_option( 'wpcom_data_sharing_opt_out' ) ) {
+	if ( 0 === $public || get_option( 'wpcom_data_sharing_opt_out' ) ) {
 		$ai_bots = array(
 			'Amazonbot',
 			'CCBot',

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -6,7 +6,7 @@
  * * WordPress Core (all sites: `blog_privacy_selector`, `blog_public`)
  * * wpcomsh (WoA: Private Site feature)
  * * WP.com (simple: `blog_public`)
- * * This jetpack-mu-wpcom feature (WoA, simple: robots.text user agent blocks)
+ * * This jetpack-mu-wpcom feature (WoA, simple: `wpcom_data_sharing_opt_out` robots.txt user agent blocks)
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -25,13 +25,13 @@ namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Blog_Privacy;
 function robots_txt( string $output, $public ): string {
 	$public = (int) $public;
 
-	// If the site is completely private, don't bother with the additional restrictions.
-	if ( -1 === $public ) {
+	// If the site is completely private or already discouraging *all* bots, don't bother with the additional restrictions.
+	if ( -1 === $public || 0 === $public ) {
 		return $output;
 	}
 
 	// An option oddly named because of history.
-	if ( 0 === $public || get_option( 'wpcom_data_sharing_opt_out' ) ) {
+	if ( get_option( 'wpcom_data_sharing_opt_out' ) ) {
 		$ai_bots = array(
 			'Amazonbot',
 			'CCBot',

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -53,4 +53,4 @@ function robots_txt( string $output, $public ): string {
 	return $output;
 }
 
-add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 20, 2 );
+add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 12, 2 );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Blog Privacy Tests
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Blog_Privacy;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/blog-privacy/blog-privacy.php';
+
+/**
+ * Tests for the functions defined in the Blog Privacy feature.
+ */
+class Blog_Privacy_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Post-test suite actions.
+	 */
+	public static function tear_down_after_class() {
+		\delete_option( 'wpcom_data_sharing_opt_out' );
+	}
+
+	/**
+	 * Data provider for ->test_robots_txt().
+	 *
+	 * @return \Iterator
+	 */
+	public function provide_robots_txt(): \Iterator {
+		$ai_blocks = <<<AI_BLOCKS
+User-agent: CCBot
+Disallow: /
+
+User-agent: SentiBot
+Disallow: /
+
+User-agent: sentibot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+User-agent: omgilibot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Bingbot
+Disallow: /
+
+AI_BLOCKS;
+
+		yield 'public, no discourage AI' => array(
+			'blog_public'                => '1',
+			'wpcom_data_sharing_opt_out' => null,
+			'expected'                   => 'TEST',
+		);
+
+		yield 'public, discourage AI' => array(
+			'blog_public'                => '1',
+			'wpcom_data_sharing_opt_out' => '1',
+			'expected'                   => "TEST\n$ai_blocks",
+		);
+
+		yield 'discourage search, no discourage AI' => array(
+			'blog_public'                => '0',
+			'wpcom_data_sharing_opt_out' => null,
+			'expected'                   => 'TEST',
+		);
+
+		yield 'discourage search, discourage AI' => array(
+			'blog_public'                => '0',
+			'wpcom_data_sharing_opt_out' => '1',
+			'expected'                   => "TEST\n$ai_blocks",
+		);
+
+		yield 'private, no discourage AI' => array(
+			'blog_public'                => '-1',
+			'wpcom_data_sharing_opt_out' => null,
+			'expected'                   => 'TEST',
+		);
+
+		yield 'private, discourage AI' => array(
+			'blog_public'                => '-1',
+			'wpcom_data_sharing_opt_out' => '1',
+			'expected'                   => 'TEST', // Private overrides wpcom_data_sharing_opt_out setting.
+		);
+	}
+
+	/**
+	 * Test for robots_txt hook.
+	 */
+	public function test_robots_txt_is_hooked() {
+		$this->assertSame( 20, \has_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt' ) );
+	}
+
+	/**
+	 * Tests for robots_txt().
+	 *
+	 * @dataProvider provide_robots_txt
+	 * @param mixed      $blog_public The value of the blog_public option.
+	 * @param mixed|null $wpcom_data_sharing_opt_out The value of the wpcom_data_sharing_opt_out option (null if the option is not set).
+	 * @param string     $expected The expected output for robots.txt.
+	 */
+	public function test_robots_txt( $blog_public, $wpcom_data_sharing_opt_out, string $expected ) {
+		if ( null === $wpcom_data_sharing_opt_out ) {
+			\delete_option( 'wpcom_data_sharing_opt_out' );
+		} else {
+			\update_option( 'wpcom_data_sharing_opt_out', $wpcom_data_sharing_opt_out );
+		}
+
+		$this->assertSame( $expected, robots_txt( 'TEST', $blog_public ) );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
@@ -31,19 +31,19 @@ class Blog_Privacy_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function provide_robots_txt(): \Iterator {
 		$ai_blocks = <<<AI_BLOCKS
+User-agent: Amazonbot
+Disallow: /
+
 User-agent: CCBot
 Disallow: /
 
-User-agent: SentiBot
-Disallow: /
-
-User-agent: sentibot
+User-agent: FacebookBot
 Disallow: /
 
 User-agent: Google-Extended
 Disallow: /
 
-User-agent: FacebookBot
+User-agent: GPTBot
 Disallow: /
 
 User-agent: omgili
@@ -52,10 +52,10 @@ Disallow: /
 User-agent: omgilibot
 Disallow: /
 
-User-agent: Amazonbot
+User-agent: SentiBot
 Disallow: /
 
-User-agent: Bingbot
+User-agent: sentibot
 Disallow: /
 
 AI_BLOCKS;

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
@@ -75,7 +75,7 @@ AI_BLOCKS;
 		yield 'discourage search, no discourage AI' => array(
 			'blog_public'                => '0',
 			'wpcom_data_sharing_opt_out' => null,
-			'expected'                   => 'TEST',
+			'expected'                   => "TEST\n$ai_blocks",
 		);
 
 		yield 'discourage search, discourage AI' => array(

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
@@ -101,7 +101,7 @@ AI_BLOCKS;
 	 * Test for robots_txt hook.
 	 */
 	public function test_robots_txt_is_hooked() {
-		$this->assertSame( 20, \has_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt' ) );
+		$this->assertSame( 12, \has_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt' ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
@@ -75,13 +75,13 @@ AI_BLOCKS;
 		yield 'discourage search, no discourage AI' => array(
 			'blog_public'                => '0',
 			'wpcom_data_sharing_opt_out' => null,
-			'expected'                   => "TEST\n$ai_blocks",
+			'expected'                   => 'TEST',
 		);
 
 		yield 'discourage search, discourage AI' => array(
 			'blog_public'                => '0',
 			'wpcom_data_sharing_opt_out' => '1',
-			'expected'                   => "TEST\n$ai_blocks",
+			'expected'                   => 'TEST', // We already discourage all user agents.
 		);
 
 		yield 'private, no discourage AI' => array(

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-mu-wpcom-ai-robots-txt-blocks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-mu-wpcom-ai-robots-txt-blocks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_21"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_22_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -129,7 +129,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "dae0cc7eec39d1aa18226cc4a392bf989e4ee2eb"
+                "reference": "af670fe1cc033703455e5ff5f2af8c1902f8e0ec"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -151,7 +151,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.12.x-dev"
+                    "dev-trunk": "5.13.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.21
+ * Version: 2.0.22-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.21",
+	"version": "2.0.22-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
## Proposed changes:
* Adds Disallow blocks to the sites's robots.txt based on the setting defined in #35509.

peGwbA-1tL-p2

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
On a WoA or Simple Site:
0. Set the site's `blog_public` option to `1` (public).
1. View the site's robots.txt.
2. Set the site's `wpcom_data_sharing_opt_out` option to `1`.
3. View the site's robots.txt. See the additional Disallow blocks.