### PR TITLE
ESlint: disable redundant role rule

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
@@ -28,7 +28,6 @@ const ConnectionScreenFooter = () => {
 				Since the list style type is set to none, `role=list` is required for VoiceOver (on Safari) to announce the list.
 				See: https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
 			*/ }
-			{ /* eslint-disable-next-line jsx-a11y/no-redundant-roles */ }
 			<ul className={ styles[ 'account-images' ] } role="list">
 				<li>
 					<img src={ wordpressLogo } className={ styles.wordpress } alt="WordPress.com" />
@@ -76,7 +75,6 @@ const ConnectionScreen = () => {
 						Since the list style type is set to none, `role=list` is required for VoiceOver (on Safari) to announce the list.
 						See: https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
 						*/ }
-						{ /* eslint-disable-next-line jsx-a11y/no-redundant-roles */ }
 						<ul role="list">
 							<li>{ __( 'Receive instant downtime alerts', 'jetpack-my-jetpack' ) }</li>
 							<li>

--- a/projects/packages/my-jetpack/changelog/update-eslint-disable-redundant-role
+++ b/projects/packages/my-jetpack/changelog/update-eslint-disable-redundant-role
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+ESlint: disabled redundant role rule

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -454,7 +454,6 @@ class Main extends React.Component {
 					Since the list style type is set to none, `role=list` is required for VoiceOver (on Safari) to announce the list.
 					See: https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
 					*/ }
-					{ /* eslint-disable-next-line jsx-a11y/no-redundant-roles */ }
 					<ul role="list">
 						<li>{ __( 'Receive instant downtime alerts', 'jetpack' ) }</li>
 						<li>{ __( 'Automatically share your content on social media', 'jetpack' ) }</li>
@@ -524,7 +523,6 @@ class Main extends React.Component {
 					Since the list style type is set to none, `role=list` is required for VoiceOver (on Safari) to announce the list.
 					See: https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
 					*/ }
-					{ /* eslint-disable-next-line jsx-a11y/no-redundant-roles */ }
 					<ul role="list">
 						<li>{ __( 'Measure your impact with Jetpack Stats', 'jetpack' ) }</li>
 						<li>{ __( 'Speed up your site with optimized images', 'jetpack' ) }</li>

--- a/projects/plugins/jetpack/changelog/update-eslint-disable-redundant-role
+++ b/projects/plugins/jetpack/changelog/update-eslint-disable-redundant-role
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+ESlint: disable redundant role rule

--- a/tools/js-tools/eslintrc/base.js
+++ b/tools/js-tools/eslintrc/base.js
@@ -150,6 +150,9 @@ module.exports = {
 				},
 			},
 		],
+		// Redundant roles are sometimes necessary for screen reader support. For instance, VoiceOver
+		// on Safari requires `role=list` to announce the list if the style is overwritten.
+		'jsx-a11y/no-redundant-roles': 0,
 		// Disabled rules for now. Ideally we should resolve all the errors these rules create.
 		'wpcalypso/redux-no-bound-selectors': 0,
 		'jsx-a11y/anchor-has-content': 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Disable the ESlint [jsx-a11y/no-redundant-roles](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/0d5321a5457c5f0da0ca216053cc5b4f571b53ae/docs/rules/no-redundant-roles.md) rule. Practically, the redundant `role=list` is often required on lists so that VoiceOver on Safari announces them as lists (read [this article](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html) for more detail).


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

n/a

