### PR TITLE
Stats: avoid Fatal errors when trying to fetch malformed data

### DIFF
--- a/projects/packages/stats/changelog/fix-stats-fetch-fatal
+++ b/projects/packages/stats/changelog/fix-stats-fetch-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid Fatal errors when saved stats data is a WP_Error object

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -437,11 +437,21 @@ class WPCOM_Stats {
 		if ( $stats_cache ) {
 			$data = reset( $stats_cache );
 
-			if ( is_wp_error( $data ) ) {
+			if (
+				! is_array( $data )
+				|| empty( $data )
+				|| is_wp_error( $data )
+			) {
 				return $data;
 			}
 
-			$time = key( $data );
+			$time  = key( $data );
+			$views = $data[ $time ] ?? null;
+
+			// Bail if data is malformed.
+			if ( ! is_numeric( $time ) || ! is_array( $views ) ) {
+				return $data;
+			}
 
 			/** This filter is already documented in projects/packages/stats/src/class-wpcom-stats.php */
 			$expiration = apply_filters(
@@ -450,7 +460,7 @@ class WPCOM_Stats {
 			);
 
 			if ( ( time() - $time ) < $expiration ) {
-				return array_merge( array( 'cached_at' => $time ), $data[ $time ] );
+				return array_merge( array( 'cached_at' => $time ), $views );
 			}
 		}
 


### PR DESCRIPTION
## Proposed changes:

This is a follow-up to #34557. It was discussed a bit here:
https://github.com/Automattic/jetpack/pull/34557/files#r1475310509

I ran into the following issue in the post editor today:

```
PHP Fatal error:  Uncaught TypeError: array_merge(): Argument #2 must be of type array, WP_Error given in wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-stats/src/class-wpcom-stats.php:453
Stack trace:
wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-stats/src/class-wpcom-stats.php(453): array_merge()
wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-stats/src/class-wpcom-stats.php(215): Automattic\Jetpack\Stats\WPCOM_Stats->fetch_post_stats()
```

The added safety checks in this PR fix the issue, by not assuming anything about the format of the returned data.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Enable beta blocks on your site: `add_filter( 'jetpack_blocks_variation', function () { return 'beta'; } );`
* Go to Posts > Add New
* Insert a Blog Stats block
* You should see no errors in the editor and in your logs.
