### PR TITLE
CRM: 35359 and 3430 - Add HPOS support to WooSync

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-35359-order_metabox_missing_on_HPOS
+++ b/projects/plugins/crm/changelog/fix-crm-35359-order_metabox_missing_on_HPOS
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WooSync: Detect and support WooCommerce HPOS configuration.

--- a/projects/plugins/crm/includes/ZeroBSCRM.ScriptsStyles.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.ScriptsStyles.php
@@ -127,47 +127,6 @@ function zeroBSCRM_scriptStyles_initStyleRegister(){
 		// ============ / Whitelabel =================
 		// ===========================================
 
-
-
-		#} ===============================================================================
-		#} === Per page CSS/JS inc (LEGACY < 3.0)
-		#} ===============================================================================
-		// this is all legacy includes, done away with from v3.0 ++ (added properly via menu's thereafter)
-		if (!$zbs->isDAL3()){
-
-			#} Slight efficiency drive, get this here:
-			$postTypeStr = ''; if (isset($_GET['post'])) $postTypeStr = get_post_type((int)$_GET['post']);
-
-			#} Quote Builder CSS
-			if (
-				(isset($_GET['page']) && $_GET['page'] == 'manage-quotes') ||
-				(isset($_GET['post_type']) && $_GET['post_type'] == 'zerobs_quote') || 
-				(!empty($postTypeStr) && $postTypeStr == 'zerobs_quote')
-					) zeroBSCRM_scriptStyles_admin_quoteBuilder();
-
-			#} Invoice Builder CSS
-			if (
-				(isset($_GET['page']) && $_GET['page'] == 'manage-invoices') ||
-				(isset($_GET['post_type']) && $_GET['post_type'] == 'zerobs_invoice') || 
-				(!empty($postTypeStr) && $postTypeStr == 'zerobs_invoice')
-					) zeroBSCRM_scriptStyles_admin_invoiceBuilder();
-
-			#} Transactions
-			if (
-				(isset($_GET['post_type']) && $_GET['post_type'] == 'zerobs_transaction') || 
-				(!empty($postTypeStr) && $postTypeStr == 'zerobs_transaction')
-					) zeroBSCRM_scriptStyles_admin_transactionBuilder();
-		
-			#} Forms
-			if (
-				(isset($_GET['post_type']) && $_GET['post_type'] == 'zerobs_form') || 
-				(!empty($postTypeStr) && $postTypeStr == 'zerobs_form')
-					) zeroBSCRM_scriptStyles_admin_formBuilder();
-		}
-		#} ===============================================================================
-		#} === /  per page CSS/JS inc (LEGACY < 3.0 )
-		#} ===============================================================================
-
 		// LEGACY SUPPORT for ext's with menus
 		if (zeroBSCRM_isAdminPage()){
 			zeroBSCRM_global_admin_styles();

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync.php
@@ -142,8 +142,14 @@ class Woo_Sync_Background_Sync {
 		add_action( 'woocommerce_order_status_changed',    array( $this, 'add_update_from_woo_order' ), 1, 1 );
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'add_update_from_woo_order' ), 100, 1 );
 		add_action( 'woocommerce_deposits_create_order',   array( $this, 'add_update_from_woo_order' ), 100, 1 );
-		add_action( 'wp_trash_post',                       array( $this, 'woocommerce_order_trashed' ), 10, 1 );
-		add_action( 'before_delete_post',                  array( $this, 'woocommerce_order_deleted' ), 10, 1 );	
+		if ( jpcrm_woosync_is_hpos_enabled() ) {
+			// These hooks are available as of Woo 7.1.0 and are required for HPOS.
+			add_action( 'woocommerce_before_trash_order', array( $this, 'woocommerce_order_trashed' ), 10, 1 );
+			add_action( 'woocommerce_before_delete_order', array( $this, 'woocommerce_order_deleted' ), 10, 1 );
+		} else {
+			add_action( 'wp_trash_post', array( $this, 'woocommerce_order_trashed' ), 10, 1 );
+			add_action( 'before_delete_post', array( $this, 'woocommerce_order_deleted' ), 10, 1 );
+		}
 
 		// Catch WooCommerce customer address changes and update contact:
 		add_action( 'woocommerce_customer_save_address',   array( $this, 'update_contact_address_from_wp_user' ), 10, 3 );
@@ -545,10 +551,12 @@ class Woo_Sync_Background_Sync {
 
 		global $zbs;
 
-		// was it an order that was deleted?
-		$post_type = get_post_type( $order_post_id );
-		if ( $post_type !== 'shop_order' ) {
-			return;
+		if ( ! jpcrm_woosync_is_hpos_enabled() ) {
+			// was it an order that was deleted?
+			$post_type = get_post_type( $order_post_id );
+			if ( $post_type !== 'shop_order' ) {
+				return;
+			}
 		}
 
 		// catch default
@@ -559,6 +567,7 @@ class Woo_Sync_Background_Sync {
 		// retrieve order
 		$order = wc_get_order( $order_post_id );
 
+		// Sometimes there's a custom order number...
 		if ( method_exists( $order, 'get_order_number' ) ) {
 			$order_num = $order->get_order_number();
 		} else {

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -81,7 +81,7 @@ class Woo_Sync_Woo_Admin_Integration {
 
 			if ( $key === 'order_status' ) {
 				// Inserting after "Status" column
-				$rebuilt_columns['jpcrm'] = __( 'CRM Contact', 'zero-bs-crm' );
+				$rebuilt_columns['jpcrm_contact'] = __( 'CRM Contact', 'zero-bs-crm' );
 			}
 		}
 
@@ -92,15 +92,19 @@ class Woo_Sync_Woo_Admin_Integration {
 	 * HTML rendering of our custom orders view column content
 	 *
 	 * @param string $column Column slug.
-	 * @param int    $order_post_id Order post ID.
+	 * @param int    $order_or_post_id Order post ID.
 	 */
-	public function render_orders_column_content( $column, $order_post_id ) {
+	public function render_orders_column_content( $column, $order_or_post_id ) {
 
 		global $zbs;
 		switch ( $column ) {
 
-			case 'jpcrm':
-				$order = wc_get_order( $order_post_id );
+			case 'jpcrm_contact':
+				if ( jpcrm_woosync_is_hpos_enabled() ) {
+					$order = $order_or_post_id;
+				} else {
+					$order = wc_get_order( $order_or_post_id );
+				}
 				$email = $order->get_billing_email();
 
 				if ( ! empty( $email ) ) {

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -176,49 +176,11 @@ class Woo_Sync_Woo_Admin_Integration {
 			$order = wc_get_order( $order_or_post->ID );
 		}
 
+		$this->render_metabox_styles();
+
 		?>
 
 			<div class='zbs-crm-contact' style="margin-bottom:20px;">
-
-				<style>
-					.zbs-crm-contact{
-						text-align:center;
-					}
-					.zbs-custom-avatar{
-						border-radius: 50% !important;
-						max-width:80px;
-						text-align:center;
-						padding:10px;
-					}
-					.edit-contact-lin{
-						margin-top:10px !important;
-					}
-					.cust-email{
-						padding-bottom:10px;
-						padding-top:10px;
-						color: black;
-						font-weight:700;
-					}
-					.jpcrm-name{
-						font-weight:900;
-					}
-					.status{
-						margin-left: 0;
-						padding: 0.3em 0.78571429em;
-						display: inline-block;
-						border-radius: 5px;
-						margin-top: 3px;
-						margin-bottom: 3px;
-						font-size: 12px !important;
-						font-weight: 500;
-						background-color: #ccc;
-					}
-					.customer{
-						background-color: #21BA45 !important;
-						border-color: #21BA45 !important;
-						color: #FFFFFF !important;
-					}
-					</style>
 				<?php 
 
 					// the customer information pane
@@ -283,5 +245,54 @@ class Woo_Sync_Woo_Admin_Integration {
 			</div>
 		<?php
 		
+	}
+
+	/**
+	 * Renders metabox styles.
+	 *
+	 * It'd be better to move this to its own file, but putting it here for now.
+	 */
+	public function render_metabox_styles() {
+		?>
+		<style>
+		.zbs-crm-contact{
+			text-align:center;
+		}
+		.zbs-custom-avatar{
+			border-radius: 50% !important;
+			max-width:80px;
+			text-align:center;
+			padding:10px;
+		}
+		.edit-contact-lin{
+			margin-top:10px !important;
+		}
+		.cust-email{
+			padding-bottom:10px;
+			padding-top:10px;
+			color: black;
+			font-weight:700;
+		}
+		.jpcrm-name{
+			font-weight:900;
+		}
+		.status{
+			margin-left: 0;
+			padding: 0.3em 0.78571429em;
+			display: inline-block;
+			border-radius: 5px;
+			margin-top: 3px;
+			margin-bottom: 3px;
+			font-size: 12px !important;
+			font-weight: 500;
+			background-color: #ccc;
+		}
+		.customer{
+			background-color: #21BA45 !important;
+			border-color: #21BA45 !important;
+			color: #FFFFFF !important;
+		}
+		</style>
+		<?php
 	}
 }

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -54,6 +54,7 @@ class Woo_Sync_Woo_Admin_Integration {
 
 		// Hook into Woo orders listview.
 		if ( jpcrm_woosync_is_hpos_enabled() ) {
+			// These hooks are available as of Woo 7.3.0 and are required for HPOS.
 			add_filter( 'woocommerce_shop_order_list_table_columns', array( $this, 'append_orders_column' ) );
 			add_action( 'woocommerce_shop_order_list_table_custom_column', array( $this, 'render_orders_column_content' ), 20, 2 );
 		} else {

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -68,33 +68,27 @@ class Woo_Sync_Woo_Admin_Integration {
 
 
 	/**
-	 * Append our CRM column to the WooCommerce orders view columns
-	 *  This should be fired via filter `manage_edit-shop_order_columns`
+	 * Add CRM contact column to Woo orders listview.
 	 *
-	 * @param array $columns
+	 * @param array $columns Listview columns.
 	 */
-	public function append_orders_column( $columns ){
+	public function append_orders_column( $columns ) {
 
 		$rebuilt_columns = array();
 
 		// Inserting columns to a specific location
-		foreach( $columns as $key => $column){
+		foreach ( $columns as $key => $column ) {
 
-			$rebuilt_columns[$key] = $column;
+			$rebuilt_columns[ $key ] = $column;
 
-			if ( $key ==  'order_status' ){
-
+			if ( $key === 'order_status' ) {
 				// Inserting after "Status" column
-				$rebuilt_columns['jpcrm'] = __( 'CRM Contact','zero-bs-crm');
-
+				$rebuilt_columns['jpcrm'] = __( 'CRM Contact', 'zero-bs-crm' );
 			}
-
 		}
 
 		return $rebuilt_columns;
-
 	}
-
 
 	/**
 	 * HTML rendering of our custom orders view column content

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -105,28 +105,30 @@ class Woo_Sync_Woo_Admin_Integration {
 				} else {
 					$order = wc_get_order( $order_or_post_id );
 				}
+
 				$email = $order->get_billing_email();
 
-				if ( ! empty( $email ) ) {
+				if ( empty( $email ) ) {
+					return;
+				}
 
-					$contact_id = zeroBS_getCustomerIDWithEmail( $email );
+				$contact_id = zeroBS_getCustomerIDWithEmail( $email );
 
-					if ( $contact_id > 0 ) {
+				if ( $contact_id > 0 ) {
 
-						// We have an email. Add in some actions.
-						echo '<div class="zbs-actions">';
-							$url = jpcrm_esc_link( 'view', $contact_id, 'zerobs_customer' );
-							echo '<a class="button button-primary" href="' . esc_url( $url ) . '">' . esc_html__( 'View Contact', 'zero-bs-crm' ) . '</a>';
-						echo '</div>';
+					// We have an email. Add in some actions.
+					echo '<div class="zbs-actions">';
+						$url = jpcrm_esc_link( 'view', $contact_id, 'zerobs_customer' );
+						echo '<a class="button button-primary" href="' . esc_url( $url ) . '">' . esc_html__( 'View Contact', 'zero-bs-crm' ) . '</a>';
+					echo '</div>';
 
-					} else {
+				} else {
 
-						echo '<div class="zbs-actions">';
-							$url = admin_url( 'admin.php?page=' . $zbs->modules->woosync->slugs['hub'] );
-							echo '<a class="button button-secondary" href="' . esc_url( $url ) . '">' . esc_html__( 'Add Contact', 'zero-bs-crm' ) . '</a>';
-						echo '</div>';
+					echo '<div class="zbs-actions">';
+						$url = admin_url( 'admin.php?page=' . $zbs->modules->woosync->slugs['hub'] );
+						echo '<a class="button button-secondary" href="' . esc_url( $url ) . '">' . esc_html__( 'Add Contact', 'zero-bs-crm' ) . '</a>';
+					echo '</div>';
 
-					}
 				}
 				break;
 		}

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -185,70 +185,9 @@ class Woo_Sync_Woo_Admin_Integration {
 
 			// the customer information pane
 			$email = $order->get_billing_email();
-			if ( ! empty( $email ) ) {
 
-				// retrieve contact id
-				$contact_id = zeroBS_getCustomerIDWithEmail( $email );
-
-				if ( $contact_id > 0 ) {
-
-					// retrieve contact
-					$crm_contact               = $zbs->DAL->contacts->getContact( $contact_id );
-					$contact_name              = $zbs->DAL->contacts->getContactFullNameEtc( $contact_id, $crm_contact, array( false, false ) );
-					$contact_transaction_count = $zbs->DAL->specific_obj_type_count_for_assignee( $contact_id, ZBS_TYPE_TRANSACTION, ZBS_TYPE_CONTACT ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-
-					// check avatar mode
-					$avatar      = '';
-					$avatar_mode = zeroBSCRM_getSetting( 'avatarmode' );
-					if ( $avatar_mode !== 3 ) {
-						$avatar = zeroBS_customerAvatarHTML( $contact_id, $crm_contact, 100, 'ui small image centered' );
-					}
-
-					// Render HTML
-					?>
-					<div class="customer-panel-header">
-						<div id="panel-customer-avatar">
-							<?php
-							echo $avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							?>
-						</div>
-						<div id="panel-name"><span class="jpcrm-name"><?php echo esc_html( $contact_name ); ?></span></div>
-						<div id="panel-status" class="ui label status <?php echo esc_attr( strtolower( $crm_contact['status'] ) ); ?>">
-							<?php echo esc_html( $crm_contact['status'] ); ?>
-						</div>
-						<div class="simple-actions zbs-hide">
-							<a class="ui label circular"><i class="ui icon phone"></i></a>
-							<a class="ui label circular"><i class="ui icon envelope"></i></a>
-						</div>
-					</div>
-
-					<div class="ui divider"></div>
-
-					<div class="total-paid-wrap">
-						<div class="total-paid cell">
-							<div class="heading">
-								<?php
-								echo esc_html( zeroBSCRM_prettifyLongInts( $contact_transaction_count ) . ' ' . ( $contact_transaction_count > 1 ? __( 'Transactions', 'zero-bs-crm' ) : __( 'Transaction', 'zero-bs-crm' ) ) );
-								?>
-							</div>
-						</div>
-					</div>
-
-					<div class="clear"></div>
-					<div class="ui divider"></div>
-
-					<div class="panel-left-info cust-email">
-						<i class="ui icon envelope outline"></i> <span class="panel-customer-email"><?php echo esc_html( $email ); ?></span>
-					</div>
-
-					<div class="panel-edit-contact">
-						<a class="edit-contact-link button button-primary" href="<?php echo esc_url( jpcrm_esc_link( 'view', $contact_id, 'zerobs_customer' ) ); ?>"><?php echo esc_html__( 'View Contact', 'zero-bs-crm' ); ?></a>
-					</div>
-
-					<div class="clear"></div>
-					<?php
-				}
-			} else {
+			// No billing email found, so render message and return.
+			if ( empty( $email ) ) {
 				?>
 				<div class="no-crm-contact">
 					<p style="margin-top:20px;">
@@ -256,11 +195,74 @@ class Woo_Sync_Woo_Admin_Integration {
 					</p>
 				</div>
 				<?php
+				return;
 			}
+
+			// retrieve contact id
+			$contact_id = zeroBS_getCustomerIDWithEmail( $email );
+
+			// Can't find a contact under that email, so return.
+			if ( $contact_id <= 0 ) {
+				return;
+			}
+
+			// retrieve contact
+			$crm_contact               = $zbs->DAL->contacts->getContact( $contact_id );
+			$contact_name              = $zbs->DAL->contacts->getContactFullNameEtc( $contact_id, $crm_contact, array( false, false ) );
+			$contact_transaction_count = $zbs->DAL->specific_obj_type_count_for_assignee( $contact_id, ZBS_TYPE_TRANSACTION, ZBS_TYPE_CONTACT ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			// check avatar mode
+			$avatar      = '';
+			$avatar_mode = zeroBSCRM_getSetting( 'avatarmode' );
+			if ( $avatar_mode !== 3 ) {
+				$avatar = zeroBS_customerAvatarHTML( $contact_id, $crm_contact, 100, 'ui small image centered' );
+			}
+
+			// Render HTML
 			?>
+			<div class="customer-panel-header">
+				<div id="panel-customer-avatar">
+					<?php
+					echo $avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					?>
+				</div>
+				<div id="panel-name"><span class="jpcrm-name"><?php echo esc_html( $contact_name ); ?></span></div>
+				<div id="panel-status" class="ui label status <?php echo esc_attr( strtolower( $crm_contact['status'] ) ); ?>">
+					<?php echo esc_html( $crm_contact['status'] ); ?>
+				</div>
+				<div class="simple-actions zbs-hide">
+					<a class="ui label circular"><i class="ui icon phone"></i></a>
+					<a class="ui label circular"><i class="ui icon envelope"></i></a>
+				</div>
+			</div>
+
+			<div class="ui divider"></div>
+
+			<div class="total-paid-wrap">
+				<div class="total-paid cell">
+					<div class="heading">
+						<?php
+						echo esc_html( zeroBSCRM_prettifyLongInts( $contact_transaction_count ) . ' ' . ( $contact_transaction_count > 1 ? __( 'Transactions', 'zero-bs-crm' ) : __( 'Transaction', 'zero-bs-crm' ) ) );
+						?>
+					</div>
+				</div>
+			</div>
+
+			<div class="clear"></div>
+			<div class="ui divider"></div>
+
+			<div class="panel-left-info cust-email">
+				<i class="ui icon envelope outline"></i> <span class="panel-customer-email"><?php echo esc_html( $email ); ?></span>
+			</div>
+
+			<div class="panel-edit-contact">
+				<a class="edit-contact-link button button-primary" href="<?php echo esc_url( jpcrm_esc_link( 'view', $contact_id, 'zerobs_customer' ) ); ?>"><?php echo esc_html__( 'View Contact', 'zero-bs-crm' ); ?></a>
+			</div>
+
+			<div class="clear"></div>
 		</div>
 		<?php
-		 // phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	}
 
 	/**

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -140,30 +140,43 @@ class Woo_Sync_Woo_Admin_Integration {
 		}
 	}
 
-
 	/**
 	 * Add CRM meta boxes to Woo pages
 	 */
-	public function add_meta_boxes(){
-		
-		add_meta_box( 
+	public function add_meta_boxes() {
+		global $zbs;
+
+		if ( $zbs->modules->woosync->is_hpos_enabled() ) {
+			$screen = wc_get_page_screen_id( 'shop-order' );
+		} else {
+			$screen = array( 'shop_order', 'shop_subscription' );
+		}
+
+		add_meta_box(
 			'zbs_crm_contact',
 			__( 'CRM Contact', 'zero-bs-crm' ),
 			array( $this, 'render_woo_order_page_contact_box' ),
-			['shop_order', 'shop_subscription'],
+			$screen,
 			'side',
 			'core'
 		);
-
 	}
-
 
 	/**
 	 * Renders HTML for contact metabox on Woo pages
+	 *
+	 * @param WC_Order|\WP_POST $order_or_post Order or post.
 	 */
-	public function render_woo_order_page_contact_box(){
+	public function render_woo_order_page_contact_box( $order_or_post ) {
 
-		global $zbs, $post; ?>
+		global $zbs;
+		if ( $zbs->modules->woosync->is_hpos_enabled() ) {
+			$order = $order_or_post;
+		} else {
+			$order = wc_get_order( $order_or_post->ID );
+		}
+
+		?>
 
 			<div class='zbs-crm-contact' style="margin-bottom:20px;">
 
@@ -204,13 +217,11 @@ class Woo_Sync_Woo_Admin_Integration {
 						background-color: #21BA45 !important;
 						border-color: #21BA45 !important;
 						color: #FFFFFF !important;
-										
 					}
 					</style>
 				<?php 
 
 					// the customer information pane
-					$order = wc_get_order( $post->ID );
 					$email = $order->get_billing_email();
 					if ( $email != '' ){
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -115,21 +115,19 @@ class Woo_Sync_Woo_Admin_Integration {
 				$contact_id = zeroBS_getCustomerIDWithEmail( $email );
 
 				if ( $contact_id > 0 ) {
-
-					// We have an email. Add in some actions.
-					echo '<div class="zbs-actions">';
-						$url = jpcrm_esc_link( 'view', $contact_id, 'zerobs_customer' );
-						echo '<a class="button button-primary" href="' . esc_url( $url ) . '">' . esc_html__( 'View Contact', 'zero-bs-crm' ) . '</a>';
-					echo '</div>';
-
+					$url   = jpcrm_esc_link( 'view', $contact_id, 'zerobs_customer' );
+					$label = __( 'View Contact', 'zero-bs-crm' );
+					$class = 'primary';
 				} else {
-
-					echo '<div class="zbs-actions">';
-						$url = admin_url( 'admin.php?page=' . $zbs->modules->woosync->slugs['hub'] );
-						echo '<a class="button button-secondary" href="' . esc_url( $url ) . '">' . esc_html__( 'Add Contact', 'zero-bs-crm' ) . '</a>';
-					echo '</div>';
-
+					$url   = admin_url( 'admin.php?page=' . $zbs->modules->woosync->slugs['hub'] );
+					$label = __( 'Add Contact', 'zero-bs-crm' );
+					$class = 'secondary';
 				}
+				?>
+				<div class="zbs-actions">
+					<a class="button button-<?php echo esc_attr( $class ); ?>" href="<?php echo esc_url( $url ); ?>"><?php echo esc_html( $label ); ?></a>
+				</div>
+				<?php
 				break;
 		}
 	}

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -144,9 +144,7 @@ class Woo_Sync_Woo_Admin_Integration {
 	 * Add CRM meta boxes to Woo pages
 	 */
 	public function add_meta_boxes() {
-		global $zbs;
-
-		if ( $zbs->modules->woosync->is_hpos_enabled() ) {
+		if ( jpcrm_woosync_is_hpos_enabled() ) {
 			$screen = wc_get_page_screen_id( 'shop-order' );
 		} else {
 			$screen = array( 'shop_order', 'shop_subscription' );
@@ -171,7 +169,7 @@ class Woo_Sync_Woo_Admin_Integration {
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		global $zbs;
-		if ( $zbs->modules->woosync->is_hpos_enabled() ) {
+		if ( jpcrm_woosync_is_hpos_enabled() ) {
 			$order = $order_or_post;
 		} else {
 			$order = wc_get_order( $order_or_post->ID );

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -168,6 +168,7 @@ class Woo_Sync_Woo_Admin_Integration {
 	 * @param WC_Order|\WP_POST $order_or_post Order or post.
 	 */
 	public function render_woo_order_page_contact_box( $order_or_post ) {
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		global $zbs;
 		if ( $zbs->modules->woosync->is_hpos_enabled() ) {
@@ -177,74 +178,89 @@ class Woo_Sync_Woo_Admin_Integration {
 		}
 
 		$this->render_metabox_styles();
-
 		?>
 
-			<div class='zbs-crm-contact' style="margin-bottom:20px;">
-				<?php 
+		<div class="zbs-crm-contact" style="margin-bottom:20px;">
+			<?php
 
-					// the customer information pane
-					$email = $order->get_billing_email();
-					if ( $email != '' ){
+			// the customer information pane
+			$email = $order->get_billing_email();
+			if ( ! empty( $email ) ) {
 
-						// retrieve contact id
-						$contact_id = zeroBS_getCustomerIDWithEmail( $email );
-						
-						if ( $contact_id > 0 ){
+				// retrieve contact id
+				$contact_id = zeroBS_getCustomerIDWithEmail( $email );
 
-							// retrieve contact
-							$crm_contact = $zbs->DAL->contacts->getContact( $contact_id );
-							$contact_name = $zbs->DAL->contacts->getContactFullNameEtc( $contact_id, $crm_contact, array( false, false ) );
-							$contact_transaction_count = $zbs->DAL->specific_obj_type_count_for_assignee( $contact_id, ZBS_TYPE_TRANSACTION, ZBS_TYPE_CONTACT ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				if ( $contact_id > 0 ) {
 
-							// check avatar mode
-							$avatar = '';
-							$avatar_mode = zeroBSCRM_getSetting('avatarmode'); 
-             				if ( $avatar_mode !== 3 ) {
-             					$avatar = zeroBS_customerAvatarHTML( $contact_id, $crm_contact, 100, 'ui small image centered' );
-             				}
+					// retrieve contact
+					$crm_contact               = $zbs->DAL->contacts->getContact( $contact_id );
+					$contact_name              = $zbs->DAL->contacts->getContactFullNameEtc( $contact_id, $crm_contact, array( false, false ) );
+					$contact_transaction_count = $zbs->DAL->specific_obj_type_count_for_assignee( $contact_id, ZBS_TYPE_TRANSACTION, ZBS_TYPE_CONTACT ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-							// Render HTML
-							echo "<div class='customer-panel-header'>";
-								echo "<div id='panel-customer-avatar'>" . $avatar . "</div>";
-								echo "<div id='panel-name'><span class='jpcrm-name'>" . esc_html( $contact_name ) . "</span></div>";
-								echo "<div id='panel-status' class='ui label status " . esc_attr( strtolower( $crm_contact['status'] ) ) . "'>" . esc_html( $crm_contact['status'] ) . "</div>";
-								echo "<div class='simple-actions zbs-hide'>";
-									echo "<a class='ui label circular'><i class='ui icon phone'></i></a>";
-									echo "<a class='ui label circular'><i class='ui icon envelope'></i></a>";
-								echo "</div>";
-							echo "</div>";
+					// check avatar mode
+					$avatar      = '';
+					$avatar_mode = zeroBSCRM_getSetting( 'avatarmode' );
+					if ( $avatar_mode !== 3 ) {
+						$avatar = zeroBS_customerAvatarHTML( $contact_id, $crm_contact, 100, 'ui small image centered' );
+					}
 
-							echo "<div class='ui divider'></div>";
+					// Render HTML
+					?>
+					<div class="customer-panel-header">
+						<div id="panel-customer-avatar">
+							<?php
+							echo $avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							?>
+						</div>
+						<div id="panel-name"><span class="jpcrm-name"><?php echo esc_html( $contact_name ); ?></span></div>
+						<div id="panel-status" class="ui label status <?php echo esc_attr( strtolower( $crm_contact['status'] ) ); ?>">
+							<?php echo esc_html( $crm_contact['status'] ); ?>
+						</div>
+						<div class="simple-actions zbs-hide">
+							<a class="ui label circular"><i class="ui icon phone"></i></a>
+							<a class="ui label circular"><i class="ui icon envelope"></i></a>
+						</div>
+					</div>
 
-							echo "<div class='total-paid-wrap'>";
-									echo "<div class='total-paid cell'><div class='heading'> " . esc_html( zeroBSCRM_prettifyLongInts( $contact_transaction_count) . ' ' . ( $contact_transaction_count > 1 ? __( 'Transactions', 'zero-bs-crm' ) : __( 'Transaction', 'zero-bs-crm' ) ) ) . "</div></div>";
-							echo "</div>";
+					<div class="ui divider"></div>
 
-							echo "<div class='clear'></div>";
-							echo "<div class='ui divider'></div>";
+					<div class="total-paid-wrap">
+						<div class="total-paid cell">
+							<div class="heading">
+								<?php
+								echo esc_html( zeroBSCRM_prettifyLongInts( $contact_transaction_count ) . ' ' . ( $contact_transaction_count > 1 ? __( 'Transactions', 'zero-bs-crm' ) : __( 'Transaction', 'zero-bs-crm' ) ) );
+								?>
+							</div>
+						</div>
+					</div>
 
-							echo "<div class='panel-left-info cust-email'>";
-								echo "<i class='ui icon envelope outline'></i> <span class='panel-customer-email'>" . esc_html( $email ) . "</span>";
-							echo "</div>";
+					<div class="clear"></div>
+					<div class="ui divider"></div>
 
-							echo "<div class='panel-edit-contact'>";
-								echo "<a class='edit-contact-link button button-primary' href='" . jpcrm_esc_link( 'view', $contact_id, 'zerobs_customer' ) . "'>" . esc_html__( 'View Contact', 'zero-bs-crm' ) . "</a>";
-							echo "</div>";
+					<div class="panel-left-info cust-email">
+						<i class="ui icon envelope outline"></i> <span class="panel-customer-email"><?php echo esc_html( $email ); ?></span>
+					</div>
 
-							echo "<div class='clear'></div>";
-						}
+					<div class="panel-edit-contact">
+						<a class="edit-contact-link button button-primary" href="<?php echo esc_url( jpcrm_esc_link( 'view', $contact_id, 'zerobs_customer' ) ); ?>"><?php echo esc_html__( 'View Contact', 'zero-bs-crm' ); ?></a>
+					</div>
 
-					} else {
-
-						echo "<div class='no-crm-contact'><p style='margin-top:20px;'>";
-							esc_html_e( "Once you save your order to a customer with a billing email the CRM contact card will display here.", 'zero-bs-crm' );
-						echo "</p></div>";
-
-					} ?>
-			</div>
+					<div class="clear"></div>
+					<?php
+				}
+			} else {
+				?>
+				<div class="no-crm-contact">
+					<p style="margin-top:20px;">
+					<?php esc_html_e( 'Once you save your order to a customer with a billing email, the CRM contact card will display here.', 'zero-bs-crm' ); ?>
+					</p>
+				</div>
+				<?php
+			}
+			?>
+		</div>
 		<?php
-		
+		 // phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	}
 
 	/**

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -463,6 +463,20 @@ class Woo_Sync {
 
 	}
 
+	/**
+	 * Check if HPOS is enabled.
+	 *
+	 * @return bool Defaults to false.
+	 */
+	public function is_hpos_enabled() {
+		global $zbs;
+
+		if ( $zbs->woocommerce_is_active() ) {
+			return \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+		}
+		return false;
+	}
+
 
 	/**
 	 * Include filter buttons

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -921,7 +921,9 @@ class Woo_Sync {
 
 	/**
 	 * Append WooCommerce products to CRM product index (used on invoice editor)
-	 *  Applied via filter `zbs_invpro_productindex`
+	 * Applied via filter `zbs_invpro_productindex`
+	 *
+	 * This is not HPOS-friendly and will need a rework prior to enabling.
 	 *
 	 * @param array $crm_product_index
 	 */

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -469,9 +469,7 @@ class Woo_Sync {
 	 * @return bool Defaults to false.
 	 */
 	public function is_hpos_enabled() {
-		global $zbs;
-
-		if ( $zbs->woocommerce_is_active() ) {
+		if ( class_exists('Automattic\WooCommerce\Utilities\OrderUtil') ) {
 			return \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
 		}
 		return false;

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -464,19 +464,6 @@ class Woo_Sync {
 	}
 
 	/**
-	 * Check if HPOS is enabled.
-	 *
-	 * @return bool Defaults to false.
-	 */
-	public function is_hpos_enabled() {
-		if ( class_exists('Automattic\WooCommerce\Utilities\OrderUtil') ) {
-			return \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
-		}
-		return false;
-	}
-
-
-	/**
 	 * Include filter buttons
 	 * (Note, requires `contact_query_quickfilter_addition()` to be hooked into `jpcrm_contact_query_quickfilter`)
 	 */

--- a/projects/plugins/crm/modules/woo-sync/jpcrm-woo-sync-init.php
+++ b/projects/plugins/crm/modules/woo-sync/jpcrm-woo-sync-init.php
@@ -290,6 +290,17 @@ function jpcrm_add_woo_jobs_to_system_assistant( $job_list ) {
 }
 add_filter( 'jpcrm_system_assistant_jobs', 'jpcrm_add_woo_jobs_to_system_assistant' );
 
+/**
+ * Check if HPOS is enabled.
+ *
+ * @return bool Defaults to false.
+ */
+function jpcrm_woosync_is_hpos_enabled() {
+	if ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) ) {
+		return \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+	}
+	return false;
+}
 
 // Extension legacy definitions
 if ( ! defined( 'JPCRM_WOO_SYNC_ROOT_FILE' ) ) {

--- a/projects/plugins/crm/modules/woo-sync/jpcrm-woo-sync-init.php
+++ b/projects/plugins/crm/modules/woo-sync/jpcrm-woo-sync-init.php
@@ -293,6 +293,11 @@ add_filter( 'jpcrm_system_assistant_jobs', 'jpcrm_add_woo_jobs_to_system_assista
 /**
  * Check if HPOS is enabled.
  *
+ * The feature was enabled in WooCommerce 7.1.
+ *
+ * For new stores created on or after 10 October 2023, this is enabled by default.
+ * https://woo.com/posts/platform-update-high-performance-order-storage-for-woocommerce/
+ *
  * @return bool Defaults to false.
  */
 function jpcrm_woosync_is_hpos_enabled() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves #35359 and Automattic/zero-bs-crm#3430 - add HPOS support to WooSync

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR:

* Introduces `jpcrm_woosync_is_hpos_enabled()` to check for Woo HPOS. Originally I did it within the WooSync module class, but there are instances where we need it when the class isn't loaded.
* If HPOS, uses `woocommerce_shop_order_list_table_columns` filter instead of `manage_edit-shop_order_columns`.
* If HPOS, uses `woocommerce_shop_order_list_table_custom_column` action instead of `manage_shop_order_posts_custom_column`.
* If HPOS, uses `woocommerce_before_trash_order` action instead of `wp_trash_post`.
* If HPOS, uses `woocommerce_before_delete_order` action instead of `before_delete_post`.
* Updates the three callback functions to account for different param types depending on if HPOS or not.
* Adds a comment to `append_woo_products_to_crm_product_index`, which is not enabled but has non-HPOS calls.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Test on JPCRM + Woo (non-HPOS) as well as JPCRM + Woo (HPOS) to ensure no regressions. HPOS is enabled on all new empty Woo sites; one can disable it per these instructions:

https://woo.com/document/high-performance-order-storage/#section-7

1. Enable WooSync invoice creation: `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=woosync`
2. Create a Woo product: `/wp-admin/post-new.php?post_type=product`
3. Create a Woo order with a billing name and email: `/wp-admin/admin.php?page=wc-orders&action=new`
4. Visit the Woo order listview: `/wp-admin/edit.php?post_type=shop_order`
5. Visit the individual Woo order.

In `trunk`, the order listview will only show the CRM contact button on the non-HPOS site, and the order page will only show the contact metabox on the non-HPOS site.

In the `fix/crm/35359-order_metabox_missing_on_HPOS` branch, the contact button and metabox show on the HPOS site as well.

![image](https://github.com/Automattic/jetpack/assets/32492176/cd896812-f973-44e6-928d-06fd86ece7c8)
![image](https://github.com/Automattic/jetpack/assets/32492176/a7d4fc01-447c-443c-a863-bd3b432d5264)
