### PR TITLE
[Boost] Shift pre-WordPress code into a common namespace and folder

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -5,13 +5,8 @@ namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
 use Automattic\Jetpack_Boost\Contracts\Has_Activate;
 use Automattic\Jetpack_Boost\Contracts\Has_Deactivate;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
-
-/*
- * This code is shared between the autoloaded Module and advanced-cache.php loaded code.
- */
-require_once __DIR__ . '/Boost_Cache_Utils.php';
-require_once __DIR__ . '/Boost_Cache_Settings.php';
-require_once __DIR__ . '/Page_Cache_Setup.php';
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Page_Cache_Setup;
 
 class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 	/*

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -6,7 +6,6 @@ use Automattic\Jetpack_Boost\Contracts\Has_Activate;
 use Automattic\Jetpack_Boost\Contracts\Has_Deactivate;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
-use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Page_Cache_Setup;
 
 class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 	/*

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
 
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache_Utils;
+
 class Page_Cache_Setup {
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/Boost_Cache_Settings.php';
 require_once __DIR__ . '/Boost_Cache_Utils.php';
 require_once __DIR__ . '/Logger.php';
 require_once __DIR__ . '/Request.php';
+require_once __DIR__ . '/storage/Storage.php';
 require_once __DIR__ . '/storage/File_Storage.php';
 
 class Boost_Cache {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -5,6 +5,10 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
+/*
+ * Require all pre-wordpress files here. These files aren't autoloaded as they are loaded before WordPress is fully initialized.
+ * pre-wordpress files assume all other pre-wordpress files are loaded here.
+ */
 require_once __DIR__ . '/Boost_Cache_Settings.php';
 require_once __DIR__ . '/Boost_Cache_Utils.php';
 require_once __DIR__ . '/Logger.php';

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -1,9 +1,10 @@
 <?php
+
 /**
  * This file is loaded by advanced-cache.php, and so cannot rely on autoloading.
  */
 
-namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
+namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
 require_once __DIR__ . '/Boost_Cache_Settings.php';
 require_once __DIR__ . '/Boost_Cache_Utils.php';

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -1,6 +1,5 @@
 <?php
-
-/**
+/*
  * This file is loaded by advanced-cache.php, and so cannot rely on autoloading.
  */
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
@@ -1,6 +1,5 @@
 <?php
-
-/**
+/*
  * This file may be called before WordPress is fully initialized. See the README file for info.
  */
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
@@ -1,13 +1,17 @@
 <?php
 
-namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
+/**
+ * This file may be called before WordPress is fully initialized. See the README file for info.
+ */
+
+namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
+
+require_once __DIR__ . '/Boost_Cache_Utils.php';
 
 /*
  * Cache settings class.
  * Settings are stored in a file in the boost-cache directory.
- * This file is shared by autoloaded code and code loaded by advanced-cache.php
  */
-
 class Boost_Cache_Settings {
 	private static $instance = null;
 	private $settings        = array();

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
@@ -6,8 +6,6 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
-require_once __DIR__ . '/Boost_Cache_Utils.php';
-
 /*
  * Cache settings class.
  * Settings are stored in a file in the boost-cache directory.

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -1,6 +1,5 @@
 <?php
-
-/**
+/*
  * This file may be called before WordPress is fully initialized. See the README file for info.
  */
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -1,6 +1,10 @@
 <?php
 
-namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
+/**
+ * This file may be called before WordPress is fully initialized. See the README file for info.
+ */
+
+namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
 class Boost_Cache_Utils {
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
@@ -6,9 +6,6 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
-require_once __DIR__ . '/Boost_Cache_Utils.php';
-require_once __DIR__ . '/Request.php';
-
 /**
  * A utility that manages logging for the boost cache.
  */

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
@@ -1,6 +1,5 @@
 <?php
-
-/**
+/*
  * This file may be called before WordPress is fully initialized. See the README file for info.
  */
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
@@ -1,6 +1,13 @@
 <?php
 
-namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
+/**
+ * This file may be called before WordPress is fully initialized. See the README file for info.
+ */
+
+namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
+
+require_once __DIR__ . '/Boost_Cache_Utils.php';
+require_once __DIR__ . '/Request.php';
 
 /**
  * A utility that manages logging for the boost cache.

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/README.md
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/README.md
@@ -5,7 +5,7 @@ initialized. It can be called from `advanced-cache.php`, but it can also be call
 the main Boost code-base.
 
 Nothing in the `Pre_WordPress` namespace may rely on autolaoding to load things; you must include
-an explicit `require_once` instruction. It also must not rely on any WordPress functionality that is
+an explicit `require_once` instruction in the entrypoint file `Boost_Cache.php`. It also must not rely on any WordPress functionality that is
 unavailable at the time that `advanced-cache.php` is executed.
 
 You can use this code from elsewhere in Boost, and you can autoload it from outside this namespace, though.

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/README.md
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/README.md
@@ -1,0 +1,11 @@
+### Pre_WordPress namespace
+
+Everything in this directory / namespace contains code which can execute before WordPress is fully
+initialized. It can be called from `advanced-cache.php`, but it can also be called directly from
+the main Boost code-base.
+
+Nothing in the `Pre_WordPress` namespace may rely on autolaoding to load things; you must include
+an explicit `require_once` instruction. It also must not rely on any WordPress functionality that is
+unavailable at the time that `advanced-cache.php` is executed.
+
+You can use this code from elsewhere in Boost, and you can autoload it from outside this namespace, though.

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
@@ -1,6 +1,5 @@
 <?php
-
-/**
+/*
  * This file may be called before WordPress is fully initialized. See the README file for info.
  */
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
@@ -1,6 +1,13 @@
 <?php
 
-namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
+/**
+ * This file may be called before WordPress is fully initialized. See the README file for info.
+ */
+
+namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
+
+require_once __DIR__ . '/Boost_Cache_Settings.php';
+require_once __DIR__ . '/Logger.php';
 
 class Request {
 	/**
@@ -120,11 +127,6 @@ class Request {
 			return false;
 		}
 
-		if ( $this->is_url_excluded() ) {
-			Logger::debug( 'Url excluded, not cached!' ); // phpcs:ignore -- This is a debug message
-			return false;
-		}
-
 		if ( function_exists( 'is_user_logged_in' ) && is_user_logged_in() ) {
 			return false;
 		}
@@ -138,6 +140,11 @@ class Request {
 		}
 
 		if ( $this->is_backend() ) {
+			return false;
+		}
+
+		if ( $this->is_url_excluded() ) {
+			Logger::debug( 'Url excluded, not cached!' ); // phpcs:ignore -- This is a debug message
 			return false;
 		}
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
@@ -6,9 +6,6 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
-require_once __DIR__ . '/Boost_Cache_Settings.php';
-require_once __DIR__ . '/Logger.php';
-
 class Request {
 	/**
 	 * @var Request - The request instance for current request.

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
@@ -127,6 +127,11 @@ class Request {
 			return false;
 		}
 
+		if ( $this->is_url_excluded() ) {
+			Logger::debug( 'Url excluded, not cached!' ); // phpcs:ignore -- This is a debug message
+			return false;
+		}
+
 		if ( function_exists( 'is_user_logged_in' ) && is_user_logged_in() ) {
 			return false;
 		}
@@ -140,11 +145,6 @@ class Request {
 		}
 
 		if ( $this->is_backend() ) {
-			return false;
-		}
-
-		if ( $this->is_url_excluded() ) {
-			Logger::debug( 'Url excluded, not cached!' ); // phpcs:ignore -- This is a debug message
 			return false;
 		}
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -1,6 +1,5 @@
 <?php
-
-/**
+/*
  * This file may be called before WordPress is fully initialized. See the README file for info.
  */
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -1,12 +1,15 @@
 <?php
 
-namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Storage;
+/**
+ * This file may be called before WordPress is fully initialized. See the README file for info.
+ */
 
-// This file is loaded by advanced-cache.php, and so cannot rely on autoload.
+namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Storage;
+
 require_once __DIR__ . '/Storage.php';
 require_once dirname( __DIR__ ) . '/Boost_Cache_Utils.php';
 
-use Automattic\Jetpack_Boost\Modules\Page_Cache\Boost_Cache_Utils;
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache_Utils;
 
 /**
  * File Storage - handles writing to disk, reading from disk, purging and pruning old content.

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -6,9 +6,6 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Storage;
 
-require_once __DIR__ . '/Storage.php';
-require_once dirname( __DIR__ ) . '/Boost_Cache_Utils.php';
-
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache_Utils;
 
 /**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
@@ -1,6 +1,5 @@
 <?php
-
-/**
+/*
  * This file may be called before WordPress is fully initialized. See the README file for info.
  */
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
@@ -1,6 +1,10 @@
 <?php
 
-namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Storage;
+/**
+ * This file may be called before WordPress is fully initialized. See the README file for info.
+ */
+
+namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Storage;
 
 /**
  * Interface for Cache storage - a system for storing and purging caches.

--- a/projects/plugins/boost/changelog/boost-rearrange-cache-folder
+++ b/projects/plugins/boost/changelog/boost-rearrange-cache-folder
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Rearrange folder for clarity on pre-wordpress code
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack_Boost\Lib\Super_Cache_Info;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_CSS;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_JS;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Data_Sync_Actions\Run_Setup;
-use Automattic\Jetpack_Boost\Modules\Page_Cache\Logger;
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Logger;
 
 if ( ! defined( 'JETPACK_BOOST_DATASYNC_NAMESPACE' ) ) {
 	define( 'JETPACK_BOOST_DATASYNC_NAMESPACE', 'jetpack_boost_ds' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35670

Move all of the Boost Cache code which can execute without autoload and without WordPress present into a common namespace / folder for clarity. Add a readme note for future developers.

## Proposed changes:
* Move pre-WordPress functionality into the pre-WordPress folder, with a namespace of Pre_WordPress
* Add a README explaining the folder.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Don't forget to `composer dump-autoload`
* Make sure the cache functionality still works.

