### PR TITLE
CRM: Resolves 3429 - use existing tags if possible in helper functions

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3429-use_existing_tags_if_possible
+++ b/projects/plugins/crm/changelog/fix-crm-3429-use_existing_tags_if_possible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tags: Use existing tags if possible when using helper functions to create objects.

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -5804,17 +5804,14 @@ function jpcrm_deleted_invoice_counts( $all_invoices = null ) {
 						$args['data']['tags'][] = $tag_id;
 					}
 				}
-							}
-
-				#} Update record (All IA is now fired intrinsicaly)
-				return $zbs->DAL->transactions->addUpdateTransaction($args);
-
 			}
 
-
-		return false;
+			// Update record (All IA is now fired intrinsicaly)
+			return $zbs->DAL->transactions->addUpdateTransaction( $args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	}
 
+	return false;
+}
 
 	// Please use direct dal calls in future work, not this.
 	#} Quick wrapper to future-proof.

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -3691,21 +3691,37 @@ function zeroBS_getCompanyIDWithName( $company_name = '' ) {
 	                if ($we_have_tags){
 
 	                	$zbsCompanyMeta['tags'] = array();
-						foreach($company_tags as $cTag){
+				foreach ( $company_tags as $tag_name ) {
 
-							// find/add tag
-							$tagID = $zbs->DAL->addUpdateTag(array(
-								'data'=>array(
-									'objtype' 		=> ZBS_TYPE_COMPANY,
-									'name' 			=> $cTag
-									)));
+					// Check for existing tag under this name.
+					$tag_id = $zbs->DAL->getTag( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						-1,
+						array(
+							'objtype' => ZBS_TYPE_COMPANY,
+							'name'    => $tag_name,
+							'onlyID'  => true,
+						)
+					);
 
-							if (!empty($tagID)) $zbsCompanyMeta['tags'][] = $tagID;
+					// If tag doesn't exist, create one.
+					if ( empty( $tag_id ) ) {
+						$tag_id = $zbs->DAL->addUpdateTag( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+							array(
+								'data' => array(
+									'objtype' => ZBS_TYPE_COMPANY,
+									'name'    => $tag_name,
+								),
+							)
+						);
+					}
 
-						}
-
+					// Add tag to list.
+					if ( ! empty( $tag_id ) ) {
+						$zbsCompanyMeta['tags'][] = $tag_id; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					}
 				}
+			}
+		}
 
 
 				#} Add external source/externalid

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -5774,20 +5774,36 @@ function jpcrm_deleted_invoice_counts( $all_invoices = null ) {
 										);
 									}
 
-				                	$args['data']['tags'] = array();
-									foreach($transactionTags as $tTag){
+				$args['data']['tags'] = array();
+				foreach ( $transactionTags as $tag_name ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
-										// find/add tag
-										//wp_set_object_terms($postID , $cTag, 'zerobscrm_customertag', true );
-										$tagID = $zbs->DAL->addUpdateTag(array(
-											'data'=>array(
-												'objtype' 		=> ZBS_TYPE_TRANSACTION,
-												'name' 			=> $tTag
-												)));
+					// Check for existing tag under this name.
+					$tag_id = $zbs->DAL->getTag( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						-1,
+						array(
+							'objtype' => ZBS_TYPE_TRANSACTION,
+							'name'    => $tag_name,
+							'onlyID'  => true,
+						)
+					);
 
-										if (!empty($tagID)) $args['data']['tags'][] = $tagID;
+					// If tag doesn't exist, create one.
+					if ( empty( $tag_id ) ) {
+						$tag_id = $zbs->DAL->addUpdateTag( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+							array(
+								'data' => array(
+									'objtype' => ZBS_TYPE_TRANSACTION,
+									'name'    => $tag_name,
+								),
+							)
+						);
+					}
 
-									}
+					// Add tag to list.
+					if ( ! empty( $tag_id ) ) {
+						$args['data']['tags'][] = $tag_id;
+					}
+				}
 							}
 
 				#} Update record (All IA is now fired intrinsicaly)

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -3688,9 +3688,9 @@ function zeroBS_getCompanyIDWithName( $company_name = '' ) {
 						$we_have_tags = true;
 					}
 
-	                if ($we_have_tags){
+			if ( $we_have_tags ) {
 
-	                	$zbsCompanyMeta['tags'] = array();
+				$zbsCompanyMeta['tags'] = array(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				foreach ( $company_tags as $tag_name ) {
 
 					// Check for existing tag under this name.

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -1946,24 +1946,41 @@ function zeroBS_addUpdateCustomer(
 					$we_have_tags = true;
 				}
 
-                if($we_have_tags){
+			if ( $we_have_tags ) {
 
-                	$zbsCustomerMeta['tags'] = array();
-					foreach($customer_tags as $cTag){
+				$zbsCustomerMeta['tags'] = array(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				foreach ( $customer_tags as $tag_name ) {
 
-						// find/add tag
-						//wp_set_object_terms($postID , $cTag, 'zerobscrm_customertag', true );
-						$tagID = $zbs->DAL->addUpdateTag(array(
-							'data'=>array(
-								'objtype' 		=> ZBS_TYPE_CONTACT,
-								'name' 			=> $cTag
-								)));
+					// Check for existing tag under this name.
+					$tag_id = $zbs->DAL->getTag( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						-1,
+						array(
+							'objtype' => ZBS_TYPE_CONTACT,
+							'name'    => $tag_name,
+							'onlyID'  => true,
+						)
+					);
 
-						if (!empty($tagID)) $zbsCustomerMeta['tags'][] = $tagID;
-
+					// If tag doesn't exist, create one.
+					if ( empty( $tag_id ) ) {
+						$tag_id = $zbs->DAL->addUpdateTag( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+							array(
+								'data' => array(
+									'objtype' => ZBS_TYPE_CONTACT,
+									'name'    => $tag_name,
+								),
+							)
+						);
 					}
+
+					// Add tag to list.
+					if ( ! empty( $tag_id ) ) {
+						$zbsCustomerMeta['tags'][] = $tag_id; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					}
+
 				}
 			}
+		}
 
 
 			#} Add external source/externalid

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -1227,27 +1227,6 @@ function zeroBS_setOwner($objID=-1,$ownerID=-1,$objTypeID=false){
         // here we check that the potential owner CAN even own
         if (!user_can($ownerID,'admin_zerobs_usr')) return false;
 
-        /* DAL3 simplifies this
-
-		// BECAUSE db2 doesn't have all objects as tables, find out the type + then switch here
-		// ... we need to pass object really to third param, until we switch DB over
-		if (!$objType) $objType = get_post_type($postID);
-
-		// if not new db2:
-		if ($objType !== false && $objType !== 'zerobs_customer'){
-
-			return update_post_meta($postID, 'zbs_owner', (int)$ownerID);
-
-		} else {
-
-			global $zbs;
-
-			return $zbs->DAL->contacts->addUpdateContact(array(
-					'id'			=>	$postID,
-					'limitedFields'	=>array(
-						array('key'=>'zbs_owner','val'=>$ownerID,'type'=>'%d')
-						)));
-		} */
 		global $zbs;
 
 		return $zbs->DAL->setFieldByID(array(
@@ -6065,75 +6044,6 @@ function jpcrm_deleted_invoice_counts( $all_invoices = null ) {
 
    // Add an event
    function zeroBS_addUpdateEvent($eventID = -1, $eventFields = array(), $reminders=array()){
-
-		/*
-		
-			-EVENT FIELDS ARE
-
-			v2....
-			$event_fields = array(
-
-				'title' => event title
-				'customer' => ID of the customer the event is for (if any)
-				'notes' => customer notes string
-				'to' => to date, format date('m/d/Y H') . ":00:00";
-				'from' => from date, format date('m/d/Y H') . ":00:00";
-				'notify' => 0 or 24 (never or 24 hours before)
-				'complete' => 0 or 1 (boolean),
-				'owner' => who owns the event (-1 for no one),
-				'event_id' => the event ID
-
-
-			);
-
-
-			v3....
-			$event_fields = array(
-
-
-                'title' => '',
-                'desc' => '',
-                'start' => '',
-                'end' => '',
-                'complete' => '',
-                'show_on_portal' => '',
-                'show_on_cal' => '',
-
-                // obj links:
-                'contacts' => false, // array of id's
-                'companies' => false, // array of id's
-
-                // reminders:
-                'reminders'     => false, 
-                // will be an array of eventreminder lines (as per matching eventreminder database model)
-                // note:    if no change desired, pass "false"
-                //          if removal of all/change, pass array
-
-                // Note Custom fields may be passed here, but will not have defaults so check isset()
-
-                'tags' => -1, // if this is an array of ID's, they'll REPLACE existing tags against contact
-
-                'externalSources' => -1, // if this is an array(array('source'=>src,'uid'=>uid),multiple()) it'll add :)
-
-                // allow this to be set for MS sync etc.
-                'created' => -1,
-                'lastupdated' => '',
-
-
-			);
-
-		*/
-		/*
-		
-			-Reminder fields are (WH added in MS style for DAL3, and modified in events save )
-			$event_fields = array(
-
-	        'remind_at' => +- event time (e.g. -86400 for 1 day before)
-	        'sent' => has reminder been sent?
-
-			);
-
-		*/
 
 		// if using 'from' and 'to', probably using v1 dal, so translate dates:
 		if (isset($eventFields['from'])) $eventFields['from'] = strtotime($eventFields['from']);

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -1897,54 +1897,29 @@ function zeroBS_addUpdateCustomer(
 			#} Build using centralised func below, passing any existing meta (updates not overwrites)
 			$zbsCustomerMeta = zeroBS_buildCustomerMeta($cFields,$existingMeta,$metaBuilderPrefix,'',true);
 
-			/* dealt with in DAL2 now :)
-			// log any change of status
-			if (!empty($zbsCustomerMeta['status']) && !empty($originalStatus) && $zbsCustomerMeta['status'] != $originalStatus){
+		$we_have_tags = false; // set to false.. duh..
 
-				// status change
-				$statusChange = array(
-					'from' => $originalStatus,
-					'to' => $zbsCustomerMeta['status']
+		// TAG customer (if exists) - clean etc here too
+		if ( ! empty( $cFields['tags'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$tags = $cFields['tags']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			// Sanitize tags
+			if ( is_array( $tags ) ) {
+				$customer_tags = filter_var_array( $tags, FILTER_UNSAFE_RAW );
+				// Formerly this used FILTER_SANITIZE_STRING, which is now deprecated as it was fairly broken. This is basically equivalent.
+				// @todo Replace this with something more correct.
+				foreach ( $customer_tags as $k => $v ) {
+					$customer_tags[ $k ] = strtr(
+						strip_tags( $v ), // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
+						array(
+							"\0" => '',
+							'"'  => '&#34;',
+							"'"  => '&#39;',
+							'<'  => '',
+						)
 					);
-			} */
-
-
-			/* dealt with in DAL2 now :)
-			#} If no status, and default is specified in settings, add that in :)
-			if (is_null($zbsCustomerMeta['status']) || !isset($zbsCustomerMeta['status']) || empty($zbsCustomerMeta['status'])){
-
-				$defaultStatusStr = zeroBSCRM_getSetting('defaultstatus');
-
-				// allow "empties" if (!empty($defaultStatusStr)) 
-				$zbsCustomerMeta['status'] = $defaultStatusStr;
-
-			}
-			*/
-
-
-            $we_have_tags = false; //set to false.. duh..
-
-            # TAG customer (if exists) - clean etc here too 
-            if(!empty($cFields['tags'])){
-				$tags 		= $cFields['tags'];
-				#} Santize tags
-				if(is_array($tags)){
-					$customer_tags = filter_var_array($tags,FILTER_UNSAFE_RAW); 
-					// Formerly this used FILTER_SANITIZE_STRING, which is now deprecated as it was fairly broken. This is basically equivalent.
-					// @todo Replace this with something more correct.
-					foreach ( $customer_tags as $k => $v ) {
-						$customer_tags[$k] = strtr(
-							strip_tags( $v ),
-							array(
-								"\0" => '',
-								'"' => '&#34;',
-								"'" => '&#39;',
-								"<" => '',
-							)
-						);
-					}
-					$we_have_tags = true;
 				}
+				$we_have_tags = true;
+			}
 
 			if ( $we_have_tags ) {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3429 - use existing tags if possible in helper functions

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When using legacy DAL helper functions (i.e. `zeroBS_addUpdateCustomer`, `zeroBS_addUpdateCompany`, and `zeroBS_addUpdateTransaction`), any passed tag names would use `addUpdateTag()`, which creates anew with an iterated slug.

In particular, this affects the API, merging customers, and many extensions.

This PR ensures the tag name for the given object doesn't already exist prior to creating the tag. It also chops some pre-DAL3 code. The gist of the fix can be seen in 73af2e76a791b39bb9cd1a17d28b3bae9f57ad7c.

Note: there's tons of redundant code here, but that's out of scope.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a contact with tags via the API.
2. Add/update/create a new contact with the same tags via the API.
3. Go to `/wp-admin/admin.php?page=tag-manager&tagtype=contact` and look for the tag.

In `trunk`, you'll see the tag name with a different slug for each run.

In the `fix/crm/3429-use_existing_tags_if_possible` branch, the same tag name is always used.