### PR TITLE
WordAds: ensure the CMP banner works in production environments

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wordads-cmp-post-35165
+++ b/projects/plugins/jetpack/changelog/fix-wordads-cmp-post-35165
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordAds: ensure the new CMP banner can be loaded in production environments.

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
@@ -74,8 +74,16 @@ function load_assets( $attr, $content ) {
 	// and we should send fresh HTML with the cookie block in it.
 	notify_batcache_that_content_changed();
 
-	// Filters the display of the Cookie-consent Block e.g by GDPR CMP banner on WordAds sites.
-	if ( apply_filters( 'jetpack_disable_cookie_consent_block', false ) ) {
+	if (
+		/**
+		 * Filters the display of the Cookie-consent Block e.g by GDPR CMP banner on WordAds sites.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $disable_cookie_consent_block Whether to disable the Cookie-consent Block.
+		 */
+		apply_filters( 'jetpack_disable_cookie_consent_block', false )
+	) {
 		return '';
 	}
 

--- a/projects/plugins/jetpack/modules/wordads/js/cmp-loader.js
+++ b/projects/plugins/jetpack/modules/wordads/js/cmp-loader.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-unused-vars
 function a8c_cmp_callback( data ) {
 	if ( data && data.scripts && Array.isArray( data.scripts ) ) {
 		if ( data.config ) {
@@ -19,3 +18,4 @@ function a8c_cmp_callback( data ) {
 		} );
 	}
 }
+window.a8c_cmp_callback = a8c_cmp_callback;

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-consent-management-provider.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-consent-management-provider.php
@@ -68,15 +68,16 @@ class WordAds_Consent_Management_Provider {
 	 * Enqueues the main frontend Javascript.
 	 */
 	public static function enqueue_frontend_scripts() {
-		wp_enqueue_script(
+		Assets::register_script(
 			'cmp_script_loader',
-			Assets::get_file_url_for_environment(
-				'__inc/build/wordads/js/cmp-loader.min.js',
-				'modules/wordads/js/cmp-loader.js'
-			),
-			array(),
-			JETPACK__VERSION,
-			false
+			'_inc/build/wordads/js/cmp-loader.min.js',
+			JETPACK__PLUGIN_FILE,
+			array(
+				'nonmin_path'  => 'modules/wordads/js/cmp-loader.js',
+				'dependencies' => array(),
+				'enqueue'      => true,
+				'version'      => JETPACK__VERSION,
+			)
 		);
 
 		$request_url = self::get_config_url();

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-consent-management-provider.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-consent-management-provider.php
@@ -80,14 +80,10 @@ class WordAds_Consent_Management_Provider {
 			)
 		);
 
-		$request_url = self::get_config_url();
 		wp_enqueue_script(
 			'cmp_config_script',
-			Assets::get_file_url_for_environment(
-				$request_url,
-				$request_url
-			),
-			array(),
+			esc_url( self::get_config_url() ),
+			array( 'cmp_script_loader' ),
 			JETPACK__VERSION,
 			false
 		);

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-consent-management-provider.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-consent-management-provider.php
@@ -95,18 +95,11 @@ class WordAds_Consent_Management_Provider {
 	 * @return string The value to store in the opt-in cookie.
 	 */
 	private static function get_config_url() {
-		$locale      = strtolower( get_locale() ); // Defaults to en_US not en.
-		$request_url = 'https://public-api.wordpress.com/wpcom/v2/sites/' . self::get_blog_id() . '/cmp/configuration/' . $locale . '/?_jsonp=a8c_cmp_callback';
-		return $request_url;
-	}
-
-	/**
-	 * Get the blog ID.
-	 *
-	 * @return Object current blog id.
-	 */
-	private static function get_blog_id() {
-		return Jetpack_Options::get_option( 'id' );
+		return sprintf(
+			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/cmp/configuration/%2$s/?_jsonp=a8c_cmp_callback',
+			(int) Jetpack_Options::get_option( 'id' ),
+			strtolower( get_locale() ) // Defaults to en_US not en.
+		);
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #35165

## Proposed changes:

This PR fixes a few issues introduced in the last PR, and ensure the banner will work in production environments as well.

- Cookie Consent Block: document new filter usage so it can be documented in the codex.
- CMP Loader: force the function to be used. The function was dropped from the production build since it wasn't used within the file. This workaround ensures the production build includes the function, and thus isn't empty.
- Switch to Asset method to enqueue the file and fix file reference: The production file we tried to load wasn't correct. This PR fixes that, and switches over to the `register_script` method which is a bit more readable.
- Simplify enqueuing of the second resource
- Simplify building endpoint URL and sanitize URL parts

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* No

## Does this pull request change what data or activity we track or use?

* No, but the last PR introduced a new cookie, `euconsent-v2`, which will need to be documented in our privacy documents.

## Testing instructions:

* See #35165
* Ensure that `define( 'SCRIPT_DEBUG', false );` in your site's `wp-config.php` file, to load the production version of the CMP loader.
