### PR TITLE
Boost: Add cache invalidation on module toggle

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2024-02-19
+### Added
+- AI Client: add support for audio transcriptions. [#35691]
+- AI Client: add support for transcription post-processing. [#35734]
+
+### Changed
+- AI Client: Update voice to content feature [#35698]
+- Make build usable in projects using tsc with `moduleResolution` set to 'nodenext'. [#35453]
+- Voice to Content: Add states and refactor duration calculation [#35717]
+
 ## [0.6.1] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -210,6 +220,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.7.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.5.0...v0.5.1

--- a/projects/js-packages/ai-client/changelog/fix-tsc-moduleResolution
+++ b/projects/js-packages/ai-client/changelog/fix-tsc-moduleResolution
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Make build usable in projects using tsc with `moduleResolution` set to 'nodenext'.

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-add-transcription-post-processing-machinery
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-add-transcription-post-processing-machinery
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-AI Client: add support for transcription post-processing.

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-handle-audio-transcription-request
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-handle-audio-transcription-request
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-AI Client: add support for audio transcriptions.

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-modal
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Client: Update voice to content feature

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-states
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-states
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Voice to Content: Add states and refactor duration calculation

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.7.0-alpha",
+	"version": "0.7.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.23] - 2024-02-19
+### Changed
+- Update build configuration to better match supported target environments. [#35713]
+
 ## [0.1.22] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -103,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.23]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.22...v0.1.23
 [0.1.22]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.19...v0.1.20

--- a/projects/js-packages/boost-score-api/changelog/add-my-jetpack-boost-speed-score
+++ b/projects/js-packages/boost-score-api/changelog/add-my-jetpack-boost-speed-score
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Simply moving a utility function over to the boost-score-api js-package.
-
-

--- a/projects/js-packages/boost-score-api/changelog/fix-remove-use-of-ts-loader
+++ b/projects/js-packages/boost-score-api/changelog/fix-remove-use-of-ts-loader
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update build configuration to better match supported target environments.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.23-alpha",
+	"version": "0.1.23",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.48.3] - 2024-02-19
+### Added
+- Added support for annotations in graph [#34978]
+
 ## [0.48.2] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -941,6 +945,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.48.3]: https://github.com/Automattic/jetpack-components/compare/0.48.2...0.48.3
 [0.48.2]: https://github.com/Automattic/jetpack-components/compare/0.48.1...0.48.2
 [0.48.1]: https://github.com/Automattic/jetpack-components/compare/0.48.0...0.48.1
 [0.48.0]: https://github.com/Automattic/jetpack-components/compare/0.47.0...0.48.0

--- a/projects/js-packages/components/changelog/add-annotations
+++ b/projects/js-packages/components/changelog/add-annotations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added support for annotations in graph

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.48.3-alpha",
+	"version": "0.48.3",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.32.2] - 2024-02-19
+### Added
+- Add connection indicator for screen readers [#35714]
+
 ## [0.32.1] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -702,6 +706,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.32.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.2...v0.32.0
 [0.31.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.31.1...v0.31.2

--- a/projects/js-packages/connection/changelog/update-my-jetpack-connect-page-status-role
+++ b/projects/js-packages/connection/changelog/update-my-jetpack-connect-page-status-role
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add connection indicator for screen readers

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.32.2-alpha",
+	"version": "0.32.2",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.2.0 - 2024-02-19
+### Added
+- Add an option to include `fork-ts-checker-webpack-plugin`. As this requires `typescript` as a peer dep, it needs to be explicitly enabled. [#35476]
+- Add `resolve.extensionAlias` with entries for tsc compatibility. [#35453]
+
+### Changed
+- Sort plugins in documentation and code. [#35476]
+
 ## 3.1.2 - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]

--- a/projects/js-packages/webpack-config/changelog/add-webpack-config-fork-ts-checker-webpack-plugin
+++ b/projects/js-packages/webpack-config/changelog/add-webpack-config-fork-ts-checker-webpack-plugin
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add an option to include `fork-ts-checker-webpack-plugin`. As this requires `typescript` as a peer dep, it needs to be explicitly enabled.

--- a/projects/js-packages/webpack-config/changelog/add-webpack-config-fork-ts-checker-webpack-plugin#2
+++ b/projects/js-packages/webpack-config/changelog/add-webpack-config-fork-ts-checker-webpack-plugin#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Sort plugins in documentation and code.

--- a/projects/js-packages/webpack-config/changelog/fix-tsc-moduleResolution
+++ b/projects/js-packages/webpack-config/changelog/fix-tsc-moduleResolution
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add `resolve.extensionAlias` with entries for tsc compatibility.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.2.0-alpha",
+	"version": "3.2.0",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2024-02-19
+### Added
+- Added price in blaze/posts endpoint [#35066]
+
+### Changed
+- Changes the Blaze Dashboard entry points to be compatible with Woo Blaze [#34964]
+- Post Links: allow third-parties to toggle them depending on post type. [#35730]
+
 ## [0.16.0] - 2024-02-13
 ### Added
 - Blaze: Whiteliste /media/new WPCOM REST API call for image uploading [#34790]
@@ -285,6 +293,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.17.0]: https://github.com/automattic/jetpack-blaze/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/automattic/jetpack-blaze/compare/v0.15.3...v0.16.0
 [0.15.3]: https://github.com/automattic/jetpack-blaze/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/automattic/jetpack-blaze/compare/v0.15.1...v0.15.2

--- a/projects/packages/blaze/changelog/update-blaze-dashboard-compatibility
+++ b/projects/packages/blaze/changelog/update-blaze-dashboard-compatibility
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Changes the Blaze Dashboard entry points to be compatible with Woo Blaze

--- a/projects/packages/blaze/changelog/update-blaze-post-links-option-optout
+++ b/projects/packages/blaze/changelog/update-blaze-post-links-option-optout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Post Links: allow third-parties to toggle them depending on post type.

--- a/projects/packages/blaze/changelog/vdimitrakis-add-price-in-posts-endpoint
+++ b/projects/packages/blaze/changelog/vdimitrakis-add-price-in-posts-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added price in blaze/posts endpoint

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.17.0-alpha",
+	"version": "0.17.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.17.0-alpha';
+	const PACKAGE_VERSION = '0.17.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/forms/changelog/remove-old-filter-contact-form
+++ b/projects/packages/forms/changelog/remove-old-filter-contact-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: deprecated
+
+Deprecate the temporary tmp_grunion_allow_editor_view filter.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.5",
+	"version": "0.30.6-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.5';
+	const PACKAGE_VERSION = '0.30.6-alpha';
 
 	/**
 	 * Load the contact form module.
@@ -30,7 +30,7 @@ class Jetpack_Forms {
 			$dashboard->init();
 		}
 
-		if ( is_admin() && apply_filters( 'tmp_grunion_allow_editor_view', true ) ) {
+		if ( is_admin() && apply_filters_deprecated( 'tmp_grunion_allow_editor_view', array( true ), '0.30.5', '', 'This functionality will be removed in an upcoming version.' ) ) {
 			add_action( 'current_screen', '\Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.13.0] - 2024-02-19
+### Added
+- Blog Privacy: Add AI User Agents to robots.txt depending on blog setting. [#35704]
+- Don't override Site Editor's back button URL for sites with classic view enabled. [#35721]
+- jetpack-mu-wpcom: Added the wpcom-site-menu feature to add a WordPress.com sidebar menu item. [#35702]
+
+### Fixed
+- Create and use Preact signal for subscriptionModalStatus to fix issue of undefined value sent on comment submission. [#35741]
+
 ## [5.12.2] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -581,6 +590,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.13.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.12.2...v5.13.0
 [5.12.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.12.1...v5.12.2
 [5.12.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.12.0...v5.12.1
 [5.12.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.11.0...v5.12.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-mu-wpcom-ai-robots-txt-blocks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-mu-wpcom-ai-robots-txt-blocks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Blog Privacy: Add AI User Agents to robots.txt depending on blog setting.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-site-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-site-menu
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-jetpack-mu-wpcom: Added the wpcom-site-menu feature to add a WordPress.com sidebar menu item.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-subscription-modal-status-form-submission
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-subscription-modal-status-form-submission
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Create and use Preact signal for subscriptionModalStatus to fix issue of undefined value sent on comment submission.

--- a/projects/packages/jetpack-mu-wpcom/changelog/site-editor-back-button-classic-view
+++ b/projects/packages/jetpack-mu-wpcom/changelog/site-editor-back-button-classic-view
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Don't override Site Editor's back button URL for sites with classic view enabled.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.13.0-alpha",
+	"version": "5.13.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.13.0-alpha';
+	const PACKAGE_VERSION = '5.13.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.10.0] - 2024-02-19
+### Added
+- Add Boost Speed Score into My Jetpack Boost product card [#35606]
+- Add connection indicator for screen readers [#35714]
+
+### Fixed
+- Improved accessibility of Dismiss button in Connection Banner [#35694]
+- My Jeptack Connection: Make footer logos a list for better screen readers interpretation. [#35667]
+- My Jetpack: add label for screen readers to connect page close button [#35712]
+
 ## [4.9.2] - 2024-02-13
 ### Changed
 - My Jetpack: various improvements to the Stats card. [#35355]
@@ -1244,6 +1254,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.10.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.9.2...4.10.0
 [4.9.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.9.1...4.9.2
 [4.9.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.9.0...4.9.1
 [4.9.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.8.0...4.9.0

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-boost-speed-score
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-boost-speed-score
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add Boost Speed Score into My Jetpack Boost product card

--- a/projects/packages/my-jetpack/changelog/connection-dismiss-banner-accessibility
+++ b/projects/packages/my-jetpack/changelog/connection-dismiss-banner-accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Improved accessibility of Dismiss button in Connection Banner

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-connect-screen-close-btn-a11y
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-connect-screen-close-btn-a11y
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: add label for screen readers to connect page close button

--- a/projects/packages/my-jetpack/changelog/update-connection-footer-logos-to-list
+++ b/projects/packages/my-jetpack/changelog/update-connection-footer-logos-to-list
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jeptack Connection: Make footer logos a list for better screen readers interpretation.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-page-status-role
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-page-status-role
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add connection indicator for screen readers

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.10.0-alpha",
+	"version": "4.10.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -35,7 +35,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.10.0-alpha';
+	const PACKAGE_VERSION = '4.10.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.2] - 2024-02-19
+### Changed
+- Internal updates.
+
 ## [0.43.1] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -894,6 +898,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.43.2]: https://github.com/Automattic/jetpack-search/compare/v0.43.1...v0.43.2
 [0.43.1]: https://github.com/Automattic/jetpack-search/compare/v0.43.0...v0.43.1
 [0.43.0]: https://github.com/Automattic/jetpack-search/compare/v0.42.1...v0.43.0
 [0.42.1]: https://github.com/Automattic/jetpack-search/compare/v0.42.0...v0.42.1

--- a/projects/packages/search/changelog/remove-postcss-custom-properties-importFrom
+++ b/projects/packages/search/changelog/remove-postcss-custom-properties-importFrom
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Replace `postcss-custom-properties` `importFrom` with `@csstools/postcss-global-data`. Should be no change to the package itself.
-
-

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.43.2-alpha",
+	"version": "0.43.2",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.43.2-alpha';
+	const VERSION = '0.43.2';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.0 - 2024-02-19
+### Added
+- Stats: added support for Email stats [#35703]
+
 ## 0.15.3 - 2024-02-14
 ### Fixed
 - Stats: clear usage, modules, module-settings cache after purchase [#35590]

--- a/projects/packages/stats-admin/changelog/update-enable-email-stats-for-odyssey
+++ b/projects/packages/stats-admin/changelog/update-enable-email-stats-for-odyssey
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Stats: added support for Email stats

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.16.0-alpha",
+	"version": "0.16.0",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.16.0-alpha';
+	const VERSION = '0.16.0';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2024-02-19
+### Fixed
+- Avoid Fatal errors when saved stats data is a WP_Error object [#35746]
+
 ## [0.10.0] - 2024-02-05
 ### Added
 - Stats fetching mechanism: add filter allowing one to customize how long we cache results. [#35421]
@@ -129,6 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.10.1]: https://github.com/Automattic/jetpack-stats/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Automattic/jetpack-stats/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Automattic/jetpack-stats/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Automattic/jetpack-stats/compare/v0.7.2...v0.8.0

--- a/projects/packages/stats/changelog/fix-stats-fetch-fatal
+++ b/projects/packages/stats/changelog/fix-stats-fetch-fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Avoid Fatal errors when saved stats data is a WP_Error object

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2024-02-19
+### Changed
+- Add jetpack_newsletters_publishing_default_frequency to Sync [#35672]
+
 ## [2.6.1] - 2024-02-13
 ### Changed
 - Internal updates.
@@ -1047,6 +1051,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.7.0]: https://github.com/Automattic/jetpack-sync/compare/v2.6.1...v2.7.0
 [2.6.1]: https://github.com/Automattic/jetpack-sync/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/Automattic/jetpack-sync/compare/v2.5.1...v2.6.0
 [2.5.1]: https://github.com/Automattic/jetpack-sync/compare/v2.5.0...v2.5.1

--- a/projects/packages/sync/changelog/add-newsletter-publisher-default-delivery-option
+++ b/projects/packages/sync/changelog/add-newsletter-publisher-default-delivery-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Add jetpack_newsletters_publishing_default_frequency to Sync

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.7.0-alpha';
+	const PACKAGE_VERSION = '2.7.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.3] - 2024-02-19
+### Changed
+- Internal updates.
+
 ## [0.23.2] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -1259,6 +1263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.2...v0.23.3
 [0.23.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.1...v0.23.2
 [0.23.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.22.4...v0.23.0

--- a/projects/packages/videopress/changelog/remove-postcss-custom-properties-importFrom
+++ b/projects/packages/videopress/changelog/remove-postcss-custom-properties-importFrom
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Replace `postcss-custom-properties` `importFrom` with `@csstools/postcss-global-data`. Should be no change to the package itself.
-
-

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.3-alpha",
+	"version": "0.23.3",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.3-alpha';
+	const PACKAGE_VERSION = '0.23.3';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/woocommerce-analytics/.gitattributes
+++ b/projects/packages/woocommerce-analytics/.gitattributes
@@ -1,0 +1,16 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# Remember to end all directories with `/**` to properly tag every file.
+.gitignore        production-exclude
+changelog/**      production-exclude
+phpunit.xml.dist  production-exclude
+.phpcs.dir.xml    production-exclude
+tests/**          production-exclude
+.phpcsignore      production-exclude

--- a/projects/packages/woocommerce-analytics/.gitignore
+++ b/projects/packages/woocommerce-analytics/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/packages/woocommerce-analytics/.phpcs.dir.xml
+++ b/projects/packages/woocommerce-analytics/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="woocommerce-analytics" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="woocommerce-analytics" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="woocommerce-analytics" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/woocommerce-analytics/CHANGELOG.md
+++ b/projects/packages/woocommerce-analytics/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/packages/woocommerce-analytics/README.md
+++ b/projects/packages/woocommerce-analytics/README.md
@@ -1,0 +1,24 @@
+# woocommerce-analytics
+
+Enhanced analytics for WooCommerce users.
+
+## How to install woocommerce-analytics
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we would recommend that you use [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader. This will allow for maximum interoperability with other plugins that use this package as well.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+woocommerce-analytics is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/packages/woocommerce-analytics/changelog/initial-version
+++ b/projects/packages/woocommerce-analytics/changelog/initial-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Initial version.

--- a/projects/packages/woocommerce-analytics/composer.json
+++ b/projects/packages/woocommerce-analytics/composer.json
@@ -1,0 +1,56 @@
+{
+	"name": "automattic/woocommerce-analytics",
+	"description": "Enhanced analytics for WooCommerce users.",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.0"
+	},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "1.1.0",
+		"automattic/jetpack-changelogger": "@dev"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		],
+		"test-php": [
+			"@composer phpunit"
+		],
+		"build-production": "echo 'Add your build step to composer.json, please!'",
+		"build-development": "echo 'Add your build step to composer.json, please!'"
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/woocommerce-analytics",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/woocommerce-analytics/compare/v${old}...v${new}"
+		},
+		"autotagger": true,
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"textdomain": "woocommerce-analytics",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-woocommerce-analytics.php"
+		}
+	},
+	"suggest": {
+		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+	}
+}

--- a/projects/packages/woocommerce-analytics/phpunit.xml.dist
+++ b/projects/packages/woocommerce-analytics/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Package description here
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Class description.
+ */
+class Woocommerce_Analytics {
+
+	const PACKAGE_VERSION = '0.1.0-alpha';
+}

--- a/projects/packages/woocommerce-analytics/tests/.phpcs.dir.xml
+++ b/projects/packages/woocommerce-analytics/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/woocommerce-analytics/tests/php/bootstrap.php
+++ b/projects/packages/woocommerce-analytics/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/projects/plugins/boost/app/contracts/Changes_Output.php
+++ b/projects/plugins/boost/app/contracts/Changes_Output.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Contracts;
+
+/**
+ * Modules can implement this interface to indicate that they change the HTML output for the site visitor.
+ */
+interface Changes_Output {}

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
@@ -34,6 +34,7 @@ class Critical_CSS_Invalidator {
 
 		$state = new Critical_CSS_State();
 		$state->clear();
+		do_action( 'jetpack_boost_critical_css_invalidated' );
 
 		Cloud_CSS_Followup::unschedule();
 	}
@@ -44,8 +45,6 @@ class Critical_CSS_Invalidator {
 	public static function handle_environment_change( $is_major_change ) {
 		if ( $is_major_change ) {
 			self::clear_data();
-
-			do_action( 'critical_css_invalidated' );
 		}
 	}
 

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -133,6 +133,7 @@ class Critical_CSS_State {
 
 		if ( $is_done ) {
 			$this->state['status'] = self::GENERATION_STATES['generated'];
+			do_action( 'jetpack_boost_critical_css_generated' );
 		}
 	}
 

--- a/projects/plugins/boost/app/modules/Modules_Index.php
+++ b/projects/plugins/boost/app/modules/Modules_Index.php
@@ -53,6 +53,24 @@ class Modules_Index {
 		}
 	}
 
+	/**
+	 * Get all modules that implement a specific interface.
+	 *
+	 * @param string $interface - The interface to search for.
+	 * @return array - An array of module classes that implement the interface.
+	 */
+	public function get_modules_implementing( string $interface ): array {
+		$matching_modules = array();
+
+		foreach ( self::MODULES as $module ) {
+			if ( in_array( $interface, class_implements( $module ), true ) ) {
+				$matching_modules[] = $module;
+			}
+		}
+
+		return $matching_modules;
+	}
+
 	public function available_modules() {
 		$forced_disabled_modules = $this->get_disabled_modules();
 

--- a/projects/plugins/boost/app/modules/Modules_Index.php
+++ b/projects/plugins/boost/app/modules/Modules_Index.php
@@ -57,14 +57,14 @@ class Modules_Index {
 	 * Get all modules that implement a specific interface.
 	 *
 	 * @param string $interface - The interface to search for.
-	 * @return array - An array of module classes that implement the interface.
+	 * @return array - An array of module classes indexed by slug that implement the interface.
 	 */
 	public static function get_modules_implementing( string $interface ): array {
 		$matching_modules = array();
 
 		foreach ( self::MODULES as $module ) {
 			if ( in_array( $interface, class_implements( $module ), true ) ) {
-				$matching_modules[] = $module;
+				$matching_modules[ $module::get_slug() ] = $module;
 			}
 		}
 

--- a/projects/plugins/boost/app/modules/Modules_Index.php
+++ b/projects/plugins/boost/app/modules/Modules_Index.php
@@ -59,7 +59,7 @@ class Modules_Index {
 	 * @param string $interface - The interface to search for.
 	 * @return array - An array of module classes that implement the interface.
 	 */
-	public function get_modules_implementing( string $interface ): array {
+	public static function get_modules_implementing( string $interface ): array {
 		$matching_modules = array();
 
 		foreach ( self::MODULES as $module ) {

--- a/projects/plugins/boost/app/modules/cache/Garbage_Collection.php
+++ b/projects/plugins/boost/app/modules/cache/Garbage_Collection.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
+
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache;
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Logger;
+
+class Garbage_Collection {
+	const ACTION        = 'jetpack_boost_cache_garbage_collection';
+	const INTERVAL_NAME = 'jetpack_boost_cache_gc_interval';
+
+	/**
+	 * Register hooks.
+	 */
+	public static function setup() {
+		add_filter( 'cron_schedules', array( self::class, 'add_cron_interval' ) );
+
+		$cache = new Boost_Cache();
+		add_action( self::ACTION, array( $cache->get_storage(), 'garbage_collect' ) );
+		add_action( self::ACTION, array( Logger::class, 'delete_old_logs' ) );
+	}
+
+	/**
+	 * Setup the garbage collection cron job.
+	 */
+	public static function activate() {
+		self::setup();
+
+		if ( ! wp_next_scheduled( self::ACTION ) ) {
+			wp_schedule_event( time(), self::INTERVAL_NAME, self::ACTION );
+		}
+	}
+
+	/**
+	 * Remove the garbage collection cron job.
+	 */
+	public static function deactivate() {
+		wp_clear_scheduled_hook( self::ACTION );
+	}
+
+	/**
+	 * Register a custom interval for garbage collection cron jobs.
+	 */
+	public static function add_cron_interval( $schedules ) {
+		$schedules[ self::INTERVAL_NAME ] = array(
+			'interval' => 900,
+			'display'  => __( 'Every 15 minutes', 'jetpack-boost' ),
+		);
+
+		return $schedules;
+	}
+}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -42,6 +42,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 		Garbage_Collection::setup();
 
 		add_action( 'jetpack_boost_module_status_updated', array( $this, 'handle_module_status_updated' ) );
+		add_action( 'jetpack_boost_critical_css_invalidated', array( $this, 'invalidate_cache' ) );
 	}
 
 	/**
@@ -61,9 +62,13 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 		);
 
 		if ( in_array( $module_slug, $slugs, true ) ) {
-			$cache = new Boost_Cache();
-			$cache->get_storage()->invalidate( Boost_Cache_Utils::normalize_request_uri( home_url() ), '*' );
+			$this->invalidate_cache();
 		}
+	}
+
+	public function invalidate_cache() {
+		$cache = new Boost_Cache();
+		$cache->get_storage()->invalidate( Boost_Cache_Utils::normalize_request_uri( home_url() ), '*' );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -43,6 +43,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 
 		add_action( 'jetpack_boost_module_status_updated', array( $this, 'handle_module_status_updated' ) );
 		add_action( 'jetpack_boost_critical_css_invalidated', array( $this, 'invalidate_cache' ) );
+		add_action( 'jetpack_boost_critical_css_generated', array( $this, 'invalidate_cache' ) );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -34,13 +34,16 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 		register_uninstall_hook( JETPACK_BOOST_PATH, array( Page_Cache_Setup::class, 'uninstall' ) );
 	}
 
-	public function setup() {}
+	public function setup() {
+		Garbage_Collection::setup();
+	}
 
 	/**
 	 * Runs the setup when the feature is activated.
 	 */
 	public static function activate() {
 		Page_Cache_Setup::run_setup();
+		Garbage_Collection::activate();
 	}
 
 	/**
@@ -48,6 +51,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 	 */
 	public static function deactivate() {
 		Page_Cache_Setup::deactivate();
+		Garbage_Collection::deactivate();
 	}
 
 	public static function is_available() {

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -55,12 +55,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 		// Get a list of modules that can change the HTML output.
 		$modules = Modules_Index::get_modules_implementing( Changes_Output::class );
 
-		$slugs = array_map(
-			function ( $module ) {
-				return $module::get_slug();
-			},
-			$modules
-		);
+		$slugs = array_keys( $modules );
 
 		if ( in_array( $module_slug, $slugs, true ) ) {
 			$this->invalidate_cache();

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
 
+use Automattic\Jetpack_Boost\Modules\Cache\Pre_WordPress\Filesystem_Utils;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache_Utils;
 
 class Page_Cache_Setup {
@@ -92,7 +93,7 @@ require_once( \'' . $boost_cache_filename . '\');
 ( new Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache() )->serve();
 ';
 
-		$write_advanced_cache = Boost_Cache_Utils::write_to_file( $advanced_cache_filename, $contents );
+		$write_advanced_cache = Filesystem_Utils::write_to_file( $advanced_cache_filename, $contents );
 		if ( is_wp_error( $write_advanced_cache ) ) {
 			return new \WP_Error( 'unable-to-write-to-advanced-cache', $write_advanced_cache->get_error_message() );
 		}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -153,7 +153,7 @@ define( \'WP_CACHE\', true );',
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
-		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', '*/' );
+		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', '/*' );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -89,8 +89,9 @@ if ( ! file_exists( \'' . $boost_cache_filename . '\' ) ) {
 return;
 }
 require_once( \'' . $boost_cache_filename . '\');
-
-( new Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache() )->serve();
+$boost_cache = new Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache();
+$boost_cache->init_actions();
+$boost_cache->serve();
 ';
 
 		$write_advanced_cache = Filesystem_Utils::write_to_file( $advanced_cache_filename, $contents );

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -153,7 +153,7 @@ define( \'WP_CACHE\', true );',
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
-		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache' );
+		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', '*/' );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -141,7 +141,7 @@ class Boost_Cache {
 				$this->delete_cache_for_post( get_post( $posts_page_id ) );
 			}
 		} else {
-			$this->storage->invalidate_home_page( Boost_Cache_Utils::normalize_request_uri( home_url() ) );
+			$this->storage->invalidate( Boost_Cache_Utils::normalize_request_uri( home_url() ), '*' );
 			error_log( 'delete front page cache ' . Boost_Cache_Utils::normalize_request_uri( home_url() ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
@@ -193,13 +193,25 @@ class Boost_Cache {
 	 */
 	public function delete_on_comment_post( $comment_id, $comment_approved, $commentdata ) {
 		$post = get_post( $commentdata['comment_post_ID'] );
-
+		error_Log( "delete_on_comment_post: $comment_id, $comment_approved, {$post->ID}" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		/**
 		 * If a comment is not approved, we only need to delete the cache for
 		 * this post for this visitor so the unmoderated comment is shown to them.
 		 */
 		if ( $comment_approved !== 1 ) {
-			$this->storage->invalidate_single_visitor( Boost_Cache_Utils::normalize_request_uri( get_permalink( $post->ID ) ), $this->request->get_parameters() );
+			$parameters = $this->request->get_parameters();
+			/**
+			 * if there are no cookies, then visitor did not click "remember me".
+			 * No need to delete the cache for this visitor as they'll be
+			 * redirected to a page with a hash in the URL for the moderation
+			 * message.
+			 */
+			if ( isset( $parameters['cookies'] ) && ! empty( $parameters['cookies'] ) ) {
+				$this->storage->invalidate(
+					Boost_Cache_Utils::normalize_request_uri( get_permalink( $post->ID ) ),
+					'/**/' . Boost_Cache_Utils::get_request_filename( $this->request->get_parameters() )
+				);
+			}
 			return;
 		}
 
@@ -313,7 +325,7 @@ class Boost_Cache {
 		error_log( 'delete_cache_for_url: ' . $url ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = Boost_Cache_Utils::normalize_request_uri( $url );
 
-		return $this->storage->invalidate( $path );
+		return $this->storage->invalidate( $path, '*/' );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -325,7 +325,7 @@ class Boost_Cache {
 		error_log( 'delete_cache_for_url: ' . $url ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = Boost_Cache_Utils::normalize_request_uri( $url );
 
-		return $this->storage->invalidate( $path, '*/' );
+		return $this->storage->invalidate( $path, '/*' );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -11,6 +11,7 @@ namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
  */
 require_once __DIR__ . '/Boost_Cache_Settings.php';
 require_once __DIR__ . '/Boost_Cache_Utils.php';
+require_once __DIR__ . '/Filesystem_Utils.php';
 require_once __DIR__ . '/Logger.php';
 require_once __DIR__ . '/Request.php';
 require_once __DIR__ . '/storage/Storage.php';
@@ -23,7 +24,7 @@ class Boost_Cache {
 	private $settings;
 
 	/**
-	 * @var Boost_Cache_Storage - The storage system used by Boost Cache.
+	 * @var Storage\Storage - The storage system used by Boost Cache.
 	 */
 	private $storage;
 
@@ -66,6 +67,15 @@ class Boost_Cache {
 		if ( ! $this->serve_cached() ) {
 			$this->ob_start();
 		}
+	}
+
+	/**
+	 * Get the storage instance used by Boost Cache.
+	 *
+	 * @return Storage\Storage
+	 */
+	public function get_storage() {
+		return $this->storage;
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -41,14 +41,12 @@ class Boost_Cache {
 		$home           = isset( $_SERVER['HTTP_HOST'] ) ? strtolower( $_SERVER['HTTP_HOST'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$this->storage  = $storage ?? new Storage\File_Storage( $home );
 		$this->request  = Request::current();
-
-		$this->init_actions();
 	}
 
 	/**
 	 * Initialize the actions for the cache.
 	 */
-	protected function init_actions() {
+	public function init_actions() {
 		add_action( 'transition_post_status', array( $this, 'delete_on_post_transition' ), 10, 3 );
 		add_action( 'transition_comment_status', array( $this, 'delete_on_comment_transition' ), 10, 3 );
 		add_action( 'comment_post', array( $this, 'delete_on_comment_post' ), 10, 3 );

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Settings.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
+use Automattic\Jetpack_Boost\Modules\Cache\Pre_WordPress\Filesystem_Utils;
+
 /*
  * Cache settings class.
  * Settings are stored in a file in the boost-cache directory.
@@ -120,7 +122,7 @@ class Boost_Cache_Settings {
 		$this->settings = array_merge( $this->settings, $settings );
 
 		$contents = "<?php die();\n/*\n * Configuration data for Jetpack Boost Cache. Do not edit.\n" . json_encode( $this->settings ) . "\n */"; // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
-		$result   = Boost_Cache_Utils::write_to_file( $this->config_file, $contents );
+		$result   = Filesystem_Utils::write_to_file( $this->config_file, $contents );
 		if ( is_wp_error( $result ) ) {
 			$this->last_error = $result->get_error_message();
 			return false;

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -9,7 +9,7 @@ class Boost_Cache_Utils {
 	/**
 	 * Recursively delete a directory.
 	 * @param string $dir - The directory to delete.
-	 * @param bool   $recurse - If false, only delete the files in the directory, do not recurse into subdirectories.
+	 * @param bool   $filter - The filter to use. '*' to delete all files in the given directory. '*\/' to delete everything in the given directory, recursively. '\/**\/' to delete a single file or directory in the given directory.
 	 * @return bool|WP_Error
 	 */
 	public static function delete_directory( $dir, $filter = null ) {
@@ -212,7 +212,6 @@ class Boost_Cache_Utils {
 	/**
 	 * Given a request_uri and its parameters, return the filename to use for this cached data. Does not include the file path.
 	 *
-	 * @param string $request_uri - The URI of this request (excluding GET parameters)
 	 * @param array  $parameters  - An associative array of all the things that make this request special/different. Includes GET parameters and COOKIEs normally.
 	 */
 	public static function get_request_filename( $parameters ) {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -36,7 +36,7 @@ class Boost_Cache_Utils {
 				}
 			}
 			return true;
-		} elseif ( $filter === '*/' ) { // everything in given directory, recursively.
+		} elseif ( $filter === '/*' ) { // everything in given directory, recursively.
 			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $dir, \RecursiveDirectoryIterator::SKIP_DOTS ) );
 			foreach ( $iterator as $file ) {
 				if ( $file->isDir() ) {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -126,20 +126,6 @@ class Boost_Cache_Utils {
 	}
 
 	/**
-	 * Creates the directory if it doesn't exist.
-	 *
-	 * @param string $path - The path to the directory to create.
-	 */
-	public static function create_directory( $path ) {
-		if ( ! is_dir( $path ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.dir_mkdir_dirname, WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
-			return mkdir( $path, 0755, true );
-		}
-
-		return true;
-	}
-
-	/**
 	 * Returns true if the given directory is inside the boost-cache directory.
 	 * @param string $dir - The directory to check.
 	 * @return bool
@@ -170,29 +156,6 @@ class Boost_Cache_Utils {
 		}
 
 		return $request_uri;
-	}
-
-	/**
-	 * Writes data to a file.
-	 * This creates a temporary file first, then renames the file to the final filename.
-	 * This is done to prevent the file from being read while it is being written to.
-	 *
-	 * @param string $filename - The filename to write to.
-	 * @param string $data - The data to write to the file.
-	 * @return bool|WP_Error - true on sucess or WP_Error on failure.
-	 */
-	public static function write_to_file( $filename, $data ) {
-		$tmp_filename = $filename . uniqid( uniqid(), true ) . '.tmp';
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		if ( false === file_put_contents( $tmp_filename, $data ) ) {
-			return new \WP_Error( 'Could not write to tmp file: ' . $tmp_filename );
-		}
-
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
-		if ( ! rename( $tmp_filename, $filename ) ) {
-			return new \WP_Error( 'Could not rename tmp file to final file: ' . $filename );
-		}
-		return true;
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Filesystem_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Filesystem_Utils.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Modules\Cache\Pre_WordPress;
+
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Logger;
+
+class Filesystem_Utils {
+	/**
+	 * Recursively garbage collect a directory.
+	 *
+	 * @param string $directory - The directory to garbage collect.
+	 * @param int    $file_ttl  - Specify number of seconds after which a file is considered expired.
+	 * @return int - The number of files deleted.
+	 */
+	public static function garbage_collect( $directory, $file_ttl ) {
+		clearstatcache();
+
+		return self::delete_expired_files( $directory, $file_ttl );
+	}
+
+	/**
+	 * Recursively garbage collect a directory.
+	 *
+	 * @param string $directory - The directory to garbage collect.
+	 * @param int    $file_ttl  - Specify number of seconds after which a file is considered expired.
+	 * @return int - The number of files deleted.
+	 */
+	private static function delete_expired_files( $directory, $file_ttl ) {
+		$count  = 0;
+		$now    = time();
+		$handle = is_readable( $directory ) && is_dir( $directory ) ? opendir( $directory ) : false;
+
+		// Could not open directory, exit early.
+		if ( ! $handle ) {
+			return $count;
+		}
+
+		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+		while ( false !== ( $file = readdir( $handle ) ) ) {
+			if ( $file === '.' || $file === '..' ) {
+				// Skip and continue to next file
+				continue;
+			}
+
+			$file_path = $directory . '/' . $file;
+
+			if ( ! file_exists( $file_path ) ) {
+				// File doesn't exist, skip and continue to next file
+				continue;
+			}
+
+			// Handle directories recursively.
+			if ( is_dir( $file_path ) ) {
+				$count += self::delete_expired_files( $file_path, $file_ttl );
+				continue;
+			}
+
+			$filemtime = filemtime( $file_path );
+			$expired   = ( $filemtime + $file_ttl ) <= $now;
+			if ( $expired ) {
+				if ( self::delete_file( $file_path ) ) {
+					++$count;
+				} else {
+					Logger::debug( 'Could not delete file: ' . $file_path );
+				}
+			}
+		}
+		closedir( $handle );
+
+		// If the directory is empty after processing it's files, delete it.
+		$is_dir_empty = self::is_dir_empty( $directory );
+		if ( is_wp_error( $is_dir_empty ) ) {
+			Logger::debug( 'Could not check directory emptiness: ' . $is_dir_empty->get_error_message() );
+			return $count;
+		}
+
+		if ( $is_dir_empty === true ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
+			@rmdir( $directory );
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Creates the directory if it doesn't exist.
+	 *
+	 * @param string $path - The path to the directory to create.
+	 */
+	public static function create_directory( $path ) {
+		if ( ! is_dir( $path ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.dir_mkdir_dirname, WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+			return mkdir( $path, 0755, true );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Delete a file.
+	 *
+	 * @param string $file_path - The file to delete.
+	 * @return bool - True if the file was deleted, false otherwise.
+	 */
+	public static function delete_file( $file_path ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+		$deletable = is_writable( $file_path );
+
+		if ( $deletable ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+			return unlink( $file_path );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if a directory is empty.
+	 *
+	 * @param string $dir - The directory to check.
+	 */
+	public static function is_dir_empty( $dir ) {
+		if ( ! is_readable( $dir ) ) {
+			return new \WP_Error( 'directory_not_readable', 'Directory is not readable' );
+		}
+
+		return ( count( scandir( $dir ) ) === 2 ); // All directories have '.' and '..'
+	}
+
+	/**
+	 * Writes data to a file.
+	 * This creates a temporary file first, then renames the file to the final filename.
+	 * This is done to prevent the file from being read while it is being written to.
+	 *
+	 * @param string $filename - The filename to write to.
+	 * @param string $data - The data to write to the file.
+	 * @return bool|WP_Error - true on sucess or WP_Error on failure.
+	 */
+	public static function write_to_file( $filename, $data ) {
+		$tmp_filename = $filename . uniqid( uniqid(), true ) . '.tmp';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		if ( false === file_put_contents( $tmp_filename, $data ) ) {
+			return new \WP_Error( 'Could not write to tmp file: ' . $tmp_filename );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+		if ( ! rename( $tmp_filename, $filename ) ) {
+			return new \WP_Error( 'Could not rename tmp file to final file: ' . $filename );
+		}
+		return true;
+	}
+}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Filesystem_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Filesystem_Utils.php
@@ -12,20 +12,9 @@ class Filesystem_Utils {
 	 * @param int    $file_ttl  - Specify number of seconds after which a file is considered expired.
 	 * @return int - The number of files deleted.
 	 */
-	public static function garbage_collect( $directory, $file_ttl ) {
+	public static function delete_expired_files( $directory, $file_ttl ) {
 		clearstatcache();
 
-		return self::delete_expired_files( $directory, $file_ttl );
-	}
-
-	/**
-	 * Recursively garbage collect a directory.
-	 *
-	 * @param string $directory - The directory to garbage collect.
-	 * @param int    $file_ttl  - Specify number of seconds after which a file is considered expired.
-	 * @return int - The number of files deleted.
-	 */
-	private static function delete_expired_files( $directory, $file_ttl ) {
 		$count  = 0;
 		$now    = time();
 		$handle = is_readable( $directory ) && is_dir( $directory ) ? opendir( $directory ) : false;

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
@@ -116,6 +116,6 @@ class Logger {
 	}
 
 	public static function delete_old_logs() {
-		Filesystem_Utils::garbage_collect( self::LOG_DIRECTORY, 24 * 60 * 60 );
+		Filesystem_Utils::delete_expired_files( self::LOG_DIRECTORY, 24 * 60 * 60 );
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress;
 
+use Automattic\Jetpack_Boost\Modules\Cache\Pre_WordPress\Filesystem_Utils;
+
 /**
  * A utility that manages logging for the boost cache.
  */
@@ -18,6 +20,11 @@ class Logger {
 	 * The header to place on top of every log file.
 	 */
 	const LOG_HEADER = "<?php die(); // This file is not intended to be accessed directly. ?>\n\n";
+
+	/**
+	 * The directory where log files are stored.
+	 */
+	const LOG_DIRECTORY = WP_CONTENT_DIR . '/boost-cache/logs';
 
 	/**
 	 * Get the singleton instance of the logger.
@@ -47,11 +54,11 @@ class Logger {
 		}
 
 		$directory = dirname( $log_file );
-		if ( ! Boost_Cache_Utils::create_directory( $directory ) ) {
+		if ( ! Filesystem_Utils::create_directory( $directory ) ) {
 			return new \WP_Error( 'Could not create boost cache log directory' );
 		}
 
-		return Boost_Cache_Utils::write_to_file( $log_file, self::LOG_HEADER );
+		return Filesystem_Utils::write_to_file( $log_file, self::LOG_HEADER );
 	}
 
 	/**
@@ -105,6 +112,10 @@ class Logger {
 	 */
 	private static function get_log_file() {
 		$today = gmdate( 'Y-m-d' );
-		return WP_CONTENT_DIR . "/boost-cache/logs/log-{$today}.log.php";
+		return self::LOG_DIRECTORY . "/log-{$today}.log.php";
+	}
+
+	public static function delete_old_logs() {
+		Filesystem_Utils::garbage_collect( self::LOG_DIRECTORY, 24 * 60 * 60 );
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -91,7 +91,7 @@ class File_Storage implements Storage {
 	 * @param string $path - The path to delete.
 	 */
 	public function invalidate( $request_uri, $filter = '*' ) {
-		error_log( "invalidate: $request_uri" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( "invalidate: $request_uri $filter" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$path = $this->root_path . $request_uri;
 
 		return Boost_Cache_Utils::delete_directory( $path, $filter );

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -5,7 +5,9 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Storage;
 
+use Automattic\Jetpack_Boost\Modules\Cache\Pre_WordPress\Filesystem_Utils;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache_Utils;
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Logger;
 
 /**
  * File Storage - handles writing to disk, reading from disk, purging and pruning old content.
@@ -32,11 +34,11 @@ class File_Storage implements Storage {
 		$directory = self::get_uri_directory( $request_uri );
 		$filename  = Boost_Cache_Utils::get_request_filename( $parameters );
 
-		if ( ! Boost_Cache_Utils::create_directory( $directory ) ) {
+		if ( ! Filesystem_Utils::create_directory( $directory ) ) {
 			return new \WP_Error( 'Could not create cache directory' );
 		}
 
-		return Boost_Cache_Utils::write_to_file( $directory . $filename, $data );
+		return Filesystem_Utils::write_to_file( $directory . $filename, $data );
 	}
 
 	/**
@@ -56,6 +58,22 @@ class File_Storage implements Storage {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Garbage collect expired files.
+	 */
+	public function garbage_collect() {
+		$cache_duration = apply_filters( 'jetpack_boost_cache_duration', 3600 );
+
+		if ( $cache_duration === 0 ) {
+			// Garbage collection is disabled.
+			return false;
+		}
+
+		$count = Filesystem_Utils::garbage_collect( $this->root_path, $cache_duration );
+
+		Logger::debug( "Garbage collected $count files" );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -71,7 +71,7 @@ class File_Storage implements Storage {
 			return false;
 		}
 
-		$count = Filesystem_Utils::garbage_collect( $this->root_path, $cache_duration );
+		$count = Filesystem_Utils::delete_expired_files( $this->root_path, $cache_duration );
 
 		Logger::debug( "Garbage collected $count files" );
 	}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -49,7 +49,6 @@ class File_Storage implements Storage {
 		$directory = self::get_uri_directory( $request_uri );
 		$filename  = Boost_Cache_Utils::get_request_filename( $parameters );
 		$hash_path = $directory . $filename;
-		error_log( "hash_path: $hash_path" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
 		if ( file_exists( $hash_path ) ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
@@ -12,5 +12,8 @@ interface Storage {
 
 	public function write( $request_uri, $parameters, $data );
 	public function read( $request_uri, $parameters );
-	public function invalidate( $request_uri, $filter = '*' );
+	public function garbage_collect();
+	public function invalidate( $request_uri );
+	public function invalidate_single_visitor( $request_uri, $parameters );
+	public function invalidate_home_page( $dir );
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/Storage.php
@@ -12,7 +12,5 @@ interface Storage {
 
 	public function write( $request_uri, $parameters, $data );
 	public function read( $request_uri, $parameters );
-	public function invalidate( $request_uri );
-	public function invalidate_single_visitor( $request_uri, $parameters );
-	public function invalidate_home_page( $dir );
+	public function invalidate( $request_uri, $filter = '*' );
 }

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -40,8 +40,8 @@ class Cloud_CSS implements Pluggable, Has_Endpoints, Changes_Output {
 	public function setup() {
 		add_action( 'wp', array( $this, 'display_critical_css' ) );
 		add_action( 'save_post', array( $this, 'handle_save_post' ), 10, 2 );
+		add_action( 'jetpack_boost_critical_css_invalidated', array( $this, 'handle_critical_css_invalidated' ) );
 		add_filter( 'jetpack_boost_total_problem_count', array( $this, 'update_total_problem_count' ) );
-		add_filter( 'critical_css_invalidated', array( $this, 'handle_critical_css_invalidated' ) );
 		add_filter( 'query_vars', array( '\Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator', 'add_generate_query_action_to_list' ) );
 
 		Generator::init();

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS;
 
 use Automattic\Jetpack\Boost_Core\Lib\Boost_API;
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
@@ -15,7 +16,7 @@ use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Update_Cloud_CSS;
 
-class Cloud_CSS implements Pluggable, Has_Endpoints {
+class Cloud_CSS implements Pluggable, Has_Endpoints, Changes_Output {
 
 	/**
 	 * Critical CSS storage class instance.

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS;
 
 use Automattic\Jetpack_Boost\Admin\Regenerate_Admin_Notice;
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
@@ -13,7 +14,7 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 
-class Critical_CSS implements Pluggable {
+class Critical_CSS implements Pluggable, Changes_Output {
 
 	/**
 	 * Critical CSS storage class instance.

--- a/projects/plugins/boost/app/modules/optimizations/image-cdn/class-image-cdn.php
+++ b/projects/plugins/boost/app/modules/optimizations/image-cdn/class-image-cdn.php
@@ -3,10 +3,11 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Image_CDN;
 
 use Automattic\Jetpack\Image_CDN\Image_CDN_Setup;
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 
-class Image_CDN implements Pluggable {
+class Image_CDN implements Pluggable, Changes_Output {
 
 	public function setup() {
 		Image_CDN_Setup::load();

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
@@ -2,10 +2,11 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Minify;
 
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_CSS;
 
-class Minify_CSS implements Pluggable {
+class Minify_CSS implements Pluggable, Changes_Output {
 
 	public static $default_excludes = array( 'admin-bar', 'dashicons', 'elementor-app' );
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
@@ -2,10 +2,11 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Minify;
 
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_JS;
 
-class Minify_JS implements Pluggable {
+class Minify_JS implements Pluggable, Changes_Output {
 
 	public static $default_excludes = array( 'jquery', 'jquery-core', 'underscore', 'backbone' );
 

--- a/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -9,13 +9,14 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Render_Blocking_JS;
 
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Output_Filter;
 
 /**
  * Class Render_Blocking_JS
  */
-class Render_Blocking_JS implements Pluggable {
+class Render_Blocking_JS implements Pluggable, Changes_Output {
 	/**
 	 * Holds the script tags removed from the output buffer.
 	 *

--- a/projects/plugins/boost/changelog/add-garbage-collection
+++ b/projects/plugins/boost/changelog/add-garbage-collection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Garbage collection for page cache
+
+

--- a/projects/plugins/boost/changelog/boost-cache-update-storage-invalidate
+++ b/projects/plugins/boost/changelog/boost-cache-update-storage-invalidate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: rearrange how Storage invalidate() function operates

--- a/projects/plugins/boost/changelog/update-garbage-collection
+++ b/projects/plugins/boost/changelog/update-garbage-collection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Minor change to garbage collection
+
+

--- a/projects/plugins/boost/compatibility/wp-super-cache.php
+++ b/projects/plugins/boost/compatibility/wp-super-cache.php
@@ -43,6 +43,7 @@ function clear_cache() {
 	}
 }
 add_action( 'jetpack_boost_critical_css_generated', __NAMESPACE__ . '\clear_cache' );
+add_action( 'jetpack_boost_critical_css_invalidated', __NAMESPACE__ . '\clear_cache' );
 
 /**
  * Clear Super Cache's cache when a module is enabled or disabled.

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,11 +2,49 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 13.2-a.5 - 2024-02-14
+## 13.2-a.7 - 2024-02-19
+### Enhancements
+- Added custom message textarea to send a message via email when adding new users [#35277]
+- Add images while publishing on the web via the jetpack app [#35583]
+- Add some extra margin around Stats settings toggles [#35720]
+- Add support for Email stats [#35703]
+- Comment: Add Goodreads embed block in Gutenberg. [#33395]
+- SSO: Add user invite revoke row action in users table [#35277]
+- SSO: improve messaging and account binding between local and wp.com users [#35277]
+- SSO: Updated column heading and row background color when invitation is pending. [#35277]
+- SSO: When creating a new users, mail the users with an invitation to WPCom. [#35277]
+- We added the Welcome Email Message setting to Newsletter settings [#35621]
+
+### Improved compatibility
+- Add 'if_not_modified_since' to the update post endpoints this will help clients fails if the post has been updated since last retrieved [#35526]
+- Add support for WP Super Cache and Boost Cache [#35598]
+
+### Bug fixes
+- Jetpack Google Fonts: Fix some Google fonts aren't displayed correctly on front end [#35706]
+- Scan: ensure the Admin notice resources are always properly loaded. [#35648]
+
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
-- Adds error messaging to endpoint when connected account for memberships cannot be loaded. [#35564]
-- Like block: Update block's Learn more link logic [#35641]
-- Make Jetpack redirect to the Jetpack page after multisite activation. [#35559]
+- Add caching for user invites [#35277]
+- Added price in blaze/posts endpoint [#35066]
+- Add jetpack_newsletters_publishing_default_frequency to Sync [#35672]
+- Adds a standalone mode indicator to the Firewall settings [#34854]
+- Blaze: display post links for products. [#35730]
+- Email notifications: update from "follows" to "subscribes" [#35755]
+- Fix message translation content [#35277]
+- Improve column by renaming and adding icon [#35277]
+- Jetpack AI: Add transcription post-processing example to Voice-to-Content block. [#35734]
+- Jetpack AI: include audio transcription usage example to Voice-to-Content block. [#35691]
+- Jetpack AI Voice to content: Update to modal UI [#35698]
+- Move user customization to seperate file [#35277]
+- Persist user-new.php custom message form field after submission with errors [#35277]
+- Related Posts: remove duplicated HTML attributes [#35686]
+- Rename status column to sso status and add tooltip [#35277]
+- Replace question mark icon [#35277]
+- SSO: revoke invites sent to users upon users deletion [#35277]
+- Trigger user invitation for new users [#35277]
+- update readme [#35671]
+- Update users table ssorow background colors [#35277]
+- Voice to Content: Add states and refactor duration calculation [#35717]
 
 ## 13.1.2 - 2024-02-19
 ### Security Improvements
@@ -15,6 +53,12 @@
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
 - Jetpack: readme.txt tweaks. [#35727]
 - Jetpack: redirect to the Jetpack page after multisite activation. [#35559]
+
+## 13.2-a.5 - 2024-02-14
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Adds error messaging to endpoint when connected account for memberships cannot be loaded. [#35564]
+- Like block: Update block's Learn more link logic [#35641]
+- Make Jetpack redirect to the Jetpack page after multisite activation. [#35559]
 
 ## 13.2-a.3 - 2024-02-13
 ### Enhancements

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -8,6 +8,14 @@
 - Like block: Update block's Learn more link logic [#35641]
 - Make Jetpack redirect to the Jetpack page after multisite activation. [#35559]
 
+## 13.1.2 - 2024-02-19
+### Security Improvements
+- Like block: fix XSS vulnerability in avatar URL encoding. [#35747]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Jetpack: readme.txt tweaks. [#35727]
+- Jetpack: redirect to the Jetpack page after multisite activation. [#35559]
+
 ## 13.2-a.3 - 2024-02-13
 ### Enhancements
 - Blaze: remove "Promote with Blaze" links appearing in the Posts list when the Blaze feature is enabled. You can still go to Tools > Advertising to create and manage Blaze campaigns on your site. [#35586]

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2651,7 +2651,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'subscriptions',
 			),
 			'social_notifications_subscribe'       => array(
-				'description'       => esc_html__( 'Send email notification when someone follows my blog', 'jetpack' ),
+				'description'       => esc_html__( 'Send email notification when someone subscribes to my blog', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',

--- a/projects/plugins/jetpack/changelog/Add column tooltip
+++ b/projects/plugins/jetpack/changelog/Add column tooltip
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Rename status column to sso status and add tooltip

--- a/projects/plugins/jetpack/changelog/Improve column
+++ b/projects/plugins/jetpack/changelog/Improve column
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Improve column by renaming and adding icon

--- a/projects/plugins/jetpack/changelog/Improve question mark icon
+++ b/projects/plugins/jetpack/changelog/Improve question mark icon
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Replace question mark icon

--- a/projects/plugins/jetpack/changelog/[Memberships] Add support for WP Super Cache and Boost Cache
+++ b/projects/plugins/jetpack/changelog/[Memberships] Add support for WP Super Cache and Boost Cache
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Add support for WP Super Cache and Boost Cache

--- a/projects/plugins/jetpack/changelog/add-app-upload-media-enabled
+++ b/projects/plugins/jetpack/changelog/add-app-upload-media-enabled
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add images while publishing on the web via the jetpack app

--- a/projects/plugins/jetpack/changelog/add-goodreads-block
+++ b/projects/plugins/jetpack/changelog/add-goodreads-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Comment: Add Goodreads embed block in Gutenberg.

--- a/projects/plugins/jetpack/changelog/add-jetpack-waf-standalone-mode-indicator
+++ b/projects/plugins/jetpack/changelog/add-jetpack-waf-standalone-mode-indicator
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Adds a standalone mode indicator to the Firewall settings

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-boost-speed-score
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-boost-speed-score
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-new-user-additional-email-message
+++ b/projects/plugins/jetpack/changelog/add-new-user-additional-email-message
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Added custom message textarea to send a message via email when adding new users

--- a/projects/plugins/jetpack/changelog/add-newsletter-publisher-default-delivery-option
+++ b/projects/plugins/jetpack/changelog/add-newsletter-publisher-default-delivery-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add jetpack_newsletters_publishing_default_frequency to Sync

--- a/projects/plugins/jetpack/changelog/add-sso-cached-invites
+++ b/projects/plugins/jetpack/changelog/add-sso-cached-invites
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add caching for user invites

--- a/projects/plugins/jetpack/changelog/add-sso-move-to-admin-class
+++ b/projects/plugins/jetpack/changelog/add-sso-move-to-admin-class
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Move user customization to seperate file

--- a/projects/plugins/jetpack/changelog/add-sso-users-table-revoke-invite
+++ b/projects/plugins/jetpack/changelog/add-sso-users-table-revoke-invite
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-SSO: Add user invite revoke row action in users table

--- a/projects/plugins/jetpack/changelog/add-welcome-email-message-setting
+++ b/projects/plugins/jetpack/changelog/add-welcome-email-message-setting
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-We added the Welcome Email Message setting to Newsletter settings

--- a/projects/plugins/jetpack/changelog/fix-github-deployments-copy
+++ b/projects/plugins/jetpack/changelog/fix-github-deployments-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Wordpress.com Tools Menu: Update Github Deployments submenu copy

--- a/projects/plugins/jetpack/changelog/fix-jetpack-google-font
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-google-font
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Jetpack Google Fonts: Fix some Google fonts aren't displayed correctly on front end

--- a/projects/plugins/jetpack/changelog/fix-registration-user-invite
+++ b/projects/plugins/jetpack/changelog/fix-registration-user-invite
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Trigger user invitation for new users

--- a/projects/plugins/jetpack/changelog/fix-related-post-duplicate-selector-in-editor
+++ b/projects/plugins/jetpack/changelog/fix-related-post-duplicate-selector-in-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Related Posts: remove duplicated HTML attributes

--- a/projects/plugins/jetpack/changelog/fix-scan-file-location
+++ b/projects/plugins/jetpack/changelog/fix-scan-file-location
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Scan: ensure the Admin notice resources are always properly loaded.

--- a/projects/plugins/jetpack/changelog/fix-scan-file-location
+++ b/projects/plugins/jetpack/changelog/fix-scan-file-location
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Scan: ensure the Admin notice resources are always properly loaded.

--- a/projects/plugins/jetpack/changelog/fix-simple-sites-tiled-gallery-qr-code-upload
+++ b/projects/plugins/jetpack/changelog/fix-simple-sites-tiled-gallery-qr-code-upload
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: this fixes bugs that were never released yet so not important externally
-
-

--- a/projects/plugins/jetpack/changelog/fix-translations
+++ b/projects/plugins/jetpack/changelog/fix-translations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix message translation content

--- a/projects/plugins/jetpack/changelog/fix-xss-vulnerability-in-like-block
+++ b/projects/plugins/jetpack/changelog/fix-xss-vulnerability-in-like-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Like block: Encode Avatar URLs

--- a/projects/plugins/jetpack/changelog/improve-binding-local-remote-users
+++ b/projects/plugins/jetpack/changelog/improve-binding-local-remote-users
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-SSO: improve messaging and account binding between local and wp.com users

--- a/projects/plugins/jetpack/changelog/improve_invite_form
+++ b/projects/plugins/jetpack/changelog/improve_invite_form
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-SSO: When creating a new users, mail the users with an invitation to WPCom.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: Init 13.2-a.6
+Comment: Init 13.2-a.8
 
 

--- a/projects/plugins/jetpack/changelog/jetpack-readme-validation-tweaks
+++ b/projects/plugins/jetpack/changelog/jetpack-readme-validation-tweaks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-readme tweaks

--- a/projects/plugins/jetpack/changelog/readme-updates-feb-13-24
+++ b/projects/plugins/jetpack/changelog/readme-updates-feb-13-24
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-update readme

--- a/projects/plugins/jetpack/changelog/remove-old-filter-contact-form
+++ b/projects/plugins/jetpack/changelog/remove-old-filter-contact-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Contact Form: deprecate temporary tmp_grunion_allow_editor_view filter.

--- a/projects/plugins/jetpack/changelog/remove-postcss-custom-properties-importFrom
+++ b/projects/plugins/jetpack/changelog/remove-postcss-custom-properties-importFrom
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Replace `postcss-custom-properties` `importFrom` with `@csstools/postcss-global-data`. Should be no change to the plugin itself.
-
-

--- a/projects/plugins/jetpack/changelog/revoke-deleted-users
+++ b/projects/plugins/jetpack/changelog/revoke-deleted-users
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-SSO: revoke invites sent to users upon users deletion

--- a/projects/plugins/jetpack/changelog/try-update-post-endpoint-to-fail-on-old-revision
+++ b/projects/plugins/jetpack/changelog/try-update-post-endpoint-to-fail-on-old-revision
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-Add 'if_not_modified_since' to the update post endpoints this will help clients fails if the post has been updated since last retrieved 

--- a/projects/plugins/jetpack/changelog/update-blaze-dashboard-compatibility
+++ b/projects/plugins/jetpack/changelog/update-blaze-dashboard-compatibility
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-blaze-post-links-option-optout
+++ b/projects/plugins/jetpack/changelog/update-blaze-post-links-option-optout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Blaze: display post links for products.

--- a/projects/plugins/jetpack/changelog/update-email-notification-on-follow-label
+++ b/projects/plugins/jetpack/changelog/update-email-notification-on-follow-label
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Email notifications: update from "follows" to "subscribes"

--- a/projects/plugins/jetpack/changelog/update-email-notification-on-follow-label
+++ b/projects/plugins/jetpack/changelog/update-email-notification-on-follow-label
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Email notifications: update from "follows" to "subscribes"

--- a/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey
+++ b/projects/plugins/jetpack/changelog/update-enable-email-stats-for-odyssey
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Add support for Email stats

--- a/projects/plugins/jetpack/changelog/update-improve-users-table
+++ b/projects/plugins/jetpack/changelog/update-improve-users-table
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-SSO: Updated column heading and row background color when invitation is pending.

--- a/projects/plugins/jetpack/changelog/update-tweak-spacing-stats-settings-toggles
+++ b/projects/plugins/jetpack/changelog/update-tweak-spacing-stats-settings-toggles
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add some extra margin around Stats settings toggles

--- a/projects/plugins/jetpack/changelog/update-user-new-save-form-data
+++ b/projects/plugins/jetpack/changelog/update-user-new-save-form-data
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Persist user-new.php custom message form field after submission with errors

--- a/projects/plugins/jetpack/changelog/update-users-table-sso-background-colors
+++ b/projects/plugins/jetpack/changelog/update-users-table-sso-background-colors
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Update users table ssorow background colors

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-add-transcription-post-processing-machinery
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-add-transcription-post-processing-machinery
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: Add transcription post-processing example to Voice-to-Content block.

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-handle-audio-transcription-request
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-handle-audio-transcription-request
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack AI: include audio transcription usage example to Voice-to-Content block.

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-modal
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI Voice to content: Update to modal UI

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-states
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-states
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Voice to Content: Add states and refactor duration calculation

--- a/projects/plugins/jetpack/changelog/vdimitrakis-add-price-in-posts-endpoint
+++ b/projects/plugins/jetpack/changelog/vdimitrakis-add-price-in-posts-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Added price in blaze/posts endpoint

--- a/projects/plugins/jetpack/changelog/wordads-cmp-support
+++ b/projects/plugins/jetpack/changelog/wordads-cmp-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Privacy: Add preliminary support for WordAds Consent Management Provider

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_6",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
@@ -74,6 +74,11 @@ function load_assets( $attr, $content ) {
 	// and we should send fresh HTML with the cookie block in it.
 	notify_batcache_that_content_changed();
 
+	// Filters the display of the Cookie-consent Block e.g by GDPR CMP banner on WordAds sites.
+	if ( apply_filters( 'jetpack_disable_cookie_consent_block', false ) ) {
+		return '';
+	}
+
 	// If the user has already accepted the cookie consent, don't show the block.
 	if ( isset( $_COOKIE[ COOKIE_NAME ] ) ) {
 		return '';

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/goodreads.php
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/goodreads.php
@@ -2,7 +2,7 @@
 /**
  * Goodreads Block.
  *
- * @since $$next-version$$
+ * @since 13.2
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.2-a.6
+ * Version: 13.2-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.2-a.6' );
+define( 'JETPACK__VERSION', '13.2-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -79,7 +79,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 			'moderation_notify'                       => '(bool) Email me when a comment is helf for moderation?',
 			'social_notifications_like'               => '(bool) Email me when someone likes my post?',
 			'social_notifications_reblog'             => '(bool) Email me when someone reblogs my post?',
-			'social_notifications_subscribe'          => '(bool) Email me when someone follows my blog?',
+			'social_notifications_subscribe'          => '(bool) Email me when someone subscribes to my blog?',
 			'comment_moderation'                      => '(bool) Moderate comments for manual approval?',
 			'comment_previously_approved'             => '(bool) Moderate comments unless author has a previously-approved comment?',
 			'comment_max_links'                       => '(int) Moderate comments that contain X or more links',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -68,7 +68,7 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint(
 			'moderation_notify'                       => '(bool) Email me when a comment is helf for moderation?',
 			'social_notifications_like'               => '(bool) Email me when someone likes my post?',
 			'social_notifications_reblog'             => '(bool) Email me when someone reblogs my post?',
-			'social_notifications_subscribe'          => '(bool) Email me when someone follows my blog?',
+			'social_notifications_subscribe'          => '(bool) Email me when someone subscribes to my blog?',
 			'comment_moderation'                      => '(bool) Moderate comments for manual approval?',
 			'comment_previously_approved'             => '(bool) Moderate comments unless author has a previously-approved comment?',
 			'comment_max_links'                       => '(int) Moderate comments that contain X or more links',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -68,7 +68,7 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint(
 			'moderation_notify'                       => '(bool) Email me when a comment is helf for moderation?',
 			'social_notifications_like'               => '(bool) Email me when someone likes my post?',
 			'social_notifications_reblog'             => '(bool) Email me when someone reblogs my post?',
-			'social_notifications_subscribe'          => '(bool) Email me when someone follows my blog?',
+			'social_notifications_subscribe'          => '(bool) Email me when someone subscribes to my blog?',
 			'comment_moderation'                      => '(bool) Moderate comments for manual approval?',
 			'comment_previously_approved'             => '(bool) Moderate comments unless author has a previously-approved comment?',
 			'comment_max_links'                       => '(int) Moderate comments that contain X or more links',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -69,7 +69,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'moderation_notify'                       => '(bool) Email me when a comment is helf for moderation?',
 			'social_notifications_like'               => '(bool) Email me when someone likes my post?',
 			'social_notifications_reblog'             => '(bool) Email me when someone reblogs my post?',
-			'social_notifications_subscribe'          => '(bool) Email me when someone follows my blog?',
+			'social_notifications_subscribe'          => '(bool) Email me when someone subscribes to my blog?',
 			'comment_moderation'                      => '(bool) Moderate comments for manual approval?',
 			'comment_previously_approved'             => '(bool) Moderate comments unless author has a previously-approved comment?',
 			'comment_max_links'                       => '(int) Moderate comments that contain X or more links',

--- a/projects/plugins/jetpack/modules/contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form.php
@@ -45,10 +45,11 @@ require_once __DIR__ . '/contact-form/grunion-contact-form.php';
  * Expected to be removed in Jetpack 5.8 or if a security issue merits removing the old code sooner.
  *
  * @since 5.2.0
+ * @deprecated 13.2.0
  *
  * @param boolean $view Use new Editor View. Default true.
  */
-if ( is_admin() && apply_filters( 'tmp_grunion_allow_editor_view', true ) ) {
+if ( is_admin() && apply_filters_deprecated( 'tmp_grunion_allow_editor_view', array( true ), '13.2.0', '', 'This functionality will be removed in an upcoming version.' ) ) {
 	require_once __DIR__ . '/contact-form/grunion-editor-view.php';
 }
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -458,10 +458,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		add_submenu_page( 'tools.php', esc_attr__( 'Site Monitoring', 'jetpack' ), __( 'Site Monitoring', 'jetpack' ), 'manage_options', 'https://wordpress.com/site-monitoring/' . $this->domain, null, 7 );
 
 		/**
-		 * Adds the WordPress.com Github Deployments submenu under the main Tools menu.
+		 * Adds the WordPress.com GitHub Deployments submenu under the main Tools menu.
 		 */
 		if ( apply_filters( 'jetpack_show_wpcom_github_deployments_menu', false ) ) {
-			add_submenu_page( 'tools.php', esc_attr__( 'Github Deployments', 'jetpack' ), __( 'Github Deployments', 'jetpack' ), 'manage_options', 'https://wordpress.com/github-deployments/' . $this->domain, null, 7 );
+			add_submenu_page( 'tools.php', esc_attr__( 'GitHub Deployments', 'jetpack' ), __( 'GitHub Deployments', 'jetpack' ), 'manage_options', 'https://wordpress.com/github-deployments/' . $this->domain, null, 7 );
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
@@ -108,11 +108,11 @@ class Admin_Bar_Notice {
 		Assets::register_script(
 			self::SCRIPT_NAME,
 			'_inc/build/scan/admin-bar-notice.min.js',
-			__FILE__,
+			JETPACK__PLUGIN_FILE,
 			array(
 				'in_footer'    => true,
 				'strategy'     => 'defer',
-				'nonmin_path'  => '_inc/build/scan/admin-bar-notice.js',
+				'nonmin_path'  => 'modules/scan/admin-bar-notice.js',
 				'dependencies' => array( 'admin-bar' ),
 				'version'      => self::SCRIPT_VERSION,
 				'enqueue'      => true,

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -373,12 +373,12 @@ class Jetpack_Subscriptions {
 			'sm_enabled'
 		);
 
-		/** Email me whenever: Someone follows my blog */
+		/** Email me whenever: Someone subscribes to my blog */
 		/* @since 8.1 */
 
 		add_settings_section(
 			'notifications_section',
-			__( 'Someone follows my blog', 'jetpack' ),
+			__( 'Someone subscribes to my blog', 'jetpack' ),
 			array( $this, 'social_notifications_subscribe_section' ),
 			'discussion'
 		);
@@ -511,7 +511,7 @@ class Jetpack_Subscriptions {
 	}
 
 	/**
-	 * Someone follows my blog section
+	 * Someone subscribes to my blog section
 	 *
 	 * @since 8.1
 	 */
@@ -537,7 +537,7 @@ class Jetpack_Subscriptions {
 	}
 
 	/**
-	 * Someone follows my blog Toggle
+	 * Someone subscribes to my blog Toggle
 	 *
 	 * @since 8.1
 	 */
@@ -549,14 +549,14 @@ class Jetpack_Subscriptions {
 			<input type="checkbox" name="social_notifications_subscribe" id="social_notifications_subscribe" value="1" <?php checked( $checked ); ?> />
 			<?php
 				/* translators: this is a label for a setting that starts with "Email me whenever" */
-				esc_html_e( 'Someone follows my blog', 'jetpack' );
+				esc_html_e( 'Someone subscribes to my blog', 'jetpack' );
 			?>
 		</label>
 		<?php
 	}
 
 	/**
-	 * Validate "Someone follows my blog" option
+	 * Validate "Someone subscribes to my blog" option
 	 *
 	 * @since 8.1
 	 *

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -19,6 +19,7 @@ require_once WORDADS_ROOT . '/php/class-wordads-api.php';
 require_once WORDADS_ROOT . '/php/class-wordads-cron.php';
 require_once WORDADS_ROOT . '/php/class-wordads-california-privacy.php';
 require_once WORDADS_ROOT . '/php/class-wordads-ccpa-do-not-sell-link-widget.php';
+require_once WORDADS_ROOT . '/php/class-wordads-consent-management-provider.php';
 
 /**
  * Primary WordAds class.
@@ -179,6 +180,7 @@ class WordAds {
 
 		if ( is_admin() ) {
 			WordAds_California_Privacy::init_ajax_actions();
+			WordAds_Consent_Management_Provider::init_ajax_actions();
 		}
 	}
 
@@ -205,6 +207,11 @@ class WordAds {
 		// Include California Privacy Act related features if enabled.
 		if ( $this->params->options['wordads_ccpa_enabled'] ) {
 			WordAds_California_Privacy::init();
+		}
+
+		// Initialize CMP  if enabled.
+		if ( isset( $this->params->options['wordads_cmp_enabled'] ) && $this->params->options['wordads_cmp_enabled'] ) {
+			WordAds_Consent_Management_Provider::init();
 		}
 
 		if ( isset( $_SERVER['REQUEST_URI'] ) && '/ads.txt' === $_SERVER['REQUEST_URI'] ) {
@@ -363,7 +370,7 @@ class WordAds {
 		$is_logged_in = is_user_logged_in() ? '1' : '0';
 		?>
 		<script<?php echo esc_attr( $data_tags ); ?> type="text/javascript">
-			var __ATA_PP = { pt: <?php echo esc_js( $pagetype ); ?>, ht: <?php echo esc_js( $hosting_type ); ?>, tn: '<?php echo esc_js( get_stylesheet() ); ?>', uloggedin: <?php echo esc_js( $is_logged_in ); ?>, amp: false, siteid: <?php echo esc_js( $site_id ); ?>, consent: <?php echo esc_js( $consent ); ?>, ad: { label: { text: '<?php echo esc_js( __( 'Advertisements', 'jetpack' ) ); ?>' }, reportAd: { text: '<?php echo esc_js( __( 'Report this ad', 'jetpack' ) ); ?>' } } };
+			var __ATA_PP = { pt: <?php echo esc_js( $pagetype ); ?>, ht: <?php echo esc_js( $hosting_type ); ?>, tn: '<?php echo esc_js( get_stylesheet() ); ?>', uloggedin: <?php echo esc_js( $is_logged_in ); ?>, amp: false, siteid: <?php echo esc_js( $site_id ); ?>, consent: <?php echo esc_js( $consent ); ?>, ad: { label: { text: '<?php echo esc_js( __( 'Advertisements', 'jetpack' ) ); ?>' }, reportAd: { text: '<?php echo esc_js( __( 'Report this ad', 'jetpack' ) ); ?>' }, privacySettings: { text: '<?php echo esc_js( __( 'Privacy', 'jetpack' ) ); ?>', onClick: function() { window.__tcfapi && window.__tcfapi('showUi'); } } } };
 			var __ATA = __ATA || {};
 			__ATA.cmd = __ATA.cmd || [];
 			__ATA.criteo = __ATA.criteo || {};
@@ -742,6 +749,7 @@ JS;
 						},
 						privacySettings: {
 							text: '{$privacy_settings_text}',
+							onClick: function() { window.__tcfapi && window.__tcfapi('showUi'); },
 						}
 					}
 				});

--- a/projects/plugins/jetpack/modules/wordads/js/cmp-loader.js
+++ b/projects/plugins/jetpack/modules/wordads/js/cmp-loader.js
@@ -1,0 +1,21 @@
+// eslint-disable-next-line no-unused-vars
+function a8c_cmp_callback( data ) {
+	if ( data && data.scripts && Array.isArray( data.scripts ) ) {
+		if ( data.config ) {
+			let configurationScript = document.createElement( 'script' );
+			configurationScript.id = 'cmp-configuration';
+			configurationScript.type = 'application/configuration';
+			configurationScript.innerHTML = JSON.stringify( data.config );
+
+			// Add the cmp-configuration script element to the document's body
+			document.head.appendChild( configurationScript );
+		}
+
+		// Load each cmp script
+		data.scripts.forEach( function ( scriptUrl ) {
+			let script = document.createElement( 'script' );
+			script.src = scriptUrl;
+			document.head.appendChild( script );
+		} );
+	}
+}

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-consent-management-provider.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-consent-management-provider.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * WordAds Consent Management Provider
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Assets;
+
+/**
+ * Class WordAds_Consent_Management_Provider
+ *
+ * This is an integration with the GDPR Consent Management Provider
+ * to comply with GDPR requirements for privacy and transparency related to advertising.
+ */
+class WordAds_Consent_Management_Provider {
+
+	/**
+	 * IAB specified cookie name for storing the consent string.
+	 */
+	const COOKIE_NAME = 'euconsent-v2';
+
+	/**
+	 * Initializes loading of the frontend framework.
+	 */
+	public static function init() {
+		// Prevent Cookies & Consent banner from displaying when the CMP is active.
+		add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true' );
+		add_filter( 'jetpack_disable_cookie_consent_block', '__return_true' );
+
+		// Enqueue scripts.
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_frontend_scripts' ) );
+	}
+
+	/**
+	 * AJAX handlers for fetching purposes and vendor data and setting the cookie serverside.
+	 *
+	 * Serverside cookie used so that the expiration can be longer than one week.
+	 * This function is called from: /mu-plugins/wordads-ajax.php to ensure they run on all
+	 * requests including admin requests.
+	 */
+	public static function init_ajax_actions() {
+		add_action( 'wp_ajax_gdpr_set_consent', array( __CLASS__, 'handle_set_consent_request' ) );
+		add_action( 'wp_ajax_nopriv_gdpr_set_consent', array( __CLASS__, 'handle_set_consent_request' ) );
+	}
+
+	/**
+	 * Handler for setting consent cookie AJAX request.
+	 */
+	public static function handle_set_consent_request() {
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		if ( ! isset( $_POST['consent'] ) ) {
+			wp_send_json_error();
+		}
+
+		// TODO: Is there better sanitizing we can do here?
+		$consent = trim( wp_unslash( $_POST['consent'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		setcookie( self::COOKIE_NAME, $consent, time() + YEAR_IN_SECONDS, '/', self::get_cookie_domain(), is_ssl(), false ); // phpcs:ignore Jetpack.Functions.SetCookie -- Client side CMP needs to be able to read this value.
+
+		wp_send_json_success( true );
+
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+	}
+
+	/**
+	 * Enqueues the main frontend Javascript.
+	 */
+	public static function enqueue_frontend_scripts() {
+		wp_enqueue_script(
+			'cmp_script_loader',
+			Assets::get_file_url_for_environment(
+				'__inc/build/wordads/js/cmp-loader.min.js',
+				'modules/wordads/js/cmp-loader.js'
+			),
+			array(),
+			JETPACK__VERSION,
+			false
+		);
+
+		$request_url = self::get_config_url();
+		wp_enqueue_script(
+			'cmp_config_script',
+			Assets::get_file_url_for_environment(
+				$request_url,
+				$request_url
+			),
+			array(),
+			JETPACK__VERSION,
+			false
+		);
+	}
+
+	/**
+	 * Gets the value to be used when an opt-in cookie is set.
+	 *
+	 * @return string The value to store in the opt-in cookie.
+	 */
+	private static function get_config_url() {
+		$locale      = strtolower( get_locale() ); // Defaults to en_US not en.
+		$request_url = 'https://public-api.wordpress.com/wpcom/v2/sites/' . self::get_blog_id() . '/cmp/configuration/' . $locale . '/?_jsonp=a8c_cmp_callback';
+		return $request_url;
+	}
+
+	/**
+	 * Get the blog ID.
+	 *
+	 * @return Object current blog id.
+	 */
+	private static function get_blog_id() {
+		return Jetpack_Options::get_option( 'id' );
+	}
+
+	/**
+	 * Gets the domain to be used for the opt-out cookie.
+	 * Use the site's custom domain, or if the site has a wordpress.com subdomain, use .wordpress.com to share the cookie.
+	 *
+	 * @return string The domain to set for the opt-out cookie.
+	 */
+	public static function get_cookie_domain() {
+		$host = 'localhost';
+
+		if ( isset( $_SERVER['HTTP_HOST'] ) ) {
+			$host = filter_var( wp_unslash( $_SERVER['HTTP_HOST'] ) );
+		}
+
+		return '.wordpress.com' === substr( $host, -strlen( '.wordpress.com' ) ) ? '.wordpress.com' : '.' . $host;
+	}
+}

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.2.0-a.6",
+	"version": "13.2.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack - WP Security, Backup, Speed, & Growth ===
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, barry, batmoo, beaulebens, bindlegirl, biskobe, bjorsch, blobaugh, brbrr, cainm, cena, cfinke, cgastrell, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, daniloercoli, davoraltman, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, joen, jblz, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lhkowalski, lschuyler, macmanx, martinremy, matt, mattwiebe, matveb, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, nunyvega, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, renatoagds, retrofox, richardmtl, richardmuscat, robertbpugh, roccotripaldi, ryancowles, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, thehenridev, tmoorewp, tyxla, Viper007Bond, westi, williamvianas, wpkaren, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, performance
-Stable tag: 13.1.1
+Stable tag: 13.1.2
 Requires at least: 6.3
 Requires PHP: 7.0
 Tested up to: 6.4
@@ -136,15 +136,15 @@ If you like Jetpack, consider checking out our other products and bundles
 * [Jetpack Social](https://jetpack.com/redirect?source=org-social) - Automatically share your website content to your favorite social media platforms, from one place.
 * [Jetpack CRM](https://jetpack.com/redirect?source=org-crm) - Jetpack CRM has all of the tools you need to grow your business. It’s also modular, so you can customize it to suit your needs.
 * [Jetpack Creator](https://jetpack.com/redirect?source=org-creator) - Craft stunning content, boost your subscriber base, and monetize your online presence.
-* [Jetpack  Newsletter](https://jetpack.com/redirect?source=org-newsletter) - Transform your blog posts into newsletters to easily reach your subscribers. Offer paid subscriptions and earn from your content. 
+* [Jetpack  Newsletter](https://jetpack.com/redirect?source=org-newsletter) - Transform your blog posts into newsletters to easily reach your subscribers. Offer paid subscriptions and earn from your content.
 
-= KEEP SPAM OFF YOUR WEBSITE = 
+= KEEP SPAM OFF YOUR WEBSITE =
 * [Akismet Anti-spam](https://jetpack.com/redirect?source=org-spam) - Automatically clear spam from comments and forms. Save time, get more responses, give your visitors a better experience - all without lifting a finger.
 
 = PROMOTE YOUR CONTENT FOR MORE VIEWS =
 * [Blaze](https://jetpack.com/redirect?source=org-blaze) - Find new fans by promoting your posts and pages across millions of sites in the WordPress.com and Tumblr ad network.
 
-= MANAGE MORE THAN ONE SITE? = 
+= MANAGE MORE THAN ONE SITE? =
 * [Jetpack Manage](https://jetpack.com/manage/) - All the tools you need to manage multiple WordPress sites. Monitor site security, performance, and traffic, and get alerted if a site needs attention.
 
 = FLY HIGHER WITH INDIVIDUAL PLUGINS =

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,7 +326,27 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.2-a.5 - 2024-02-14
+### 13.2-a.7 - 2024-02-19
+#### Enhancements
+- Added custom message textarea to send a message via email when adding new users
+- Add images while publishing on the web via the jetpack app
+- Add some extra margin around Stats settings toggles
+- Add support for Email stats
+- Comment: Add Goodreads embed block in Gutenberg.
+- SSO: Add user invite revoke row action in users table
+- SSO: improve messaging and account binding between local and wp.com users
+- SSO: Updated column heading and row background color when invitation is pending.
+- SSO: When creating a new users, mail the users with an invitation to WPCom.
+- We added the Welcome Email Message setting to Newsletter settings
+
+#### Improved compatibility
+- Add 'if_not_modified_since' to the update post endpoints this will help clients fails if the post has been updated since last retrieved
+- Add support for WP Super Cache and Boost Cache
+
+#### Bug fixes
+- Jetpack Google Fonts: Fix some Google fonts aren't displayed correctly on front end
+- Scan: ensure the Admin notice resources are always properly loaded.
+
 --------
 
 [See the previous changelogs here](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/CHANGELOG.md#changelog)

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -218,7 +218,7 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 					'moderation_notify'                    => '(bool) Email me when a comment is helf for moderation?',
 					'social_notifications_like'            => '(bool) Email me when someone likes my post?',
 					'social_notifications_reblog'          => '(bool) Email me when someone reblogs my post?',
-					'social_notifications_subscribe'       => '(bool) Email me when someone follows my blog?',
+					'social_notifications_subscribe'       => '(bool) Email me when someone subscribes to my blog?',
 					'comment_moderation'                   => '(bool) Moderate comments for manual approval?',
 					'comment_previously_approved'          => '(bool) Moderate comments unless author has a previously-approved comment?',
 					'comment_max_links'                    => '(int) Moderate comments that contain X or more links',

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.22 - 2024-02-19
+### Changed
+- Internal updates.
+
 ## 2.0.21 - 2024-02-14
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-mu-wpcom-ai-robots-txt-blocks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-mu-wpcom-ai-robots-txt-blocks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_22_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_22"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.22-alpha
+ * Version: 2.0.22
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.22-alpha",
+	"version": "2.0.22",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
Depends on:
- #35753

Fixes #35748 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Invalidate cache on module toggle
* Invalidate cache on critical CSS generation
* Super Cache compatibility fix:
  * Invalidate cache only on output changing module toggle
  * Invalidate cache on C.CSS invalidation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

