### PR TITLE
Untangle: Update Social Connections Link

### DIFF
--- a/projects/packages/publicize/changelog/update-social-connections-link
+++ b/projects/packages/publicize/changelog/update-social-connections-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Link Jetpack Social Settings to cloud.jetpack

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.2",
+	"version": "0.42.3-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1819,7 +1819,7 @@ abstract class Publicize_Base {
 	/**
 	 * Get Calypso URL for Publicize connections.
 	 *
-	 * @param string $source The idenfitier of the place the function is called from.
+	 * @param string $source The identifier of the place the function is called from.
 	 * @return string
 	 */
 	public function publicize_connections_url( $source = 'calypso-marketing-connections' ) {

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -133,7 +133,7 @@ class Publicize_UI {
 						),
 					)
 				),
-				esc_url( $this->publicize->publicize_connections_url() )
+				esc_url( $this->publicize->publicize_connections_url( 'jetpack-social-connections-classic-editor' ) )
 			);
 			?>
 		</h4>

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -124,7 +124,7 @@ class Publicize_UI {
 			printf(
 				wp_kses(
 					/* translators: %s is the link to the Publicize page in Calypso */
-					__( "We've made some updates to Jetpack Social. Please visit the <a href='%s' class='jptracks' data-jptracks-name='legacy_publicize_settings'>WordPress.com sharing page</a> to manage your Jetpack Social connections or use the button below.", 'jetpack-publicize-pkg' ),
+					__( "We've made some updates to Jetpack Social. Please visit the <a href='%s' class='jptracks' data-jptracks-name='legacy_publicize_settings'>Connections page</a> to manage your Jetpack Social connections or use the button below.", 'jetpack-publicize-pkg' ),
 					array(
 						'a' => array(
 							'href'               => array(),
@@ -138,7 +138,7 @@ class Publicize_UI {
 			?>
 		</h4>
 
-		<a href="<?php echo esc_url( $this->publicize->publicize_connections_url() ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Jetpack Social Settings', 'jetpack-publicize-pkg' ); ?></a>
+		<a href="<?php echo esc_url( $this->publicize->publicize_connections_url( 'jetpack-social-connections-classic-editor' ) ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Jetpack Social Settings', 'jetpack-publicize-pkg' ); ?></a>
 		<?php
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5552

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates the Jetpack Social link & button to redirect to the Jetpack Cloud Social Connections page for sites with access to Jetpack Cloud. (Note that proxied Atomic sites with the Classic admin interface enabled are now granted access to Jetpack Cloud via D138559-code)
* This PR also updates the link copy from "WordPress.com sharing page" to "Connections page". This way the copy makes sense whether it redirects to Calypso or Jetpack Cloud.

Atomic Site WP-Admin
Before | After
--|--
<img width="1526" alt="classic-before" src="https://github.com/Automattic/jetpack/assets/140841/d17798a6-be42-4c76-9093-1c06c8c465e0"> | <img width="1523" alt="classic-after" src="https://github.com/Automattic/jetpack/assets/140841/3edd3b40-147c-4026-ae83-c1ffd86cc38c">

Jetpack Site
Before | After
--|--
<img width="1526" alt="jetpack-before" src="https://github.com/Automattic/jetpack/assets/140841/704095c1-dd62-4969-af81-172be8e9bb2f">  | <img width="1526" alt="jetpack-after" src="https://github.com/Automattic/jetpack/assets/140841/285fae8f-e76b-4440-9e1c-40d3ef5f4101">





### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1708126615252529-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the Jetpack Beta plugin to load this PR.
* On a Jetpack site goto /wp-admin/options-general.php?page=sharing click on the "Connections page" link and "Jetpack Social Settings" button highlighted in the picture above. The links should redirect you to the Jetpack Cloud "Social Connections" page at https://cloud.jetpack.com/jetpack-social/[site-id]
* The above should also be true on an Atomic site with Classic admin enabled while you're proxied.
* Test the links above un-proxied. They should now redirect you to Calypso https://wordpress.com/marketing/connections/[site-id]?site=[site-id]
* Now test proxied, but with "Default" admin view enabled. It should redirect you to Calypso https://wordpress.com/marketing/connections/[site-id]?site=[site-id]