### PR TITLE
Boost: fix loading the File_Storage.php code, and the cache path

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Boost_Cache.php
@@ -7,7 +7,7 @@ namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
  */
 require_once __DIR__ . '/Boost_Cache_Settings.php';
 require_once __DIR__ . '/Boost_Cache_Utils.php';
-require_once __DIR__ . '/Storage/File_Storage.php';
+require_once __DIR__ . '/storage/File_Storage.php';
 
 class Boost_Cache {
 	/*

--- a/projects/plugins/boost/app/modules/cache/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/storage/File_Storage.php
@@ -19,7 +19,7 @@ class File_Storage implements Storage {
 	private $root_path;
 
 	public function __construct( $root_path ) {
-		$this->root_path = WP_CONTENT_DIR . '/boost-cache/cache' . Boost_Cache_Utils::sanitize_file_path( Boost_Cache_Utils::trailingslashit( $root_path ) );
+		$this->root_path = WP_CONTENT_DIR . '/boost-cache/cache/' . Boost_Cache_Utils::sanitize_file_path( Boost_Cache_Utils::trailingslashit( $root_path ) );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/boost-cache-fix-storage-dir
+++ b/projects/plugins/boost/changelog/boost-cache-fix-storage-dir
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Boost: fixed the require_once that loads the Storage code as the directory became lowercase
+
+


### PR DESCRIPTION
The Storage directory had an uppercase S but was changed to s. This fixes loading the File_Storage.php code in there.
The root_path defined in File_Storage.php was missing a "/". This added that back in.

## Proposed changes:
* Fixed the require_once in Boost_Cache.php

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Apply this PR and make sure the Boost settings page loads.
Go into wp-content/boost-cache/ and make sure that your test site is in the cache directory.