### PR TITLE
Untangle: Prevent Publicize, Sharedaddy, and Likes registering Settings > Sharing menu item

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-sharedaddy-action-subscription-menu
+++ b/projects/plugins/jetpack/changelog/remove-sharedaddy-action-subscription-menu
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Remove Settings > Sharing menu item registered by Sharedaddy
+Remove Settings > Sharing menu item registered by Publicize, Sharedaddy, and Likes.

--- a/projects/plugins/jetpack/changelog/remove-sharedaddy-action-subscription-menu
+++ b/projects/plugins/jetpack/changelog/remove-sharedaddy-action-subscription-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove Settings > Sharing menu item registered by Sharedaddy

--- a/projects/plugins/jetpack/modules/comment-likes.php
+++ b/projects/plugins/jetpack/modules/comment-likes.php
@@ -74,11 +74,6 @@ class Jetpack_Comment_Likes {
 		if ( ! Jetpack::is_module_active( 'likes' ) ) {
 			$active = Jetpack::get_active_modules();
 
-			if ( ! in_array( 'sharedaddy', $active, true ) && ! in_array( 'publicize', $active, true ) ) {
-				// we don't have a sharing page yet.
-				add_action( 'admin_menu', array( $this->settings, 'sharing_menu' ) );
-			}
-
 			if ( in_array( 'publicize', $active, true ) && ! in_array( 'sharedaddy', $active, true ) ) {
 				// we have a sharing page but not the global options area.
 				add_action( 'pre_admin_screen_sharing', array( $this->settings, 'sharing_block' ), 20 );

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -83,11 +83,6 @@ class Jetpack_Likes {
 
 		$active = Jetpack::get_active_modules();
 
-		if ( ! in_array( 'sharedaddy', $active, true ) && ! in_array( 'publicize', $active, true ) ) {
-			// we don't have a sharing page yet.
-			add_action( 'admin_menu', array( $this->settings, 'sharing_menu' ) );
-		}
-
 		if ( in_array( 'publicize', $active, true ) && ! in_array( 'sharedaddy', $active, true ) ) {
 			// we have a sharing page but not the global options area.
 			add_action( 'pre_admin_screen_sharing', array( $this->settings, 'sharing_block' ), 20 );

--- a/projects/plugins/jetpack/modules/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize.php
@@ -47,11 +47,6 @@ class Jetpack_Publicize {
 		if ( $this->in_jetpack ) {
 			Jetpack::enable_module_configurable( __FILE__ );
 
-			// if sharedaddy isn't active, the sharing menu hasn't been added yet.
-			if ( $this->modules->is_active( 'publicize' ) && ! $this->modules->is_active( 'sharedaddy' ) ) {
-				add_action( 'admin_menu', array( &$publicize_ui, 'sharing_menu' ) );
-			}
-
 			/*
 			 * The Publicize Options array does not currently have UI since it is being added
 			 * for a specific purpose and not part of a broader Publicize sprint.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -30,15 +30,6 @@ class Sharing_Admin {
 
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
-		/**
-		 * The following action is commented out since it creates an entry to a legacy page.
-		 *
-		 * This menu item was previously hidden via https://github.com/Automattic/jetpack/pull/1960
-		 * but now we are preventing its registration altogether.
-		 *
-		 * add_action( 'admin_menu', array( $this, 'subscription_menu' ) );
-		 */
-
 		// Insert our CSS and JS
 		add_action( 'load-settings_page_sharing', array( $this, 'sharing_head' ) );
 

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -29,7 +29,15 @@ class Sharing_Admin {
 		require_once WP_SHARING_PLUGIN_DIR . 'sharing-service.php';
 
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
-		add_action( 'admin_menu', array( $this, 'subscription_menu' ) );
+
+		/**
+		 * The following action is commented out since it creates an entry to a legacy page.
+		 *
+		 * This menu item was previously hidden via https://github.com/Automattic/jetpack/pull/1960
+		 * but now we are preventing its registration altogether.
+		 *
+		 * add_action( 'admin_menu', array( $this, 'subscription_menu' ) );
+		 */
 
 		// Insert our CSS and JS
 		add_action( 'load-settings_page_sharing', array( $this, 'sharing_head' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5672

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR removes the action that registers the Settings > Sharing menu item via Publicize, Sharedaddy, and Likes. This menu item should be hidden since it links to a legacy page.

For more context see p1708341185724819/1708339800.549179-slack-C06DN6QQVAQ

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure that the Settings > Sharing menu item is no longer present in both WoA and Jetpack sites when either module is activates:
  * Publicize.
  * Sharedaddy.
  * Likes.