### PR TITLE
[Boost] Do not cache _jb_static in boost-cache

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -22,8 +22,8 @@ function jetpack_boost_page_optimize_service_request() {
 	$cache_dir = Config::get_cache_dir_path();
 	$use_cache = ! empty( $cache_dir );
 
-	// If handling the cache here, tell other caches not to.
-	if ( $use_cache && ! defined( 'DONOTCACHEPAGE' ) ) {
+	// We handle the cache here, tell other caches not to.
+	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 		define( 'DONOTCACHEPAGE', true );
 	}
 

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -22,6 +22,11 @@ function jetpack_boost_page_optimize_service_request() {
 	$cache_dir = Config::get_cache_dir_path();
 	$use_cache = ! empty( $cache_dir );
 
+	// If handling the cache here, tell other caches not to.
+	if ( $use_cache && ! defined( 'DONOTCACHEPAGE' ) ) {
+		define( 'DONOTCACHEPAGE', true );
+	}
+
 	// Ensure the cache directory exists.
 	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
 	if ( $use_cache && ! is_dir( $cache_dir ) && ! mkdir( $cache_dir, 0775, true ) ) {

--- a/projects/plugins/boost/changelog/boost-do-not-cache-jb-static
+++ b/projects/plugins/boost/changelog/boost-do-not-cache-jb-static
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Do not cache _jb_static URLs in other caches, if we're doing it ourselves
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #https://github.com/Automattic/jetpack/issues/35669

Ensure that Boost Cache doesn't cover jb_static if the css/js minifier are handling their own caching internally.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that Boost Cache doesn't cover jb_static if the css/js minifier are handling their own caching internally.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Purge your cache
* Load your site front page with js/css minify enabled
* Ensure Boost Cache doesn't cache them; they will already be cached by the minify system.