### PR TITLE
Atomic i18n: Fix mixed translations after WordPress.com user locale switch

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mixed-translations-after-wpcom-locale-switch
+++ b/projects/plugins/jetpack/changelog/fix-mixed-translations-after-wpcom-locale-switch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Atomic i18n: Fix mixed translations after WordPress.com user locale switch

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-masterbar.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-masterbar.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Tests for Masterbar class.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Dashboard_Customizations\Masterbar;
+
+require_once JETPACK__PLUGIN_DIR . 'modules/masterbar/masterbar/class-masterbar.php';
+
+/**
+ * Class Test_Masterbar.
+ *
+ * @coversDefaultClass Automattic\Jetpack\Dashboard_Customizations\Masterbar
+ */
+class Test_Masterbar extends WP_UnitTestCase {
+	/**
+	 * Mock user ID.
+	 *
+	 * @var int
+	 */
+	private static $user_id = 0;
+
+	/**
+	 * A backup of the original $l10n global.
+	 *
+	 * @var array
+	 */
+	private $l10n_backup;
+
+	/**
+	 * Create shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Fixture factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		$factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Set up data.
+	 */
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( static::$user_id );
+
+		global $l10n;
+		$this->l10n_backup = $l10n;
+	}
+
+	/**
+	 * Restore the original state.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		// Restore the original global.
+		global $l10n;
+		$l10n = $this->l10n_backup;
+	}
+
+	/**
+	 * Tests unload_non_default_textdomains_on_wpcom_user_locale_switch
+	 *
+	 * @param string $stored_user_locale The user's locale as stored on the site.
+	 * @param string $detected_wpcom_locale The user's WordPress.com locale as detected by the Masterbar.
+	 *
+	 * @dataProvider wpcom_user_locale_switch_data_provider
+	 * @covers ::unload_non_default_textdomains_on_wpcom_user_locale_switch
+	 */
+	public function test_unload_non_default_textdomains_on_wpcom_user_locale_switch(
+		$stored_user_locale,
+		$detected_wpcom_locale
+	) {
+		// Pretend some textdomains have been loaded.
+		global $l10n;
+		$l10n = array(
+			'default'       => 'MO file',
+			'jetpack'       => 'MO file',
+			'jetpack-boost' => 'MO file',
+		);
+
+		// Make get_user_locale() return $stored_user_locale.
+		wp_get_current_user()->locale = $stored_user_locale;
+
+		$masterbar = $this->getMockBuilder( Masterbar::class )
+			->disableOriginalConstructor()
+			->setMethodsExcept( array( 'unload_non_default_textdomains_on_wpcom_user_locale_switch' ) )
+			->getMock();
+		$masterbar->unload_non_default_textdomains_on_wpcom_user_locale_switch( $detected_wpcom_locale );
+
+		// Check the result.
+		$user_switched_locale = $stored_user_locale !== $detected_wpcom_locale;
+		if ( $user_switched_locale ) {
+			// All non-default textdomains should have been unloaded.
+			$this->assertEquals( array( 'default' ), array_keys( $l10n ) );
+		} else {
+			// No textdomains should have been unloaded.
+			$this->assertEquals( array( 'default', 'jetpack', 'jetpack-boost' ), array_keys( $l10n ) );
+		}
+	}
+
+	/**
+	 * Data provider for test_unload_non_default_textdomains_on_wpcom_user_locale_switch.
+	 *
+	 * @return array With format [stored_user_locale, detected_wpcom_locale].
+	 */
+	public function wpcom_user_locale_switch_data_provider() {
+		return array(
+			// Simulate the user changing their locale on WordPress.com.
+			array( 'fr_FR', 'en_US' ),
+			array( 'en_US', 'fr_FR' ),
+			array( 'nl_NL', 'fr_FR' ),
+
+			// No locale change.
+			array( 'nl_NL', 'nl_NL' ),
+			array( 'fr_FR', 'fr_FR' ),
+		);
+	}
+}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In the Masterbar, for Atomic sites, unload all non-default textdomains and flag them for just-in-time reloading if a WordPress.com user locale switch is detected.

PR https://github.com/Automattic/jetpack/pull/19525 added detection of the user's WordPress.com locale for Atomic sites to the Masterbar class. The user locale's language pack is installed in `install_locale` if it's not installed yet, and the locale is stored using `update_user_option` to make the rest of the site aware of the locale.

However, at that point, some plugins and their translations have already been loaded (including Jetpack's). If the user just changed their locale on WordPress.com, then for these plugins the old locale's translations have been loaded, and the user will see a mix of the old and new locale's translations until the next page load. This is especially apparent in the admin sidebar, but also on pages like `/wp-admin/edit.php?post_type=feedback`.  Here's an example after switching from English to Japanese on https://wordpress.com/me/account:

<img width="283" alt="image" src="https://github.com/Automattic/jetpack/assets/75777864/7eb9c5f5-15aa-4b23-b0a2-f0c80d053665">

For Core translations, this has been working fine because the default textdomain is always reloaded after all plugins have been loaded, in [wp-settings.php](https://github.com/WordPress/wordpress-develop/blob/8ee7651d0e953f0bdc5705bb5359f4067fefa89b/src/wp-settings.php#L712). However, such a reload is not done for plugins, so to get plugin translations to be shown correctly on the first page-load, we need to add one for the plugin textdomains.

To solve the mixed translations, this PR adds functionality to unload all non-default textdomains and flag them for just-in-time reloading if a WordPress.com user locale switch is detected.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
731-gh-Automattic/i18n-issues
5344-gh-Automattic/dotcom-forge
p1706819623324399-slack-CKZHG0QCR

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Reproduce the error**

1. Open two browser tabs:
    1. `https://[your_atomic_site].wpcomstaging.com/wp-admin/`
    1. https://wordpress.com/me/account
2. Change your user locale in `/me/account`.
3. Refresh the `/wp-admin` page and confirm that you see a mix of locales as per the screenshot above.
4. Refresh the `/wp-admin` page once more and confirm that all translations are now loaded correctly.

**Confirm that the error is fixed**

1. On your Atomic site, activate this PR's branch in Jetpack Beta.
2. Repeat the steps above and verify that the correct translations are now loaded on the first refresh of the `/wp-admin` page.