### PR TITLE
My Jetpack: Fix wrong prop type passed to ConnectedProductCard

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
@@ -11,7 +11,8 @@ const StatsSection = () => {
 	const slug = 'stats';
 	const { detail } = useProduct( slug );
 	const { status } = detail;
-	const { userIsAdmin } = window?.myJetpackInitialState ?? false;
+	const initialState = 'undefined' === typeof window ? {} : window.myJetpackInitialState;
+	const userIsAdmin = 'object' === typeof initialState && Number( initialState.userIsAdmin ) === 1;
 	const { statsCounts } = useStatsCounts();
 	const counts = statsCounts?.past_seven_days || {};
 	const previousCounts = statsCounts?.between_past_eight_and_fifteen_days || {};

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-product-card-error
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-product-card-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix wrong prop type passed to ConnectedProductCard

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.10.0",
+	"version": "4.10.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -35,7 +35,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.10.0';
+	const PACKAGE_VERSION = '4.10.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes the exception below, thrown in the My Jetpack page. It ensures a boolean is passed to the `admin` prop.
<img width="704" alt="Screenshot 2024-02-20 at 11 23 00 AM" src="https://github.com/Automattic/jetpack/assets/1620183/10a085ca-656f-435c-969f-13daed693cc8">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- If you run the branch locally, make sure to build `packages/my-jetpack`
- Open the dev console
- Visit `/wp-admin/admin.php?page=my-jetpack`
- Notice the exception hasn't been thrown
- If you have the React Components panel, check that the `admin` prop is set to `true`
<img width="632" alt="Screenshot 2024-02-20 at 12 25 15 PM" src="https://github.com/Automattic/jetpack/assets/1620183/2d0c2243-7e03-49af-99b1-d1c346a111c2">


