### PR TITLE
Voice to Content: Add states and refactor duration calculation

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-states
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-states
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Voice to Content: Add states and refactor duration calculation

--- a/projects/js-packages/ai-client/src/components/audio-duration-display/index.tsx
+++ b/projects/js-packages/ai-client/src/components/audio-duration-display/index.tsx
@@ -1,18 +1,14 @@
 /*
- * External dependencies
- */
-import { useState, useEffect } from '@wordpress/element';
-/*
  * Internal dependencies
  */
-import { formatTime, getDuration } from './lib/media.js';
+import { formatTime } from './lib/media.js';
 /*
  * Types
  */
 import type React from 'react';
 
 type AudioDurationDisplayProps = {
-	url: string;
+	duration: number;
 	className?: string | null;
 };
 
@@ -23,17 +19,8 @@ type AudioDurationDisplayProps = {
  * @returns {React.ReactElement}              Rendered component.
  */
 export default function AudioDurationDisplay( {
-	url,
+	duration,
 	className,
 }: AudioDurationDisplayProps ): React.ReactElement {
-	const [ duration, setDuration ] = useState( 0 );
-	useEffect( () => {
-		if ( ! url ) {
-			return;
-		}
-
-		getDuration( url ).then( setDuration );
-	}, [ url ] );
-
 	return <span className={ className }>{ formatTime( duration, { addDecimalPart: false } ) }</span>;
 }

--- a/projects/js-packages/ai-client/src/components/audio-duration-display/lib/media.ts
+++ b/projects/js-packages/ai-client/src/components/audio-duration-display/lib/media.ts
@@ -1,34 +1,3 @@
-/**
- * Function to get duration of audio file
- *
- * @param {string} url - The url of the audio file
- * @returns {Promise<number>} The duration of the audio file
- * @see https://stackoverflow.com/questions/21522036/html-audio-tag-duration-always-infinity
- */
-export function getDuration( url: string ): Promise< number > {
-	return new Promise( next => {
-		const tmpAudioInstance = new Audio( url );
-		tmpAudioInstance.addEventListener(
-			'durationchange',
-			function () {
-				if ( this.duration === Infinity ) {
-					return;
-				}
-
-				const duration = this.duration;
-				tmpAudioInstance.remove(); // remove instance from memory
-				next( duration );
-			},
-			false
-		);
-
-		tmpAudioInstance.load();
-		tmpAudioInstance.currentTime = 24 * 60 * 60; // Fake big time
-		tmpAudioInstance.volume = 0;
-		tmpAudioInstance.play(); // This will call `durationchange` event
-	} );
-}
-
 type FormatTimeOptions = {
 	/**
 	 * Whether to add the decimal part to the formatted time.
@@ -50,19 +19,18 @@ type FormatTimeOptions = {
  * Formats the given time in milliseconds into a string with the format HH:MM:SS.DD,
  * adding hours and minutes only when needed.
  *
- * @param {number} time               - The time in seconds to format.
+ * @param {number} time               - The time in millisecons to format.
  * @param {FormatTimeOptions} options - The arguments.
  * @returns {string}                    The formatted time string.
  * @example
- * const formattedTime1 = formatTime( 1234567 );                       // Returns "20:34.56"
- * const formattedTime2 = formatTime( 45123 );                         // Returns "45.12"
- * const formattedTime3 = formatTime( 64, { addDecimalPart: false } ); // Returns "01:04"
+ * const formattedTime1 = formatTime( 1234567, { addDecimalPart: true } ); // Returns "20:34.56"
+ * const formattedTime2 = formatTime( 45123 );                             // Returns "00.45"
+ * const formattedTime3 = formatTime( 1200, { showHours: true } );         // Returns "00:00:01"
  */
 export function formatTime(
 	time: number,
-	{ addDecimalPart = true, showMinutes = true, showHours = false }: FormatTimeOptions = {}
+	{ addDecimalPart = false, showMinutes = true, showHours = false }: FormatTimeOptions = {}
 ): string {
-	time = time * 1000;
 	const hours = Math.floor( time / 3600000 );
 	const minutes = Math.floor( time / 60000 ) % 60;
 	const seconds = Math.floor( time / 1000 ) % 60;

--- a/projects/js-packages/ai-client/src/components/audio-duration-display/lib/media.ts
+++ b/projects/js-packages/ai-client/src/components/audio-duration-display/lib/media.ts
@@ -19,7 +19,7 @@ type FormatTimeOptions = {
  * Formats the given time in milliseconds into a string with the format HH:MM:SS.DD,
  * adding hours and minutes only when needed.
  *
- * @param {number} time               - The time in millisecons to format.
+ * @param {number} time               - The time in milliseconds to format.
  * @param {FormatTimeOptions} options - The arguments.
  * @returns {string}                    The formatted time string.
  * @example

--- a/projects/js-packages/ai-client/src/hooks/use-media-recording/stories/index.stories.tsx
+++ b/projects/js-packages/ai-client/src/hooks/use-media-recording/stories/index.stories.tsx
@@ -14,7 +14,7 @@ import useMediaRecording from '../index.js';
 import type { Meta } from '@storybook/react';
 
 const RecorderComponent = ( { timeslice } ) => {
-	const { controls, state, blob, url } = useMediaRecording();
+	const { controls, state, blob, duration } = useMediaRecording();
 	const { start, pause, resume, stop } = controls;
 
 	return (
@@ -40,7 +40,7 @@ const RecorderComponent = ( { timeslice } ) => {
 				<div>
 					<span>Duration: </span>
 					<strong>
-						<AudioDurationDisplay url={ url } />
+						<AudioDurationDisplay duration={ duration } />
 					</strong>
 				</div>
 			</div>

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-states
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-states
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Voice to Content: Add states and refactor duration calculation

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -79,6 +79,7 @@ function AudioStatusPanel( { state, error = null, audioURL = null, duration = 0 
 	return null;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ActionButtons( { state, mediaControls, onError } ) {
 	const { start, pause, resume, stop, reset } = mediaControls ?? {};
 

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -25,7 +25,7 @@ function Oscilloscope( { audioURL } ) {
 	return <img src={ oscilloscope } alt="" />;
 }
 
-function AudioStatusPanel( { state, error = null, audioURL = null } ) {
+function AudioStatusPanel( { state, error = null, audioURL = null, duration = 0 } ) {
 	if ( state === 'inactive' ) {
 		return (
 			<div className="jetpack-ai-voice-to-content__information">
@@ -39,7 +39,7 @@ function AudioStatusPanel( { state, error = null, audioURL = null } ) {
 			<div className="jetpack-ai-voice-to-content__audio">
 				<AudioDurationDisplay
 					className="jetpack-ai-voice-to-content__audio--duration"
-					url={ audioURL }
+					duration={ duration }
 				/>
 				<Oscilloscope audioURL={ audioURL } />
 				<span className="jetpack-ai-voice-to-content__information">
@@ -54,7 +54,7 @@ function AudioStatusPanel( { state, error = null, audioURL = null } ) {
 			<div className="jetpack-ai-voice-to-content__audio">
 				<AudioDurationDisplay
 					className="jetpack-ai-voice-to-content__audio--duration"
-					url={ audioURL }
+					duration={ duration }
 				/>
 				<Oscilloscope audioURL={ audioURL } />
 				<span className="jetpack-ai-voice-to-content__information">
@@ -175,18 +175,15 @@ function ActionButtons( { state, mediaControls, onError } ) {
 }
 
 export default function VoiceToContentEdit( { clientId } ) {
-	const { state, controls, url, error, onError } = useMediaRecording( {
-		onDone: blob => {
-			console.log( 'Blob created: ', blob ); // eslint-disable-line no-console
+	const { state, controls, url, error, onError, duration } = useMediaRecording( {
+		onDone: ( lastBlob, lastUrl ) => {
+			console.log( 'Blob created: ', lastBlob, lastUrl ); // eslint-disable-line no-console
 		},
 	} );
 
 	const dispatch = useDispatch( 'core/block-editor' );
 
 	const destroyBlock = useCallback( () => {
-		// eslint-disable-next-line no-console
-		console.log( 'VTC: destroy' );
-
 		// Remove the block from the editor
 		setTimeout( () => {
 			dispatch.removeBlock( clientId );
@@ -194,8 +191,6 @@ export default function VoiceToContentEdit( { clientId } ) {
 	}, [ dispatch, clientId ] );
 
 	const handleClose = () => {
-		// eslint-disable-next-line no-console
-		console.log( 'VTC: close' );
 		destroyBlock();
 	};
 
@@ -218,7 +213,12 @@ export default function VoiceToContentEdit( { clientId } ) {
 							) }
 						</span>
 						<div className="jetpack-ai-voice-to-content__contextual-row">
-							<AudioStatusPanel state={ state } audioURL={ url } error={ error } />
+							<AudioStatusPanel
+								state={ state }
+								audioURL={ url }
+								error={ error }
+								duration={ duration }
+							/>
 						</div>
 						<ActionButtons state={ state } mediaControls={ controls } onError={ onError } />
 					</div>

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -25,7 +25,7 @@ function Oscilloscope( { audioURL } ) {
 	return <img src={ oscilloscope } alt="" />;
 }
 
-function ContextualRow( { state, error = null, audioURL = null } ) {
+function AudioStatusPanel( { state, error = null, audioURL = null } ) {
 	if ( state === 'inactive' ) {
 		return (
 			<div className="jetpack-ai-voice-to-content__information">
@@ -220,7 +220,7 @@ export default function VoiceToContentEdit( { clientId } ) {
 							) }
 						</span>
 						<div className="jetpack-ai-voice-to-content__contextual-row">
-							<ContextualRow state={ state } audioURL={ url } error={ error } />
+							<AudioStatusPanel state={ state } audioURL={ url } error={ error } />
 						</div>
 						<ActionButtons state={ state } mediaControls={ controls } />
 					</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #35547

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the `processing` and `error` states
* Fixes the duration calculation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a voice to content block
* Start a recording
* Check that the recording duration is updated correctly (it seemed to be off by 1 second before)
* Click Done
* Check that it changes state to `processing`, changing the UI accordingly
