### PR TITLE
Jetpack Logo: prevent VoiceOver on Safari from reading SVG content

### DIFF
--- a/projects/js-packages/components/changelog/fix-connect-screen-jetpack-logo-a11y
+++ b/projects/js-packages/components/changelog/fix-connect-screen-jetpack-logo-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Logo: prevent VoiceOver on Safari from reading SVG content

--- a/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
+++ b/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
@@ -18,16 +18,17 @@ exports[`JetpackFooter Render the component should match the snapshot: all props
             aria-labelledby="jetpack-logo-title"
             class="jetpack-logo"
             height="16"
+            role="img"
             viewBox="0 0 32 32"
             x="0px"
             xmlns="http://www.w3.org/2000/svg"
             y="0px"
           >
-            <desc
+            <title
               id="jetpack-logo-title"
             >
               Jetpack Logo
-            </desc>
+            </title>
             <path
               d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"
               fill="#000"

--- a/projects/js-packages/components/components/jetpack-logo/index.tsx
+++ b/projects/js-packages/components/components/jetpack-logo/index.tsx
@@ -22,8 +22,10 @@ const JetpackLogo: React.FC< JetpackLogoProps > = ( {
 			aria-labelledby="jetpack-logo-title"
 			height={ height }
 			{ ...otherProps }
+			// role="img" is required to prevent VoiceOver on Safari reading the content of the SVG
+			role="img"
 		>
-			<desc id="jetpack-logo-title">{ __( 'Jetpack Logo', 'jetpack' ) }</desc>
+			<title id="jetpack-logo-title">{ __( 'Jetpack Logo', 'jetpack' ) }</title>
 			<path
 				fill={ logoColor }
 				d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.48.3",
+	"version": "0.48.4-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35484

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The screen reader VoiceOver (VO) on Safari reads the content of the Jetpack logo which is a frustrating experience for VO users. This PR prevents this by implementing the fix described [in this article](https://css-tricks.com/accessible-svgs/#aa-2-inline-svg): using the `title` tag in the markup and adding the `role="img"` attribute on the `svg` tag.

_On Safari, VoiceOver reads the content of the logo_
<img width="500" alt="Screenshot 2024-02-19 at 9 49 27 AM" src="https://github.com/Automattic/jetpack/assets/1620183/3e3e0881-f26d-48b7-b5f8-9db4ce706c95">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-xS-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

If you can use VoiceOver on Safari:
- Spin up a test site with this branch
- Make sure it's not connected
- Visit `/wp-admin/admin.php?page=my-jetpack#/connection`
- Make sure VO doesn't read the inner content of the Jetpack SVG

