### PR TITLE
Untangle: Don't override Site Editor's back button URL for sites with classic view enabled

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/site-editor-back-button-classic-view
+++ b/projects/packages/jetpack-mu-wpcom/changelog/site-editor-back-button-classic-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Don't override Site Editor's back button URL for sites with classic view enabled.

--- a/projects/packages/jetpack-mu-wpcom/src/features/site-editor-dashboard-link/site-editor-dashboard-link.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/site-editor-dashboard-link/site-editor-dashboard-link.php
@@ -28,6 +28,11 @@ add_filter(
 			}
 		}
 
+		// On sites with Classic view, don't override the dashboard link.
+		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+			return $settings;
+		}
+
 		if ( ! empty( $_GET['wp_theme_preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			// Point the `<` link to the theme showcase when previewing a theme.
 			$settings['__experimentalDashboardLink'] = $calypso_origin . '/themes/' . wpcom_get_site_slug();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:

- https://github.com/Automattic/dotcom-forge/issues/5466

## Proposed changes:

This PR removes the URL override we applied to the Site Editor's back button, when the site has classic view enabled. With this, the back button always point to wp-admin dashboard.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

NOTE: It's better to test this in conjunction with:

- https://github.com/Automattic/wp-calypso/pull/87526

so that we can test 2 PRs in a single testing session 😄 🙏 

1. Apply this `jetpack-mu-wpcom` to your Atomic site.
2. Enable Default view for your Atomic site.
3. Go to Site Editor. Verify that the back button (`< Design`) point to Calypso Home.
2. Enable Classic view for your Atomic site.
3. Go to Site Editor. Verify that the back button (`< Design`) point to wp-admin Dashboard.
