### PR TITLE
Voice to Content: Handle editor content insertion

### DIFF
--- a/projects/plugins/jetpack/changelog/update-voice-to-content-handle-editor-content-insertion
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-handle-editor-content-insertion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Voice to Content: Add hook to handle transcription insertion into the editor.

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -21,6 +21,7 @@ import { external } from '@wordpress/icons';
  * Internal dependencies
  */
 import oscilloscope from './assets/oscilloscope.svg';
+import useEditorInserter from './hooks/use-editor-inserter';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function Oscilloscope( { audioURL } ) {
@@ -84,20 +85,24 @@ function AudioStatusPanel( { state, error = null, audioURL = null, duration = 0 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ActionButtons( { state, mediaControls, onError } ) {
 	const { start, pause, resume, stop, reset } = mediaControls ?? {};
+	const { upsertTranscription } = useEditorInserter();
 
 	const { processTranscription } = useTranscriptionPostProcessing( {
 		feature: 'voice-to-content',
-		onReady: result => {
-			// eslint-disable-next-line no-console
-			console.log( 'Post-processing ready: ', result );
+		onReady: postProcessingResult => {
+			// Insert the content into the editor
+			upsertTranscription( postProcessingResult );
 		},
 		onError: error => {
 			// eslint-disable-next-line no-console
 			console.log( 'Post-processing error: ', error );
 		},
 		onUpdate: currentPostProcessingResult => {
-			// eslint-disable-next-line no-console
-			console.log( 'Post-processing update: ', currentPostProcessingResult );
+			/*
+			 * We can upsert partial results because the hook take care of replacing
+			 * the previous result with the new one.
+			 */
+			upsertTranscription( currentPostProcessingResult );
 		},
 	} );
 

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -21,7 +21,7 @@ import { external } from '@wordpress/icons';
  * Internal dependencies
  */
 import oscilloscope from './assets/oscilloscope.svg';
-import useEditorInserter from './hooks/use-editor-inserter';
+import useTranscriptionInserter from './hooks/use-transcription-inserter';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function Oscilloscope( { audioURL } ) {
@@ -85,7 +85,7 @@ function AudioStatusPanel( { state, error = null, audioURL = null, duration = 0 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ActionButtons( { state, mediaControls, onError } ) {
 	const { start, pause, resume, stop, reset } = mediaControls ?? {};
-	const { upsertTranscription } = useEditorInserter();
+	const { upsertTranscription } = useTranscriptionInserter();
 
 	const { processTranscription } = useTranscriptionPostProcessing( {
 		feature: 'voice-to-content',

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-editor-inserter/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-editor-inserter/index.ts
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { rawHandler } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useRef } from '@wordpress/element';
+import debugFactory from 'debug';
+import MarkdownIt from 'markdown-it';
+
+const debug = debugFactory( 'voice-to-content:use-editor-inserter' );
+
+/**
+ * The return value for the editor inserter hook.
+ */
+export type UseEditorInserterReturn = {
+	upsertTranscription: ( transcription: string ) => void;
+};
+
+/**
+ * Create a new markdown converter
+ */
+const markdownConverter = new MarkdownIt( {
+	breaks: true,
+} );
+
+/**
+ * Hook to handle the insertion of the transcription into the editor.
+ *
+ * @returns {UseEditorInserterReturn} - Object with function to handle editor block upserting.
+ */
+export default function useEditorInserter(): UseEditorInserterReturn {
+	const { replaceBlocks, insertBlocks } = useDispatch( 'core/block-editor' );
+
+	/*
+	 * List of blocks currently on the editor.
+	 */
+	const currentBlocks = useRef( [] );
+
+	const upsertTranscription = useCallback(
+		( transcription: string ) => {
+			debug( 'Upserting transcription' );
+
+			// Convert the markdown to HTML
+			const html = markdownConverter
+				.render( transcription || '' )
+				// Fix list indentation
+				.replace( /<li>\s+<p>/g, '<li>' )
+				.replace( /<\/p>\s+<\/li>/g, '</li>' );
+
+			// Parse the HTML into blocks
+			const blocksFromHTML = rawHandler( { HTML: html } );
+
+			/*
+			 * Replace the current blocks with the new ones
+			 */
+			if ( blocksFromHTML.length > 0 ) {
+				if ( currentBlocks.current.length === 0 ) {
+					insertBlocks( blocksFromHTML );
+					currentBlocks.current = blocksFromHTML;
+				} else {
+					replaceBlocks(
+						currentBlocks.current.map( b => b.clientId ),
+						blocksFromHTML
+					);
+					currentBlocks.current = blocksFromHTML;
+				}
+			}
+		},
+		[ currentBlocks, insertBlocks, replaceBlocks ]
+	);
+
+	return {
+		upsertTranscription,
+	};
+}

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-inserter/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-inserter/index.ts
@@ -7,12 +7,12 @@ import { useCallback, useRef } from '@wordpress/element';
 import debugFactory from 'debug';
 import MarkdownIt from 'markdown-it';
 
-const debug = debugFactory( 'voice-to-content:use-editor-inserter' );
+const debug = debugFactory( 'voice-to-content:use-transcription-inserter' );
 
 /**
- * The return value for the editor inserter hook.
+ * The return value for the transcription inserter hook.
  */
-export type UseEditorInserterReturn = {
+export type UseTranscriptionInserterReturn = {
 	upsertTranscription: ( transcription: string ) => void;
 };
 
@@ -26,9 +26,9 @@ const markdownConverter = new MarkdownIt( {
 /**
  * Hook to handle the insertion of the transcription into the editor.
  *
- * @returns {UseEditorInserterReturn} - Object with function to handle editor block upserting.
+ * @returns {UseTranscriptionInserterReturn} - Object with function to handle transcription upserting.
  */
-export default function useEditorInserter(): UseEditorInserterReturn {
+export default function useTranscriptionInserter(): UseTranscriptionInserterReturn {
 	const { replaceBlocks, insertBlocks } = useDispatch( 'core/block-editor' );
 
 	/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #35549.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create the `use-transcription-inserter` hook to abstract content insertion into the editor
* Add an example of how to use it on the Voice-to-Content block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open the browser's development console, so you can check debug messages
* Insert a `Voice to Content` block and then click "Upload audio" to pick an audio for testing

<img width="600" alt="Screenshot 2024-02-19 at 17 47 08" src="https://github.com/Automattic/jetpack/assets/6760046/1dddd485-486a-4ba4-a9ae-d72603aa9e05">

* Once you pick the file, the transcription process will start and you will see some messages regarding it
   * For this PR, I used this file from OpenAI: https://cdn.openai.com/whisper/draft-20220913a/micro-machines.wav
* After the transcription is ready, you will automatically see the post-processing step starting
* When the post-processing request starts to stream back, you will see:
   * the result being printed on the console
   * the result being added to the block editor, chunk by chunk

<img width="500" alt="Screenshot 2024-02-19 at 17 50 40" src="https://github.com/Automattic/jetpack/assets/6760046/6d6b3cf8-d765-4ab6-8db3-0e40f4cd74bb">

* When the response streaming is done, you will see the content on the editor and the modal over it:

<img width="800" alt="Screenshot 2024-02-19 at 17 50 55" src="https://github.com/Automattic/jetpack/assets/6760046/3c9d3f48-e385-45bf-a758-d27a77706d20">

* When you close the modal, you can see and edit the content freely, since it's now on native blocks:

<img width="600" alt="Screenshot 2024-02-19 at 17 51 11" src="https://github.com/Automattic/jetpack/assets/6760046/1937b485-a07f-4343-acc9-e8b20518208a">