### PR TITLE
Email notification toggle label: switch from "follow" to "subscribe" term

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2651,7 +2651,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'subscriptions',
 			),
 			'social_notifications_subscribe'       => array(
-				'description'       => esc_html__( 'Send email notification when someone follows my blog', 'jetpack' ),
+				'description'       => esc_html__( 'Send email notification when someone subscribes to my blog', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',

--- a/projects/plugins/jetpack/changelog/update-email-notification-on-follow-label
+++ b/projects/plugins/jetpack/changelog/update-email-notification-on-follow-label
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Email notifications: update from "follows" to "subscribes"

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -79,7 +79,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 			'moderation_notify'                       => '(bool) Email me when a comment is helf for moderation?',
 			'social_notifications_like'               => '(bool) Email me when someone likes my post?',
 			'social_notifications_reblog'             => '(bool) Email me when someone reblogs my post?',
-			'social_notifications_subscribe'          => '(bool) Email me when someone follows my blog?',
+			'social_notifications_subscribe'          => '(bool) Email me when someone subscribes to my blog?',
 			'comment_moderation'                      => '(bool) Moderate comments for manual approval?',
 			'comment_previously_approved'             => '(bool) Moderate comments unless author has a previously-approved comment?',
 			'comment_max_links'                       => '(int) Moderate comments that contain X or more links',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -68,7 +68,7 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint(
 			'moderation_notify'                       => '(bool) Email me when a comment is helf for moderation?',
 			'social_notifications_like'               => '(bool) Email me when someone likes my post?',
 			'social_notifications_reblog'             => '(bool) Email me when someone reblogs my post?',
-			'social_notifications_subscribe'          => '(bool) Email me when someone follows my blog?',
+			'social_notifications_subscribe'          => '(bool) Email me when someone subscribes to my blog?',
 			'comment_moderation'                      => '(bool) Moderate comments for manual approval?',
 			'comment_previously_approved'             => '(bool) Moderate comments unless author has a previously-approved comment?',
 			'comment_max_links'                       => '(int) Moderate comments that contain X or more links',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -68,7 +68,7 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint(
 			'moderation_notify'                       => '(bool) Email me when a comment is helf for moderation?',
 			'social_notifications_like'               => '(bool) Email me when someone likes my post?',
 			'social_notifications_reblog'             => '(bool) Email me when someone reblogs my post?',
-			'social_notifications_subscribe'          => '(bool) Email me when someone follows my blog?',
+			'social_notifications_subscribe'          => '(bool) Email me when someone subscribes to my blog?',
 			'comment_moderation'                      => '(bool) Moderate comments for manual approval?',
 			'comment_previously_approved'             => '(bool) Moderate comments unless author has a previously-approved comment?',
 			'comment_max_links'                       => '(int) Moderate comments that contain X or more links',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -69,7 +69,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'moderation_notify'                       => '(bool) Email me when a comment is helf for moderation?',
 			'social_notifications_like'               => '(bool) Email me when someone likes my post?',
 			'social_notifications_reblog'             => '(bool) Email me when someone reblogs my post?',
-			'social_notifications_subscribe'          => '(bool) Email me when someone follows my blog?',
+			'social_notifications_subscribe'          => '(bool) Email me when someone subscribes to my blog?',
 			'comment_moderation'                      => '(bool) Moderate comments for manual approval?',
 			'comment_previously_approved'             => '(bool) Moderate comments unless author has a previously-approved comment?',
 			'comment_max_links'                       => '(int) Moderate comments that contain X or more links',

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -373,12 +373,12 @@ class Jetpack_Subscriptions {
 			'sm_enabled'
 		);
 
-		/** Email me whenever: Someone follows my blog */
+		/** Email me whenever: Someone subscribes to my blog */
 		/* @since 8.1 */
 
 		add_settings_section(
 			'notifications_section',
-			__( 'Someone follows my blog', 'jetpack' ),
+			__( 'Someone subscribes to my blog', 'jetpack' ),
 			array( $this, 'social_notifications_subscribe_section' ),
 			'discussion'
 		);
@@ -511,7 +511,7 @@ class Jetpack_Subscriptions {
 	}
 
 	/**
-	 * Someone follows my blog section
+	 * Someone subscribes to my blog section
 	 *
 	 * @since 8.1
 	 */
@@ -537,7 +537,7 @@ class Jetpack_Subscriptions {
 	}
 
 	/**
-	 * Someone follows my blog Toggle
+	 * Someone subscribes to my blog Toggle
 	 *
 	 * @since 8.1
 	 */
@@ -549,14 +549,14 @@ class Jetpack_Subscriptions {
 			<input type="checkbox" name="social_notifications_subscribe" id="social_notifications_subscribe" value="1" <?php checked( $checked ); ?> />
 			<?php
 				/* translators: this is a label for a setting that starts with "Email me whenever" */
-				esc_html_e( 'Someone follows my blog', 'jetpack' );
+				esc_html_e( 'Someone subscribes to my blog', 'jetpack' );
 			?>
 		</label>
 		<?php
 	}
 
 	/**
-	 * Validate "Someone follows my blog" option
+	 * Validate "Someone subscribes to my blog" option
 	 *
 	 * @since 8.1
 	 *

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -218,7 +218,7 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 					'moderation_notify'                    => '(bool) Email me when a comment is helf for moderation?',
 					'social_notifications_like'            => '(bool) Email me when someone likes my post?',
 					'social_notifications_reblog'          => '(bool) Email me when someone reblogs my post?',
-					'social_notifications_subscribe'       => '(bool) Email me when someone follows my blog?',
+					'social_notifications_subscribe'       => '(bool) Email me when someone subscribes to my blog?',
 					'comment_moderation'                   => '(bool) Moderate comments for manual approval?',
 					'comment_previously_approved'          => '(bool) Moderate comments unless author has a previously-approved comment?',
 					'comment_max_links'                    => '(int) Moderate comments that contain X or more links',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Context https://github.com/Automattic/wp-calypso/issues/76941

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Simple label rename for the toggle
* API field description update

Before
<img width="900" alt="Screenshot 2024-02-19 at 18 31 47" src="https://github.com/Automattic/jetpack/assets/87168/cb63f321-6368-4189-be7e-1bc44e707d99">

After
<img width="758" alt="Screenshot 2024-02-19 at 18 33 56" src="https://github.com/Automattic/jetpack/assets/87168/c973d5bb-f724-4211-ac13-7e10d21603d3">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

