### PR TITLE
Integrate categories with TreeSelector on newsletter settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
@@ -56,15 +56,11 @@ export function withModuleSettingsFormHelpers( InnerComponent ) {
 		};
 
 		updateFormStateAndSaveOptionValue = ( optionMaybeOptions, optionValue = undefined ) => {
-			this.props.updateOptions( this.state.options ).then( () => {
-				if ( 'string' === typeof optionMaybeOptions ) {
-					optionMaybeOptions = { [ optionMaybeOptions ]: optionValue };
-				}
-				const newOptions = {
-					...this.state.options,
-					...optionMaybeOptions,
-				};
-				this.setState( { options: newOptions } );
+			if ( 'string' === typeof optionMaybeOptions ) {
+				optionMaybeOptions = { [ optionMaybeOptions ]: optionValue };
+			}
+			this.props.updateOptions( { ...this.state.options, ...optionMaybeOptions } ).then( () => {
+				this.setState( { options: { ...this.state.options, ...optionMaybeOptions } } );
 			} );
 		};
 

--- a/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
@@ -55,6 +55,19 @@ export function withModuleSettingsFormHelpers( InnerComponent ) {
 			return true;
 		};
 
+		updateFormStateAndSaveOptionValue = ( optionMaybeOptions, optionValue = undefined ) => {
+			this.props.updateOptions( this.state.options ).then( () => {
+				if ( 'string' === typeof optionMaybeOptions ) {
+					optionMaybeOptions = { [ optionMaybeOptions ]: optionValue };
+				}
+				const newOptions = {
+					...this.state.options,
+					...optionMaybeOptions,
+				};
+				this.setState( { options: newOptions } );
+			} );
+		};
+
 		/**
 		 * Receives an option and the module it depends on.
 		 * If the module is active, only the option is added to the list of form values to send.
@@ -199,6 +212,7 @@ export function withModuleSettingsFormHelpers( InnerComponent ) {
 					onSubmit={ this.onSubmit }
 					onOptionChange={ this.onOptionChange }
 					updateFormStateOptionValue={ this.updateFormStateOptionValue }
+					updateFormStateAndSaveOptionValue={ this.updateFormStateAndSaveOptionValue }
 					toggleModuleNow={ this.toggleModuleNow }
 					updateFormStateModuleOption={ this.updateFormStateModuleOption }
 					shouldSaveButtonBeDisabled={ this.shouldSaveButtonBeDisabled }

--- a/projects/plugins/jetpack/_inc/client/components/tree-selector/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-selector/index.jsx
@@ -3,7 +3,7 @@ import './style.scss';
 import { createFlatTreeItems } from './utils';
 
 const TreeSelector = props => {
-	const { items, onChange, selectedItems, keyword = '' } = props;
+	const { items, onChange, selectedItems, disabled, keyword = '' } = props;
 
 	const flatTreeItems = createFlatTreeItems( items );
 
@@ -30,6 +30,7 @@ const TreeSelector = props => {
 				name="jp-tree-item"
 				checked={ selectedItems.includes( item.id ) }
 				onChange={ toggleCheckbox( item.id ) }
+				disabled={ disabled }
 			/>
 			<label htmlFor={ `jp-tree-item-${ item.id }` }>
 				{ item.name }

--- a/projects/plugins/jetpack/_inc/client/components/tree-selector/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tree-selector/style.scss
@@ -8,4 +8,7 @@ li.jp-tree-item {
     small {
         color: var( --jp-gray-40 );
     }
+    input:disabled+label {
+        color: var( --jp-gray-20 );
+      }
 }

--- a/projects/plugins/jetpack/_inc/client/components/tree-selector/utils.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-selector/utils.jsx
@@ -1,22 +1,22 @@
 /**
  * Adds depth and parentNames property to an array of tree items.
  *
- * @param {Array} items - Array of objects containing at least ID, parent, and name.
+ * @param {Array} items - Array of objects containing at least id, parent, and name.
  * @returns {Array} flatList - Array of objects including a depth property and an array of parent names.
  */
 function createFlatTreeItems( items ) {
 	const map = {};
 	const flatList = [];
 
-	// First pass: create a map of all items by their ID
+	// First pass: create a map of all items by their id
 	items.forEach( item => {
-		map[ item.ID ] = { ...item, children: [] };
+		map[ item.id ] = { ...item, children: [] };
 	} );
 
 	// Second pass: populate children for each item
 	items.forEach( item => {
 		if ( item.parent !== 0 && map[ item.parent ] ) {
-			map[ item.parent ].children.push( item.ID );
+			map[ item.parent ].children.push( item.id );
 		}
 	} );
 
@@ -32,7 +32,7 @@ function createFlatTreeItems( items ) {
 	};
 
 	// Initialize processing for root items (those without parents or parent === 0)
-	items.filter( item => item.parent === 0 ).forEach( item => processItem( item.ID, 0, [] ) );
+	items.filter( item => item.parent === 0 ).forEach( item => processItem( item.id, 0, [] ) );
 
 	// Remove children property as it's not required in the output
 	return flatList.map( ( { children, ...item } ) => item );

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -2,7 +2,7 @@ import { ToggleControl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { connect } from 'react-redux';
 import {
 	isUnavailableInOfflineMode,
@@ -11,8 +11,7 @@ import {
 } from 'state/connection';
 import { getModule } from 'state/modules';
 import { withModuleSettingsFormHelpers } from '../components/module-settings/with-module-settings-form-helpers';
-import TextInput from '../components/text-input';
-import Textarea from '../components/textarea';
+import TreeSelector from '../components/tree-selector';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
 const mapCategoriesIds = category => {
@@ -37,31 +36,43 @@ function NewsletterCategories( props ) {
 		updateFormStateModuleOption,
 		isNewsletterCategoriesEnabled,
 		newsletterCategories,
-		updateFormStateOptionValue,
 		categories,
 		isUnavailableDueOfflineMode,
 		isUnavailableDueSiteConnectionMode,
 		subscriptionsModule,
+		updateFormStateAndSaveOptionValue,
 	} = props;
-
-	const [ newCategories, setNewCategories ] = useState( '' );
 
 	const handleEnableNewsletterCategoriesToggleChange = useCallback( () => {
 		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, 'wpcom_newsletter_categories_enabled' );
 	}, [ updateFormStateModuleOption ] );
 
-	const categoriesValue = JSON.stringify( newsletterCategories.map( mapCategoriesIds ) );
-	const parseArray = useCallback( () => {
-		try {
-			updateFormStateOptionValue( 'wpcom_newsletter_categories', JSON.parse( newCategories ) );
-		} catch ( error ) {
-			alert( 'Invalid JSON' );
-		}
-	}, [ newCategories, updateFormStateOptionValue ] );
+	const checkedCategoriesIds = newsletterCategories.map( mapCategoriesIds );
 
-	const onCategoriesChange = useCallback( e => {
-		setNewCategories( e.target.value );
-	}, [] );
+	const mappedCategories = useMemo(
+		() =>
+			categories.map( category => ( {
+				...category,
+				name: category.cat_name,
+				id: category.term_id,
+			} ) ),
+		[ categories ]
+	);
+
+	const onSelectedCategoryChange = useCallback(
+		( id, checkedValue ) => {
+			let newCheckedCategoriesIds;
+			if ( checkedValue ) {
+				if ( ! checkedCategoriesIds.includes( id ) ) {
+					newCheckedCategoriesIds = [ ...checkedCategoriesIds, id ].sort( ( a, b ) => a - b );
+				}
+			} else {
+				newCheckedCategoriesIds = checkedCategoriesIds.filter( category => category !== id );
+			}
+			updateFormStateAndSaveOptionValue( 'wpcom_newsletter_categories', newCheckedCategoriesIds );
+		},
+		[ checkedCategoriesIds, updateFormStateAndSaveOptionValue ]
+	);
 
 	return (
 		<SettingsCard
@@ -72,23 +83,28 @@ function NewsletterCategories( props ) {
 		>
 			<SettingsGroup
 				hasChild
-				disableInOfflineMode={ requiresConnection }
-				disableInSiteConnectionMode={ requiresConnection }
+				disableInOfflineMode
+				disableInSiteConnectionMode
 				module={ subscriptionsModule }
 			>
+				<p>
+					{ __(
+						'Newsletter categories allow visitors to subscribe only to specific topics. When enabled, only posts published under the categories selected below will be emailed to your subscribers.',
+						'jetpack'
+					) }
+				</p>
 				<ToggleControl
 					disabled={ isUnavailableDueOfflineMode || isUnavailableDueSiteConnectionMode }
 					checked={ isNewsletterCategoriesEnabled }
 					onChange={ handleEnableNewsletterCategoriesToggleChange }
 					label={ __( 'Enable newsletter categories', 'jetpack' ) }
 				/>
-				All categories:
-				<Textarea disabled value={ JSON.stringify( categories ) } />
-				Checked categories (by ID):
-				<TextInput value={ categoriesValue } disabled />
-				New Checked categories value:
-				<TextInput value={ newCategories } onChange={ onCategoriesChange } />
-				<button onClick={ parseArray }>Parse array to state</button>
+				<TreeSelector
+					items={ mappedCategories }
+					selectedItems={ checkedCategoriesIds }
+					onChange={ onSelectedCategoryChange }
+				/>
+				<p>{ __( 'Add New Category', 'jetpack' ) }</p>
 			</SettingsGroup>
 		</SettingsCard>
 	);

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -41,6 +41,7 @@ function NewsletterCategories( props ) {
 		isUnavailableDueSiteConnectionMode,
 		subscriptionsModule,
 		updateFormStateAndSaveOptionValue,
+		isSavingAnyOption,
 	} = props;
 
 	const handleEnableNewsletterCategoriesToggleChange = useCallback( () => {
@@ -103,6 +104,7 @@ function NewsletterCategories( props ) {
 					items={ mappedCategories }
 					selectedItems={ checkedCategoriesIds }
 					onChange={ onSelectedCategoryChange }
+					disabled={ isSavingAnyOption( [ 'wpcom_newsletter_categories' ] ) }
 				/>
 				<p>{ __( 'Add New Category', 'jetpack' ) }</p>
 			</SettingsGroup>

--- a/projects/plugins/jetpack/changelog/update-integrate-categories-tree
+++ b/projects/plugins/jetpack/changelog/update-integrate-categories-tree
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Interation on newsletter categories. Work in progress under feature flag.

--- a/projects/plugins/jetpack/changelog/update-integrate-categories-tree
+++ b/projects/plugins/jetpack/changelog/update-integrate-categories-tree
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Interation on newsletter categories. Work in progress under feature flag.
+Interaction on newsletter categories. Work in progress under feature flag.


### PR DESCRIPTION
![image](https://github.com/Automattic/jetpack/assets/33497086/1fa90c3f-0313-402c-ab84-2bb2dedab3c3)

This PR integrates the `<TreeSelector>` component with the newsletter categories setting.
This also refactors the `<TreeSelector>` allowing the checked items to be controlled on the parent level.

The copies for `Newsletter categories allow visitors to subscribe only to specific topics. When enabled, only posts published under the categories selected below will be emailed to your subscribers.` and `Add New Category` were added to trigger the translation process.

It is ok if items do not match the design since we are interacting on it and it is under a feature flag.

![Screen Recording 2024-02-20 at 16 46 04](https://github.com/Automattic/jetpack/assets/33497086/88929e16-8918-478f-8e46-89e29811adcd)

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
To enable the feature flag navigate with **enable-newsletter-categories** query param:
`wp-admin/admin.php?enable-newsletter-categories=true&page=jetpack#/newsletter`

- Check or uncheck a few categories.
- The update settings message should appear everytime you check/uncheck.
- Check that your changes persist after refreshing the page.

