### PR TITLE
WordAds: Add additional states to US Privacy law opt-out

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ccpa-states
+++ b/projects/plugins/jetpack/changelog/update-ccpa-states
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+WordAds: Add additional states to US Privacy law opt-out

--- a/projects/plugins/jetpack/modules/wordads/js/wordads-ccpa.js
+++ b/projects/plugins/jetpack/modules/wordads/js/wordads-ccpa.js
@@ -314,8 +314,21 @@
 						var data = JSON.parse( this.response );
 						var region = data.region ? data.region.toLowerCase() : '';
 						var ccpaApplies =
-							[ 'california', 'colorado', 'connecticut', 'utah', 'virginia' ].indexOf( region ) >
-							-1;
+							[
+								'california',
+								'colorado',
+								'connecticut',
+								'delaware',
+								'indiana',
+								'iowa',
+								'montana',
+								'new jersey',
+								'oregon',
+								'tennessee',
+								'texas',
+								'utah',
+								'virginia',
+							].indexOf( region ) > -1;
 
 						// Set CCPA applies cookie. This keeps us from having to make a geo request too frequently.
 						setCcpaAppliesCookie( ccpaApplies );


### PR DESCRIPTION
## Proposed changes:
- Adds Delaware, Indiana, Iowa, Montana, New Jersey, Oregon, Tennessee, and Texas as additional states covered by US Privacy (USP) opt-outs.

## Testing instructions:
- Have Ads enabled on your site
- From Jetpack Settings->Monetize toggle on `Enable targeted advertising to site visitors in all US states`
- Visit the site from one of the states listed above. (VPN if necessary)
- Verify that the `ccpa_applies` cookie is set to `true`
- 
## Does this pull request change what data or activity we track or use?
It allows additional states to opt out of sharing personal information for advertising purposes.
