### PR TITLE
Boost: add excluded URLs list and is_cacheable() to serve() function

### DIFF
--- a/projects/plugins/boost/changelog/boost-cache-add-excluded-urls
+++ b/projects/plugins/boost/changelog/boost-cache-add-excluded-urls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Boost: add an excluded URL list to container regex to exclude URLs to cache.


### PR DESCRIPTION
Add an excluded URLs list to the is_cacheable() check.

The list is an array that will be generated by the UI using a textarea. Each entry is a regex so it's quite flexible.
This PR also adds an is_cacheable() check to the serve() function. This will stop the plugin creating an output buffer when it will be discarded eventually.
I added the default 'wp-.*\.php' which can't be removed. That will match wp-comment-post.php or other files like that as well as any php files in wp-admin/.

Fixes [#35057](https://github.com/Automattic/jetpack/issues/35057)

## Proposed changes:
* is_cacheable() is added to serve() function.
* Added is_url_excluded() function that compares the current or given URI against a list of regex and returns true if a match is found.
* Call is_url_excluded() from is_cacheable().

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR in usual way
* Edit Boost_cache::is_url_excluded and add a new regex that will match some of your pages. Try '20??' or simple '2024' or '2.*'
* Load a post that matches the regex and watch the error log for "url excluded, not cached!' messages.
