### PR TITLE
Boost: rearrange how the File_Storage invalidate() function operates

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -153,7 +153,7 @@ define( \'WP_CACHE\', true );',
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
-		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', '/*' );
+		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', JBCACHE_ALL );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -154,7 +154,7 @@ define( \'WP_CACHE\', true );',
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
-		$result = Boost_Cache_Utils::delete( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::ALL );
+		$result = Boost_Cache_Utils::delete( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::DELETE_ALL );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -154,7 +154,7 @@ define( \'WP_CACHE\', true );',
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
-		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', JBCACHE_ALL );
+		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::JBCACHE_ALL );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -153,7 +153,7 @@ define( \'WP_CACHE\', true );',
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
-		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', '*/' );
+		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', '/*' );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -154,7 +154,7 @@ define( \'WP_CACHE\', true );',
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
-		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::JBCACHE_ALL );
+		$result = Boost_Cache_Utils::delete( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::JBCACHE_ALL );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -154,7 +154,7 @@ define( \'WP_CACHE\', true );',
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
-		$result = Boost_Cache_Utils::delete( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::JBCACHE_ALL );
+		$result = Boost_Cache_Utils::delete( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::ALL );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -154,7 +154,7 @@ define( \'WP_CACHE\', true );',
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
-		$result = Boost_Cache_Utils::delete( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::DELETE_ALL );
+		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::DELETE_ALL );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -153,7 +153,7 @@ define( \'WP_CACHE\', true );',
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
-		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache' );
+		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', '*/' );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -217,12 +217,8 @@ class Boost_Cache {
 			 * message.
 			 */
 			if ( isset( $parameters['cookies'] ) && ! empty( $parameters['cookies'] ) ) {
-				$filename_hash = Boost_Cache_Utils::get_request_filename( $this->request->get_parameters() );
-				$this->storage->invalidate(
-					get_permalink( $post->ID ),
-					Boost_Cache_Utils::FILE,
-					$filename_hash
-				);
+				$filename = trailingslashit( get_permalink( $post->ID ) ) . Boost_Cache_Utils::get_request_filename( $this->request->get_parameters() );
+				$this->storage->invalidate( $filename, Boost_Cache_Utils::FILE );
 			}
 			return;
 		}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -151,7 +151,7 @@ class Boost_Cache {
 				$this->delete_cache_for_post( get_post( $posts_page_id ) );
 			}
 		} else {
-			$this->storage->invalidate( home_url(), Boost_Cache_Utils::FILES );
+			$this->storage->invalidate( home_url(), Boost_Cache_Utils::DELETE_FILES );
 			error_log( 'delete front page cache ' . Boost_Cache_Utils::normalize_request_uri( home_url() ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
@@ -218,7 +218,7 @@ class Boost_Cache {
 			 */
 			if ( isset( $parameters['cookies'] ) && ! empty( $parameters['cookies'] ) ) {
 				$filename = trailingslashit( get_permalink( $post->ID ) ) . Boost_Cache_Utils::get_request_filename( $parameters );
-				$this->storage->invalidate( $filename, Boost_Cache_Utils::FILE );
+				$this->storage->invalidate( $filename, Boost_Cache_Utils::DELETE_FILE );
 			}
 			return;
 		}
@@ -332,7 +332,7 @@ class Boost_Cache {
 	public function delete_cache_for_url( $url ) {
 		error_log( 'delete_cache_for_url: ' . $url ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
-		return $this->storage->invalidate( $url, Boost_Cache_Utils::ALL );
+		return $this->storage->invalidate( $url, Boost_Cache_Utils::DELETE_ALL );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -141,7 +141,7 @@ class Boost_Cache {
 				$this->delete_cache_for_post( get_post( $posts_page_id ) );
 			}
 		} else {
-			$this->storage->invalidate_home_page( Boost_Cache_Utils::normalize_request_uri( home_url() ) );
+			$this->storage->invalidate( Boost_Cache_Utils::normalize_request_uri( home_url() ), '*' );
 			error_log( 'delete front page cache ' . Boost_Cache_Utils::normalize_request_uri( home_url() ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
@@ -193,13 +193,25 @@ class Boost_Cache {
 	 */
 	public function delete_on_comment_post( $comment_id, $comment_approved, $commentdata ) {
 		$post = get_post( $commentdata['comment_post_ID'] );
-
+		error_Log( "delete_on_comment_post: $comment_id, $comment_approved, {$post->ID}" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		/**
 		 * If a comment is not approved, we only need to delete the cache for
 		 * this post for this visitor so the unmoderated comment is shown to them.
 		 */
 		if ( $comment_approved !== 1 ) {
-			$this->storage->invalidate_single_visitor( Boost_Cache_Utils::normalize_request_uri( get_permalink( $post->ID ) ), $this->request->get_parameters() );
+			$parameters = $this->request->get_parameters();
+			/**
+			 * if there are no cookies, then visitor did not click "remember me".
+			 * No need to delete the cache for this visitor as they'll be
+			 * redirected to a page with a hash in the URL for the moderation
+			 * message.
+			 */
+			if ( isset( $parameters['cookies'] ) && ! empty( $parameters['cookies'] ) ) {
+				$this->storage->invalidate(
+					Boost_Cache_Utils::normalize_request_uri( get_permalink( $post->ID ) ),
+					'/**/' . Boost_Cache_Utils::get_request_filename( $this->request->get_parameters() )
+				);
+			}
 			return;
 		}
 
@@ -313,7 +325,7 @@ class Boost_Cache {
 		error_log( 'delete_cache_for_url: ' . $url ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = Boost_Cache_Utils::normalize_request_uri( $url );
 
-		return $this->storage->invalidate( $path );
+		return $this->storage->invalidate( $path, '*/' );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -325,7 +325,7 @@ class Boost_Cache {
 		error_log( 'delete_cache_for_url: ' . $url ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = Boost_Cache_Utils::normalize_request_uri( $url );
 
-		return $this->storage->invalidate( $path, '*/' );
+		return $this->storage->invalidate( $path, '/*' );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -141,7 +141,7 @@ class Boost_Cache {
 				$this->delete_cache_for_post( get_post( $posts_page_id ) );
 			}
 		} else {
-			$this->storage->invalidate( home_url(), '*' );
+			$this->storage->invalidate( home_url(), JBCACHE_FILES );
 			error_log( 'delete front page cache ' . Boost_Cache_Utils::normalize_request_uri( home_url() ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
@@ -207,9 +207,11 @@ class Boost_Cache {
 			 * message.
 			 */
 			if ( isset( $parameters['cookies'] ) && ! empty( $parameters['cookies'] ) ) {
+				$filename_hash = Boost_Cache_Utils::get_request_filename( $this->request->get_parameters() );
 				$this->storage->invalidate(
 					get_permalink( $post->ID ),
-					'/**/' . Boost_Cache_Utils::get_request_filename( $this->request->get_parameters() )
+					JBCACHE_FILE,
+					$filename_hash
 				);
 			}
 			return;
@@ -324,7 +326,7 @@ class Boost_Cache {
 	public function delete_cache_for_url( $url ) {
 		error_log( 'delete_cache_for_url: ' . $url ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
-		return $this->storage->invalidate( $url, '/*' );
+		return $this->storage->invalidate( $url, JBCACHE_ALL );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -151,7 +151,7 @@ class Boost_Cache {
 				$this->delete_cache_for_post( get_post( $posts_page_id ) );
 			}
 		} else {
-			$this->storage->invalidate( home_url(), JBCACHE_FILES );
+			$this->storage->invalidate( home_url(), Boost_Cache_Utils::JBCACHE_FILES );
 			error_log( 'delete front page cache ' . Boost_Cache_Utils::normalize_request_uri( home_url() ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
@@ -220,7 +220,7 @@ class Boost_Cache {
 				$filename_hash = Boost_Cache_Utils::get_request_filename( $this->request->get_parameters() );
 				$this->storage->invalidate(
 					get_permalink( $post->ID ),
-					JBCACHE_FILE,
+					Boost_Cache_Utils::JBCACHE_FILE,
 					$filename_hash
 				);
 			}
@@ -336,7 +336,7 @@ class Boost_Cache {
 	public function delete_cache_for_url( $url ) {
 		error_log( 'delete_cache_for_url: ' . $url ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
-		return $this->storage->invalidate( $url, JBCACHE_ALL );
+		return $this->storage->invalidate( $url, Boost_Cache_Utils::JBCACHE_ALL );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -141,7 +141,7 @@ class Boost_Cache {
 				$this->delete_cache_for_post( get_post( $posts_page_id ) );
 			}
 		} else {
-			$this->storage->invalidate( Boost_Cache_Utils::normalize_request_uri( home_url() ), '*' );
+			$this->storage->invalidate( home_url(), '*' );
 			error_log( 'delete front page cache ' . Boost_Cache_Utils::normalize_request_uri( home_url() ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
@@ -208,7 +208,7 @@ class Boost_Cache {
 			 */
 			if ( isset( $parameters['cookies'] ) && ! empty( $parameters['cookies'] ) ) {
 				$this->storage->invalidate(
-					Boost_Cache_Utils::normalize_request_uri( get_permalink( $post->ID ) ),
+					get_permalink( $post->ID ),
 					'/**/' . Boost_Cache_Utils::get_request_filename( $this->request->get_parameters() )
 				);
 			}
@@ -323,9 +323,8 @@ class Boost_Cache {
 	 */
 	public function delete_cache_for_url( $url ) {
 		error_log( 'delete_cache_for_url: ' . $url ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		$path = Boost_Cache_Utils::normalize_request_uri( $url );
 
-		return $this->storage->invalidate( $path, '/*' );
+		return $this->storage->invalidate( $url, '/*' );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -217,7 +217,7 @@ class Boost_Cache {
 			 * message.
 			 */
 			if ( isset( $parameters['cookies'] ) && ! empty( $parameters['cookies'] ) ) {
-				$filename = trailingslashit( get_permalink( $post->ID ) ) . Boost_Cache_Utils::get_request_filename( $this->request->get_parameters() );
+				$filename = trailingslashit( get_permalink( $post->ID ) ) . Boost_Cache_Utils::get_request_filename( $parameters );
 				$this->storage->invalidate( $filename, Boost_Cache_Utils::FILE );
 			}
 			return;

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -151,7 +151,7 @@ class Boost_Cache {
 				$this->delete_cache_for_post( get_post( $posts_page_id ) );
 			}
 		} else {
-			$this->storage->invalidate( home_url(), Boost_Cache_Utils::JBCACHE_FILES );
+			$this->storage->invalidate( home_url(), Boost_Cache_Utils::FILES );
 			error_log( 'delete front page cache ' . Boost_Cache_Utils::normalize_request_uri( home_url() ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
@@ -220,7 +220,7 @@ class Boost_Cache {
 				$filename_hash = Boost_Cache_Utils::get_request_filename( $this->request->get_parameters() );
 				$this->storage->invalidate(
 					get_permalink( $post->ID ),
-					Boost_Cache_Utils::JBCACHE_FILE,
+					Boost_Cache_Utils::FILE,
 					$filename_hash
 				);
 			}
@@ -336,7 +336,7 @@ class Boost_Cache {
 	public function delete_cache_for_url( $url ) {
 		error_log( 'delete_cache_for_url: ' . $url ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
-		return $this->storage->invalidate( $url, Boost_Cache_Utils::JBCACHE_ALL );
+		return $this->storage->invalidate( $url, Boost_Cache_Utils::ALL );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -18,7 +18,7 @@ class Boost_Cache_Utils {
 	 * @param string $filename - The filename to delete. Only used when $filter is JBCACHE_FILE.
 	 * @return bool|WP_Error
 	 */
-	public static function delete_directory( $dir, $filter, $filename = '' ) {
+	public static function delete( $dir, $filter, $filename = '' ) {
 		error_log( "delete directory: $dir $filter $filename" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$dir = realpath( $dir );
 		if ( ! $dir ) {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -7,14 +7,14 @@ namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
 class Boost_Cache_Utils {
 
-	const ALL   = 'delete-all'; // delete all files and directories in a given directory, recursively.
-	const FILE  = 'delete-single'; // delete a single file or recursively delete a single directory in a given directory.
-	const FILES = 'delete-files'; // delete all files in a given directory.
+	const DELETE_ALL   = 'delete-all'; // delete all files and directories in a given directory, recursively.
+	const DELETE_FILE  = 'delete-single'; // delete a single file or recursively delete a single directory in a given directory.
+	const DELETE_FILES = 'delete-files'; // delete all files in a given directory.
 
 	/**
 	 * Recursively delete a directory.
 	 * @param string $path - The directory to delete.
-	 * @param bool   $type - The type of delete. FILES to delete all files in the given directory. ALL to delete everything in the given directory, recursively. FILE to delete a single file or directory in the given directory.
+	 * @param bool   $type - The type of delete. DELETE_FILES to delete all files in the given directory. DELETE_ALL to delete everything in the given directory, recursively. DELETE_FILE to delete a single file or directory in the given directory.
 	 * @return bool|WP_Error
 	 */
 	public static function delete( $path, $type ) {
@@ -32,7 +32,7 @@ class Boost_Cache_Utils {
 		}
 
 		switch ( $type ) {
-			case self::ALL: // delete all files and directories in the given directory.
+			case self::DELETE_ALL: // delete all files and directories in the given directory.
 				if ( is_dir( $path ) === true ) {
 					$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \RecursiveDirectoryIterator::SKIP_DOTS ) );
 					foreach ( $iterator as $file ) {
@@ -47,7 +47,7 @@ class Boost_Cache_Utils {
 					return @rmdir( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged,
 				}
 				break;
-			case self::FILE: // delete a single file or directory in the given directory.
+			case self::DELETE_FILE: // delete a single file or directory in the given directory.
 				if ( ! file_exists( $path ) ) {
 					return true;
 				}
@@ -70,7 +70,7 @@ class Boost_Cache_Utils {
 					return @rmdir( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
 				}
 				break;
-			case self::FILES: // delete all files in the given directory.
+			case self::DELETE_FILES: // delete all files in the given directory.
 				if ( is_dir( $path ) === true ) {
 					$files = array_diff( scandir( $path ), array( '.', '..' ) );
 					foreach ( $files as $file ) {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -14,6 +14,7 @@ class Boost_Cache_Utils {
 	 * Recursively delete a directory.
 	 * @param string $dir - The directory to delete.
 	 * @param bool   $filter - The filter to use. JBCACHE_FILES to delete all files in the given directory. JBCACHE_ALL to delete everything in the given directory, recursively. JBCACHE_FILE to delete a single file or directory in the given directory.
+	 * @param string $filename - The filename to delete. Only used when $filter is JBCACHE_FILE.
 	 * @return bool|WP_Error
 	 */
 	public static function delete_directory( $dir, $filter, $filename = '' ) {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -9,7 +9,7 @@ class Boost_Cache_Utils {
 	/**
 	 * Recursively delete a directory.
 	 * @param string $dir - The directory to delete.
-	 * @param bool   $recurse - If false, only delete the files in the directory, do not recurse into subdirectories.
+	 * @param bool   $filter - The filter to use. '*' to delete all files in the given directory. '*\/' to delete everything in the given directory, recursively. '\/**\/' to delete a single file or directory in the given directory.
 	 * @return bool|WP_Error
 	 */
 	public static function delete_directory( $dir, $filter = null ) {
@@ -212,7 +212,6 @@ class Boost_Cache_Utils {
 	/**
 	 * Given a request_uri and its parameters, return the filename to use for this cached data. Does not include the file path.
 	 *
-	 * @param string $request_uri - The URI of this request (excluding GET parameters)
 	 * @param array  $parameters  - An associative array of all the things that make this request special/different. Includes GET parameters and COOKIEs normally.
 	 */
 	public static function get_request_filename( $parameters ) {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -5,11 +5,12 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
-define( 'JBCACHE_ALL', 1 ); // delete all files and directories in a given directory, recursively.
-define( 'JBCACHE_FILE', 2 ); // delete a single file or recursively delete a single directory in a given directory.
-define( 'JBCACHE_FILES', 3 ); // delete all files in a given directory.
-
 class Boost_Cache_Utils {
+
+	const JBCACHE_ALL   = 'delete-all'; // delete all files and directories in a given directory, recursively.
+	const JBCACHE_FILE  = 'delete-single'; // delete a single file or recursively delete a single directory in a given directory.
+	const JBCACHE_FILES = 'delete-files'; // delete all files in a given directory.
+
 	/**
 	 * Recursively delete a directory.
 	 * @param string $dir - The directory to delete.
@@ -18,7 +19,7 @@ class Boost_Cache_Utils {
 	 * @return bool|WP_Error
 	 */
 	public static function delete_directory( $dir, $filter, $filename = '' ) {
-		error_log( "delete directory: $dir $filter" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( "delete directory: $dir $filter $filename" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$dir = realpath( $dir );
 		if ( ! $dir ) {
 			// translators: %s is the directory that does not exist.
@@ -32,7 +33,7 @@ class Boost_Cache_Utils {
 		}
 
 		switch ( $filter ) {
-			case JBCACHE_ALL: // delete all files and directories in the given directory.
+			case self::JBCACHE_ALL: // delete all files and directories in the given directory.
 				if ( is_dir( $dir ) === true ) {
 					$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $dir, \RecursiveDirectoryIterator::SKIP_DOTS ) );
 					foreach ( $iterator as $file ) {
@@ -47,7 +48,7 @@ class Boost_Cache_Utils {
 					return @rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged, 
 				}
 				break;
-			case JBCACHE_FILE: // delete a single file or directory in the given directory.
+			case self::JBCACHE_FILE: // delete a single file or directory in the given directory.
 				if ( '' === $filename || ! file_exists( $dir . $filename ) ) {
 					return true;
 				}
@@ -70,7 +71,7 @@ class Boost_Cache_Utils {
 					return @rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
 				}
 				break;
-			case JBCACHE_FILES: // delete all files in the given directory.
+			case self::JBCACHE_FILES: // delete all files in the given directory.
 				if ( is_dir( $dir ) === true ) {
 					$files = array_diff( scandir( $dir ), array( '.', '..' ) );
 					foreach ( $files as $file ) {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -7,15 +7,15 @@ namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
 class Boost_Cache_Utils {
 
-	const JBCACHE_ALL   = 'delete-all'; // delete all files and directories in a given directory, recursively.
-	const JBCACHE_FILE  = 'delete-single'; // delete a single file or recursively delete a single directory in a given directory.
-	const JBCACHE_FILES = 'delete-files'; // delete all files in a given directory.
+	const ALL   = 'delete-all'; // delete all files and directories in a given directory, recursively.
+	const FILE  = 'delete-single'; // delete a single file or recursively delete a single directory in a given directory.
+	const FILES = 'delete-files'; // delete all files in a given directory.
 
 	/**
 	 * Recursively delete a directory.
 	 * @param string $dir - The directory to delete.
-	 * @param bool   $filter - The filter to use. JBCACHE_FILES to delete all files in the given directory. JBCACHE_ALL to delete everything in the given directory, recursively. JBCACHE_FILE to delete a single file or directory in the given directory.
-	 * @param string $filename - The filename to delete. Only used when $filter is JBCACHE_FILE.
+	 * @param bool   $filter - The filter to use. FILES to delete all files in the given directory. ALL to delete everything in the given directory, recursively. FILE to delete a single file or directory in the given directory.
+	 * @param string $filename - The filename to delete. Only used when $filter is FILE.
 	 * @return bool|WP_Error
 	 */
 	public static function delete( $dir, $filter, $filename = '' ) {
@@ -33,7 +33,7 @@ class Boost_Cache_Utils {
 		}
 
 		switch ( $filter ) {
-			case self::JBCACHE_ALL: // delete all files and directories in the given directory.
+			case self::ALL: // delete all files and directories in the given directory.
 				if ( is_dir( $dir ) === true ) {
 					$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $dir, \RecursiveDirectoryIterator::SKIP_DOTS ) );
 					foreach ( $iterator as $file ) {
@@ -48,7 +48,7 @@ class Boost_Cache_Utils {
 					return @rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged, 
 				}
 				break;
-			case self::JBCACHE_FILE: // delete a single file or directory in the given directory.
+			case self::FILE: // delete a single file or directory in the given directory.
 				if ( '' === $filename || ! file_exists( $dir . $filename ) ) {
 					return true;
 				}
@@ -71,7 +71,7 @@ class Boost_Cache_Utils {
 					return @rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
 				}
 				break;
-			case self::JBCACHE_FILES: // delete all files in the given directory.
+			case self::FILES: // delete all files in the given directory.
 				if ( is_dir( $dir ) === true ) {
 					$files = array_diff( scandir( $dir ), array( '.', '..' ) );
 					foreach ( $files as $file ) {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -36,7 +36,7 @@ class Boost_Cache_Utils {
 				}
 			}
 			return true;
-		} elseif ( $filter === '*/' ) { // everything in given directory, recursively.
+		} elseif ( $filter === '/*' ) { // everything in given directory, recursively.
 			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $dir, \RecursiveDirectoryIterator::SKIP_DOTS ) );
 			foreach ( $iterator as $file ) {
 				if ( $file->isDir() ) {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -91,7 +91,7 @@ class File_Storage implements Storage {
 	 * @param string $path - The path to delete.
 	 */
 	public function invalidate( $request_uri, $filter = '*' ) {
-		error_log( "invalidate: $request_uri" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( "invalidate: $request_uri $filter" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = $this->root_path . $request_uri;
 
 		return Boost_Cache_Utils::delete_directory( $path, $filter );

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -113,6 +113,10 @@ class File_Storage implements Storage {
 		error_log( "invalidate: $path $type" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$normalized_path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $path );
 
-		return Boost_Cache_Utils::delete( $normalized_path, $type );
+		if ( is_dir( $normalized_path ) ) {
+			return Boost_Cache_Utils::delete_directory( $normalized_path, $type );
+		} else {
+			return Filesystem_Utils::delete_file( $normalized_path );
+		}
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -107,6 +107,8 @@ class File_Storage implements Storage {
 	 * Delete all cached data for the given path.
 	 *
 	 * @param string $path - The path to delete.
+	 * @param string $filter - The filter to use for deleting files: JBCACHE_FILE, JBCACHE_FILES, JBCACHE_ALL.
+	 * @param string $filename - The filename to delete.
 	 */
 	public function invalidate( $request_uri, $filter = JBCACHE_FILE, $filename = '' ) {
 		error_log( "invalidate: $request_uri $filter" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -106,14 +106,13 @@ class File_Storage implements Storage {
 	/**
 	 * Delete all cached data for the given path.
 	 *
-	 * @param string $path - The path to delete.
-	 * @param string $filter - The filter to use for deleting files: FILE, FILES, ALL.
-	 * @param string $filename - The filename to delete.
+	 * @param string $path - The path to delete. File or directory.
+	 * @param string $type - defines what files/directories are deleted: FILE, FILES, ALL.
 	 */
-	public function invalidate( $request_uri, $filter = Boost_Cache_Utils::FILE, $filename = '' ) {
-		error_log( "invalidate: $request_uri $filter $filename" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		$path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $request_uri );
+	public function invalidate( $path, $type ) {
+		error_log( "invalidate: $path $type" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		$normalized_path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $path );
 
-		return Boost_Cache_Utils::delete( $path, $filter, $filename );
+		return Boost_Cache_Utils::delete( $normalized_path, $type );
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -107,7 +107,7 @@ class File_Storage implements Storage {
 	 * Delete all cached data for the given path.
 	 *
 	 * @param string $path - The path to delete. File or directory.
-	 * @param string $type - defines what files/directories are deleted: FILE, FILES, ALL.
+	 * @param string $type - defines what files/directories are deleted: DELETE_FILE, DELETE_FILES, DELETE_ALL.
 	 */
 	public function invalidate( $path, $type ) {
 		error_log( "invalidate: $path $type" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -114,6 +114,6 @@ class File_Storage implements Storage {
 		error_log( "invalidate: $request_uri $filter $filename" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $request_uri );
 
-		return Boost_Cache_Utils::delete_directory( $path, $filter, $filename );
+		return Boost_Cache_Utils::delete( $path, $filter, $filename );
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -110,8 +110,8 @@ class File_Storage implements Storage {
 	 * @param string $filter - The filter to use for deleting files: JBCACHE_FILE, JBCACHE_FILES, JBCACHE_ALL.
 	 * @param string $filename - The filename to delete.
 	 */
-	public function invalidate( $request_uri, $filter = JBCACHE_FILE, $filename = '' ) {
-		error_log( "invalidate: $request_uri $filter" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+	public function invalidate( $request_uri, $filter = Boost_Cache_Utils::JBCACHE_FILE, $filename = '' ) {
+		error_log( "invalidate: $request_uri $filter $filename" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $request_uri );
 
 		return Boost_Cache_Utils::delete_directory( $path, $filter, $filename );

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -92,7 +92,7 @@ class File_Storage implements Storage {
 	 */
 	public function invalidate( $request_uri, $filter = '*' ) {
 		error_log( "invalidate: $request_uri $filter" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		$path = $this->root_path . $request_uri;
+		$path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $request_uri );
 
 		return Boost_Cache_Utils::delete_directory( $path, $filter );
 	}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -113,9 +113,9 @@ class File_Storage implements Storage {
 		error_log( "invalidate: $path $type" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$normalized_path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $path );
 
-		if ( is_dir( $normalized_path ) ) {
+		if ( in_array( $type, array( Boost_Cache_Utils::DELETE_FILES, Boost_Cache_Utils::DELETE_ALL ), true ) && is_dir( $normalized_path ) ) {
 			return Boost_Cache_Utils::delete_directory( $normalized_path, $type );
-		} else {
+		} elseif ( $type === Boost_Cache_Utils::DELETE_FILE ) {
 			return Filesystem_Utils::delete_file( $normalized_path );
 		}
 	}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -49,7 +49,6 @@ class File_Storage implements Storage {
 		$directory = self::get_uri_directory( $request_uri );
 		$filename  = Boost_Cache_Utils::get_request_filename( $parameters );
 		$hash_path = $directory . $filename;
-		error_log( "hash_path: $hash_path" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
 		if ( file_exists( $hash_path ) ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -90,7 +90,7 @@ class File_Storage implements Storage {
 	 *
 	 * @param string $path - The path to delete.
 	 */
-	public function invalidate( $request_uri, $filter = '*' ) {
+	public function invalidate( $request_uri, $filter = JBCACHE_FILE ) {
 		error_log( "invalidate: $request_uri $filter" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $request_uri );
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -107,10 +107,10 @@ class File_Storage implements Storage {
 	 * Delete all cached data for the given path.
 	 *
 	 * @param string $path - The path to delete.
-	 * @param string $filter - The filter to use for deleting files: JBCACHE_FILE, JBCACHE_FILES, JBCACHE_ALL.
+	 * @param string $filter - The filter to use for deleting files: FILE, FILES, ALL.
 	 * @param string $filename - The filename to delete.
 	 */
-	public function invalidate( $request_uri, $filter = Boost_Cache_Utils::JBCACHE_FILE, $filename = '' ) {
+	public function invalidate( $request_uri, $filter = Boost_Cache_Utils::FILE, $filename = '' ) {
 		error_log( "invalidate: $request_uri $filter $filename" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $request_uri );
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -108,10 +108,10 @@ class File_Storage implements Storage {
 	 *
 	 * @param string $path - The path to delete.
 	 */
-	public function invalidate( $request_uri, $filter = JBCACHE_FILE ) {
+	public function invalidate( $request_uri, $filter = JBCACHE_FILE, $filename = '' ) {
 		error_log( "invalidate: $request_uri $filter" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $request_uri );
 
-		return Boost_Cache_Utils::delete_directory( $path, $filter );
+		return Boost_Cache_Utils::delete_directory( $path, $filter, $filename );
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
@@ -12,7 +12,5 @@ interface Storage {
 
 	public function write( $request_uri, $parameters, $data );
 	public function read( $request_uri, $parameters );
-	public function invalidate( $request_uri );
-	public function invalidate_single_visitor( $request_uri, $parameters );
-	public function invalidate_home_page( $dir );
+	public function invalidate( $request_uri, $filter = '*' );
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
@@ -12,6 +12,6 @@ interface Storage {
 
 	public function write( $request_uri, $parameters, $data );
 	public function read( $request_uri, $parameters );
-	public function invalidate( $request_uri, $filter = '', $filename = '' );
+	public function invalidate( $request_uri, $type );
 	public function garbage_collect();
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
@@ -12,6 +12,6 @@ interface Storage {
 
 	public function write( $request_uri, $parameters, $data );
 	public function read( $request_uri, $parameters );
-	public function invalidate( $request_uri, $filter = '*' );
+	public function invalidate( $request_uri, $filter = JBCACHE_FILES, $filename = '' );
 	public function garbage_collect();
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
@@ -12,6 +12,6 @@ interface Storage {
 
 	public function write( $request_uri, $parameters, $data );
 	public function read( $request_uri, $parameters );
-	public function invalidate( $request_uri, $filter = JBCACHE_FILES, $filename = '' );
+	public function invalidate( $request_uri, $filter = '', $filename = '' );
 	public function garbage_collect();
 }

--- a/projects/plugins/boost/changelog/boost-cache-update-storage-invalidate
+++ b/projects/plugins/boost/changelog/boost-cache-update-storage-invalidate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: rearrange how Storage invalidate() function operates


### PR DESCRIPTION
Instead of having 3 invalidate functions, run everything through one, using a filter to select what to do with the files and directories.

## Proposed changes:
* Remove the other invalidate functions from File_Storage.
* Add a filter to invalidate()
* Update delete_directory so it uses the filter to operate differently. Avoid recursion and use PHP's RecursiveDirectoryIterator class.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply PR.
Edit a post and watch error log to make sure files were deleted.
Post a comment in a private window, and do not click "remember me" checkbox. If moderated, confirm that only your own cache file was deleted. Might be tricky to test as it checks if COOKIE array is empty, and then refuses to delete the cache as it's the anon user.
