### PR TITLE
Boost: Update cache logging to respect config settings

### DIFF
--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Logger.php
@@ -65,9 +65,13 @@ class Logger {
 	 * Add a debug message to the log file after doing necessary checks.
 	 */
 	public static function debug( $message ) {
+		$settings = Boost_Cache_Settings::get_instance();
+		if ( ! $settings->get_logging() ) {
+			return;
+		}
+
 		$logger = self::get_instance();
 
-		// TODO: Check to make sure that logging is enabled in the settings.
 		// TODO: Check to make sure that current request IP is allowed to create logs.
 
 		if ( ! is_wp_error( $logger ) ) {

--- a/projects/plugins/boost/changelog/update-cache-logging-respect-settings
+++ b/projects/plugins/boost/changelog/update-cache-logging-respect-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update cache logging to respect config settings.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35778

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update cache logging to only work when necessary.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable cache logging and check the logs page to make sure logs work;
* Disable logging and check the logs page to make sure logging is disabled.