### PR TITLE
Jetpack: Carousel: Don't open if no images in gallery

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-no-images
+++ b/projects/plugins/jetpack/changelog/fix-carousel-no-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: don't open if no images are found in the gallery.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1457,6 +1457,11 @@
 				return; // don't run if the default gallery functions weren't used
 			}
 
+			const images = gallery.querySelectorAll( settings.imgSelector );
+			if ( ! images.length ) {
+				return; // don't run if we found no images in the gallery (somehow it has images that aren't in the media library?)
+			}
+
 			initializeCarousel();
 
 			if ( carousel.isOpen ) {
@@ -1493,7 +1498,7 @@
 			carousel.overlay.style.opacity = 1;
 			carousel.overlay.style.display = 'block';
 
-			initCarouselSlides( gallery.querySelectorAll( settings.imgSelector ), settings.startIndex );
+			initCarouselSlides( images, settings.startIndex );
 
 			swiper = new window.Swiper670( '.jp-carousel-swiper-container', {
 				centeredSlides: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the gallery has no (recognized) images, don't open the carousel instead of loading and then throwing a JS error.

Possibly there's better falling-back that could be done for the specific test case below. Someone who knows what that might be is welcome to do that in a separate PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1708445855888779/1708425842.573889-slack-C02FMH4G8

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a gallery block with a single image.
* Go into the code view. The block will look something like this:
  ```html
  <!-- wp:gallery {"linkTo":"none"} -->
  <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":8,"sizeSlug":"large","linkDestination":"none"} -->
  <figure class="wp-block-image size-large"><img src="https://example.org/wp-content/uploads/2024/02/field-clouds-sky-earth-46160-1024x686.jpeg" alt="brown field and blue sky" class="wp-image-8"/></figure>
  <!-- /wp:image --></figure>
  <!-- /wp:gallery -->
  ```
* Edit the code to remove the `"id"` property from the JSON in the `<!-- wp:image {...} -->` bit, and remove the `class` attribute from the `<img>` tag.
  ```html
  <!-- wp:gallery {"linkTo":"none"} -->
  <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
  <figure class="wp-block-image size-large"><img src="https://example.org/wp-content/uploads/2024/02/field-clouds-sky-earth-46160-1024x686.jpeg" alt="brown field and blue sky"/></figure>
  <!-- /wp:image --></figure>
  <!-- /wp:gallery -->
  ```
* Save and view the post. Attempt to click on the image.