### PR TITLE
Jetpack Connection: Add connection indicator for screen readers

### DIFF
--- a/projects/js-packages/connection/changelog/update-my-jetpack-connect-page-status-role
+++ b/projects/js-packages/connection/changelog/update-my-jetpack-connect-page-status-role
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add connection indicator for screen readers

--- a/projects/js-packages/connection/components/connect-screen/basic/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/index.jsx
@@ -10,6 +10,7 @@ import ConnectScreenVisual from './visual';
  * @param {object} props -- The properties.
  * @param {string?} props.title -- The Title.
  * @param {string?} props.buttonLabel -- The Connect Button label.
+ * @param {string?} props.loadingLabel -- The text read by screen readers when connecting.
  * @param {string} props.apiRoot -- API root.
  * @param {string} props.apiNonce -- API nonce.
  * @param {string} props.registrationNonce -- Registration nonce.
@@ -27,6 +28,7 @@ import ConnectScreenVisual from './visual';
 const ConnectScreen = ( {
 	title,
 	buttonLabel,
+	loadingLabel,
 	apiRoot,
 	apiNonce,
 	registrationNonce,
@@ -66,6 +68,7 @@ const ConnectScreen = ( {
 			images={ images }
 			assetBaseUrl={ assetBaseUrl }
 			buttonLabel={ buttonLabel }
+			loadingLabel={ loadingLabel }
 			handleButtonClick={ handleRegisterSite }
 			displayButtonError={ displayButtonError }
 			errorCode={ errorCode }
@@ -82,6 +85,7 @@ const ConnectScreen = ( {
 ConnectScreen.propTypes = {
 	title: PropTypes.string,
 	buttonLabel: PropTypes.string,
+	loadingLabel: PropTypes.string,
 	apiRoot: PropTypes.string.isRequired,
 	apiNonce: PropTypes.string.isRequired,
 	registrationNonce: PropTypes.string.isRequired,

--- a/projects/js-packages/connection/components/connect-screen/basic/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/basic/style.scss
@@ -40,6 +40,22 @@
 		}
 	}
 
+	&__loading-message {
+		// Hidden visually but not from screen readers
+		position: absolute;
+		clip: rect(1px, 1px, 1px, 1px);
+		padding: 0;
+		border: 0;
+		height: 1px;
+		width: 1px;
+		overflow: hidden;
+		white-space: nowrap;	
+		
+		&:empty {
+			display: none;
+		}
+	}
+
 	&__footer {
 		margin-top: 32px;
 	}

--- a/projects/js-packages/connection/components/connect-screen/basic/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/visual.jsx
@@ -24,6 +24,7 @@ const ConnectScreenVisual = props => {
 		displayButtonError,
 		errorCode,
 		buttonIsLoading,
+		loadingLabel,
 		footer,
 		isOfflineMode,
 		logo,
@@ -83,6 +84,9 @@ const ConnectScreenVisual = props => {
 					isLoading={ buttonIsLoading }
 					isDisabled={ isOfflineMode }
 				/>
+				<span className="jp-connection__connect-screen__loading-message" role="status">
+					{ buttonIsLoading ? loadingLabel : '' }
+				</span>
 
 				{ footer && <div className="jp-connection__connect-screen__footer">{ footer }</div> }
 			</div>
@@ -109,6 +113,8 @@ ConnectScreenVisual.propTypes = {
 	errorCode: PropTypes.string,
 	/** Whether the button is loading or not. */
 	buttonIsLoading: PropTypes.bool,
+	/** Text read by screen readers after the button is activated */
+	loadingLabel: PropTypes.string,
 	/** Node that will be rendered after ToS */
 	footer: PropTypes.node,
 	/** Whether the site is in offline mode. */
@@ -120,6 +126,7 @@ ConnectScreenVisual.propTypes = {
 ConnectScreenVisual.defaultProps = {
 	isLoading: false,
 	buttonIsLoading: false,
+	loadingLabel: __( 'Loading', 'jetpack' ),
 	displayButtonError: false,
 	errorCode: null,
 	handleButtonClick: () => {},

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.32.1",
+	"version": "0.32.2-alpha",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
@@ -55,6 +55,7 @@ const ConnectionScreen = () => {
 							'jetpack-my-jetpack'
 						) }
 						buttonLabel={ __( 'Connect your user account', 'jetpack-my-jetpack' ) }
+						loadingLabel={ __( 'Connecting your account…', 'jetpack-my-jetpack' ) }
 						apiRoot={ apiRoot }
 						apiNonce={ apiNonce }
 						images={ [ connectImage ] }

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-page-status-role
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-page-status-role
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add connection indicator for screen readers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35487

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the "Connect Account" screen, clicking _Connect your user account_ doesn’t provide any feedback to screen reader users, such as a loading notice. Since, at this point, it can easily take 5 to 10 seconds to render the next page, users are left wondering what’s happening. This PR adds a status message for screen readers.

This article describes the implementation: https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-1/#2.-using-live-region-roles

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-xS-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- If you're running it locally, make sure to build the plugin
- Ensure your site is not connected
- Visit `/wp-admin/admin.php?page=my-jetpack#/connection`
- If you can use a screen reader, open it
- Otherwise, monitor the following element in the inspector
<img width="634" alt="Screenshot 2024-02-15 at 3 41 26 PM" src="https://github.com/Automattic/jetpack/assets/1620183/954f7377-2d18-4f32-b3c1-43cff01e26b9">

- If you're using the inspector, ensure the text "Connecting your account" is added to the DOM element (this might be difficult to notice, depending on the speed of the queries) after you click the button
- If you're using a screen reader, it should read "Connecting your account" after you click the button