### PR TITLE
Repo Gardening: change the order of the tasks running

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-task-order
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-task-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tasks: run the Board update task before other tasks.

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -19,6 +19,11 @@ const ifNotFork = require( './utils/if-not-fork' );
 
 const automations = [
 	{
+		event: 'issues',
+		action: [ 'labeled', 'opened' ],
+		task: updateBoard,
+	},
+	{
 		event: 'pull_request_target',
 		action: [ 'opened', 'synchronize', 'edited' ],
 		task: ifNotFork( assignIssues ),
@@ -86,11 +91,6 @@ const automations = [
 		event: 'issues',
 		action: [ 'closed' ],
 		task: replyToCustomersReminder,
-	},
-	{
-		event: 'issues',
-		action: [ 'labeled', 'opened' ],
-		task: updateBoard,
 	},
 ];
 


### PR DESCRIPTION
## Proposed changes:

We currently have 2 different tasks that can trigger Slack Notifications:

- `triageIssues`
- `updateBoard`

Both of those tasks rely on the `notifyImportantIssues` utility function to post to Slack. That utility, after posting a message to Slack, adds a label ("[Status] Priority Review Triggered") to ensure that we do not post to Slack multiple times.

As a result, the 2 tasks above cannot both post to Slack: the one that runs first does, and the other one bails because the label already exists.

I think the `updateBoard` task should take prriority, since it warns the team working on the product directly, while the `triageIssues` task "only" warns triage teams that will in turn contact the product teams if necessary.

As a result, I'd like the Board update task to run first, before issues get triaged, so that the Slack notifications potentially triggered by the board update task happen first, before the Slack notifications sent by the triageIssues task.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This cannot be tested in this repo before the PR is merged. It can only be tested in a fork.
