### PR TITLE
Security Monitor: remove link to notifications settings and add link to their wordpress account

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/monitor.jsx
@@ -1,4 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import ConnectUserBar from 'components/connect-user-bar';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
@@ -47,9 +49,14 @@ export const Monitor = withModuleSettingsFormHelpers(
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ __(
-									'Get alerts if your site goes offline. Alerts are sent to your <a href="https://wordpress.com/me" target="_blank">WordPress.com account</a> email address.',
-									'jetpack'
+								{ createInterpolateElement(
+									__(
+										'Get alerts if your site goes offline. Alerts are sent to your <a>WordPress.com account</a> email address.',
+										'jetpack'
+									),
+									{
+										a: <ExternalLink href="https://wordpress.com/me/account" />,
+									}
 								) }
 							</span>
 						</ModuleToggle>

--- a/projects/plugins/jetpack/_inc/client/security/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/monitor.jsx
@@ -13,7 +13,7 @@ import React, { Component } from 'react';
 export const Monitor = withModuleSettingsFormHelpers(
 	class extends Component {
 		trackConfigureClick = () => {
-			analytics.tracks.recordJetpackClick( 'configure-monitor' );
+			analytics.tracks.recordJetpackClick( 'configure-monitor-email' );
 		};
 
 		render() {
@@ -55,7 +55,12 @@ export const Monitor = withModuleSettingsFormHelpers(
 										'jetpack'
 									),
 									{
-										a: <ExternalLink href="https://wordpress.com/me/account" />,
+										a: (
+											<ExternalLink
+												href="https://wordpress.com/me/account"
+												onClick={ this.trackConfigureClick }
+											/>
+										),
 									}
 								) }
 							</span>

--- a/projects/plugins/jetpack/_inc/client/security/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/monitor.jsx
@@ -1,6 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
-import Card from 'components/card';
 import ConnectUserBar from 'components/connect-user-bar';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
@@ -49,25 +48,12 @@ export const Monitor = withModuleSettingsFormHelpers(
 						>
 							<span className="jp-form-toggle-explanation">
 								{ __(
-									'Get alerts if your site goes offline. We’ll let you know when it’s back up, too.',
+									'Get alerts if your site goes offline. Alerts are sent to your <a href="https://wordpress.com/me" target="_blank">WordPress.com account</a> email address.',
 									'jetpack'
 								) }
 							</span>
 						</ModuleToggle>
 					</SettingsGroup>
-					{ hasConnectedOwner && (
-						<Card
-							compact
-							className="jp-settings-card__configure-link"
-							onClick={ this.trackConfigureClick }
-							href={ getRedirectUrl( 'calypso-settings-security', {
-								site: this.props.blogID ?? this.props.siteRawUrl,
-							} ) }
-							target="_blank"
-						>
-							{ __( 'Configure your notification settings', 'jetpack' ) }
-						</Card>
-					) }
 
 					{ ! hasConnectedOwner && ! isOfflineMode && (
 						<ConnectUserBar

--- a/projects/plugins/jetpack/changelog/fix-monitoring-notification-settings-link
+++ b/projects/plugins/jetpack/changelog/fix-monitoring-notification-settings-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Security Monitor: remove link to notifications and add link to wordpress account


### PR DESCRIPTION
Fixes #24937

Related to https://github.com/Automattic/dotcom-forge/issues/5655#issuecomment-1953522431 and p1708379298289459-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the "Downtime Monitoring" card in Jetpack Settings > Security:
  * remove the remove link to the notifications settings
  * update the copy to include an external link to the user's WordPress account so they can change the email  
  * update the tracking event from `configure-monitor` to `configure-monitor-email`

|BEFORE|AFTER|
|-|-|
|<img width="1062" alt="Screenshot 2567-02-20 at 14 17 55" src="https://github.com/Automattic/jetpack/assets/1881481/e9ca0acb-fe79-45c0-b6ec-a1124b4570de">|<img width="1036" alt="Screenshot 2567-02-20 at 14 20 49" src="https://github.com/Automattic/jetpack/assets/1881481/9c4192d2-ad48-4f78-8a67-9b3c3cf39394">|

The link points to https://wordpress.com/me/account

<img width="1278" alt="Screenshot 2567-02-20 at 14 04 47" src="https://github.com/Automattic/jetpack/assets/1881481/85a766c9-a055-48d0-8ce7-b6d14bfbf33d">

### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
We update the tracking event from `configure-monitor` to `configure-monitor-email`.

<img width="788" alt="Screenshot 2567-02-20 at 14 31 12" src="https://github.com/Automattic/jetpack/assets/1881481/c27143f4-f47e-42e0-9445-b97732335415">

<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Settings > Security`
* Find the `Downtime Monitoring` option
* Verify the UI looks as expected and the link `WordPress account` opens your account in a new tab 