### PR TITLE
My Jetpack: add label for screen readers to connect page close button

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/close-link/index.js
+++ b/projects/packages/my-jetpack/_inc/components/close-link/index.js
@@ -6,10 +6,12 @@ import styles from './styles.module.scss';
 
 const CloseLink = ( { className, accessibleName } ) => {
 	return (
-		<Link to="/" className={ classNames( styles.link, className ) }>
+		<Link
+			to="/"
+			className={ classNames( styles.link, className ) }
+			aria-label={ accessibleName || null }
+		>
 			<Icon icon={ close } className={ styles.icon } />
-			{ /* Screen reader users require a textual information of what the button does. */ }
-			<span className={ styles[ 'visually-hidden' ] }>{ accessibleName }</span>
 		</Link>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/close-link/index.js
+++ b/projects/packages/my-jetpack/_inc/components/close-link/index.js
@@ -4,10 +4,12 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import styles from './styles.module.scss';
 
-const CloseLink = ( { className } ) => {
+const CloseLink = ( { className, accessibleName } ) => {
 	return (
 		<Link to="/" className={ classNames( styles.link, className ) }>
 			<Icon icon={ close } className={ styles.icon } />
+			{ /* Screen reader users require a textual information of what the button does. */ }
+			<span className={ styles[ 'visually-hidden' ] }>{ accessibleName }</span>
 		</Link>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/close-link/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/close-link/styles.module.scss
@@ -9,3 +9,15 @@
 	text-decoration: none;
 	align-items: center;
 }
+
+// Hide content from screen but not from screen readers
+.visually-hidden {
+	position: absolute;
+	clip: rect(1px, 1px, 1px, 1px);
+	padding: 0;
+	border: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	width: 1px;
+	height: 1px;
+}

--- a/projects/packages/my-jetpack/_inc/components/close-link/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/close-link/styles.module.scss
@@ -9,15 +9,3 @@
 	text-decoration: none;
 	align-items: center;
 }
-
-// Hide content from screen but not from screen readers
-.visually-hidden {
-	position: absolute;
-	clip: rect(1px, 1px, 1px, 1px);
-	padding: 0;
-	border: 0;
-	overflow: hidden;
-	white-space: nowrap;
-	width: 1px;
-	height: 1px;
-}

--- a/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
@@ -52,7 +52,10 @@ const ConnectionScreen = () => {
 		<AdminPage showHeader={ false } showBackground={ false }>
 			<Container horizontalSpacing={ 8 } horizontalGap={ 0 }>
 				<Col className={ styles[ 'relative-col' ] }>
-					<CloseLink className={ styles[ 'close-link' ] } />
+					<CloseLink
+						className={ styles[ 'close-link' ] }
+						accessibleName={ __( 'Go back to previous screen', 'jetpack-my-jetpack' ) }
+					/>
 				</Col>
 				<Col>
 					<ConnectScreen

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-connect-screen-close-btn-a11y
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-connect-screen-close-btn-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: add label for screen readers to connect page close button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the connect screen of My Jetpack (see screenshot below), the close button has no accessible name. Screen readers end up reading the URL of the link, which is not optimal. This PR adds a label to this button for screen readers.

_Connect screen_
<img width="500" alt="Screenshot 2024-02-15 at 9 54 57 AM" src="https://github.com/Automattic/jetpack/assets/1620183/99354cbc-6a1a-402f-9eb2-9b648ba52caf">

_The `a` tag has no accessible name: see the `Name` property in the Computed Properties panel_
<img width="489" alt="Screenshot 2024-02-15 at 9 54 50 AM" src="https://github.com/Automattic/jetpack/assets/1620183/35178bd5-5a56-4747-a47b-5c4c9b231137">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: pf5801-xS-p2
Issue: https://github.com/Automattic/jetpack/issues/35483

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- If you're testing locally, make sure the `my-jetpack` package is built
- Ensure Jetpack is disconnected
- Visit `/wp-admin/admin.php?page=my-jetpack#/connection`
- Notice the close button has an accessible name, either by using a screen reader (see capture below) or using the dev tools (see capture above).

_Catpure of VoiceOver reading_
<img width="500" alt="Screenshot 2024-02-15 at 10 02 39 AM" src="https://github.com/Automattic/jetpack/assets/1620183/a29bfc09-65cc-46cf-88a9-d4adc33ea618">

