### PR TITLE
JITMs: only enqueue resources on pages that need it

### DIFF
--- a/projects/packages/jitm/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/packages/jitm/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Performance: only enqueue the JITM JavaScript on pages where it will be used.

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -66,7 +66,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.0.x-dev"
+			"dev-trunk": "3.1.x-dev"
 		}
 	}
 }

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -131,10 +131,41 @@ class JITM {
 	}
 
 	/**
+	 * Check if the current page is a Jetpack or WooCommerce admin page.
+	 * Noting that this is a very basic check, and pages from other plugins may also match.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool True if the current page is a Jetpack or WooCommerce admin page, else false.
+	 */
+	public function is_a8c_admin_page() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		$current_screen = get_current_screen();
+
+		// We never want to show JITMs on the block editor.
+		if (
+			method_exists( $current_screen, 'is_block_editor' )
+			&& $current_screen->is_block_editor()
+		) {
+			return false;
+		}
+
+		return (
+			$current_screen
+			&& $current_screen->id
+			&& (bool) preg_match( '/jetpack|woo|shop|product/', $current_screen->id )
+		);
+	}
+
+	/**
 	 * Function to enqueue jitm css and js
 	 */
 	public function jitm_enqueue_files() {
-		if ( $this->is_gutenberg_page() ) {
+		// Only load those files on the Jetpack or Woo admin pages.
+		if ( ! $this->is_a8c_admin_page() ) {
 			return;
 		}
 
@@ -145,9 +176,9 @@ class JITM {
 			array(
 				'in_footer'    => true,
 				'dependencies' => array( 'jquery' ),
+				'enqueue'      => true,
 			)
 		);
-		Assets::enqueue_script( 'jetpack-jitm' );
 		wp_localize_script(
 			'jetpack-jitm',
 			'jitm_config',
@@ -167,8 +198,11 @@ class JITM {
 	 *
 	 * @since 1.1.0
 	 * @since-jetpack 8.0.0
+	 *
+	 * @deprecated $$next-version$$
 	 */
 	public function is_gutenberg_page() {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
 		$current_screen = get_current_screen();
 		return ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() );
 	}
@@ -192,8 +226,8 @@ class JITM {
 			return;
 		}
 
-		// do not display on Gutenberg pages.
-		if ( $this->is_gutenberg_page() ) {
+		// Only add this to Jetpack or Woo admin pages.
+		if ( ! $this->is_a8c_admin_page() ) {
 			return;
 		}
 

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.0.4';
+	const PACKAGE_VERSION = '3.1.0-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/plugins/backup/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/plugins/backup/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -941,7 +941,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "92515c635df727b2db5a0f25fa6c19ad132f30dc"
+                "reference": "c21ef5f64d44c453e7a7dddbe13202c41aecb942"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -973,7 +973,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.0.x-dev"
+                    "dev-trunk": "3.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/plugins/boost/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -866,7 +866,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "92515c635df727b2db5a0f25fa6c19ad132f30dc"
+                "reference": "c21ef5f64d44c453e7a7dddbe13202c41aecb942"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -898,7 +898,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.0.x-dev"
+                    "dev-trunk": "3.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/plugins/jetpack/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1500,7 +1500,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/jitm",
-				"reference": "92515c635df727b2db5a0f25fa6c19ad132f30dc"
+				"reference": "c21ef5f64d44c453e7a7dddbe13202c41aecb942"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1532,7 +1532,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "3.0.x-dev"
+					"dev-trunk": "3.1.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/migration/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/plugins/migration/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -941,7 +941,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "92515c635df727b2db5a0f25fa6c19ad132f30dc"
+                "reference": "c21ef5f64d44c453e7a7dddbe13202c41aecb942"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -973,7 +973,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.0.x-dev"
+                    "dev-trunk": "3.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/plugins/protect/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -854,7 +854,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "92515c635df727b2db5a0f25fa6c19ad132f30dc"
+                "reference": "c21ef5f64d44c453e7a7dddbe13202c41aecb942"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -886,7 +886,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.0.x-dev"
+                    "dev-trunk": "3.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/plugins/search/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -797,7 +797,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "92515c635df727b2db5a0f25fa6c19ad132f30dc"
+                "reference": "c21ef5f64d44c453e7a7dddbe13202c41aecb942"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -829,7 +829,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.0.x-dev"
+                    "dev-trunk": "3.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/plugins/social/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -797,7 +797,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/jitm",
-				"reference": "92515c635df727b2db5a0f25fa6c19ad132f30dc"
+				"reference": "c21ef5f64d44c453e7a7dddbe13202c41aecb942"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -829,7 +829,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "3.0.x-dev"
+					"dev-trunk": "3.1.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/starter-plugin/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/plugins/starter-plugin/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -797,7 +797,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "92515c635df727b2db5a0f25fa6c19ad132f30dc"
+                "reference": "c21ef5f64d44c453e7a7dddbe13202c41aecb942"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -829,7 +829,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.0.x-dev"
+                    "dev-trunk": "3.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/plugins/videopress/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -797,7 +797,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "92515c635df727b2db5a0f25fa6c19ad132f30dc"
+                "reference": "c21ef5f64d44c453e7a7dddbe13202c41aecb942"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -829,7 +829,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.0.x-dev"
+                    "dev-trunk": "3.1.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
> [!WARNING]
> Not proceeding with this as there are still pre-connection messages, displayed on specific sites, that need to be displayed on multiple non-jetpack page such as the post list, the media library, the widgets page.

## Proposed changes:

JITMs were built to be added on just about any page of the WordPress admin dashboard. We've since limited the number of pages where we display messages; we only display them on Jetpack admin pages and WooCommerce admin pages nowadays.

We can consequently start limiting the number of screens where we enqueue the necessary JavaScript and markup to display those messages. Let's limit them to Jetpack admin pages and Woo admin pages for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1HpG7-r5K-p2#comment-69845

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

You will need a site with both Jetpack and WooCommerce installed.

* Connect your site to WordPress.com.
* Go to the Products menu.
* You should see a JITM at the top of the page.
* No go to the main dashboard page.
* There, open your browser's network tools, and filter for js files including the string `jitm`.
* You should see no such files loaded on the page.
