### PR TITLE
Voice to Content: change text insertion logic to avoid replacing the blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-voice-to-content-reduce-block-flickering
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-reduce-block-flickering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Voice to Content: avoid replacing blocks when inserting transcription into editor.

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-inserter/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-inserter/index.ts
@@ -29,7 +29,8 @@ const markdownConverter = new MarkdownIt( {
  * @returns {UseTranscriptionInserterReturn} - Object with function to handle transcription upserting.
  */
 export default function useTranscriptionInserter(): UseTranscriptionInserterReturn {
-	const { replaceBlocks, insertBlocks } = useDispatch( 'core/block-editor' );
+	const { updateBlockAttributes, insertBlock, replaceInnerBlocks } =
+		useDispatch( 'core/block-editor' );
 
 	/*
 	 * List of blocks currently on the editor.
@@ -40,33 +41,63 @@ export default function useTranscriptionInserter(): UseTranscriptionInserterRetu
 		( transcription: string ) => {
 			debug( 'Upserting transcription' );
 
-			// Convert the markdown to HTML
+			/*
+			 * Convert the markdown to HTML
+			 */
 			const html = markdownConverter
 				.render( transcription || '' )
 				// Fix list indentation
 				.replace( /<li>\s+<p>/g, '<li>' )
 				.replace( /<\/p>\s+<\/li>/g, '</li>' );
 
-			// Parse the HTML into blocks
+			/*
+			 * Parse the HTML into blocks
+			 */
 			const blocksFromHTML = rawHandler( { HTML: html } );
 
 			/*
-			 * Replace the current blocks with the new ones
+			 * Go through the blocks and update or insert them
 			 */
-			if ( blocksFromHTML.length > 0 ) {
-				if ( currentBlocks.current.length === 0 ) {
-					insertBlocks( blocksFromHTML );
-					currentBlocks.current = blocksFromHTML;
+			for ( let i = 0; i < blocksFromHTML.length; i++ ) {
+				/*
+				 * If the block is already there, update its content
+				 */
+				if ( i < currentBlocks.current.length ) {
+					const currentblockClientId = currentBlocks.current[ i ].clientId;
+					const currentBlockContent = currentBlocks.current[ i ].attributes.content;
+
+					/*
+					 * If the block has content, update it
+					 */
+					if (
+						blocksFromHTML[ i ].attributes?.content &&
+						currentBlockContent !== blocksFromHTML[ i ].attributes?.content
+					) {
+						updateBlockAttributes( currentblockClientId, {
+							content: blocksFromHTML[ i ].attributes.content,
+						} );
+					}
+
+					/*
+					 * If the block has inner blocks, update them
+					 */
+					if ( blocksFromHTML[ i ].innerBlocks.length > 0 ) {
+						replaceInnerBlocks( currentblockClientId, blocksFromHTML[ i ].innerBlocks );
+					}
 				} else {
-					replaceBlocks(
-						currentBlocks.current.map( b => b.clientId ),
-						blocksFromHTML
-					);
-					currentBlocks.current = blocksFromHTML;
+					/*
+					 * The block is not there, insert it
+					 */
+					insertBlock( blocksFromHTML[ i ] );
+
+					/*
+					 * Append the new block to the list of current blocks
+					 */
+					currentBlocks.current.push( blocksFromHTML[ i ] );
 				}
 			}
 		},
-		[ currentBlocks, insertBlocks, replaceBlocks ]
+		[ currentBlocks, insertBlock, updateBlockAttributes, replaceInnerBlocks ]
 	);
 
 	return {

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-inserter/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-inserter/index.ts
@@ -29,7 +29,7 @@ const markdownConverter = new MarkdownIt( {
  * @returns {UseTranscriptionInserterReturn} - Object with function to handle transcription upserting.
  */
 export default function useTranscriptionInserter(): UseTranscriptionInserterReturn {
-	const { updateBlockAttributes, insertBlock, replaceInnerBlocks } =
+	const { updateBlockAttributes, insertBlocks, replaceInnerBlocks } =
 		useDispatch( 'core/block-editor' );
 
 	/*
@@ -86,9 +86,14 @@ export default function useTranscriptionInserter(): UseTranscriptionInserterRetu
 					}
 				} else {
 					/*
-					 * The block is not there, insert it
+					 * The block is not there, insert it. Using the insertBlocks version since
+					 * it allows to manage the block focus after inserting, disabling the focus
+					 * on the inserted block. To do it, it's necessary to set index and rootClientId
+					 * as undefined so they are set to the default values. updateSelection is set to
+					 * true to stay as the default value. The last parameter is set to null to prevent
+					 * focusing the inserted block, the behavior we want.
 					 */
-					insertBlock( blocksFromHTML[ i ] );
+					insertBlocks( [ blocksFromHTML[ i ] ], undefined, undefined, true, null );
 
 					/*
 					 * Append the new block to the list of current blocks
@@ -97,7 +102,7 @@ export default function useTranscriptionInserter(): UseTranscriptionInserterRetu
 				}
 			}
 		},
-		[ currentBlocks, insertBlock, updateBlockAttributes, replaceInnerBlocks ]
+		[ currentBlocks, insertBlocks, updateBlockAttributes, replaceInnerBlocks ]
 	);
 
 	return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #35549.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the way the transcription blocks are inserted on the editor: instead of replacing the blocks every time, reuse the old ones and update it's content
* This will reduce the flickering while inserting the transcription

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open the browser's development console, so you can check debug messages
* Insert a `Voice to Content` block and then click "Upload audio" to pick an audio for testing
    * For this PR, I used this file from OpenAI: https://cdn.openai.com/whisper/draft-20220913a/micro-machines.wav

<img width="600" alt="Screenshot 2024-02-19 at 17 47 08" src="https://github.com/Automattic/jetpack/assets/6760046/1dddd485-486a-4ba4-a9ae-d72603aa9e05">

* Once you pick the file, the transcription process will start
* After some seconds, you should see the transcription being streamed into the block editor
* Confirm the modal is still present over the editor
   * Before this PR, the modal was being closed, not the desired behavior for now 
* Confirm there is minimum/none sidebar flickering while the transcription is added to the editor
   * Before this PR, the sidebar would show and hide sections on every piece of transcription added to the editor, causing a flickering effect
   * With this PR, this should be solved
* Confirm there is also minimum/none toolbar flickering on the paragraph blocks being added
   * Before this PR, the toolbar would contract and expand on every piece of transcription added to the editor
   * With this PR, this should be solved