### PR TITLE
CRM: 3431 - PHP fatal on empty Woo fees

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3431-PHP_fatal_on_empty_fees
+++ b/projects/plugins/crm/changelog/fix-crm-3431-PHP_fatal_on_empty_fees
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WooSync: Catch PHP error if order has empty fee value.

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1217,8 +1217,16 @@ class Woo_Sync_Background_Sync_Job {
 			// Force Woo order totals recalculation to ensure taxes were applied correctly
 			// Only force recalculation if the order is not paid yet
 			if ( $order->get_status() === 'pending' || $order->get_status() === 'on-hold' ) {
-				$order->calculate_totals();
-				$order->save();
+				try {
+					$order->calculate_totals();
+					$order->save();
+				} catch ( \TypeError $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+
+					/*
+					This is a Woo bug with empty fees: https://github.com/woocommerce/woocommerce/issues/44859
+					For now we'll just ignore it and carry on.
+					*/
+				}
 			}
 
 			$order_data = $order->get_data();

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -101,7 +101,7 @@ class Woo_Sync_Background_Sync_Job {
 
 		// good to go?
 		if ( empty( $this->site_key ) || !is_array( $this->site_info ) ){
-			
+
 			return false;
 
 		}
@@ -119,7 +119,6 @@ class Woo_Sync_Background_Sync_Job {
 
 	}
 
-
 	/**
 	 * Returns full settings array from main settings class
 	 */
@@ -128,8 +127,6 @@ class Woo_Sync_Background_Sync_Job {
 		return $this->woosync()->settings->getAll();
 
 	}
-
-
 
 	/**
 	 * Returns 'local' or 'api'
@@ -153,7 +150,6 @@ class Woo_Sync_Background_Sync_Job {
 
 	}
 
-	
 	/**
 	 * If $this->debug is true, outputs passed string
 	 *
@@ -168,7 +164,6 @@ class Woo_Sync_Background_Sync_Job {
 		}
 
 	}
-
 
 	/**
 	 * Main job function: this will retrieve and import orders from WooCommerce into CRM. 
@@ -501,7 +496,7 @@ class Woo_Sync_Background_Sync_Job {
 
 				// if Domain
 				if ( $domain ) {
-					
+
 					$origin = $zbs->DAL->add_origin_prefix( $domain, 'domain' );
 
 				}
@@ -673,7 +668,6 @@ class Woo_Sync_Background_Sync_Job {
 
 	}
 
-
 	/**
 	 * Add or Update an order from WooCommerce
 	 *  (previously `add_order_from_id`)
@@ -737,7 +731,6 @@ class Woo_Sync_Background_Sync_Job {
 
 	}
 
-
 	/**
 	 * Set's a completion status for woo order imports
 	 *
@@ -761,7 +754,6 @@ class Woo_Sync_Background_Sync_Job {
 		return $status_bool;
 
 	}
-
 
 	/**
 	 * Returns a completion status for woo order imports
@@ -799,7 +791,6 @@ class Woo_Sync_Background_Sync_Job {
 
 	}
 
-
 	/**
 	 * Return current working page index (to resume from)
 	 *
@@ -811,16 +802,15 @@ class Woo_Sync_Background_Sync_Job {
 
 	}
 
-
 	/**
 	 * Adds or updates crm objects related to a processed woocommerce order
 	 *  (requires that the $order_data has been passed through `woocommerce_order_to_crm_objects`)
 	 *  Previously `import_woocommerce_order_from_order_data`
 	 *
 	 * @param array $crm_object_data (Woo Order data passed through `woocommerce_order_to_crm_objects`)
-	 * 
+	 *
 	 * @return int $transaction_id
-	 * 
+	 *
 	 */
 	public function import_crm_object_data( $crm_object_data ) {
 
@@ -1096,7 +1086,6 @@ class Woo_Sync_Background_Sync_Job {
 		return $transaction_id;
 
 	}
-
 
 	/**
 	 * Translates a local store order into an import-ready crm objects array
@@ -1476,7 +1465,7 @@ class Woo_Sync_Background_Sync_Job {
 
 			}
 
-			// Retrieve any WooCommerce Checkout metaa data & try to store it against contact if match custom fields
+			// Retrieve any WooCommerce Checkout metadata & try to store it against contact if match custom fields
 			// Returns array of WC_Meta_Data objects https://woocommerce.github.io/code-reference/classes/WC-Meta-Data.html
 			// Filters to support WooCommerce Checkout Field Editor, Field editor Pro etc.
 			/*
@@ -1969,7 +1958,6 @@ class Woo_Sync_Background_Sync_Job {
 		return apply_filters( 'jpcrm_woo_sync_order_data', $data );
 	}
 
-
 	/**
 	 * Translates an API order into an import-ready crm objects array
 	 *  previously `tidy_order_from_api`
@@ -2095,8 +2083,6 @@ class Woo_Sync_Background_Sync_Job {
 		);
 
 	}
-
-
 
 	/**
 	 * Attempts to return the percentage completed of a sync
@@ -2233,7 +2219,6 @@ class Woo_Sync_Background_Sync_Job {
 
 	}
 
-
 	/**
 	 * Filter contact data passed through the woo checkout
 	 * .. allows us to hook in support for things like WooCommerce Checkout Field Editor
@@ -2269,7 +2254,6 @@ class Woo_Sync_Background_Sync_Job {
 	    return $contact_data;
 
 	}
-
 
 	/**
 	 * Filter to add Checkout Field Editor custom fields support, where installed
@@ -2346,7 +2330,6 @@ class Woo_Sync_Background_Sync_Job {
 
 	}
 
-	
 	/**
 	 * Filter to add Checkout Field Editor Pro (Checkout Manager) for WooCommerce support, where installed
 	 * https://wordpress.org/plugins/woo-checkout-field-editor-pro/
@@ -2519,7 +2502,6 @@ class Woo_Sync_Background_Sync_Job {
 	    return $contact_data;
 
 	}
-
 
 	/*
 	 * Catch site sync connection errors (and log count per site)

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1706,10 +1706,14 @@ class Woo_Sync_Background_Sync_Job {
 			if ( is_array( $fees ) && count( $fees ) > 0 ) {
 				foreach ( $fees as $fee ) {
 					if ( $fee instanceof \WC_Order_Item_Fee ) {
+
 						$value = $fee->get_amount( false );
+
+						// Woo allows a fee's value to be an empty string, so account for that to prevent a PHP fatal.
 						if ( empty( $value ) ) {
 							$value = 0;
 						}
+
 						$new_line_item = array(
 							'order'    => $order_post_id, // passed as parameter to this function
 							'currency' => $order_currency,

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1670,7 +1670,7 @@ class Woo_Sync_Background_Sync_Job {
 			        	}
 
 			        }
-			        			        
+
 			    }
 
 				// attributes not yet translatable but originally referenced: `variation_id|tax_class|subtotal_tax`
@@ -1706,13 +1706,17 @@ class Woo_Sync_Background_Sync_Job {
 			if ( is_array( $fees ) && count( $fees ) > 0 ) {
 				foreach ( $fees as $fee ) {
 					if ( $fee instanceof \WC_Order_Item_Fee ) {
+						$value = $fee->get_amount( false );
+						if ( empty( $value ) ) {
+							$value = 0;
+						}
 						$new_line_item = array(
 							'order'    => $order_post_id, // passed as parameter to this function
 							'currency' => $order_currency,
 							'quantity' => 1,
-							'price'    => $fee->get_amount( false ),
-							'fee'      => $fee->get_amount( false ),
-							'total'    => $fee->get_amount( false ),
+							'price'    => $value,
+							'fee'      => $value,
+							'total'    => $value,
 							'title'    => esc_html__( 'Fee', 'zero-bs-crm' ),
 							'desc'     => $fee->get_name(),
 							'tax'      => $fee->get_total_tax(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3431 - PHP fatal on empty Woo fees

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Originally I suspected this was related to HPOS, but it turned out to be unrelated. Basically WooCommerce allows one to save an empty string as a fee value, and while PHP generally casts when doing math operations, it doesn't cast an empty string.

This PR explicitly sets the value of an empty fee to `0`. I considered casting, but I prefer the explicit logic here.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure WooSync invoice creation is enabled.
2. Create an order with a fee.
3. Save the order.
4. Edit the fee and delete the fee value (don't put `0` as the value, but delete the value so the `0` placeholder shows).
5. Update the order.

In `trunk`, one gets a PHP fatal.

In the `fix/crm/3431-PHP_fatal_on_empty_fees` branch, the fee is handled gracefully.