### PR TITLE
Replace `ts-loader` with `@babel/preset-typescript` and `fork-ts-checker-webpack-plugin`

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -97,6 +97,8 @@ For more information on how to use `$$next-version$$`, please see the [packages 
 - Use Gutenberg's [@wordpress/i18n](https://www.npmjs.com/package/@wordpress/i18n) package.
 - Use an appropriate unique text domain in your JS code.
 - Make use of [@automattic/babel-plugin-replace-textdomain](https://www.npmjs.com/package/@automattic/babel-plugin-replace-textdomain) when bundling to ensure i18n works in the published plugin.
+- When using TypeScript in Webpack, use `@babel/preset-typescript` rather than `ts-loader`.
+  - To generate `.d.ts` files, either `fork-ts-checker-webpack-plugin` or `tsc --emitDeclarationOnly` may be used.
 
 ## Where should my code live? 
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,9 +243,6 @@ importers:
       jest-environment-jsdom:
         specifier: 29.7.0
         version: 29.7.0
-      ts-loader:
-        specifier: 9.4.2
-        version: 9.4.2(typescript@5.0.4)(webpack@5.76.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -697,9 +694,6 @@ importers:
       svelte-preprocess:
         specifier: 5.0.4
         version: 5.0.4(@babel/core@7.23.5)(postcss@8.4.31)(sass@1.64.1)(svelte@3.58.0)(typescript@5.0.4)
-      ts-loader:
-        specifier: 9.4.2
-        version: 9.4.2(typescript@5.0.4)(webpack@5.76.0)
       tslib:
         specifier: 2.5.0
         version: 2.5.0
@@ -988,9 +982,6 @@ importers:
       react:
         specifier: 18.2.0
         version: 18.2.0
-      ts-loader:
-        specifier: 9.4.2
-        version: 9.4.2(typescript@5.0.4)(webpack@5.76.0)
       tslib:
         specifier: 2.5.0
         version: 2.5.0
@@ -1349,9 +1340,6 @@ importers:
       svelte:
         specifier: 3.58.0
         version: 3.58.0
-      ts-loader:
-        specifier: 9.4.2
-        version: 9.4.2(typescript@5.0.4)(webpack@5.76.0)
       tslib:
         specifier: 2.5.0
         version: 2.5.0
@@ -1385,9 +1373,6 @@ importers:
       jest:
         specifier: '*'
         version: 29.7.0
-      ts-loader:
-        specifier: 9.4.2
-        version: 9.4.2(typescript@5.0.4)(webpack@5.76.0)
       tslib:
         specifier: 2.5.0
         version: 2.5.0
@@ -23415,21 +23400,6 @@ packages:
       semver: 7.6.0
       typescript: 5.0.4
       yargs-parser: 21.1.1
-    dev: true
-
-  /ts-loader@9.4.2(typescript@5.0.4)(webpack@5.76.0):
-    resolution: {integrity: sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      typescript: '*'
-      webpack: ^5.0.0
-    dependencies:
-      chalk: 4.1.2
-      enhanced-resolve: 5.15.0
-      micromatch: 4.0.5
-      semver: 7.5.2
-      typescript: 5.0.4
-      webpack: 5.76.0(webpack-cli@4.9.1)
     dev: true
 
   /tsconfig-paths@3.15.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2903,9 +2903,6 @@ importers:
       concurrently:
         specifier: 7.6.0
         version: 7.6.0
-      fork-ts-checker-webpack-plugin:
-        specifier: 9.0.2
-        version: 9.0.2(typescript@5.0.4)(webpack@5.76.0)
       livereload:
         specifier: 0.9.3
         version: 0.9.3
@@ -13709,7 +13706,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.2.3
 
   /app-root-dir@1.0.2:
     resolution: {integrity: sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==}
@@ -16899,10 +16896,11 @@ packages:
       minimatch: 3.1.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.6.0
+      semver: 7.5.2
       tapable: 2.2.1
       typescript: 5.0.4
       webpack: 5.76.0(webpack-cli@4.9.1)
+    dev: false
 
   /form-data@2.5.1:
     resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
@@ -21780,7 +21778,7 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.2.3
 
   /recast@0.23.4:
     resolution: {integrity: sha512-qtEDqIZGVcSZCHniWwZWbRy79Dc6Wp3kT/UmDA2RJKBPg7+7k51aQBZirHmUGn5uvHf2rg8DkjizrN26k61ATw==}
@@ -22343,6 +22341,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2903,6 +2903,9 @@ importers:
       concurrently:
         specifier: 7.6.0
         version: 7.6.0
+      fork-ts-checker-webpack-plugin:
+        specifier: 9.0.2
+        version: 9.0.2(typescript@5.0.4)(webpack@5.76.0)
       livereload:
         specifier: 0.9.3
         version: 0.9.3
@@ -13706,7 +13709,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.2.3
+      picomatch: 2.3.1
 
   /app-root-dir@1.0.2:
     resolution: {integrity: sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==}
@@ -16896,11 +16899,10 @@ packages:
       minimatch: 3.1.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.5.2
+      semver: 7.6.0
       tapable: 2.2.1
       typescript: 5.0.4
       webpack: 5.76.0(webpack-cli@4.9.1)
-    dev: false
 
   /form-data@2.5.1:
     resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
@@ -21778,7 +21780,7 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
     dependencies:
-      picomatch: 2.2.3
+      picomatch: 2.3.1
 
   /recast@0.23.4:
     resolution: {integrity: sha512-qtEDqIZGVcSZCHniWwZWbRy79Dc6Wp3kT/UmDA2RJKBPg7+7k51aQBZirHmUGn5uvHf2rg8DkjizrN26k61ATw==}
@@ -22341,7 +22343,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}

--- a/projects/js-packages/boost-score-api/changelog/fix-remove-use-of-ts-loader
+++ b/projects/js-packages/boost-score-api/changelog/fix-remove-use-of-ts-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update build configuration to better match supported target environments.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -29,7 +29,6 @@
 		"eslint": "8.51.0",
 		"jest": "29.7.0",
 		"jest-environment-jsdom": "29.7.0",
-		"ts-loader": "9.4.2",
 		"typescript": "5.0.4",
 		"webpack": "5.76.0",
 		"webpack-cli": "4.9.1"

--- a/projects/js-packages/boost-score-api/tsconfig.json
+++ b/projects/js-packages/boost-score-api/tsconfig.json
@@ -8,8 +8,7 @@
 		"outDir": "./build/",
 		"noEmit": false,
 		"declaration": true,
-		"module": "es6",
-		"target": "es5",
+		"module": "nodenext",
 		"moduleResolution": "nodenext"
 	}
 }

--- a/projects/js-packages/boost-score-api/webpack.config.cjs
+++ b/projects/js-packages/boost-score-api/webpack.config.cjs
@@ -8,11 +8,10 @@ module.exports = {
 	module: {
 		strictExportPresence: true,
 		rules: [
-			{
-				test: /\.ts?$/,
-				use: 'ts-loader',
-				exclude: /node_modules/,
-			},
+			// Transpile JavaScript and TypeScript
+			jetpackWebpackConfig.TranspileRule( {
+				exclude: /node_modules\//,
+			} ),
 		],
 	},
 	optimization: {
@@ -30,5 +29,10 @@ module.exports = {
 			type: 'umd',
 		},
 	},
-	plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+	plugins: [
+		...jetpackWebpackConfig.StandardPlugins( {
+			// Generate `.d.ts` files per tsconfig settings.
+			ForkTSCheckerPlugin: {},
+		} ),
+	],
 };

--- a/projects/js-packages/image-guide/changelog/fix-remove-use-of-ts-loader
+++ b/projects/js-packages/image-guide/changelog/fix-remove-use-of-ts-loader
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unused JS dev dependency.
+
+

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -54,7 +54,6 @@
 		"sass": "1.64.1",
 		"svelte": "3.58.0",
 		"svelte-preprocess": "5.0.4",
-		"ts-loader": "9.4.2",
 		"tslib": "2.5.0",
 		"typescript": "5.0.4",
 		"webpack": "5.76.0",

--- a/projects/js-packages/react-data-sync-client/changelog/fix-remove-use-of-ts-loader
+++ b/projects/js-packages/react-data-sync-client/changelog/fix-remove-use-of-ts-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update build configuration to better match supported target environments.

--- a/projects/js-packages/react-data-sync-client/package.json
+++ b/projects/js-packages/react-data-sync-client/package.json
@@ -27,7 +27,6 @@
 		"@tanstack/react-query": "5.0.5",
 		"jest": "*",
 		"react": "18.2.0",
-		"ts-loader": "9.4.2",
 		"tslib": "2.5.0",
 		"typescript": "5.0.4",
 		"webpack": "5.76.0",

--- a/projects/js-packages/react-data-sync-client/tsconfig.json
+++ b/projects/js-packages/react-data-sync-client/tsconfig.json
@@ -7,8 +7,8 @@
 		"forceConsistentCasingInFileNames": true,
 		"outDir": "./build/",
 		"noEmit": false,
-		"declaration": true,
-		"module": "es6",
-		"target": "es5"
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"declaration": true
 	}
 }

--- a/projects/js-packages/react-data-sync-client/webpack.config.cjs
+++ b/projects/js-packages/react-data-sync-client/webpack.config.cjs
@@ -10,11 +10,10 @@ module.exports = {
 	module: {
 		strictExportPresence: true,
 		rules: [
-			{
-				test: /\.ts?$/,
-				use: 'ts-loader',
-				exclude: /node_modules/,
-			},
+			// Transpile JavaScript and TypeScript
+			jetpackWebpackConfig.TranspileRule( {
+				exclude: /node_modules\//,
+			} ),
 		],
 	},
 	optimization: {
@@ -32,5 +31,10 @@ module.exports = {
 			type: 'umd',
 		},
 	},
-	plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+	plugins: [
+		...jetpackWebpackConfig.StandardPlugins( {
+			// Generate `.d.ts` files per tsconfig settings.
+			ForkTSCheckerPlugin: {},
+		} ),
+	],
 };

--- a/projects/js-packages/svelte-data-sync-client/changelog/fix-remove-use-of-ts-loader
+++ b/projects/js-packages/svelte-data-sync-client/changelog/fix-remove-use-of-ts-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Adjust build to work with `tsc` and `moduleResolution:nodenext`.

--- a/projects/js-packages/svelte-data-sync-client/changelog/fix-remove-use-of-ts-loader#2
+++ b/projects/js-packages/svelte-data-sync-client/changelog/fix-remove-use-of-ts-loader#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update build configuration to better match supported target environments.

--- a/projects/js-packages/svelte-data-sync-client/package.json
+++ b/projects/js-packages/svelte-data-sync-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-svelte-data-sync-client",
-	"version": "0.3.5",
+	"version": "0.3.6-alpha",
 	"description": "A Svelte.js client for the wp-js-data-sync package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/svelte-data-sync-client/#readme",
 	"type": "module",
@@ -29,7 +29,6 @@
 		"eslint": "8.51.0",
 		"jest": "29.7.0",
 		"svelte": "3.58.0",
-		"ts-loader": "9.4.2",
 		"tslib": "2.5.0",
 		"typescript": "5.0.4",
 		"webpack": "5.76.0",

--- a/projects/js-packages/svelte-data-sync-client/src/DataSync.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/DataSync.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { ApiError } from './ApiError';
-import type { ParsedValue } from './types';
-import type { JSONSchema } from './utils';
+import { ApiError } from './ApiError.js';
+import type { ParsedValue } from './types.js';
+import type { JSONSchema } from './utils.js';
 
 type RequestParams = string | JSONSchema;
 type RequestMethods = 'GET' | 'POST' | 'DELETE';

--- a/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts
@@ -1,13 +1,13 @@
 import { Writable, writable } from 'svelte/store';
-import { ApiError } from './ApiError';
+import { ApiError } from './ApiError.js';
 import {
 	Pending,
 	SyncedStoreInterface,
 	SyncedWritable,
 	SyncedStoreCallback,
 	SyncedStoreError,
-} from './types';
-import { sleep } from './utils';
+} from './types.js';
+import { sleep } from './utils.js';
 
 /*
  * A custom Svelte Store that's used to indicate if a value is being synced.

--- a/projects/js-packages/svelte-data-sync-client/src/index.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/index.ts
@@ -1,9 +1,9 @@
-export { SyncedStore } from './SyncedStore';
-export { initializeClient } from './initializeClient';
+export { SyncedStore } from './SyncedStore.js';
+export { initializeClient } from './initializeClient.js';
 export type {
 	SyncedStoreCallback,
 	SyncedStoreInterface,
 	ParsedValue as ValidatedValue,
 	SyncedWritable,
 	SyncedStoreError,
-} from './types';
+} from './types.js';

--- a/projects/js-packages/svelte-data-sync-client/src/initializeClient.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/initializeClient.ts
@@ -1,7 +1,7 @@
 import { derived } from 'svelte/store';
 import { z } from 'zod';
-import { DataSync } from './DataSync';
-import { SyncedStore } from './SyncedStore';
+import { DataSync } from './DataSync.js';
+import { SyncedStore } from './SyncedStore.js';
 
 /**
  * Initialize the client-side data sync.

--- a/projects/js-packages/svelte-data-sync-client/tsconfig.json
+++ b/projects/js-packages/svelte-data-sync-client/tsconfig.json
@@ -7,8 +7,8 @@
 		"forceConsistentCasingInFileNames": true,
 		"outDir": "./build/",
 		"noEmit": false,
-		"declaration": true,
-		"module": "es6",
-		"target": "es5"
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"declaration": true
 	}
 }

--- a/projects/js-packages/svelte-data-sync-client/webpack.config.cjs
+++ b/projects/js-packages/svelte-data-sync-client/webpack.config.cjs
@@ -10,11 +10,10 @@ module.exports = {
 	module: {
 		strictExportPresence: true,
 		rules: [
-			{
-				test: /\.ts?$/,
-				use: 'ts-loader',
-				exclude: /node_modules/,
-			},
+			// Transpile JavaScript and TypeScript
+			jetpackWebpackConfig.TranspileRule( {
+				exclude: /node_modules\//,
+			} ),
 		],
 	},
 	optimization: {
@@ -32,5 +31,10 @@ module.exports = {
 			type: 'umd',
 		},
 	},
-	plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+	plugins: [
+		...jetpackWebpackConfig.StandardPlugins( {
+			// Generate `.d.ts` files per tsconfig settings.
+			ForkTSCheckerPlugin: {},
+		} ),
+	],
 };

--- a/projects/js-packages/videopress-core/changelog/fix-remove-use-of-ts-loader
+++ b/projects/js-packages/videopress-core/changelog/fix-remove-use-of-ts-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update build configuration to better match supported target environments.

--- a/projects/js-packages/videopress-core/package.json
+++ b/projects/js-packages/videopress-core/package.json
@@ -27,7 +27,6 @@
 		"@babel/core": "7.23.5",
 		"@babel/preset-react": "7.23.3",
 		"@types/jest": "29.5.12",
-		"ts-loader": "9.4.2",
 		"tslib": "2.5.0",
 		"typescript": "5.0.4",
 		"webpack": "5.76.0",

--- a/projects/js-packages/videopress-core/tsconfig.json
+++ b/projects/js-packages/videopress-core/tsconfig.json
@@ -7,8 +7,8 @@
 		"forceConsistentCasingInFileNames": true,
 		"outDir": "./build/",
 		"noEmit": false,
-		"declaration": true,
-		"module": "es6",
-		"target": "es5"
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"declaration": true
 	}
 }

--- a/projects/js-packages/videopress-core/webpack.config.cjs
+++ b/projects/js-packages/videopress-core/webpack.config.cjs
@@ -10,11 +10,10 @@ module.exports = {
 	module: {
 		strictExportPresence: true,
 		rules: [
-			{
-				test: /\.ts?$/,
-				use: 'ts-loader',
-				exclude: /node_modules/,
-			},
+			// Transpile JavaScript and TypeScript
+			jetpackWebpackConfig.TranspileRule( {
+				exclude: /node_modules\//,
+			} ),
 		],
 	},
 	optimization: {
@@ -32,5 +31,10 @@ module.exports = {
 			type: 'umd',
 		},
 	},
-	plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+	plugins: [
+		...jetpackWebpackConfig.StandardPlugins( {
+			// Generate `.d.ts` files per tsconfig settings.
+			ForkTSCheckerPlugin: {},
+		} ),
+	],
 };

--- a/projects/plugins/boost/changelog/fix-remove-use-of-ts-loader
+++ b/projects/plugins/boost/changelog/fix-remove-use-of-ts-loader
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Changed build process to use babel/preset-typescript
-
-

--- a/projects/plugins/boost/changelog/fix-remove-use-of-ts-loader
+++ b/projects/plugins/boost/changelog/fix-remove-use-of-ts-loader
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Changed build process to use babel/preset-typescript
+
+

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -38,7 +38,6 @@
 		"@types/jquery": "3.5.25",
 		"@wordpress/i18n": "4.51.0",
 		"concurrently": "7.6.0",
-		"fork-ts-checker-webpack-plugin": "9.0.2",
 		"livereload": "0.9.3",
 		"postcss": "8.4.31",
 		"react": "18.2.0",

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -38,6 +38,7 @@
 		"@types/jquery": "3.5.25",
 		"@wordpress/i18n": "4.51.0",
 		"concurrently": "7.6.0",
+		"fork-ts-checker-webpack-plugin": "9.0.2",
 		"livereload": "0.9.3",
 		"postcss": "8.4.31",
 		"react": "18.2.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We've decided (pdWQjU-FO-p2) to prefer `@babel/preset-typescript` over `ts-loader` for dealing with TypeScript in the context of Webpack. For generating the definition files, we're generally going to use `fork-ts-checker-webpack-plugin` (although `tsc --emitDeclarationOnly` is also an option).

Also, as cleanup, these packages are switched to `moduleResolution:nodenext` to ensure the `.d.ts` files are usable by consumers using that rather than `bundler`.

Of the packages affected by this:

* image-guide apparently just had a dep on ts-loader but doesn't use it.
* videopress-core has no changes in the build artifacts.
* boost-score-api, react-data-sync-client, and svelte-data-sync-client all wind up with smaller bundles (by 14K–19K) now that Babel decides what needs transpiling based on the browserslist config, so they use native classes, generators, promises, and array-spread operators now.

This PR also adds a linting check to warn against re-introduction of ts-loader, and mentions this in the relevant doc.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdWQjU-FO-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Changes in the artifacts for these packages should be as described above.
* Wouldn't hurt to give Boost's features a spin.
