### PR TITLE
Update: is bot list for User Agent Info class

### DIFF
--- a/projects/packages/device-detection/changelog/update-is-bot-list
+++ b/projects/packages/device-detection/changelog/update-is-bot-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update the bot list with more bots

--- a/projects/packages/device-detection/composer.json
+++ b/projects/packages/device-detection/composer.json
@@ -44,7 +44,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.0.x-dev"
+			"dev-trunk": "2.1.x-dev"
 		}
 	}
 }

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -1564,6 +1564,20 @@ class User_Agent_Info {
 			'cloudflare-alwaysonline',
 			'cookieinformationscanner', // p1699315886066389-slack-C0438NHCLSY
 			'facebookexternalhit', // https://www.facebook.com/externalhit_uatext.php
+			'feedburner',
+			'yacybot', // http://yacy.net/bot.html
+			'trendictionbot',  // http://www.trendiction.de/bot;
+			'elisabot',
+			'linkfluence', // http://linkfluence.com/
+			'semrushbot', // https://www.semrush.com/bot/
+			'archive.org_bot', // http://archive.org/details/archive.org_bot
+			'ezlynxbot', // https://www.ezoic.com/bot
+			'siteauditbot', // https://www.semrush.com/bot/
+			'snapchat', // https://developers.snap.com/robots
+			'applebot', // https://support.apple.com/en-ca/HT204683
+			'bne.es_bot', // https://www.bne.es/es/colecciones/archivo-web-espanola/aviso-webmasters
+			'google-safety;', // https://www.google.com/bot.html
+			'mojeekbot', // https://www.mojeek.com/bot.html
 		);
 
 		foreach ( $bot_agents as $bot_agent ) {

--- a/projects/plugins/backup/changelog/update-is-bot-list
+++ b/projects/plugins/backup/changelog/update-is-bot-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -760,7 +760,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "8f53628f970ba5bc8912232a574aa439e7236311"
+                "reference": "a6696f57f2f6f29f4a6930727ae5063c4e89fab4"
             },
             "require": {
                 "php": ">=7.0"
@@ -780,7 +780,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/update-is-bot-list
+++ b/projects/plugins/boost/changelog/update-is-bot-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -616,7 +616,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "8f53628f970ba5bc8912232a574aa439e7236311"
+                "reference": "a6696f57f2f6f29f4a6930727ae5063c4e89fab4"
             },
             "require": {
                 "php": ">=7.0"
@@ -636,7 +636,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-is-bot-list
+++ b/projects/plugins/jetpack/changelog/update-is-bot-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1001,7 +1001,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/device-detection",
-				"reference": "8f53628f970ba5bc8912232a574aa439e7236311"
+				"reference": "a6696f57f2f6f29f4a6930727ae5063c4e89fab4"
 			},
 			"require": {
 				"php": ">=7.0"
@@ -1021,7 +1021,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.0.x-dev"
+					"dev-trunk": "2.1.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/migration/changelog/update-is-bot-list
+++ b/projects/plugins/migration/changelog/update-is-bot-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -760,7 +760,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "8f53628f970ba5bc8912232a574aa439e7236311"
+                "reference": "a6696f57f2f6f29f4a6930727ae5063c4e89fab4"
             },
             "require": {
                 "php": ">=7.0"
@@ -780,7 +780,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/update-is-bot-list
+++ b/projects/plugins/protect/changelog/update-is-bot-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -673,7 +673,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "8f53628f970ba5bc8912232a574aa439e7236311"
+                "reference": "a6696f57f2f6f29f4a6930727ae5063c4e89fab4"
             },
             "require": {
                 "php": ">=7.0"
@@ -693,7 +693,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/update-is-bot-list
+++ b/projects/plugins/search/changelog/update-is-bot-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -616,7 +616,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "8f53628f970ba5bc8912232a574aa439e7236311"
+                "reference": "a6696f57f2f6f29f4a6930727ae5063c4e89fab4"
             },
             "require": {
                 "php": ">=7.0"
@@ -636,7 +636,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/update-is-bot-list
+++ b/projects/plugins/social/changelog/update-is-bot-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -616,7 +616,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/device-detection",
-				"reference": "8f53628f970ba5bc8912232a574aa439e7236311"
+				"reference": "a6696f57f2f6f29f4a6930727ae5063c4e89fab4"
 			},
 			"require": {
 				"php": ">=7.0"
@@ -636,7 +636,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.0.x-dev"
+					"dev-trunk": "2.1.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/starter-plugin/changelog/update-is-bot-list
+++ b/projects/plugins/starter-plugin/changelog/update-is-bot-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -616,7 +616,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "8f53628f970ba5bc8912232a574aa439e7236311"
+                "reference": "a6696f57f2f6f29f4a6930727ae5063c4e89fab4"
             },
             "require": {
                 "php": ">=7.0"
@@ -636,7 +636,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/super-cache/changelog/update-is-bot-list
+++ b/projects/plugins/super-cache/changelog/update-is-bot-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/super-cache/composer.lock
+++ b/projects/plugins/super-cache/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "8f53628f970ba5bc8912232a574aa439e7236311"
+                "reference": "a6696f57f2f6f29f4a6930727ae5063c4e89fab4"
             },
             "require": {
                 "php": ">=7.0"
@@ -32,7 +32,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/update-is-bot-list
+++ b/projects/plugins/videopress/changelog/update-is-bot-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -616,7 +616,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "8f53628f970ba5bc8912232a574aa439e7236311"
+                "reference": "a6696f57f2f6f29f4a6930727ae5063c4e89fab4"
             },
             "require": {
                 "php": ">=7.0"
@@ -636,7 +636,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
This PR add a new set of bots that were found while looking at the user agents of `wpcom_get_jetpack_app_autoredirect` track event. 

## Proposed changes:
* This PR adds a bunch of new strings to look for when searching the user agents string for bots. 
* See pejTkB-1bC-p2

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*