### PR TITLE
Upate/allow my jetpack cards install standalone async

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -92,7 +92,7 @@ const ConnectedProductCard = ( {
 
 		installStandalonePlugin()
 			.then( () => {
-				window?.location?.reload();
+				setInstallingStandalone( false );
 			} )
 			.catch( () => {
 				setInstallingStandalone( false );

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -185,6 +185,7 @@ const ActionButton = ( {
 		onAdd,
 		onFixConnection,
 		onActivate,
+		onInstall,
 		onLearnMore,
 		purchaseUrl,
 		upgradeInInterstitial,

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -33,6 +33,7 @@ const ActionButton = ( {
 	isDeactivatingStandalone,
 	className,
 	onAdd,
+	onInstall,
 	onLearnMore,
 	upgradeInInterstitial,
 } ) => {
@@ -55,8 +56,7 @@ const ActionButton = ( {
 
 	const getStatusAction = useCallback( () => {
 		switch ( status ) {
-			case PRODUCT_STATUSES.ABSENT:
-			case PRODUCT_STATUSES.ABSENT_WITH_PLAN: {
+			case PRODUCT_STATUSES.ABSENT: {
 				const buttonText = __( 'Learn more', 'jetpack-my-jetpack' );
 				return {
 					...buttonState,
@@ -69,6 +69,18 @@ const ActionButton = ( {
 					...( primaryActionOverride &&
 						PRODUCT_STATUSES.ABSENT in primaryActionOverride &&
 						primaryActionOverride[ PRODUCT_STATUSES.ABSENT ] ),
+				};
+			}
+			case PRODUCT_STATUSES.ABSENT_WITH_PLAN: {
+				const buttonText = __( 'Install Plugin', 'jetpack-my-jetpack' );
+				return {
+					...buttonState,
+					href: '',
+					size: 'small',
+					variant: 'primary',
+					weight: 'regular',
+					label: buttonText,
+					onClick: onInstall,
 					...( primaryActionOverride &&
 						PRODUCT_STATUSES.ABSENT_WITH_PLAN in primaryActionOverride &&
 						primaryActionOverride[ PRODUCT_STATUSES.ABSENT_WITH_PLAN ] ),

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -18,7 +18,7 @@ export const PRODUCT_STATUSES_LABELS = {
 	[ PRODUCT_STATUSES.NEEDS_PURCHASE ]: __( 'Inactive', 'jetpack-my-jetpack' ),
 	[ PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE ]: __( 'Inactive', 'jetpack-my-jetpack' ),
 	[ PRODUCT_STATUSES.ABSENT ]: __( 'Inactive', 'jetpack-my-jetpack' ),
-	[ PRODUCT_STATUSES.ABSENT_WITH_PLAN ]: __( 'Inactive', 'jetpack-my-jetpack' ),
+	[ PRODUCT_STATUSES.ABSENT_WITH_PLAN ]: __( 'Needs Plugin', 'jetpack-my-jetpack' ),
 	[ PRODUCT_STATUSES.ERROR ]: __( 'Needs connection', 'jetpack-my-jetpack' ),
 	[ PRODUCT_STATUSES.CAN_UPGRADE ]: __( 'Active', 'jetpack-my-jetpack' ),
 };
@@ -215,12 +215,16 @@ const ProductCard = props => {
 	/**
 	 * Calls the passed function onActivate after firing Tracks event
 	 */
-	const activateHandler = useCallback( () => {
-		recordEvent( 'jetpack_myjetpack_product_card_activate_click', {
-			product: slug,
-		} );
-		onActivate();
-	}, [ slug, onActivate, recordEvent ] );
+	const activateHandler = useCallback(
+		event => {
+			event.preventDefault();
+			recordEvent( 'jetpack_myjetpack_product_card_activate_click', {
+				product: slug,
+			} );
+			onActivate();
+		},
+		[ slug, onActivate, recordEvent ]
+	);
 
 	/**
 	 * Calls the passed function onAdd after firing Tracks event
@@ -261,22 +265,30 @@ const ProductCard = props => {
 	/**
 	 * Use a Tracks event to count a standalone plugin install request
 	 */
-	const installStandaloneHandler = useCallback( () => {
-		recordEvent( 'jetpack_myjetpack_product_card_install_standalone_plugin_click', {
-			product: slug,
-		} );
-		onInstallStandalone();
-	}, [ slug, onInstallStandalone, recordEvent ] );
+	const installStandaloneHandler = useCallback(
+		event => {
+			event.preventDefault();
+			recordEvent( 'jetpack_myjetpack_product_card_install_standalone_plugin_click', {
+				product: slug,
+			} );
+			onInstallStandalone();
+		},
+		[ slug, onInstallStandalone, recordEvent ]
+	);
 
 	/**
 	 * Use a Tracks event to count a standalone plugin activation request
 	 */
-	const activateStandaloneHandler = useCallback( () => {
-		recordEvent( 'jetpack_myjetpack_product_card_activate_standalone_plugin_click', {
-			product: slug,
-		} );
-		onActivateStandalone();
-	}, [ slug, onActivateStandalone, recordEvent ] );
+	const activateStandaloneHandler = useCallback(
+		event => {
+			event.preventDefault();
+			recordEvent( 'jetpack_myjetpack_product_card_activate_standalone_plugin_click', {
+				product: slug,
+			} );
+			onActivateStandalone();
+		},
+		[ slug, onActivateStandalone, recordEvent ]
+	);
 
 	/**
 	 * Use a Tracks event to count a standalone plugin deactivation menu click
@@ -325,6 +337,7 @@ const ProductCard = props => {
 						onFixConnection={ fixConnectionHandler }
 						onManage={ manageHandler }
 						onAdd={ addHandler }
+						onInstall={ installStandaloneHandler }
 						onLearnMore={ learnMoreHandler }
 						className={ styles.button }
 						additionalActions={ additionalActions }

--- a/projects/packages/my-jetpack/_inc/components/product-card/status.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/status.jsx
@@ -9,6 +9,8 @@ const getStatusClassName = status => {
 		case PRODUCT_STATUSES.ACTIVE:
 		case PRODUCT_STATUSES.CAN_UPGRADE:
 			return styles.active;
+		case PRODUCT_STATUSES.ABSENT_WITH_PLAN:
+			return styles.warning;
 		case PRODUCT_STATUSES.INACTIVE:
 		case PRODUCT_STATUSES.NEEDS_PURCHASE:
 		case PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE:

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -91,7 +91,7 @@ $box-shadow-color: rgba( 0, 0, 0, 0.1 );
 			background-color: var( --jp-gray-0 );
 		}
 	}
-	
+
 	.dropdown-item-label {
 		display: flex;
 		align-items: center;
@@ -132,6 +132,7 @@ $box-shadow-color: rgba( 0, 0, 0, 0.1 );
 	$statuses: (
 		"active": "--jp-green-50",
 		"inactive": "--jp-gray-50",
+		"warning": "--jp-yellow-40",
 		"error": "--jp-red-60"
 	);
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/index.tsx
@@ -9,7 +9,7 @@ const BoostCard: FC< { admin: boolean } > = ( { admin } ) => {
 	// Override the primary action button to read "Boost your site" instead
 	// of the default text, "Lern more".
 	const primaryActionOverride = {
-		[ PRODUCT_STATUSES.ABSENT_WITH_PLAN ]: {
+		[ PRODUCT_STATUSES.ABSENT ]: {
 			label: __( 'Boost your site', 'jetpack-my-jetpack' ),
 		},
 	};

--- a/projects/packages/my-jetpack/changelog/upate-allow-my-jetpack-cards-install-standalone-async
+++ b/projects/packages/my-jetpack/changelog/upate-allow-my-jetpack-cards-install-standalone-async
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+change status and action of My Jetpack cards when plugin is missing

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -237,17 +237,6 @@ class REST_Products {
 			);
 		}
 
-		/**
-		 * If the product is not hybrid, there is no need to deal with a standalone plugin.
-		 */
-		if ( ! is_subclass_of( $product['class'], Hybrid_Product::class ) ) {
-			return new \WP_Error(
-				'not_hybrid',
-				__( 'This product does not have a standalone plugin to install', 'jetpack-my-jetpack' ),
-				array( 'status' => 400 )
-			);
-		}
-
 		$install_product_result = call_user_func( array( $product['class'], 'install_and_activate_standalone' ) );
 		if ( is_wp_error( $install_product_result ) ) {
 			$install_product_result->add_data( array( 'status' => 400 ) );

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -261,6 +261,27 @@ class Boost extends Product {
 	}
 
 	/**
+	 * Checks whether the current plan (or purchases) of the site already supports the product
+	 *
+	 * @return boolean
+	 */
+	public static function has_required_plan() {
+		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
+			return false;
+		}
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				// Boost is available as standalone bundle and as part of the Complete plan.
+				if ( strpos( $purchase->product_slug, 'jetpack_boost' ) !== false || str_starts_with( $purchase->product_slug, 'jetpack_complete' ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Get the URL where the user manages the product
 	 *
 	 * @return ?string

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -265,7 +265,7 @@ class Boost extends Product {
 	 *
 	 * @return boolean
 	 */
-	public static function has_required_plan() {
+	public static function has_paid_plan_for_product() {
 		$purchases_data = Wpcom_Products::get_site_current_purchases();
 		if ( is_wp_error( $purchases_data ) ) {
 			return false;

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -130,33 +130,8 @@ abstract class Hybrid_Product extends Product {
 	 *
 	 * @return boolean|WP_Error
 	 */
-	final public static function install_and_activate_standalone() {
-		/**
-		 * Check for the presence of the standalone plugin, ignoring Jetpack presence.
-		 *
-		 * If the standalone plugin is not installed and the user can install plugins, proceed with the installation.
-		 */
-		if ( ! parent::is_plugin_installed() ) {
-			/**
-			 * Check for permissions
-			 */
-			if ( ! current_user_can( 'install_plugins' ) ) {
-				return new WP_Error( 'not_allowed', __( 'You are not allowed to install plugins on this site.', 'jetpack-my-jetpack' ) );
-			}
-
-			/**
-			 * Install the plugin
-			 */
-			$installed = Plugins_Installer::install_plugin( static::get_plugin_slug() );
-			if ( is_wp_error( $installed ) ) {
-				return $installed;
-			}
-		}
-
-		/**
-		 * Activate the installed plugin
-		 */
-		$result = static::activate_plugin();
+	public static function install_and_activate_standalone() {
+		$result = parent::install_and_activate_standalone();
 
 		if ( is_wp_error( $result ) ) {
 			return $result;

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -26,6 +26,15 @@ abstract class Hybrid_Product extends Product {
 	public static $has_standalone_plugin = true;
 
 	/**
+	 * For Hybrid products, we can use either the standalone or Jetpack plugin
+	 *
+	 * @return bool
+	 */
+	public static function is_plugin_installed() {
+		return parent::is_plugin_installed() || parent::is_jetpack_plugin_installed();
+	}
+
+	/**
 	 * Checks whether the Product is active
 	 *
 	 * @return boolean
@@ -141,7 +150,7 @@ abstract class Hybrid_Product extends Product {
 		 * Activate the module as well, if the user has a plan
 		 * or the product does not require a plan to work
 		 */
-		if ( static::has_required_plan() ) {
+		if ( static::has_required_plan() && isset( static::$module_name ) ) {
 			$module_activation = ( new Modules() )->activate( static::$module_name, false, false );
 
 			if ( ! $module_activation ) {

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -297,6 +297,19 @@ abstract class Product {
 	}
 
 	/**
+	 * Checks whether the site has a paid plan for the product
+	 * This ignores free products, it only checks if there is a purchase that supports the product
+	 *
+	 * @return boolean
+	 */
+	public static function has_paid_plan_for_product() {
+		// TODO: this is not always the same.
+		// There should be checks on each individual product class for paid plans if the product has a free offering
+		// For products with no free offering, checking has_required_plan works fine
+		return static::has_required_plan();
+	}
+
+	/**
 	 * Checks whether the current plan (or purchases) of the site already supports the tiers
 	 *
 	 * @return array Key/value pairs of tier slugs and whether they are supported or not.
@@ -365,7 +378,7 @@ abstract class Product {
 	public static function get_status() {
 		if ( ! static::is_plugin_installed() ) {
 			$status = 'plugin_absent';
-			if ( static::has_required_plan() ) {
+			if ( static::has_paid_plan_for_product() ) {
 				$status = 'plugin_absent_with_plan';
 			}
 		} elseif ( static::is_active() ) {

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -580,4 +580,44 @@ abstract class Product {
 
 		self::filter_action_links( $filenames );
 	}
+
+	/**
+	 * Install and activate the standalone plugin in the case it's missing.
+	 *
+	 * @return boolean|WP_Error
+	 */
+	public static function install_and_activate_standalone() {
+		/**
+		 * Check for the presence of the standalone plugin, ignoring Jetpack presence.
+		 *
+		 * If the standalone plugin is not installed and the user can install plugins, proceed with the installation.
+		 */
+		if ( ! static::is_plugin_installed() ) {
+			/**
+			 * Check for permissions
+			 */
+			if ( ! current_user_can( 'install_plugins' ) ) {
+				return new WP_Error( 'not_allowed', __( 'You are not allowed to install plugins on this site.', 'jetpack-my-jetpack' ) );
+			}
+
+			/**
+			 * Install the plugin
+			 */
+			$installed = Plugins_Installer::install_plugin( static::get_plugin_slug() );
+			if ( is_wp_error( $installed ) ) {
+				return $installed;
+			}
+		}
+
+		/**
+		 * Activate the installed plugin
+		 */
+		$result = static::activate_plugin();
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return true;
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -218,6 +218,19 @@ class Protect extends Product {
 	}
 
 	/**
+	 * Checks if the site has a paid plan for the product
+	 *
+	 * @return bool
+	 */
+	public static function has_paid_plan_for_product() {
+		$scan_data = static::get_state_from_wpcom();
+		if ( is_wp_error( $scan_data ) ) {
+			return false;
+		}
+		return is_object( $scan_data ) && isset( $scan_data->state ) && 'unavailable' !== $scan_data->state;
+	}
+
+	/**
 	 * Get the URL where the user manages the product
 	 *
 	 * @return ?string

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\My_Jetpack\Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Jetpack_Options;
+use WP_Error;
 
 /**
  * Class responsible for handling the Protect product

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -203,6 +203,27 @@ class Stats extends Module_Product {
 	}
 
 	/**
+	 * Checks if the site has a paid plan that supports this product
+	 *
+	 * @return boolean
+	 */
+	public static function has_paid_plan_for_product() {
+		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
+			return false;
+		}
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				// Stats is available as standalone product and as part of the Complete plan.
+				if ( strpos( $purchase->product_slug, 'jetpack_stats' ) !== false || str_starts_with( $purchase->product_slug, 'jetpack_complete' ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Returns a productType parameter for an upgrade URL, determining whether
 	 * to show the PWYW upgrade interstitial or commercial upgrade interstitial.
 	 *


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This diff updates My Jetpack products to show "Needs Plugin" as the status if the site has a plan for that product but it is missing the corresponding plugin to drive that functionality.
* Cards in this state show a CTA of "Install Plugin" which installs the requisite plugin asynchronously
* This diff also makes some adjustments to the Hybrid_Product class to make the active/inactive statuses more accurate after purchasing a plan for a site.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p6TEKc-7Ef-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Obtain a new Jetpack site with a Jetpack Scan subscription
* From My Jetpack, with no other plugins installed but the main Jetpack plugin, confirm that the Protect card shows a status of "Needs Plugin" and a CTA of "Install Plugin"
* Clicking "Install Plugin" should install the Protect standalone plugin in the background
* Now remove the protect plugin and your scan subscription
* Repeat the test with a subscription for Jetpack Complete
* Products that work with the main Jetpack plugin or standalone (VideoPress, Backup, Search, Creator) should automatically show as "Active" after the purchase. Protect, Boost, and CRM should show as "Needs Plugin". You should be able to install these plugins asynchronously via the CTAs on the page.