### PR TITLE
Fixed XSS vulnerability in avatarURL in Likes block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-xss-vulnerability-in-like-block
+++ b/projects/plugins/jetpack/changelog/fix-xss-vulnerability-in-like-block
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-A bug was fixed related to avatar urls in the Likes block.
+Like block: Encode Avatar URLs

--- a/projects/plugins/jetpack/changelog/fix-xss-vulnerability-in-like-block
+++ b/projects/plugins/jetpack/changelog/fix-xss-vulnerability-in-like-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+A bug was fixed related to avatar urls in the Likes block.

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -241,7 +241,7 @@ function JetpackLikesMessageListener( event ) {
 				if ( newLayout ) {
 					element.innerHTML = `
 					<a href="${ encodeURI( liker.profile_URL ) }" rel="nofollow" target="_parent" class="wpl-liker">
-						<img src="${ liker.avatar_URL }"
+						<img src="${ encodeURI( liker.avatar_URL ) }"
 							alt=""
 							style="width: 28px; height: 28px;" />
 						<span></span>
@@ -250,7 +250,7 @@ function JetpackLikesMessageListener( event ) {
 				} else {
 					element.innerHTML = `
 					<a href="${ encodeURI( liker.profile_URL ) }" rel="nofollow" target="_parent" class="wpl-liker">
-						<img src="${ liker.avatar_URL }"
+						<img src="${ encodeURI( liker.avatar_URL ) }"
 							alt=""
 							style="width: 30px; height: 30px; padding-right: 3px;" />
 					</a>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87589

## Proposed changes:
We are encoding the avatar URLs to avoid an XSS vulnerability. More info here: p1707736101488709-slack-CRA4UEQQ3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1707736101488709-slack-CRA4UEQQ3

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes locally.
- Go to a post in your JT site with the Jetpack Likes block and at least 5 likes. Several of them should have no avatar set in their gravatar configuration.
- You should see their avatars correctly displayed.
Note: There is a problem with the Mistery Person avatar configuration. It seems to be sent from the backend already encoded, so we are doing a double encoding in the front end, and the avatar doesn't work. This will be fixed in subsequent PR.

* Go to '..'
*