### PR TITLE
TreeDropdown: Add tree dropdown component

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
@@ -1,0 +1,97 @@
+import './style.scss';
+import { Icon, closeSmall, search } from '@wordpress/icons';
+import classNames from 'classnames';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import TreeSelector from '../tree-selector';
+
+const TreeDropdown = props => {
+	const { items, onChange, selectedItems, disabled } = props;
+	const [ inputValue, setInputValue ] = useState( '' );
+	const [ isDropdownVisible, setIsDropdownVisible ] = useState( false );
+	const dropdownRef = useRef( null );
+	const inputRef = useRef( null );
+	const className = classNames(
+		'tree-dropdown__input-container',
+		isDropdownVisible && 'active',
+		disabled && 'disabled'
+	);
+
+	const tags = useMemo(
+		() => selectedItems?.map( id => items.find( item => item.id === id ) ) || [],
+		[ selectedItems, items ]
+	);
+
+	const showDropdown = useCallback( () => setIsDropdownVisible( true ), [] );
+
+	const handleInputChange = useCallback( e => {
+		setInputValue( e.target.value );
+	}, [] );
+
+	const removeTag = useCallback( tag => onChange( tag.id, false ), [ onChange ] );
+
+	const handleDelete = useCallback( tag => () => removeTag( tag ), [ removeTag ] );
+
+	const handleInputKeyDown = useCallback(
+		e => {
+			if ( e.key === 'Backspace' && ! inputValue ) {
+				removeTag( tags[ tags.length - 1 ] );
+			}
+		},
+		[ inputValue, removeTag, tags ]
+	);
+
+	const handleClickOutside = useCallback( event => {
+		if ( dropdownRef.current && ! dropdownRef.current.contains( event.target ) ) {
+			setIsDropdownVisible( false );
+		}
+	}, [] );
+
+	useEffect( () => {
+		document.addEventListener( 'mousedown', handleClickOutside );
+		return () => {
+			document.removeEventListener( 'mousedown', handleClickOutside );
+		};
+	}, [ handleClickOutside ] );
+
+	return (
+		<div className="tree-dropdown" ref={ dropdownRef }>
+			<div className={ className }>
+				<Icon icon={ search } />
+				{ tags.map( ( tag, index ) => (
+					<span key={ index } className="tree-dropdown__tag">
+						{ tag.name }
+						<button onClick={ handleDelete( tag ) } className="tree-dropdown__tag-remove-button">
+							<Icon icon={ closeSmall } />
+						</button>
+					</span>
+				) ) }
+				<input
+					className="tree-dropdown__input"
+					ref={ inputRef }
+					type="text"
+					value={ inputValue }
+					onFocus={ showDropdown }
+					onChange={ handleInputChange }
+					onKeyDown={ handleInputKeyDown }
+					disabled={ disabled }
+				/>
+			</div>
+
+			{ isDropdownVisible && (
+				<div className="tree-dropdown__dropdown-container">
+					<div className="tree-dropdown__dropdown">
+						<TreeSelector
+							items={ items }
+							selectedItems={ selectedItems }
+							disabled={ disabled }
+							onChange={ onChange }
+							keyword={ inputValue }
+						/>
+					</div>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default TreeDropdown;

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
@@ -17,7 +17,7 @@ const TreeDropdown = props => {
 	);
 
 	const tags = useMemo(
-		() => selectedItems?.map( id => items.find( item => item.id === id ) ) || [],
+		() => selectedItems?.map( id => items.find( item => item.id === id ) ).filter( Boolean ) || [],
 		[ selectedItems, items ]
 	);
 

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
@@ -60,7 +60,11 @@ const TreeDropdown = props => {
 				{ tags.map( ( tag, index ) => (
 					<span key={ index } className="tree-dropdown__tag">
 						{ tag.name }
-						<button onClick={ handleDelete( tag ) } className="tree-dropdown__tag-remove-button">
+						<button
+							onClick={ handleDelete( tag ) }
+							className="tree-dropdown__tag-remove-button"
+							disabled={ disabled }
+						>
 							<Icon icon={ closeSmall } />
 						</button>
 					</span>

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
@@ -1,0 +1,92 @@
+@import '../../scss/calypso-colors';
+
+.tree-dropdown {
+	.tree-dropdown__input-container {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 6px;
+		border: solid 1px $gray-5;
+		border-radius: 4px;
+		min-height: 40px;
+		padding: 4px 8px;
+
+		&.active {
+			border-color: var(--jp-green);
+			box-shadow: 0px 0px 0px 2px var(--jp-green-5), 0px 7px 15px 0px #00000026;
+			border-radius: 4px 4px 0 0;
+		}
+
+
+		.tree-dropdown__input {
+			flex-grow: 1;
+			padding: 0;
+
+			&, &:focus {
+				border: none;
+				box-shadow: none;
+			}
+		}
+
+		.tree-dropdown__tag {
+			display: flex;
+			gap: 4px;
+			height: 24px;
+			background-color: $white;
+			border: solid 1px $gray-80;
+			border-radius: 12px;
+			padding: 2px 4px 2px 8px;
+			margin: 3px 0;
+			font-size: 0.75rem;
+		}
+
+		.tree-dropdown__tag-remove-button {
+			background: none;
+			border: none;
+			padding: 0;
+
+			&, svg {
+				width: 18px;
+				height: 18px;
+			}
+		}
+	}
+
+	.tree-dropdown__dropdown-container {
+		position: relative;
+
+		.tree-dropdown__dropdown {
+			position: absolute;
+			top: 100%;
+			width: 100%;
+			padding: 8px;
+			background-color: $white;
+			border: solid 1px var(--jp-green);
+			border-top: none;
+			border-radius: 0 0 4px 4px;
+			box-shadow: 0px 0px 0px 2px var(--jp-green-5), 0px 10px 15px 0px #00000026;
+			z-index: 1000;
+
+			&::before {
+				content: '';
+				position: absolute;
+				top: -5px;
+				left: -1px;
+				right: -1px;
+				height: 5px;
+				background-color: $white;
+				border-left: solid 1px var(--jp-green);
+				border-right: solid 1px var(--jp-green);
+			}
+
+			ul.jp-tree-items {
+				max-height: 370px;
+				overflow-y: auto;
+			}
+
+			li.jp-tree-item {
+				margin-right: 8px;
+			}
+		}
+	}
+}

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
@@ -49,6 +49,7 @@
 			background: none;
 			border: none;
 			padding: 0;
+			cursor: pointer;
 
 			&, svg {
 				width: 18px;

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
@@ -17,6 +17,11 @@
 			border-radius: 4px 4px 0 0;
 		}
 
+		&.disabled {
+			svg, .tree-dropdown__tag {
+				opacity: 0.7;
+			}
+		}
 
 		.tree-dropdown__input {
 			flex-grow: 1;

--- a/projects/plugins/jetpack/_inc/client/components/tree-selector/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-selector/index.jsx
@@ -26,7 +26,7 @@ const TreeSelector = props => {
 			style={ { marginLeft: isSearching ? 0 : item.depth * 25 } }
 		>
 			<CheckboxControl
-				id={ `jp-tree-item-${ item.ID }` }
+				id={ `jp-tree-item-${ item.id }` }
 				name="jp-tree-item"
 				checked={ selectedItems.includes( item.id ) }
 				onChange={ toggleCheckbox( item.id ) }

--- a/projects/plugins/jetpack/_inc/client/components/tree-selector/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-selector/index.jsx
@@ -1,3 +1,4 @@
+import { CheckboxControl } from '@wordpress/components';
 import { useCallback } from 'react';
 import './style.scss';
 import { createFlatTreeItems } from './utils';
@@ -24,9 +25,8 @@ const TreeSelector = props => {
 			className="jp-tree-item"
 			style={ { marginLeft: isSearching ? 0 : item.depth * 25 } }
 		>
-			<input
-				type="checkbox"
-				id={ `jp-tree-item-${ item.id }` }
+			<CheckboxControl
+				id={ `jp-tree-item-${ item.ID }` }
 				name="jp-tree-item"
 				checked={ selectedItems.includes( item.id ) }
 				onChange={ toggleCheckbox( item.id ) }

--- a/projects/plugins/jetpack/_inc/client/components/tree-selector/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tree-selector/style.scss
@@ -1,14 +1,40 @@
 @import '@automattic/jetpack-base-styles/style';
 
 ul.jp-tree-items {
-    list-style-type: none;
+	list-style-type: none;
+	margin: 0;
 }
 
 li.jp-tree-item {
-    small {
-        color: var( --jp-gray-40 );
-    }
-    input:disabled+label {
-        color: var( --jp-gray-20 );
-      }
+	display: flex;
+	margin: 0;
+	padding: 8px 6px 8px 6px;
+	gap: 8px;
+
+	label {
+		flex-grow: 1;
+		line-height: 22px;
+	}
+
+	small {
+		color: var( --jp-gray-40 );
+	}
+
+	input:disabled+label {
+		color: var( --jp-gray-20 );
+	}
+
+	.components-base-control__field, .components-checkbox-control__input-container {
+		margin: 0;
+	}
+
+	.components-checkbox-control__input[type=checkbox]:checked, .components-checkbox-control__input[type=checkbox]:indeterminate {
+		background: var(--jp-green);
+		border-color: var(--jp-green);
+	}
+
+	.components-checkbox-control__input[type=checkbox]:focus {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) #fff, 0 0 0 calc(var(--wp-admin-border-width-focus) * 2) var(--jp-green);
+		border-color: var(--jp-green);
+	}
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -11,7 +11,7 @@ import {
 } from 'state/connection';
 import { getModule } from 'state/modules';
 import { withModuleSettingsFormHelpers } from '../components/module-settings/with-module-settings-form-helpers';
-import TreeSelector from '../components/tree-selector';
+import TreeDropdown from '../components/tree-dropdown';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
 const mapCategoriesIds = category => {
@@ -100,7 +100,7 @@ function NewsletterCategories( props ) {
 					onChange={ handleEnableNewsletterCategoriesToggleChange }
 					label={ __( 'Enable newsletter categories', 'jetpack' ) }
 				/>
-				<TreeSelector
+				<TreeDropdown
 					items={ mappedCategories }
 					selectedItems={ checkedCategoriesIds }
 					onChange={ onSelectedCategoryChange }

--- a/projects/plugins/jetpack/changelog/add-tree-dropdown-component
+++ b/projects/plugins/jetpack/changelog/add-tree-dropdown-component
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Component creation, still under feature flag
+
+


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/87666

## Proposed changes:
* Create TreeDropdown component
* Update checkbox layout on TreeSelector
* Apply TreeDropdown to the newsletter settings page

<img width="1107" alt="image" src="https://github.com/Automattic/jetpack/assets/3113712/82ae0040-b2d3-42a9-b293-2305bbfcb9c4">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Apply this PR to your JT env
* Navigate to Jetpack > Settings > Newsletter with the feature flag enabled: `wp-admin/admin.php?enable-newsletter-categories=true&page=jetpack#/newsletter`
* Try testing the following actions:
  * Check/uncheck categories
  * Search by category name
  * Delete tags by pressing backspace and the delete button (x)
* All the actions above should behave as expected 
