### PR TITLE
Boost: Fix advnaced-cache.php

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -69,7 +69,7 @@ class Page_Cache_Setup {
 			}
 		}
 
-		$boost_cache_filename = WP_CONTENT_DIR . '/plugins/' . basename( dirname( plugin_dir_path( __FILE__ ), 3 ) ) . '/app/modules/cache/Boost_Cache.php';
+		$boost_cache_filename = WP_CONTENT_DIR . '/plugins/' . basename( dirname( plugin_dir_path( __FILE__ ), 3 ) ) . '/app/modules/cache/pre-wordpress/Boost_Cache.php';
 		$contents             = '<?php
 // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE . ' - ' . Page_Cache::ADVANCED_CACHE_VERSION . '
 if ( ! file_exists( \'' . $boost_cache_filename . '\' ) ) {
@@ -77,7 +77,7 @@ return;
 }
 require_once( \'' . $boost_cache_filename . '\');
 
-( new Automattic\Jetpack_Boost\Modules\Page_Cache\Boost_Cache() )->serve();
+( new Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache() )->serve();
 ';
 
 		$write_advanced_cache = Boost_Cache_Utils::write_to_file( $advanced_cache_filename, $contents );

--- a/projects/plugins/boost/changelog/fix-advnace-cache
+++ b/projects/plugins/boost/changelog/fix-advnace-cache
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed path and namespace messed up in a recent PR
+
+


### PR DESCRIPTION
## Proposed changes:
* Fixed the filepath and namespace of `Boost_Cache` file reference in `advanced-cache.php`. This was mistakenly broken in #35719

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Enable cache
* Make sure caching works

