### PR TITLE
Verbum Comments: Fix verbum_show_subscription_modal stats data

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-subscription-modal-status-form-submission
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-subscription-modal-status-form-submission
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Replace   git push --set-upstream origin fix/verbum-subscription-modal-status-form-submission
+Create and use Preact signal for subscriptionModalStatus to fix issue of undefined value sent on comment submission.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-subscription-modal-status-form-submission
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-subscription-modal-status-form-submission
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Replace   git push --set-upstream origin fix/verbum-subscription-modal-status-form-submission

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'preact/hooks';
 import { translate } from '../../i18n';
-import { userInfo, userLoggedIn, commentUrl } from '../../state';
+import { userInfo, userLoggedIn, commentUrl, subscribeModalStatus } from '../../state';
 import { SimpleSubscribeModalProps } from '../../types';
 import {
 	getSubscriptionModalViewCount,
@@ -12,12 +12,7 @@ import { SimpleSubscribeModalLoggedIn, SimpleSubscribeSetModalShowLoggedIn } fro
 import { SimpleSubscribeModalLoggedOut } from './logged-out';
 import './style.scss';
 
-export const SimpleSubscribeModal = ( {
-	setSubscribeModalStatus,
-	subscribeModalStatus,
-	closeModalHandler,
-	email,
-}: SimpleSubscribeModalProps ) => {
+export const SimpleSubscribeModal = ( { closeModalHandler, email }: SimpleSubscribeModalProps ) => {
 	const [ subscribeState, setSubscribeState ] = useState<
 		'SUBSCRIBING' | 'LOADING' | 'SUBSCRIBED'
 	>();
@@ -60,18 +55,16 @@ export const SimpleSubscribeModal = ( {
 		// When not showing the modal, we check for modal conditions to show it.
 		// This is done to avoid subscriptionApi calls for logged out users.
 		if ( userLoggedIn.value ) {
-			return (
-				<SimpleSubscribeSetModalShowLoggedIn setSubscribeModalStatus={ setSubscribeModalStatus } />
-			);
+			return <SimpleSubscribeSetModalShowLoggedIn />;
 		}
 
 		// If the user is logged out, we don't need to check is already subscribed.
-		setSubscribeModalStatus( shouldShowSubscriptionModal( false, 0 ) );
+		subscribeModalStatus.value = shouldShowSubscriptionModal( false, 0 );
 		return null;
 	}
 
 	// We use the same logic as in the comment footer to know if the user is already subscribed.
-	if ( subscribeModalStatus !== 'showed' && commentUrl.value ) {
+	if ( subscribeModalStatus.value !== 'showed' && commentUrl.value ) {
 		closeModalHandler();
 		return null;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/logged-in.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/logged-in.tsx
@@ -1,24 +1,22 @@
 import useSubscriptionApi from '../../hooks/useSubscriptionApi';
 import { translate } from '../../i18n';
-import { subscriptionSettings, userInfo, commentUrl } from '../../state';
+import { subscriptionSettings, userInfo, commentUrl, subscribeModalStatus } from '../../state';
 import { SimpleSubscribeModalProps } from '../../types';
 import { shouldShowSubscriptionModal } from '../../utils';
 import SubscriptionModal from './subscription-modal';
 
 // This determines if the modal should be shown to the user.
 // It's called before the modal is rendered.
-export const SimpleSubscribeSetModalShowLoggedIn = ( {
-	setSubscribeModalStatus,
-}: {
-	setSubscribeModalStatus: ( value: string ) => void;
-} ) => {
+export const SimpleSubscribeSetModalShowLoggedIn = () => {
 	const { email } = subscriptionSettings.value ?? {
 		email: {
 			send_posts: false,
 		},
 	};
-	setSubscribeModalStatus( shouldShowSubscriptionModal( email?.send_posts, userInfo.value?.uid ) );
-
+	subscribeModalStatus.value = shouldShowSubscriptionModal(
+		email?.send_posts,
+		userInfo.value?.uid
+	);
 	return null;
 };
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/index.tsx
@@ -21,6 +21,7 @@ import {
 	userLoggedIn,
 	commentUrl,
 	commentParent,
+	subscribeModalStatus,
 } from './state';
 import {
 	classNames,
@@ -37,13 +38,6 @@ const Verbum = ( { siteId }: VerbumComments ) => {
 	const formRef = useRef< HTMLFormElement >( null );
 	const [ showMessage, setShowMessage ] = useState( '' );
 	const [ isErrorMessage, setIsErrorMessage ] = useState( false );
-	const [ subscribeModalStatus, setSubscribeModalStatus ] = useState<
-		| 'showed'
-		| 'hidden_cookies_disabled'
-		| 'hidden_subscribe_not_enabled'
-		| 'hidden_views_limit'
-		| 'hidden_already_subscribed'
-	>();
 
 	const commentTextarea = useRef< HTMLTextAreaElement >();
 	const [ email, setEmail ] = useState( '' );
@@ -131,7 +125,7 @@ const Verbum = ( { siteId }: VerbumComments ) => {
 			setEmail( formData.get( 'email' ) as string );
 		}
 
-		formData.set( 'verbum_show_subscription_modal', subscribeModalStatus );
+		formData.set( 'verbum_show_subscription_modal', subscribeModalStatus.value );
 
 		const response = await fetch( formAction, {
 			method: 'POST',
@@ -242,12 +236,7 @@ const Verbum = ( { siteId }: VerbumComments ) => {
 			<CommentFooter toggleTray={ handleTrayToggle } />
 			<CommentMessage message={ showMessage } isError={ isErrorMessage } />
 			{ VerbumComments.enableSubscriptionModal && (
-				<SimpleSubscribeModal
-					setSubscribeModalStatus={ setSubscribeModalStatus }
-					subscribeModalStatus={ subscribeModalStatus }
-					closeModalHandler={ closeModalHandler }
-					email={ email }
-				/>
+				<SimpleSubscribeModal closeModalHandler={ closeModalHandler } email={ email } />
 			) }
 		</>
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
@@ -102,3 +102,5 @@ export const subscriptionSettings: Signal< SubscriptionDetails > = signal( undef
  * Store the comment parent which is updated by external scripts
  */
 export const commentParent = signal( 0 );
+
+export const subscribeModalStatus = signal( undefined );

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
@@ -103,4 +103,8 @@ export const subscriptionSettings: Signal< SubscriptionDetails > = signal( undef
  */
 export const commentParent = signal( 0 );
 
+/*
+ * Store the subscription modal status calculated for the user.
+ * Can be one of these values: 'showed', 'hidden_cookies_disabled', 'hidden_subscribe_not_enabled', 'hidden_views_limit' and 'hidden_already_subscribed'.
+ */
 export const subscribeModalStatus = signal( undefined );

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/types.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/types.tsx
@@ -83,13 +83,6 @@ export type EmailSubscriptionResponse = {
 export interface SimpleSubscribeModalProps {
 	closeModalHandler: () => void;
 	email: string;
-	setSubscribeModalStatus?: ( string ) => void;
-	subscribeModalStatus?:
-		| 'showed'
-		| 'hidden_cookies_disabled'
-		| 'hidden_subscribe_not_enabled'
-		| 'hidden_views_limit'
-		| 'hidden_already_subscribed';
 	subscribeState?: string;
 	setSubscribeState?: ( boolean ) => void;
 	setHasIframe?: ( boolean ) => void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

These changes will use Preact signal to persist the value and ensure that the comment post will send the latest subscribeModalStatus value.

`subscribeModalStatus` value is sent as `undefined` when a comment is submitted, which affects the metrics for the subscription modal (stats: `verbum_show_subscription_modal`)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout branch
* Run `npm run build-js` in jetpack-mu-wpcom package directory.
* Run `jetpack rsync mu-wpcom-plugin` to sync files to your sandbox
* Login to WPCOM account in Verbum
* Toggle ON Email me new posts notification
* Post a comment and verify the post data includes `verbum_show_subscription_modal='hidden_already_subscribed'`.
* Toggle OFF Email me new posts notification
* Post a comment and verify the post data includes `verbum_show_subscription_modal='showed'`.

