### PR TITLE
Blaze: allow switching off quick action links for specific CPTs

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-post-links-option-optout
+++ b/projects/packages/blaze/changelog/update-blaze-post-links-option-optout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Post Links: allow third-parties to toggle them depending on post type.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -60,17 +60,7 @@ class Blaze {
 	 * @return void
 	 */
 	public static function add_post_links_actions() {
-		if (
-			self::should_initialize()
-			/**
-			 * Allow third-party plugins to disable Blaze row actions.
-			 *
-			 * @since 0.16.0
-			 *
-			 * @param bool $blaze_post_actions_enabled Should Blaze row actions be enabled?
-			 */
-			&& apply_filters( 'jetpack_blaze_post_row_actions_enable', true )
-		) {
+		if ( self::should_initialize() ) {
 			add_filter( 'post_row_actions', array( __CLASS__, 'jetpack_blaze_row_action' ), 10, 2 );
 			add_filter( 'page_row_actions', array( __CLASS__, 'jetpack_blaze_row_action' ), 10, 2 );
 		}
@@ -309,10 +299,21 @@ class Blaze {
 	 * @return array
 	 */
 	public static function jetpack_blaze_row_action( $post_actions, $post ) {
-		$post_id = $post->ID;
+		/**
+		 * Allow third-party plugins to disable Blaze row actions.
+		 *
+		 * @since 0.16.0
+		 *
+		 * @param bool    $are_quick_links_enabled Should Blaze row actions be enabled.
+		 * @param WP_Post $post                    The current post in the post list table.
+		 */
+		$are_quick_links_enabled = apply_filters( 'jetpack_blaze_post_row_actions_enable', true, $post );
 
 		// Bail if we are not looking at one of the supported post types (post, page, or product).
-		if ( ! in_array( $post->post_type, array( 'post', 'page', 'product' ), true ) ) {
+		if (
+			! $are_quick_links_enabled
+			|| ! in_array( $post->post_type, array( 'post', 'page', 'product' ), true )
+		) {
 			return $post_actions;
 		}
 
@@ -326,7 +327,7 @@ class Blaze {
 			return $post_actions;
 		}
 
-		$blaze_url = self::get_campaign_management_url( $post_id );
+		$blaze_url = self::get_campaign_management_url( $post->ID );
 		$text      = __( 'Promote with Blaze', 'jetpack-blaze' );
 		$title     = get_the_title( $post );
 		$label     = sprintf(

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -138,23 +138,6 @@ class Test_Blaze extends BaseTestCase {
 	}
 
 	/**
-	 * Tests whether Post row actions can be disabled via a filter.
-	 *
-	 * @covers Automattic\Jetpack\Blaze::add_post_links_actions
-	 */
-	public function test_post_row_removed_filter() {
-		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
-
-		wp_set_current_user( $this->admin_id );
-		add_filter( 'jetpack_blaze_post_row_actions_enable', '__return_false' );
-		add_filter( 'jetpack_blaze_enabled', '__return_true' );
-		Blaze::add_post_links_actions();
-
-		$this->assertFalse( has_action( 'post_row_actions' ) );
-		add_filter( 'jetpack_blaze_enabled', '__return_false' );
-	}
-
-	/**
 	 * Test if the admin menu is added for admins when we force Blaze to be enabled.
 	 *
 	 * @covers Automattic\Jetpack\Blaze::enable_blaze_menu

--- a/projects/plugins/jetpack/changelog/update-blaze-post-links-option-optout
+++ b/projects/plugins/jetpack/changelog/update-blaze-post-links-option-optout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blaze: display post links for products.

--- a/projects/plugins/jetpack/modules/blaze.php
+++ b/projects/plugins/jetpack/modules/blaze.php
@@ -17,5 +17,20 @@ use Automattic\Jetpack\Blaze;
 
 Blaze::init();
 
-// Remove post row Blaze actions in the Jetpack plugin.
-add_filter( 'jetpack_blaze_post_row_actions_enable', '__return_false' );
+/**
+ * Remove post row Blaze actions in the Jetpack plugin.
+ * Keep them on for products.
+ *
+ * @param bool    $are_quick_links_enabled Should Blaze row actions be enabled.
+ * @param WP_Post $post                    The current post in the post list table.
+ *
+ * @return bool
+ */
+function jetpack_blaze_post_row_actions_disable( $are_quick_links_enabled, $post ) {
+	if ( 'product' !== $post->post_type ) {
+		return false;
+	}
+
+	return $are_quick_links_enabled;
+}
+add_filter( 'jetpack_blaze_post_row_actions_enable', 'jetpack_blaze_post_row_actions_disable', 10, 2 );


### PR DESCRIPTION
## Proposed changes:

Follow-up to #35620

If we move the filter to a bit later in the process, we allow removing the Blaze link from some post types, but not others. In this scenario, in the Jetpack plugin we can turn off the links for posts and pages, while still allowing them for products.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Start with a site where you've installed both Jetpack and the WooCommerce plugin.

* Go to Products > Add New and publish a first product.
* Ensure your site is properly connected to WordPress.com.
* Go to Jetpack > Settings > Traffic and enable Blaze
* Go to Posts > All Posts 
    * You should not see any "Blaze" link when moving your mouse hover published post links.
* Go to Products > All Products
    * You should see the "Blaze" link over the product you published.
