### PR TITLE
Boost: Update Cache UI to save/load settings

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/main/variables.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/variables.scss
@@ -26,6 +26,8 @@ $gray: $gray_50;
 $blue_50: #2271b1;
 $blue_60: #135e96;
 
+$red_40: #e65054;
+
 $jetpack_green_0: #f0f2eb;
 $jetpack_green_5: #d0e6b8;
 $jetpack_green_10: #9dd977;
@@ -73,6 +75,7 @@ $spacing-unit: 8px;
 	--gray: #{$gray};
 	--blue-50: #{$blue_50};
 	--blue-60: #{$blue_60};
+	--red-40: #{$red_40};
 	--jetpack-green-0: #{$jetpack_green_0};
 	--jetpack-green-5: #{$jetpack_green_5};
 	--jetpack-green-10: #{$jetpack_green_10};

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/health/health.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/health/health.tsx
@@ -1,10 +1,13 @@
 import { Button, Notice } from '@automattic/jetpack-components';
-import { usePageCacheErrorDS, useRunPageCacheSetupAction } from '$lib/stores/page-cache';
+import { useRunPageCacheSetupAction } from '$lib/stores/page-cache';
 import getErrorData from './lib/get-error-data';
 import { __ } from '@wordpress/i18n';
 
-const Health = () => {
-	const pageCacheError = usePageCacheErrorDS();
+type HealthProps = {
+	error: string;
+};
+
+const Health = ( { error }: HealthProps ) => {
 	const runPageCacheSetupAction = useRunPageCacheSetupAction();
 
 	const requestRunSetup = () => {
@@ -12,26 +15,22 @@ const Health = () => {
 	};
 
 	// Was there a problem trying to setup cache?
-	if ( pageCacheError !== '' ) {
-		const errorCode = pageCacheError ? pageCacheError : '';
-
-		const errorData = getErrorData( errorCode );
-		if ( errorData ) {
-			return (
-				<Notice
-					level="warning"
-					hideCloseButton={ true }
-					title={ errorData.title }
-					actions={ [
-						<Button size="small" weight="regular" onClick={ requestRunSetup } key="try-again">
-							{ __( 'Try again', 'jetpack-boost' ) }
-						</Button>,
-					] }
-				>
-					<p>{ errorData.message }</p>
-				</Notice>
-			);
-		}
+	const errorData = getErrorData( error );
+	if ( errorData ) {
+		return (
+			<Notice
+				level="warning"
+				hideCloseButton={ true }
+				title={ errorData.title }
+				actions={ [
+					<Button size="small" weight="regular" onClick={ requestRunSetup } key="try-again">
+						{ __( 'Try again', 'jetpack-boost' ) }
+					</Button>,
+				] }
+			>
+				<p>{ errorData.message }</p>
+			</Notice>
+		);
 	}
 
 	return null;

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
@@ -34,6 +34,17 @@
 				margin-top: 16px;
 			}
 
+			&.has-error {
+				textarea {
+					border-color: var( --red-40 );
+				}
+
+				.error-message {
+					display: block;
+					color: var( --red-40 );
+				}
+			}
+
 			.title {
 				margin-bottom: 16px;
 				font-size: 16px;
@@ -49,7 +60,11 @@
 				border-radius: 4px;
 				border: 1px solid var( --gray-10 );
 				background: var( --primary-white );
-				color: var( --gray-10 );
+				color: #000;
+			}
+
+			.error-message {
+				display: none;
 			}
 
 			.description {
@@ -61,8 +76,13 @@
 			}
 
 			label {
+				display: block;
 				font-size: 16px;
 				line-height: 1.5;
+
+				&:not(:last-child) {
+					margin-bottom: 8px;
+				}
 			}
 		}
 

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
@@ -2,10 +2,6 @@
 	font-size: 14px;
 	line-height: 22px;
 
-	:global(svg) {
-		fill: var(--jetpack-green-40);
-	}
-
 	:global(button ~ button) {
 		margin-left: 20px !important;
 	}
@@ -14,6 +10,10 @@
 		display: flex;
 		flex-direction: row;
 		align-items: flex-start;
+
+		:global(svg) {
+			fill: var(--jetpack-green-40);
+		}
 
 		.summary {
 			flex-grow: 1;
@@ -64,6 +64,10 @@
 				font-size: 16px;
 				line-height: 1.5;
 			}
+		}
+
+		.button {
+			margin-top: 16px;
 		}
 	}
 }

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -7,6 +7,7 @@ import Lightning from '$svg/lightning';
 import styles from './meta.module.scss';
 import { useEffect, useState } from 'react';
 import { usePageCache } from '$lib/stores/page-cache';
+import { Link } from 'react-router-dom';
 
 const Meta = () => {
 	const [ isExpanded, setIsExpanded ] = useState( true );
@@ -104,6 +105,12 @@ const Meta = () => {
 										onChange={ event => setLogging( event.target.checked ) }
 									/>{ ' ' }
 									{ __( 'Activate logging to track all your cache events.', 'jetpack-boost' ) }
+									{ settings.logging && (
+										<>
+											{ ' ' }
+											<Link to="/cache-debug-log">{ __( 'See Logs', 'jetpack-boost' ) }</Link>
+										</>
+									) }
 								</label>
 							</div>
 						</>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -137,7 +137,7 @@ const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: Exc
 	const [ inputInvalid, setInputInvalid ] = useState( false ); // @todo - implement this
 
 	// @todo - add proper link.
-	const exclusionsLink = 'TBD';
+	const exclusionsLink = 'https://jetpack.com';
 
 	useEffect( () => {
 		setInputValue( exceptions );

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -151,12 +151,6 @@ const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: Exc
 		setExceptions( inputValue );
 	}
 
-	function showExample( event: React.MouseEvent ) {
-		event.preventDefault();
-
-		// @todo - add proper example.
-	}
-
 	return (
 		<div
 			className={ classNames( styles.section, {
@@ -186,7 +180,7 @@ const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: Exc
 					__( '<help>See an example</help> or <link>learn more</link>.', 'jetpack-boost' ),
 					{
 						// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
-						help: <a href="#" target="_blank" rel="noreferrer" onClick={ showExample } />,
+						help: <a href="#" target="_blank" rel="noreferrer" />,
 						// eslint-disable-next-line jsx-a11y/anchor-has-content
 						link: <a href={ exclusionsLink } target="_blank" rel="noreferrer" />,
 					}

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/jetpack-components';
+import { Button, Notice } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import ChevronDown from '$svg/chevron-down';
@@ -94,6 +94,7 @@ const Meta = () => {
 							<Exceptions
 								exceptions={ settings.exceptions.join( '\n' ) }
 								setExceptions={ setExceptions }
+								showErrorNotice={ query.isError }
 							/>
 							<div className={ styles.section }>
 								<div className={ styles.title }>{ __( 'Logging', 'jetpack-boost' ) }</div>
@@ -126,10 +127,12 @@ export default Meta;
 type ExceptionsProps = {
 	exceptions: string;
 	setExceptions: ( newValue: string ) => void;
+	showErrorNotice: boolean;
 };
 
-const Exceptions = ( { exceptions, setExceptions }: ExceptionsProps ) => {
+const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: ExceptionsProps ) => {
 	const [ inputValue, setInputValue ] = useState( exceptions );
+	const [ showNotice, setShowNotice ] = useState( showErrorNotice );
 
 	// @todo - add proper link.
 	const exclusionsLink = 'TBD';
@@ -169,7 +172,16 @@ const Exceptions = ( { exceptions, setExceptions }: ExceptionsProps ) => {
 					}
 				) }
 			</p>
-			<Button disabled={ exceptions === inputValue } onClick={ save }>
+			{ showNotice && (
+				<Notice
+					level="error"
+					title={ __( 'Error: Unable to save changes.', 'jetpack-boost' ) }
+					onClose={ () => setShowNotice( false ) }
+				>
+					{ __( 'An error occurred while saving changes. Please, try again.', 'jetpack-boost' ) }
+				</Notice>
+			) }
+			<Button disabled={ exceptions === inputValue } onClick={ save } className={ styles.button }>
 				{ __( 'Save', 'jetpack-boost' ) }
 			</Button>
 		</div>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -28,33 +28,33 @@ const Meta = () => {
 		} );
 	};
 
-	const setExceptions = ( newValue: string ) => {
+	const setBypassPatterns = ( newValue: string ) => {
 		if ( ! setSettings || ! settings ) {
 			return;
 		}
 
 		setSettings( {
 			...settings,
-			exceptions: newValue.split( '\n' ).map( item => item.trim() ),
+			bypassPatterns: newValue.split( '\n' ).map( item => item.trim() ),
 		} );
 	};
 
-	const totalExceptions = settings?.exceptions.length || 0;
+	const totalBypassPatterns = settings?.bypassPatterns.length || 0;
 
 	return (
 		<div className={ styles.wrapper }>
 			<div className={ styles.head }>
 				<div className={ styles.summary }>
-					{ totalExceptions === 0 && ! settings?.logging ? (
+					{ totalBypassPatterns === 0 && ! settings?.logging ? (
 						__( 'No exceptions or logging.', 'jetpack-boost' )
 					) : (
 						<>
-							{ totalExceptions > 0 ? (
+							{ totalBypassPatterns > 0 ? (
 								<>
 									{ sprintf(
-										/* translators: %d is the number of exceptions. */
-										_n( '%d exception.', '%d exceptions.', totalExceptions, 'jetpack-boost' ),
-										totalExceptions
+										/* translators: %d is the number of cache bypass patterns. */
+										_n( '%d exception.', '%d exceptions.', totalBypassPatterns, 'jetpack-boost' ),
+										totalBypassPatterns
 									) }
 								</>
 							) : (
@@ -91,9 +91,9 @@ const Meta = () => {
 				<div className={ styles.body }>
 					{ settings && (
 						<>
-							<Exceptions
-								exceptions={ settings.exceptions.join( '\n' ) }
-								setExceptions={ setExceptions }
+							<BypassPatterns
+								patterns={ settings.bypassPatterns.join( '\n' ) }
+								setPatterns={ setBypassPatterns }
 								showErrorNotice={ mutation.isError }
 							/>
 							<div className={ styles.section }>
@@ -124,14 +124,18 @@ const Meta = () => {
 
 export default Meta;
 
-type ExceptionsProps = {
-	exceptions: string;
-	setExceptions: ( newValue: string ) => void;
+type BypassPatternsProps = {
+	patterns: string;
+	setPatterns: ( newValue: string ) => void;
 	showErrorNotice: boolean;
 };
 
-const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: ExceptionsProps ) => {
-	const [ inputValue, setInputValue ] = useState( exceptions );
+const BypassPatterns = ( {
+	patterns,
+	setPatterns,
+	showErrorNotice = false,
+}: BypassPatternsProps ) => {
+	const [ inputValue, setInputValue ] = useState( patterns );
 	const [ showNotice, setShowNotice ] = useState( showErrorNotice );
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [ inputInvalid, setInputInvalid ] = useState( false ); // @todo - implement this
@@ -140,15 +144,15 @@ const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: Exc
 	const exclusionsLink = 'https://jetpack.com';
 
 	useEffect( () => {
-		setInputValue( exceptions );
-	}, [ exceptions ] );
+		setInputValue( patterns );
+	}, [ patterns ] );
 
 	useEffect( () => {
 		setShowNotice( showErrorNotice );
 	}, [ showErrorNotice ] );
 
 	function save() {
-		setExceptions( inputValue );
+		setPatterns( inputValue );
 	}
 
 	return (
@@ -195,7 +199,7 @@ const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: Exc
 					{ __( 'An error occurred while saving changes. Please, try again.', 'jetpack-boost' ) }
 				</Notice>
 			) }
-			<Button disabled={ exceptions === inputValue } onClick={ save } className={ styles.button }>
+			<Button disabled={ patterns === inputValue } onClick={ save } className={ styles.button }>
 				{ __( 'Save', 'jetpack-boost' ) }
 			</Button>
 		</div>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -94,7 +94,7 @@ const Meta = () => {
 							<Exceptions
 								exceptions={ settings.exceptions.join( '\n' ) }
 								setExceptions={ setExceptions }
-								showErrorNotice={ query.isError }
+								showErrorNotice={ mutation.isError }
 							/>
 							<div className={ styles.section }>
 								<div className={ styles.title }>{ __( 'Logging', 'jetpack-boost' ) }</div>
@@ -140,6 +140,10 @@ const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: Exc
 	useEffect( () => {
 		setInputValue( exceptions );
 	}, [ exceptions ] );
+
+	useEffect( () => {
+		setShowNotice( showErrorNotice );
+	}, [ showErrorNotice ] );
 
 	function save() {
 		setExceptions( inputValue );

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -35,11 +35,11 @@ const Meta = () => {
 
 		setSettings( {
 			...settings,
-			bypassPatterns: newValue.split( '\n' ).map( item => item.trim() ),
+			bypass_patterns: newValue.split( '\n' ).map( item => item.trim() ),
 		} );
 	};
 
-	const totalBypassPatterns = settings?.bypassPatterns.length || 0;
+	const totalBypassPatterns = settings?.bypass_patterns.length || 0;
 
 	return (
 		<div className={ styles.wrapper }>
@@ -92,7 +92,7 @@ const Meta = () => {
 					{ settings && (
 						<>
 							<BypassPatterns
-								patterns={ settings.bypassPatterns.join( '\n' ) }
+								patterns={ settings.bypass_patterns.join( '\n' ) }
 								setPatterns={ setBypassPatterns }
 								showErrorNotice={ mutation.isError }
 							/>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -10,7 +10,7 @@ import { usePageCache } from '$lib/stores/page-cache';
 import { Link } from 'react-router-dom';
 
 const Meta = () => {
-	const [ isExpanded, setIsExpanded ] = useState( true );
+	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ query, mutation ] = usePageCache();
 
 	const settings = query?.data;

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -60,9 +60,8 @@ const Meta = () => {
 							) : (
 								__( 'No exceptions.', 'jetpack-boost' )
 							) }{ ' ' }
-							{ settings?.logging
-								? __( 'Logging activated.', 'jetpack-boost' )
-								: __( 'No logging.', 'jetpack-boost' ) }
+							{ settings?.logging && __( 'Logging activated.', 'jetpack-boost' ) }
+							{ ! settings?.logging && __( 'No logging.', 'jetpack-boost' ) }
 						</>
 					) }
 				</div>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -8,6 +8,7 @@ import styles from './meta.module.scss';
 import { useEffect, useState } from 'react';
 import { usePageCache } from '$lib/stores/page-cache';
 import { Link } from 'react-router-dom';
+import classNames from 'classnames';
 
 const Meta = () => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
@@ -133,6 +134,8 @@ type ExceptionsProps = {
 const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: ExceptionsProps ) => {
 	const [ inputValue, setInputValue ] = useState( exceptions );
 	const [ showNotice, setShowNotice ] = useState( showErrorNotice );
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [ inputInvalid, setInputInvalid ] = useState( false ); // @todo - implement this
 
 	// @todo - add proper link.
 	const exclusionsLink = 'TBD';
@@ -156,10 +159,24 @@ const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: Exc
 	}
 
 	return (
-		<div className={ styles.section }>
+		<div
+			className={ classNames( styles.section, {
+				[ styles[ 'has-error' ] ]: inputInvalid,
+			} ) }
+		>
 			<div className={ styles.title }>{ __( 'Exceptions', 'jetpack-boost' ) }</div>
-			<p>{ __( 'URLs of pages and posts that will never be cached:', 'jetpack-boost' ) }</p>
-			<textarea value={ inputValue } rows={ 3 } onChange={ e => setInputValue( e.target.value ) } />
+			<label htmlFor="jb-cache-exceptions">
+				{ __( 'URLs of pages and posts that will never be cached:', 'jetpack-boost' ) }
+			</label>
+			<textarea
+				value={ inputValue }
+				rows={ 3 }
+				onChange={ e => setInputValue( e.target.value ) }
+				id="jb-cache-exceptions"
+			/>
+			<p className={ classNames( styles.description, styles[ 'error-message' ] ) }>
+				{ __( 'Error: Invalid format', 'jetpack-boost' ) }
+			</p>
 			<p className={ styles.description }>
 				{ __(
 					'Use (.*) to address multiple URLs under a given path. Be sure each URL path is in its own line.',

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/jetpack-components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import ChevronDown from '$svg/chevron-down';
 import ChevronUp from '$svg/chevron-up';
@@ -102,12 +103,21 @@ type ExceptionsProps = {
 const Exceptions = ( { exceptions, setExceptions }: ExceptionsProps ) => {
 	const [ inputValue, setInputValue ] = useState( exceptions );
 
+	// @todo - add proper link.
+	const exclusionsLink = 'TBD';
+
 	useEffect( () => {
 		setInputValue( exceptions );
 	}, [ exceptions ] );
 
 	function save() {
 		setExceptions( inputValue );
+	}
+
+	function showExample( event: React.MouseEvent ) {
+		event.preventDefault();
+
+		// @todo - add proper example.
 	}
 
 	return (
@@ -117,8 +127,18 @@ const Exceptions = ( { exceptions, setExceptions }: ExceptionsProps ) => {
 			<textarea value={ inputValue } rows={ 3 } onChange={ e => setInputValue( e.target.value ) } />
 			<p className={ styles.description }>
 				{ __(
-					'Use (.*) to address multiple URLs under a given path. Be sure each URL path is in its own line. See an example or learn more.',
+					'Use (.*) to address multiple URLs under a given path. Be sure each URL path is in its own line.',
 					'jetpack-boost'
+				) }
+				<br />
+				{ createInterpolateElement(
+					__( '<help>See an example</help> or <link>learn more</link>.', 'jetpack-boost' ),
+					{
+						// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
+						help: <a href="#" target="_blank" rel="noreferrer" onClick={ showExample } />,
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						link: <a href={ exclusionsLink } target="_blank" rel="noreferrer" />,
+					}
 				) }
 			</p>
 			<Button disabled={ exceptions === inputValue } onClick={ save }>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -4,7 +4,7 @@ import ChevronDown from '$svg/chevron-down';
 import ChevronUp from '$svg/chevron-up';
 import Lightning from '$svg/lightning';
 import styles from './meta.module.scss';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { usePageCache } from '$lib/stores/page-cache';
 
 const Meta = () => {
@@ -22,6 +22,17 @@ const Meta = () => {
 		setSettings( {
 			...settings,
 			logging: newValue,
+		} );
+	};
+
+	const setExcludes = ( newValue: string ) => {
+		if ( ! setSettings || ! settings ) {
+			return;
+		}
+
+		setSettings( {
+			...settings,
+			excludes: newValue.split( '\n' ).map( item => item.trim() ),
 		} );
 	};
 
@@ -57,20 +68,7 @@ const Meta = () => {
 				<div className={ styles.body }>
 					{ settings && (
 						<>
-							<div className={ styles.section }>
-								<div className={ styles.title }>{ __( 'Exceptions', 'jetpack-boost' ) }</div>
-								<p>
-									{ __( 'URLs of pages and posts that will never be cached:', 'jetpack-boost' ) }
-								</p>
-								<textarea rows={ 3 }></textarea>
-								<p className={ styles.description }>
-									{ __(
-										'Use (*) to address multiple URLs under a given path. Be sure each URL path is in its own line. See an example or learn more.',
-										'jetpack-boost'
-									) }
-								</p>
-								<Button>{ __( 'Save', 'jetpack-boost' ) }</Button>
-							</div>
+							<Exceptions excludes={ settings.excludes.join( '\n' ) } setExcludes={ setExcludes } />
 							<div className={ styles.section }>
 								<div className={ styles.title }>{ __( 'Logging', 'jetpack-boost' ) }</div>
 								<label htmlFor="cache-logging">
@@ -92,3 +90,37 @@ const Meta = () => {
 };
 
 export default Meta;
+
+type ExceptionsProps = {
+	excludes: string;
+	setExcludes: ( newValue: string ) => void;
+};
+
+const Exceptions = ( { excludes, setExcludes }: ExceptionsProps ) => {
+	const [ inputValue, setInputValue ] = useState( excludes );
+
+	useEffect( () => {
+		setInputValue( excludes );
+	}, [ excludes ] );
+
+	function save() {
+		setExcludes( inputValue );
+	}
+
+	return (
+		<div className={ styles.section }>
+			<div className={ styles.title }>{ __( 'Exceptions', 'jetpack-boost' ) }</div>
+			<p>{ __( 'URLs of pages and posts that will never be cached:', 'jetpack-boost' ) }</p>
+			<textarea value={ inputValue } rows={ 3 } onChange={ e => setInputValue( e.target.value ) } />
+			<p className={ styles.description }>
+				{ __(
+					'Use (*) to address multiple URLs under a given path. Be sure each URL path is in its own line. See an example or learn more.',
+					'jetpack-boost'
+				) }
+			</p>
+			<Button disabled={ excludes === inputValue } onClick={ save }>
+				{ __( 'Save', 'jetpack-boost' ) }
+			</Button>
+		</div>
+	);
+};

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -5,9 +5,25 @@ import ChevronUp from '$svg/chevron-up';
 import Lightning from '$svg/lightning';
 import styles from './meta.module.scss';
 import { useState } from 'react';
+import { usePageCache } from '$lib/stores/page-cache';
 
 const Meta = () => {
-	const [ isExpanded, setIsExpanded ] = useState( false );
+	const [ isExpanded, setIsExpanded ] = useState( true );
+	const [ query, mutation ] = usePageCache();
+
+	const settings = query?.data;
+	const setSettings = mutation.mutate;
+
+	const setLogging = ( newValue: boolean ) => {
+		if ( ! setSettings || ! settings ) {
+			return;
+		}
+
+		setSettings( {
+			...settings,
+			logging: newValue,
+		} );
+	};
 
 	return (
 		<div className={ styles.wrapper }>
@@ -39,25 +55,36 @@ const Meta = () => {
 			</div>
 			{ isExpanded && (
 				<div className={ styles.body }>
-					<div className={ styles.section }>
-						<div className={ styles.title }>{ __( 'Exceptions', 'jetpack-boost' ) }</div>
-						<p>{ __( 'URLs of pages and posts that will never be cached:', 'jetpack-boost' ) }</p>
-						<textarea rows={ 3 }></textarea>
-						<p className={ styles.description }>
-							{ __(
-								'Use (*) to address multiple URLs under a given path. Be sure each URL path is in its own line. See an example or learn more.',
-								'jetpack-boost'
-							) }
-						</p>
-						<Button>{ __( 'Save', 'jetpack-boost' ) }</Button>
-					</div>
-					<div className={ styles.section }>
-						<div className={ styles.title }>{ __( 'Logging', 'jetpack-boost' ) }</div>
-						<label htmlFor="cache-logging">
-							<input type="checkbox" id="cache-logging" />{ ' ' }
-							{ __( 'Activate logging to track all your cache events.', 'jetpack-boost' ) }
-						</label>
-					</div>
+					{ settings && (
+						<>
+							<div className={ styles.section }>
+								<div className={ styles.title }>{ __( 'Exceptions', 'jetpack-boost' ) }</div>
+								<p>
+									{ __( 'URLs of pages and posts that will never be cached:', 'jetpack-boost' ) }
+								</p>
+								<textarea rows={ 3 }></textarea>
+								<p className={ styles.description }>
+									{ __(
+										'Use (*) to address multiple URLs under a given path. Be sure each URL path is in its own line. See an example or learn more.',
+										'jetpack-boost'
+									) }
+								</p>
+								<Button>{ __( 'Save', 'jetpack-boost' ) }</Button>
+							</div>
+							<div className={ styles.section }>
+								<div className={ styles.title }>{ __( 'Logging', 'jetpack-boost' ) }</div>
+								<label htmlFor="cache-logging">
+									<input
+										type="checkbox"
+										id="cache-logging"
+										checked={ settings.logging }
+										onChange={ event => setLogging( event.target.checked ) }
+									/>{ ' ' }
+									{ __( 'Activate logging to track all your cache events.', 'jetpack-boost' ) }
+								</label>
+							</div>
+						</>
+					) }
 				</div>
 			) }
 		</div>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -25,14 +25,14 @@ const Meta = () => {
 		} );
 	};
 
-	const setExcludes = ( newValue: string ) => {
+	const setExceptions = ( newValue: string ) => {
 		if ( ! setSettings || ! settings ) {
 			return;
 		}
 
 		setSettings( {
 			...settings,
-			excludes: newValue.split( '\n' ).map( item => item.trim() ),
+			exceptions: newValue.split( '\n' ).map( item => item.trim() ),
 		} );
 	};
 
@@ -68,7 +68,10 @@ const Meta = () => {
 				<div className={ styles.body }>
 					{ settings && (
 						<>
-							<Exceptions excludes={ settings.excludes.join( '\n' ) } setExcludes={ setExcludes } />
+							<Exceptions
+								exceptions={ settings.exceptions.join( '\n' ) }
+								setExceptions={ setExceptions }
+							/>
 							<div className={ styles.section }>
 								<div className={ styles.title }>{ __( 'Logging', 'jetpack-boost' ) }</div>
 								<label htmlFor="cache-logging">
@@ -92,19 +95,19 @@ const Meta = () => {
 export default Meta;
 
 type ExceptionsProps = {
-	excludes: string;
-	setExcludes: ( newValue: string ) => void;
+	exceptions: string;
+	setExceptions: ( newValue: string ) => void;
 };
 
-const Exceptions = ( { excludes, setExcludes }: ExceptionsProps ) => {
-	const [ inputValue, setInputValue ] = useState( excludes );
+const Exceptions = ( { exceptions, setExceptions }: ExceptionsProps ) => {
+	const [ inputValue, setInputValue ] = useState( exceptions );
 
 	useEffect( () => {
-		setInputValue( excludes );
-	}, [ excludes ] );
+		setInputValue( exceptions );
+	}, [ exceptions ] );
 
 	function save() {
-		setExcludes( inputValue );
+		setExceptions( inputValue );
 	}
 
 	return (
@@ -114,11 +117,11 @@ const Exceptions = ( { excludes, setExcludes }: ExceptionsProps ) => {
 			<textarea value={ inputValue } rows={ 3 } onChange={ e => setInputValue( e.target.value ) } />
 			<p className={ styles.description }>
 				{ __(
-					'Use (*) to address multiple URLs under a given path. Be sure each URL path is in its own line. See an example or learn more.',
+					'Use (.*) to address multiple URLs under a given path. Be sure each URL path is in its own line. See an example or learn more.',
 					'jetpack-boost'
 				) }
 			</p>
-			<Button disabled={ excludes === inputValue } onClick={ save }>
+			<Button disabled={ exceptions === inputValue } onClick={ save }>
 				{ __( 'Save', 'jetpack-boost' ) }
 			</Button>
 		</div>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import ChevronDown from '$svg/chevron-down';
 import ChevronUp from '$svg/chevron-up';
 import Lightning from '$svg/lightning';
@@ -37,11 +37,32 @@ const Meta = () => {
 		} );
 	};
 
+	const totalExceptions = settings?.exceptions.length || 0;
+
 	return (
 		<div className={ styles.wrapper }>
 			<div className={ styles.head }>
 				<div className={ styles.summary }>
-					{ __( 'No exceptions or logging.', 'jetpack-boost' ) }
+					{ totalExceptions === 0 && ! settings?.logging ? (
+						__( 'No exceptions or logging.', 'jetpack-boost' )
+					) : (
+						<>
+							{ totalExceptions > 0 ? (
+								<>
+									{ sprintf(
+										/* translators: %d is the number of exceptions. */
+										_n( '%d exception.', '%d exceptions.', totalExceptions, 'jetpack-boost' ),
+										totalExceptions
+									) }
+								</>
+							) : (
+								__( 'No exceptions.', 'jetpack-boost' )
+							) }{ ' ' }
+							{ settings?.logging
+								? __( 'Logging activated.', 'jetpack-boost' )
+								: __( 'No logging.', 'jetpack-boost' ) }
+						</>
+					) }
 				</div>
 				<div className={ styles.actions }>
 					<Button

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -1,6 +1,9 @@
+import { __ } from '@wordpress/i18n';
 import Meta from '$features/page-cache/meta/meta';
 import Health from '$features/page-cache/health/health';
 import { usePageCacheErrorDS } from '$lib/stores/page-cache';
+import ErrorBoundary from '$features/error-boundary/error-boundary';
+import ErrorNotice from '$features/error-notice/error-notice';
 
 const PageCache = () => {
 	const pageCacheError = usePageCacheErrorDS();
@@ -8,4 +11,17 @@ const PageCache = () => {
 	return <>{ pageCacheError ? <Health error={ pageCacheError } /> : <Meta /> }</>;
 };
 
-export default PageCache;
+export default () => {
+	return (
+		<ErrorBoundary
+			fallback={
+				<ErrorNotice
+					title={ __( 'Error', 'jetpack-boost' ) }
+					error={ new Error( __( 'Unable to load Cache settings.', 'jetpack-boost' ) ) }
+				/>
+			}
+		>
+			<PageCache />
+		</ErrorBoundary>
+	);
+};

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -1,0 +1,11 @@
+import Meta from '$features/page-cache/meta/meta';
+import Health from '$features/page-cache/health/health';
+import { usePageCacheErrorDS } from '$lib/stores/page-cache';
+
+const PageCache = () => {
+	const pageCacheError = usePageCacheErrorDS();
+
+	return <>{ pageCacheError ? <Health error={ pageCacheError } /> : <Meta /> }</>;
+};
+
+export default PageCache;

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
@@ -6,11 +6,19 @@ import {
 import { z } from 'zod';
 
 export const PageCacheError = z.string();
+export const PageCache = z.object( {
+	excludes: z.array( z.string() ),
+	logging: z.boolean(),
+} );
 
 export function usePageCacheErrorDS() {
 	const [ { data } ] = useDataSync( 'jetpack_boost_ds', 'page_cache_error', PageCacheError );
 
 	return data;
+}
+
+export function usePageCache() {
+	return useDataSync( 'jetpack_boost_ds', 'page_cache', PageCache );
 }
 
 /**

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 
 export const PageCacheError = z.string();
 export const PageCache = z.object( {
-	excludes: z.array( z.string() ),
+	exceptions: z.array( z.string() ),
 	logging: z.boolean(),
 } );
 

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 
 export const PageCacheError = z.string();
 export const PageCache = z.object( {
-	exceptions: z.array( z.string() ),
+	bypassPatterns: z.array( z.string() ),
 	logging: z.boolean(),
 } );
 

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 
 export const PageCacheError = z.string();
 export const PageCache = z.object( {
-	bypassPatterns: z.array( z.string() ),
+	bypass_patterns: z.array( z.string() ),
 	logging: z.boolean(),
 } );
 

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -15,8 +15,7 @@ import SuperCacheInfo from '$features/super-cache-info/super-cache-info';
 import { useRegenerateCriticalCssAction } from '$features/critical-css/lib/stores/critical-css-state';
 import PremiumTooltip from '$features/premium-tooltip/premium-tooltip';
 import Upgraded from '$features/ui/upgraded/upgraded';
-import PageCacheMeta from '$features/page-cache/meta/meta';
-import PageCacheHealth from '$features/page-cache/health/health';
+import PageCache from '$features/page-cache/page-cache';
 import { invalidatePageCacheError } from '$lib/stores/page-cache';
 
 const Index = () => {
@@ -133,8 +132,7 @@ const Index = () => {
 				onEnable={ invalidatePageCacheError }
 				onDisable={ invalidatePageCacheError }
 			>
-				<PageCacheMeta />
-				<PageCacheHealth />
+				<PageCache />
 			</Module>
 			<Module
 				slug="render_blocking_js"

--- a/projects/plugins/boost/app/modules/cache/data-sync/Page_Cache_Entry.php
+++ b/projects/plugins/boost/app/modules/cache/data-sync/Page_Cache_Entry.php
@@ -11,8 +11,8 @@ class Page_Cache_Entry implements Entry_Can_Get, Entry_Can_Set {
 		$cache_settings = Boost_Cache_Settings::get_instance();
 
 		$settings = array(
-			'bypassPatterns' => $cache_settings->get_bypass_patterns(),
-			'logging'        => $cache_settings->get_logging(),
+			'bypass_patterns' => $cache_settings->get_bypass_patterns(),
+			'logging'         => $cache_settings->get_logging(),
 		);
 
 		return $settings;
@@ -21,7 +21,7 @@ class Page_Cache_Entry implements Entry_Can_Get, Entry_Can_Set {
 	public function set( $value ) {
 		$cache_settings = Boost_Cache_Settings::get_instance();
 
-		$value['bypassPatterns'] = $this->sanitize_value( $value['bypassPatterns'] );
+		$value['bypass_patterns'] = $this->sanitize_value( $value['bypass_patterns'] );
 
 		$cache_settings->set( $value );
 	}

--- a/projects/plugins/boost/app/modules/cache/data-sync/Page_Cache_Entry.php
+++ b/projects/plugins/boost/app/modules/cache/data-sync/Page_Cache_Entry.php
@@ -11,8 +11,8 @@ class Page_Cache_Entry implements Entry_Can_Get, Entry_Can_Set {
 		$cache_settings = Boost_Cache_Settings::get_instance();
 
 		$settings = array(
-			'excludes' => is_array( $cache_settings->get( 'excludes' ) ) ? $cache_settings->get( 'excludes' ) : array(),
-			'logging'  => $cache_settings->get( 'logging' ),
+			'exceptions' => $cache_settings->get_exceptions(),
+			'logging'    => $cache_settings->get_logging(),
 		);
 
 		return $settings;
@@ -21,7 +21,7 @@ class Page_Cache_Entry implements Entry_Can_Get, Entry_Can_Set {
 	public function set( $value ) {
 		$cache_settings = Boost_Cache_Settings::get_instance();
 
-		$value['excludes'] = $this->sanitize_value( $value['excludes'] );
+		$value['exceptions'] = $this->sanitize_value( $value['exceptions'] );
 
 		$cache_settings->set( $value );
 	}

--- a/projects/plugins/boost/app/modules/cache/data-sync/Page_Cache_Entry.php
+++ b/projects/plugins/boost/app/modules/cache/data-sync/Page_Cache_Entry.php
@@ -11,8 +11,8 @@ class Page_Cache_Entry implements Entry_Can_Get, Entry_Can_Set {
 		$cache_settings = Boost_Cache_Settings::get_instance();
 
 		$settings = array(
-			'exceptions' => $cache_settings->get_exceptions(),
-			'logging'    => $cache_settings->get_logging(),
+			'bypassPatterns' => $cache_settings->get_bypass_patterns(),
+			'logging'        => $cache_settings->get_logging(),
 		);
 
 		return $settings;
@@ -21,7 +21,7 @@ class Page_Cache_Entry implements Entry_Can_Get, Entry_Can_Set {
 	public function set( $value ) {
 		$cache_settings = Boost_Cache_Settings::get_instance();
 
-		$value['exceptions'] = $this->sanitize_value( $value['exceptions'] );
+		$value['bypassPatterns'] = $this->sanitize_value( $value['bypassPatterns'] );
 
 		$cache_settings->set( $value );
 	}

--- a/projects/plugins/boost/app/modules/cache/data-sync/Page_Cache_Entry.php
+++ b/projects/plugins/boost/app/modules/cache/data-sync/Page_Cache_Entry.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Data_Sync;
+
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
+
+class Page_Cache_Entry implements Entry_Can_Get, Entry_Can_Set {
+	public function get( $_fallback = false ) {
+		$cache_settings = Boost_Cache_Settings::get_instance();
+
+		$settings = array(
+			'excludes' => is_array( $cache_settings->get( 'excludes' ) ) ? $cache_settings->get( 'excludes' ) : array(),
+			'logging'  => $cache_settings->get( 'logging' ),
+		);
+
+		return $settings;
+	}
+
+	public function set( $value ) {
+		$cache_settings = Boost_Cache_Settings::get_instance();
+
+		$cache_settings->set( $value );
+	}
+}

--- a/projects/plugins/boost/app/modules/cache/data-sync/Page_Cache_Entry.php
+++ b/projects/plugins/boost/app/modules/cache/data-sync/Page_Cache_Entry.php
@@ -21,6 +21,25 @@ class Page_Cache_Entry implements Entry_Can_Get, Entry_Can_Set {
 	public function set( $value ) {
 		$cache_settings = Boost_Cache_Settings::get_instance();
 
+		$value['excludes'] = $this->sanitize_value( $value['excludes'] );
+
 		$cache_settings->set( $value );
+	}
+
+	/**
+	 * Sanitizes the given value, ensuring that it is a comma-separated list of unique, trimmed strings.
+	 *
+	 * @param mixed $value The value to sanitize.
+	 *
+	 * @return string The sanitized value, as a comma-separated list of unique, trimmed strings.
+	 */
+	private function sanitize_value( $value ) {
+		if ( is_array( $value ) ) {
+			$value = array_values( array_unique( array_filter( array_map( 'trim', $value ) ) ) );
+		} else {
+			$value = array();
+		}
+
+		return $value;
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
@@ -109,8 +109,8 @@ class Boost_Cache_Settings {
 	 *
 	 * @return array
 	 */
-	public function get_exceptions() {
-		return $this->get( 'exceptions', array() );
+	public function get_bypass_patterns() {
+		return $this->get( 'bypassPatterns', array() );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
@@ -110,7 +110,7 @@ class Boost_Cache_Settings {
 	 * @return array
 	 */
 	public function get_bypass_patterns() {
-		return $this->get( 'bypassPatterns', array() );
+		return $this->get( 'bypass_patterns', array() );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
@@ -16,6 +16,15 @@ class Boost_Cache_Settings {
 	private $config_file_path;
 	private $config_file;
 
+	/**
+	 * An uninitialized config holds these settings.
+	 */
+	private $default_settings = array(
+		'enabled' => true,
+		'exclues' => array(),
+		'logging' => false,
+	);
+
 	private function __construct() {
 		$this->config_file_path = WP_CONTENT_DIR . '/boost-cache/';
 		$this->config_file      = $this->config_file_path . 'config.php';
@@ -45,7 +54,7 @@ class Boost_Cache_Settings {
 		}
 
 		if ( ! file_exists( $this->config_file ) ) {
-			if ( ! $this->set( array( 'enabled' => false ) ) ) {
+			if ( ! $this->set( $this->default_settings ) ) {
 				return false;
 			}
 		}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
@@ -20,9 +20,9 @@ class Boost_Cache_Settings {
 	 * An uninitialized config holds these settings.
 	 */
 	private $default_settings = array(
-		'enabled' => true,
-		'exclues' => array(),
-		'logging' => false,
+		'enabled'    => true,
+		'exceptions' => array(),
+		'logging'    => false,
 	);
 
 	private function __construct() {
@@ -107,8 +107,17 @@ class Boost_Cache_Settings {
 	 *
 	 * @return array
 	 */
-	public function get_excluded_urls() {
-		return $this->get( 'excluded_urls', array() );
+	public function get_exceptions() {
+		return $this->get( 'exceptions', array() );
+	}
+
+	/**
+	 * Returns whether logging is enabled or not.
+	 *
+	 * @return bool
+	 */
+	public function get_logging() {
+		return $this->get( 'logging', false );
 	}
 
 	/*

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
@@ -83,11 +83,11 @@ class Request {
 			$request_uri = $this->request_uri;
 		}
 
-		$exceptions = Boost_Cache_Settings::get_instance()->get_bypass_patterns();
-		$exceptions = apply_filters( 'boost_cache_exceptions', $exceptions );
+		$bypass_patterns = Boost_Cache_Settings::get_instance()->get_bypass_patterns();
+		$bypass_patterns = apply_filters( 'boost_cache_bypass_patterns', $bypass_patterns );
 
-		$exceptions[] = 'wp-.*\.php';
-		foreach ( $exceptions as $expr ) {
+		$bypass_patterns[] = 'wp-.*\.php';
+		foreach ( $bypass_patterns as $expr ) {
 			if ( ! empty( $expr ) && preg_match( "~$expr~", $request_uri ) ) {
 				return true;
 			}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
@@ -83,11 +83,11 @@ class Request {
 			$request_uri = $this->request_uri;
 		}
 
-		$excluded_urls = Boost_Cache_Settings::get_instance()->get_excluded_urls();
-		$excluded_urls = apply_filters( 'boost_cache_excluded_urls', $excluded_urls );
+		$exceptions = Boost_Cache_Settings::get_instance()->get_exceptions();
+		$exceptions = apply_filters( 'boost_cache_exceptions', $exceptions );
 
-		$excluded_urls[] = 'wp-.*\.php';
-		foreach ( $excluded_urls as $expr ) {
+		$exceptions[] = 'wp-.*\.php';
+		foreach ( $exceptions as $expr ) {
 			if ( ! empty( $expr ) && preg_match( "~$expr~", $request_uri ) ) {
 				return true;
 			}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
@@ -83,7 +83,7 @@ class Request {
 			$request_uri = $this->request_uri;
 		}
 
-		$exceptions = Boost_Cache_Settings::get_instance()->get_exceptions();
+		$exceptions = Boost_Cache_Settings::get_instance()->get_bypass_patterns();
 		$exceptions = apply_filters( 'boost_cache_exceptions', $exceptions );
 
 		$exceptions[] = 'wp-.*\.php';

--- a/projects/plugins/boost/changelog/update-cache-ui-save-load-settings
+++ b/projects/plugins/boost/changelog/update-cache-ui-save-load-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Update Cache UI to save/load settings.
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -363,8 +363,8 @@ jetpack_boost_register_option(
 	'page_cache',
 	Schema::as_assoc_array(
 		array(
-			'bypassPatterns' => Schema::as_array( Schema::as_string() ),
-			'logging'        => Schema::as_boolean(),
+			'bypass_patterns' => Schema::as_array( Schema::as_string() ),
+			'logging'         => Schema::as_boolean(),
 		)
 	),
 	new Page_Cache_Entry( JETPACK_BOOST_DATASYNC_NAMESPACE . '_page_cache' )

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -363,8 +363,8 @@ jetpack_boost_register_option(
 	'page_cache',
 	Schema::as_assoc_array(
 		array(
-			'excludes' => Schema::as_array( Schema::as_string() ),
-			'logging'  => Schema::as_boolean(),
+			'exceptions' => Schema::as_array( Schema::as_string() ),
+			'logging'    => Schema::as_boolean(),
 		)
 	),
 	new Page_Cache_Entry( JETPACK_BOOST_DATASYNC_NAMESPACE . '_page_cache' )

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -363,8 +363,8 @@ jetpack_boost_register_option(
 	'page_cache',
 	Schema::as_assoc_array(
 		array(
-			'exceptions' => Schema::as_array( Schema::as_string() ),
-			'logging'    => Schema::as_boolean(),
+			'bypassPatterns' => Schema::as_array( Schema::as_string() ),
+			'logging'        => Schema::as_boolean(),
 		)
 	),
 	new Page_Cache_Entry( JETPACK_BOOST_DATASYNC_NAMESPACE . '_page_cache' )

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -19,6 +19,7 @@ use Automattic\Jetpack_Boost\Lib\Premium_Pricing;
 use Automattic\Jetpack_Boost\Lib\Super_Cache_Info;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_CSS;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_JS;
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Data_Sync\Page_Cache_Entry;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Data_Sync_Actions\Run_Setup;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Logger;
 
@@ -357,3 +358,14 @@ jetpack_boost_register_option(
 );
 
 jetpack_boost_register_action( 'page_cache_error', 'run-page-cache-setup', Schema::as_void(), new Run_Setup() );
+
+jetpack_boost_register_option(
+	'page_cache',
+	Schema::as_assoc_array(
+		array(
+			'excludes' => Schema::as_array( Schema::as_string() ),
+			'logging'  => Schema::as_boolean(),
+		)
+	),
+	new Page_Cache_Entry( JETPACK_BOOST_DATASYNC_NAMESPACE . '_page_cache' )
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of  https://github.com/Automattic/jetpack/issues/35054.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* [x] Update Cache UI to save/load exclude and logging settings to/from cache config file.
* [x] Add notice when there was a problem saving excludes;
* [x] Update meta description to change based on enabled settings;
* [x] Add link to logs page when enabling logging.

There will be a follow-up to wrap-up the UI.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1HpG7-r9A-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Play around with the UI and make sure settings are saved/loaded correctly.