### PR TITLE
Backport mu-wpcom-plugin 2.0.22, jetpack 13.2-a.7 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2024-02-19
+### Added
+- AI Client: add support for audio transcriptions. [#35691]
+- AI Client: add support for transcription post-processing. [#35734]
+
+### Changed
+- AI Client: Update voice to content feature [#35698]
+- Make build usable in projects using tsc with `moduleResolution` set to 'nodenext'. [#35453]
+- Voice to Content: Add states and refactor duration calculation [#35717]
+
 ## [0.6.1] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -210,6 +220,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.7.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.5.0...v0.5.1

--- a/projects/js-packages/ai-client/changelog/fix-tsc-moduleResolution
+++ b/projects/js-packages/ai-client/changelog/fix-tsc-moduleResolution
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Make build usable in projects using tsc with `moduleResolution` set to 'nodenext'.

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-add-transcription-post-processing-machinery
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-add-transcription-post-processing-machinery
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-AI Client: add support for transcription post-processing.

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-handle-audio-transcription-request
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-handle-audio-transcription-request
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-AI Client: add support for audio transcriptions.

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-modal
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Client: Update voice to content feature

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-states
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-states
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Voice to Content: Add states and refactor duration calculation

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.7.0-alpha",
+	"version": "0.7.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.23] - 2024-02-19
+### Changed
+- Update build configuration to better match supported target environments. [#35713]
+
 ## [0.1.22] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -103,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.23]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.22...v0.1.23
 [0.1.22]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.19...v0.1.20

--- a/projects/js-packages/boost-score-api/changelog/add-my-jetpack-boost-speed-score
+++ b/projects/js-packages/boost-score-api/changelog/add-my-jetpack-boost-speed-score
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Simply moving a utility function over to the boost-score-api js-package.
-
-

--- a/projects/js-packages/boost-score-api/changelog/fix-remove-use-of-ts-loader
+++ b/projects/js-packages/boost-score-api/changelog/fix-remove-use-of-ts-loader
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update build configuration to better match supported target environments.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.23-alpha",
+	"version": "0.1.23",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.48.3] - 2024-02-19
+### Added
+- Added support for annotations in graph [#34978]
+
 ## [0.48.2] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -941,6 +945,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.48.3]: https://github.com/Automattic/jetpack-components/compare/0.48.2...0.48.3
 [0.48.2]: https://github.com/Automattic/jetpack-components/compare/0.48.1...0.48.2
 [0.48.1]: https://github.com/Automattic/jetpack-components/compare/0.48.0...0.48.1
 [0.48.0]: https://github.com/Automattic/jetpack-components/compare/0.47.0...0.48.0

--- a/projects/js-packages/components/changelog/add-annotations
+++ b/projects/js-packages/components/changelog/add-annotations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added support for annotations in graph

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.48.3-alpha",
+	"version": "0.48.3",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.32.2] - 2024-02-19
+### Added
+- Add connection indicator for screen readers [#35714]
+
 ## [0.32.1] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -702,6 +706,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.32.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.2...v0.32.0
 [0.31.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.1...v0.31.2

--- a/projects/js-packages/connection/changelog/update-my-jetpack-connect-page-status-role
+++ b/projects/js-packages/connection/changelog/update-my-jetpack-connect-page-status-role
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add connection indicator for screen readers

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.32.2-alpha",
+	"version": "0.32.2",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.2.0 - 2024-02-19
+### Added
+- Add an option to include `fork-ts-checker-webpack-plugin`. As this requires `typescript` as a peer dep, it needs to be explicitly enabled. [#35476]
+- Add `resolve.extensionAlias` with entries for tsc compatibility. [#35453]
+
+### Changed
+- Sort plugins in documentation and code. [#35476]
+
 ## 3.1.2 - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]

--- a/projects/js-packages/webpack-config/changelog/add-webpack-config-fork-ts-checker-webpack-plugin
+++ b/projects/js-packages/webpack-config/changelog/add-webpack-config-fork-ts-checker-webpack-plugin
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add an option to include `fork-ts-checker-webpack-plugin`. As this requires `typescript` as a peer dep, it needs to be explicitly enabled.

--- a/projects/js-packages/webpack-config/changelog/add-webpack-config-fork-ts-checker-webpack-plugin#2
+++ b/projects/js-packages/webpack-config/changelog/add-webpack-config-fork-ts-checker-webpack-plugin#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Sort plugins in documentation and code.

--- a/projects/js-packages/webpack-config/changelog/fix-tsc-moduleResolution
+++ b/projects/js-packages/webpack-config/changelog/fix-tsc-moduleResolution
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add `resolve.extensionAlias` with entries for tsc compatibility.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.2.0-alpha",
+	"version": "3.2.0",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2024-02-19
+### Added
+- Added price in blaze/posts endpoint [#35066]
+
+### Changed
+- Changes the Blaze Dashboard entry points to be compatible with Woo Blaze [#34964]
+- Post Links: allow third-parties to toggle them depending on post type. [#35730]
+
 ## [0.16.0] - 2024-02-13
 ### Added
 - Blaze: Whiteliste /media/new WPCOM REST API call for image uploading [#34790]
@@ -285,6 +293,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.17.0]: https://github.com/automattic/jetpack-blaze/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/automattic/jetpack-blaze/compare/v0.15.3...v0.16.0
 [0.15.3]: https://github.com/automattic/jetpack-blaze/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/automattic/jetpack-blaze/compare/v0.15.1...v0.15.2

--- a/projects/packages/blaze/changelog/update-blaze-dashboard-compatibility
+++ b/projects/packages/blaze/changelog/update-blaze-dashboard-compatibility
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Changes the Blaze Dashboard entry points to be compatible with Woo Blaze

--- a/projects/packages/blaze/changelog/update-blaze-post-links-option-optout
+++ b/projects/packages/blaze/changelog/update-blaze-post-links-option-optout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Post Links: allow third-parties to toggle them depending on post type.

--- a/projects/packages/blaze/changelog/vdimitrakis-add-price-in-posts-endpoint
+++ b/projects/packages/blaze/changelog/vdimitrakis-add-price-in-posts-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added price in blaze/posts endpoint

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.17.0-alpha",
+	"version": "0.17.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.17.0-alpha';
+	const PACKAGE_VERSION = '0.17.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.13.0] - 2024-02-19
+### Added
+- Blog Privacy: Add AI User Agents to robots.txt depending on blog setting. [#35704]
+- Don't override Site Editor's back button URL for sites with classic view enabled. [#35721]
+- jetpack-mu-wpcom: Added the wpcom-site-menu feature to add a WordPress.com sidebar menu item. [#35702]
+
+### Fixed
+- Create and use Preact signal for subscriptionModalStatus to fix issue of undefined value sent on comment submission. [#35741]
+
 ## [5.12.2] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -581,6 +590,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.13.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.12.2...v5.13.0
 [5.12.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.12.1...v5.12.2
 [5.12.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.12.0...v5.12.1
 [5.12.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.11.0...v5.12.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-mu-wpcom-ai-robots-txt-blocks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-mu-wpcom-ai-robots-txt-blocks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Blog Privacy: Add AI User Agents to robots.txt depending on blog setting.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-site-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-site-menu
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-jetpack-mu-wpcom: Added the wpcom-site-menu feature to add a WordPress.com sidebar menu item.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-subscription-modal-status-form-submission
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-subscription-modal-status-form-submission
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Create and use Preact signal for subscriptionModalStatus to fix issue of undefined value sent on comment submission.

--- a/projects/packages/jetpack-mu-wpcom/changelog/site-editor-back-button-classic-view
+++ b/projects/packages/jetpack-mu-wpcom/changelog/site-editor-back-button-classic-view
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Don't override Site Editor's back button URL for sites with classic view enabled.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.13.0-alpha",
+	"version": "5.13.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.13.0-alpha';
+	const PACKAGE_VERSION = '5.13.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.10.0] - 2024-02-19
+### Added
+- Add Boost Speed Score into My Jetpack Boost product card [#35606]
+- Add connection indicator for screen readers [#35714]
+
+### Fixed
+- Improved accessibility of Dismiss button in Connection Banner [#35694]
+- My Jeptack Connection: Make footer logos a list for better screen readers interpretation. [#35667]
+- My Jetpack: add label for screen readers to connect page close button [#35712]
+
 ## [4.9.2] - 2024-02-13
 ### Changed
 - My Jetpack: various improvements to the Stats card. [#35355]
@@ -1244,6 +1254,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.10.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.9.2...4.10.0
 [4.9.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.9.1...4.9.2
 [4.9.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.9.0...4.9.1
 [4.9.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.8.0...4.9.0

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-boost-speed-score
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-boost-speed-score
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add Boost Speed Score into My Jetpack Boost product card

--- a/projects/packages/my-jetpack/changelog/connection-dismiss-banner-accessibility
+++ b/projects/packages/my-jetpack/changelog/connection-dismiss-banner-accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Improved accessibility of Dismiss button in Connection Banner

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-connect-screen-close-btn-a11y
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-connect-screen-close-btn-a11y
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: add label for screen readers to connect page close button

--- a/projects/packages/my-jetpack/changelog/update-connection-footer-logos-to-list
+++ b/projects/packages/my-jetpack/changelog/update-connection-footer-logos-to-list
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jeptack Connection: Make footer logos a list for better screen readers interpretation.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-page-status-role
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-page-status-role
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add connection indicator for screen readers

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.10.0-alpha",
+	"version": "4.10.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -35,7 +35,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.10.0-alpha';
+	const PACKAGE_VERSION = '4.10.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.2] - 2024-02-19
+### Changed
+- Internal updates.
+
 ## [0.43.1] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -894,6 +898,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.43.2]: https://github.com/Automattic/jetpack-search/compare/v0.43.1...v0.43.2
 [0.43.1]: https://github.com/Automattic/jetpack-search/compare/v0.43.0...v0.43.1
 [0.43.0]: https://github.com/Automattic/jetpack-search/compare/v0.42.1...v0.43.0
 [0.42.1]: https://github.com/Automattic/jetpack-search/compare/v0.42.0...v0.42.1

--- a/projects/packages/search/changelog/remove-postcss-custom-properties-importFrom
+++ b/projects/packages/search/changelog/remove-postcss-custom-properties-importFrom
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Replace `postcss-custom-properties` `importFrom` with `@csstools/postcss-global-data`. Should be no change to the package itself.
-
-

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.43.2-alpha",
+	"version": "0.43.2",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.43.2-alpha';
+	const VERSION = '0.43.2';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.0 - 2024-02-19
+### Added
+- Stats: added support for Email stats [#35703]
+
 ## 0.15.3 - 2024-02-14
 ### Fixed
 - Stats: clear usage, modules, module-settings cache after purchase [#35590]

--- a/projects/packages/stats-admin/changelog/update-enable-email-stats-for-odyssey
+++ b/projects/packages/stats-admin/changelog/update-enable-email-stats-for-odyssey
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Stats: added support for Email stats

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.16.0-alpha",
+	"version": "0.16.0",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.16.0-alpha';
+	const VERSION = '0.16.0';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2024-02-19
+### Fixed
+- Avoid Fatal errors when saved stats data is a WP_Error object [#35746]
+
 ## [0.10.0] - 2024-02-05
 ### Added
 - Stats fetching mechanism: add filter allowing one to customize how long we cache results. [#35421]
@@ -129,6 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.10.1]: https://github.com/Automattic/jetpack-stats/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Automattic/jetpack-stats/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Automattic/jetpack-stats/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Automattic/jetpack-stats/compare/v0.7.2...v0.8.0

--- a/projects/packages/stats/changelog/fix-stats-fetch-fatal
+++ b/projects/packages/stats/changelog/fix-stats-fetch-fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Avoid Fatal errors when saved stats data is a WP_Error object

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2024-02-19
+### Changed
+- Add jetpack_newsletters_publishing_default_frequency to Sync [#35672]
+
 ## [2.6.1] - 2024-02-13
 ### Changed
 - Internal updates.
@@ -1047,6 +1051,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.7.0]: https://github.com/Automattic/jetpack-sync/compare/v2.6.1...v2.7.0
 [2.6.1]: https://github.com/Automattic/jetpack-sync/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/Automattic/jetpack-sync/compare/v2.5.1...v2.6.0
 [2.5.1]: https://github.com/Automattic/jetpack-sync/compare/v2.5.0...v2.5.1

--- a/projects/packages/sync/changelog/add-newsletter-publisher-default-delivery-option
+++ b/projects/packages/sync/changelog/add-newsletter-publisher-default-delivery-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Add jetpack_newsletters_publishing_default_frequency to Sync

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.7.0-alpha';
+	const PACKAGE_VERSION = '2.7.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.3] - 2024-02-19
+### Changed
+- Internal updates.
+
 ## [0.23.2] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -1259,6 +1263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.2...v0.23.3
 [0.23.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.1...v0.23.2
 [0.23.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.4...v0.23.0

--- a/projects/packages/videopress/changelog/remove-postcss-custom-properties-importFrom
+++ b/projects/packages/videopress/changelog/remove-postcss-custom-properties-importFrom
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Replace `postcss-custom-properties` `importFrom` with `@csstools/postcss-global-data`. Should be no change to the package itself.
-
-

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.3-alpha",
+	"version": "0.23.3",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.3-alpha';
+	const PACKAGE_VERSION = '0.23.3';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,11 +2,49 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 13.2-a.5 - 2024-02-14
+## 13.2-a.7 - 2024-02-19
+### Enhancements
+- Added custom message textarea to send a message via email when adding new users [#35277]
+- Add images while publishing on the web via the jetpack app [#35583]
+- Add some extra margin around Stats settings toggles [#35720]
+- Add support for Email stats [#35703]
+- Comment: Add Goodreads embed block in Gutenberg. [#33395]
+- SSO: Add user invite revoke row action in users table [#35277]
+- SSO: improve messaging and account binding between local and wp.com users [#35277]
+- SSO: Updated column heading and row background color when invitation is pending. [#35277]
+- SSO: When creating a new users, mail the users with an invitation to WPCom. [#35277]
+- We added the Welcome Email Message setting to Newsletter settings [#35621]
+
+### Improved compatibility
+- Add 'if_not_modified_since' to the update post endpoints this will help clients fails if the post has been updated since last retrieved [#35526]
+- Add support for WP Super Cache and Boost Cache [#35598]
+
+### Bug fixes
+- Jetpack Google Fonts: Fix some Google fonts aren't displayed correctly on front end [#35706]
+- Scan: ensure the Admin notice resources are always properly loaded. [#35648]
+
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
-- Adds error messaging to endpoint when connected account for memberships cannot be loaded. [#35564]
-- Like block: Update block's Learn more link logic [#35641]
-- Make Jetpack redirect to the Jetpack page after multisite activation. [#35559]
+- Add caching for user invites [#35277]
+- Added price in blaze/posts endpoint [#35066]
+- Add jetpack_newsletters_publishing_default_frequency to Sync [#35672]
+- Adds a standalone mode indicator to the Firewall settings [#34854]
+- Blaze: display post links for products. [#35730]
+- Email notifications: update from "follows" to "subscribes" [#35755]
+- Fix message translation content [#35277]
+- Improve column by renaming and adding icon [#35277]
+- Jetpack AI: Add transcription post-processing example to Voice-to-Content block. [#35734]
+- Jetpack AI: include audio transcription usage example to Voice-to-Content block. [#35691]
+- Jetpack AI Voice to content: Update to modal UI [#35698]
+- Move user customization to seperate file [#35277]
+- Persist user-new.php custom message form field after submission with errors [#35277]
+- Related Posts: remove duplicated HTML attributes [#35686]
+- Rename status column to sso status and add tooltip [#35277]
+- Replace question mark icon [#35277]
+- SSO: revoke invites sent to users upon users deletion [#35277]
+- Trigger user invitation for new users [#35277]
+- update readme [#35671]
+- Update users table ssorow background colors [#35277]
+- Voice to Content: Add states and refactor duration calculation [#35717]
 
 ## 13.1.2 - 2024-02-19
 ### Security Improvements
@@ -15,6 +53,12 @@
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
 - Jetpack: readme.txt tweaks. [#35727]
 - Jetpack: redirect to the Jetpack page after multisite activation. [#35559]
+
+## 13.2-a.5 - 2024-02-14
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Adds error messaging to endpoint when connected account for memberships cannot be loaded. [#35564]
+- Like block: Update block's Learn more link logic [#35641]
+- Make Jetpack redirect to the Jetpack page after multisite activation. [#35559]
 
 ## 13.2-a.3 - 2024-02-13
 ### Enhancements

--- a/projects/plugins/jetpack/changelog/Add column tooltip
+++ b/projects/plugins/jetpack/changelog/Add column tooltip
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Rename status column to sso status and add tooltip

--- a/projects/plugins/jetpack/changelog/Improve column
+++ b/projects/plugins/jetpack/changelog/Improve column
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Improve column by renaming and adding icon

--- a/projects/plugins/jetpack/changelog/Improve question mark icon
+++ b/projects/plugins/jetpack/changelog/Improve question mark icon
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Replace question mark icon

--- a/projects/plugins/jetpack/changelog/[Memberships] Add support for WP Super Cache and Boost Cache
+++ b/projects/plugins/jetpack/changelog/[Memberships] Add support for WP Super Cache and Boost Cache
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Add support for WP Super Cache and Boost Cache

--- a/projects/plugins/jetpack/changelog/add-app-upload-media-enabled
+++ b/projects/plugins/jetpack/changelog/add-app-upload-media-enabled
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add images while publishing on the web via the jetpack app

--- a/projects/plugins/jetpack/changelog/add-goodreads-block
+++ b/projects/plugins/jetpack/changelog/add-goodreads-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Comment: Add Goodreads embed block in Gutenberg.

--- a/projects/plugins/jetpack/changelog/add-jetpack-waf-standalone-mode-indicator
+++ b/projects/plugins/jetpack/changelog/add-jetpack-waf-standalone-mode-indicator
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Adds a standalone mode indicator to the Firewall settings

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-boost-speed-score
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-boost-speed-score
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-new-user-additional-email-message
+++ b/projects/plugins/jetpack/changelog/add-new-user-additional-email-message
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Added custom message textarea to send a message via email when adding new users

--- a/projects/plugins/jetpack/changelog/add-newsletter-publisher-default-delivery-option
+++ b/projects/plugins/jetpack/changelog/add-newsletter-publisher-default-delivery-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add jetpack_newsletters_publishing_default_frequency to Sync

--- a/projects/plugins/jetpack/changelog/add-sso-cached-invites
+++ b/projects/plugins/jetpack/changelog/add-sso-cached-invites
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add caching for user invites

--- a/projects/plugins/jetpack/changelog/add-sso-move-to-admin-class
+++ b/projects/plugins/jetpack/changelog/add-sso-move-to-admin-class
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Move user customization to seperate file

--- a/projects/plugins/jetpack/changelog/add-sso-users-table-revoke-invite
+++ b/projects/plugins/jetpack/changelog/add-sso-users-table-revoke-invite
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-SSO: Add user invite revoke row action in users table

--- a/projects/plugins/jetpack/changelog/add-welcome-email-message-setting
+++ b/projects/plugins/jetpack/changelog/add-welcome-email-message-setting
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-We added the Welcome Email Message setting to Newsletter settings

--- a/projects/plugins/jetpack/changelog/fix-jetpack-google-font
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-google-font
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Jetpack Google Fonts: Fix some Google fonts aren't displayed correctly on front end

--- a/projects/plugins/jetpack/changelog/fix-registration-user-invite
+++ b/projects/plugins/jetpack/changelog/fix-registration-user-invite
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Trigger user invitation for new users

--- a/projects/plugins/jetpack/changelog/fix-related-post-duplicate-selector-in-editor
+++ b/projects/plugins/jetpack/changelog/fix-related-post-duplicate-selector-in-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Related Posts: remove duplicated HTML attributes

--- a/projects/plugins/jetpack/changelog/fix-scan-file-location
+++ b/projects/plugins/jetpack/changelog/fix-scan-file-location
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Scan: ensure the Admin notice resources are always properly loaded.

--- a/projects/plugins/jetpack/changelog/fix-simple-sites-tiled-gallery-qr-code-upload
+++ b/projects/plugins/jetpack/changelog/fix-simple-sites-tiled-gallery-qr-code-upload
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: this fixes bugs that were never released yet so not important externally
-
-

--- a/projects/plugins/jetpack/changelog/fix-translations
+++ b/projects/plugins/jetpack/changelog/fix-translations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix message translation content

--- a/projects/plugins/jetpack/changelog/improve-binding-local-remote-users
+++ b/projects/plugins/jetpack/changelog/improve-binding-local-remote-users
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-SSO: improve messaging and account binding between local and wp.com users

--- a/projects/plugins/jetpack/changelog/improve_invite_form
+++ b/projects/plugins/jetpack/changelog/improve_invite_form
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-SSO: When creating a new users, mail the users with an invitation to WPCom.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.2-a.8
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.2-a.6
-
-

--- a/projects/plugins/jetpack/changelog/readme-updates-feb-13-24
+++ b/projects/plugins/jetpack/changelog/readme-updates-feb-13-24
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-update readme

--- a/projects/plugins/jetpack/changelog/remove-postcss-custom-properties-importFrom
+++ b/projects/plugins/jetpack/changelog/remove-postcss-custom-properties-importFrom
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Replace `postcss-custom-properties` `importFrom` with `@csstools/postcss-global-data`. Should be no change to the plugin itself.
-
-

--- a/projects/plugins/jetpack/changelog/revoke-deleted-users
+++ b/projects/plugins/jetpack/changelog/revoke-deleted-users
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-SSO: revoke invites sent to users upon users deletion

--- a/projects/plugins/jetpack/changelog/try-update-post-endpoint-to-fail-on-old-revision
+++ b/projects/plugins/jetpack/changelog/try-update-post-endpoint-to-fail-on-old-revision
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-Add 'if_not_modified_since' to the update post endpoints this will help clients fails if the post has been updated since last retrieved 

--- a/projects/plugins/jetpack/changelog/update-blaze-dashboard-compatibility
+++ b/projects/plugins/jetpack/changelog/update-blaze-dashboard-compatibility
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-blaze-post-links-option-optout
+++ b/projects/plugins/jetpack/changelog/update-blaze-post-links-option-optout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Blaze: display post links for products.

--- a/projects/plugins/jetpack/changelog/update-email-notification-on-follow-label
+++ b/projects/plugins/jetpack/changelog/update-email-notification-on-follow-label
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Email notifications: update from "follows" to "subscribes"

--- a/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey
+++ b/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Add support for Email stats

--- a/projects/plugins/jetpack/changelog/update-improve-users-table
+++ b/projects/plugins/jetpack/changelog/update-improve-users-table
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-SSO: Updated column heading and row background color when invitation is pending.

--- a/projects/plugins/jetpack/changelog/update-tweak-spacing-stats-settings-toggles
+++ b/projects/plugins/jetpack/changelog/update-tweak-spacing-stats-settings-toggles
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add some extra margin around Stats settings toggles

--- a/projects/plugins/jetpack/changelog/update-user-new-save-form-data
+++ b/projects/plugins/jetpack/changelog/update-user-new-save-form-data
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Persist user-new.php custom message form field after submission with errors

--- a/projects/plugins/jetpack/changelog/update-users-table-sso-background-colors
+++ b/projects/plugins/jetpack/changelog/update-users-table-sso-background-colors
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Update users table ssorow background colors

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-add-transcription-post-processing-machinery
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-add-transcription-post-processing-machinery
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: Add transcription post-processing example to Voice-to-Content block.

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-handle-audio-transcription-request
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-handle-audio-transcription-request
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack AI: include audio transcription usage example to Voice-to-Content block.

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-modal
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI Voice to content: Update to modal UI

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-states
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-states
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Voice to Content: Add states and refactor duration calculation

--- a/projects/plugins/jetpack/changelog/vdimitrakis-add-price-in-posts-endpoint
+++ b/projects/plugins/jetpack/changelog/vdimitrakis-add-price-in-posts-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Added price in blaze/posts endpoint

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_6",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/goodreads.php
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/goodreads.php
@@ -2,7 +2,7 @@
 /**
  * Goodreads Block.
  *
- * @since $$next-version$$
+ * @since 13.2
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.2-a.6
+ * Version: 13.2-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.2-a.6' );
+define( 'JETPACK__VERSION', '13.2-a.7' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.2-a.7
+ * Version: 13.2-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.2-a.7' );
+define( 'JETPACK__VERSION', '13.2-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.2.0-a.7",
+	"version": "13.2.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.2.0-a.6",
+	"version": "13.2.0-a.7",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,7 +326,27 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.2-a.5 - 2024-02-14
+### 13.2-a.7 - 2024-02-19
+#### Enhancements
+- Added custom message textarea to send a message via email when adding new users
+- Add images while publishing on the web via the jetpack app
+- Add some extra margin around Stats settings toggles
+- Add support for Email stats
+- Comment: Add Goodreads embed block in Gutenberg.
+- SSO: Add user invite revoke row action in users table
+- SSO: improve messaging and account binding between local and wp.com users
+- SSO: Updated column heading and row background color when invitation is pending.
+- SSO: When creating a new users, mail the users with an invitation to WPCom.
+- We added the Welcome Email Message setting to Newsletter settings
+
+#### Improved compatibility
+- Add 'if_not_modified_since' to the update post endpoints this will help clients fails if the post has been updated since last retrieved
+- Add support for WP Super Cache and Boost Cache
+
+#### Bug fixes
+- Jetpack Google Fonts: Fix some Google fonts aren't displayed correctly on front end
+- Scan: ensure the Admin notice resources are always properly loaded.
+
 --------
 
 [See the previous changelogs here](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/CHANGELOG.md#changelog)

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.22 - 2024-02-19
+### Changed
+- Internal updates.
+
 ## 2.0.21 - 2024-02-14
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-mu-wpcom-ai-robots-txt-blocks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-mu-wpcom-ai-robots-txt-blocks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_22_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_22"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.22-alpha
+ * Version: 2.0.22
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.22-alpha",
+	"version": "2.0.22",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.0.22, jetpack 13.2-a.7

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.