### PR TITLE
Add cancel subscriptions parameter to API when deleting products

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -171,7 +171,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'can_modify_products_permission_check' ),
 					'args'                => array(
 						'cancel_subscriptions' => array(
-							'type'     => 'string',
+							'type'     => 'boolean',
 							'required' => false,
 						),
 					),
@@ -354,7 +354,11 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 				return array( 'error' => $e->getMessage() );
 			}
 		} else {
-			return $this->proxy_request_to_wpcom( "product/$product_id", 'DELETE' );
+			return $this->proxy_request_to_wpcom(
+				"product/$product_id",
+				'DELETE',
+				array( 'cancel_subscriptions' => $cancel_subscriptions )
+			);
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -169,6 +169,12 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_product' ),
 					'permission_callback' => array( $this, 'can_modify_products_permission_check' ),
+					'args'                => array(
+						'cancel_subscriptions' => array(
+							'type'     => 'string',
+							'required' => false,
+						),
+					),
 				),
 			)
 		);
@@ -337,11 +343,12 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 * @return array|WP_Error
 	 */
 	public function delete_product( \WP_REST_Request $request ) {
-		$product_id = $request->get_param( 'product_id' );
+		$product_id           = $request->get_param( 'product_id' );
+		$cancel_subscriptions = $request->get_param( 'cancel_subscriptions' );
 		if ( $this->is_wpcom() ) {
 			require_lib( 'memberships' );
 			try {
-				$this->delete_product_from_wpcom( $product_id );
+				$this->delete_product_from_wpcom( $product_id, $cancel_subscriptions );
 				return array( 'deleted' => true );
 			} catch ( \Exception $e ) {
 				return array( 'error' => $e->getMessage() );
@@ -560,12 +567,13 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 * Delete a product via the WPCOM-specific Memberships_Product class.
 	 *
 	 * @param string|int $product_id The ID of the product being deleted.
+	 * @param bool       $cancel_subscriptions Whether to cancel subscriptions to the product as well.
 	 * @throws \Exception When there is a problem deleting the product.
 	 * @return void
 	 */
-	private function delete_product_from_wpcom( $product_id ) {
+	private function delete_product_from_wpcom( $product_id, $cancel_subscriptions = false ) {
 		$product = $this->find_product_from_wpcom( $product_id ); // prevents running outside of wpcom
-		$result  = $product->delete();
+		$result  = $product->delete( $cancel_subscriptions ? 'CANCEL_SUBSCRIPTIONS' : 'KEEP_SUBSCRIPTIONS' );
 		if ( is_wp_error( $result ) ) {
 			throw new \Exception( $result->get_error_message() );
 		}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -577,7 +577,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 */
 	private function delete_product_from_wpcom( $product_id, $cancel_subscriptions = false ) {
 		$product = $this->find_product_from_wpcom( $product_id ); // prevents running outside of wpcom
-		$result  = $product->delete( $cancel_subscriptions ? 'CANCEL_SUBSCRIPTIONS' : 'KEEP_SUBSCRIPTIONS' );
+		$result  = $product->delete( $cancel_subscriptions ? Memberships_Product::CANCEL_SUBSCRIPTIONS : Memberships_Product::KEEP_SUBSCRIPTIONS );
 		if ( is_wp_error( $result ) ) {
 			throw new \Exception( $result->get_error_message() );
 		}

--- a/projects/plugins/jetpack/changelog/add-product-delete-cancel-subscriptions
+++ b/projects/plugins/jetpack/changelog/add-product-delete-cancel-subscriptions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Pass API parameter to indicate when deleting a memberships product should cancel subscriptions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/263

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `cancel_subscriptions` option to DELETE method on membership product API

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* https://github.com/Automattic/wp-calypso/pull/87967