### PR TITLE
Add "new category" endpoint to Jetpack API.

### DIFF
--- a/projects/js-packages/api/changelog/add-new-category-endpoint
+++ b/projects/js-packages/api/changelog/add-new-category-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added endpoint to create a category to the Jetpack API.

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -536,6 +536,10 @@ function JetpackRestApiClient( root, nonce ) {
 			getRequest( `${ apiRoot }jetpack/v4/site/backup/undo-event`, getParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
+		createNewCategory: newCategory =>
+			postRequest( `${ apiRoot }jetpack/v4/categories/new`, postParams, {
+				body: JSON.stringify( newCategory ),
+			} ),
 	};
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-new-category-endpoint
+++ b/projects/plugins/jetpack/changelog/add-new-category-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added endpoint to create a new category to the Jetpack API.


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87561

## Proposed changes:
On the Newsletter setting page, there is the **Newsletter categories** section. There, you can find an "Add new category button".

![Image](https://github.com/Automattic/wp-calypso/assets/3832570/359738e7-368c-4c68-820c-5d01f7c2137d)

This task adds an endpoint to create a new category to the Jetpack API.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply the PR.
- You need to call the endpoint in the Jetpack API. For example, importing `import restApi from '@automattic/jetpack-api';
` in `_inc/client/newsletter/subscriptions-settings.jsx`, then putting a function like
```
const testApi = () => {
      restApi.createNewCategory( { name: `test_${new Date()}`, parent: 0 } ).then( ( response ) => {
        console.log( response );
      } ).catch( ( error ) => {
        console.log( error );
      })};
```
and then a button to call it, like `<button onClick={ testApi }>{ __( 'Test API', 'jetpack' ) }</button>`.
- You should see in the console the success message and the body of the new category object being created in the resopnse.

