### PR TITLE
Blog Privacy [jetpack-mu-wpcom]: Discourage AI bots when blog_public=0

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-mu-wpcom-ai-robots-txt-blocks-for-blog-public-0
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-mu-wpcom-ai-robots-txt-blocks-for-blog-public-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Ensure consistent robots.txt behavior between WP.com and WoA.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.13.0",
+	"version": "5.13.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.13.0';
+	const PACKAGE_VERSION = '5.13.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -25,13 +25,15 @@ namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Blog_Privacy;
 function robots_txt( string $output, $public ): string {
 	$public = (int) $public;
 
-	// If the site is completely private or already discouraging *all* bots, don't bother with the additional restrictions.
-	if ( -1 === $public || 0 === $public ) {
+	// If the site is completely private, don't bother with the additional restrictions.
+	if ( -1 === $public ) {
 		return $output;
 	}
 
+	// For blog_public=0, WP.com Disallows all user agents and Core does not (relying on <meta name="robots">).
+	// Always add Disallow blocks for blog_public=0 even on WP.com where it may be redundant.
 	// An option oddly named because of history.
-	if ( get_option( 'wpcom_data_sharing_opt_out' ) ) {
+	if ( 0 === $public || get_option( 'wpcom_data_sharing_opt_out' ) ) {
 		$ai_bots = array(
 			'Amazonbot',
 			'CCBot',

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
@@ -75,13 +75,13 @@ AI_BLOCKS;
 		yield 'discourage search, no discourage AI' => array(
 			'blog_public'                => '0',
 			'wpcom_data_sharing_opt_out' => null,
-			'expected'                   => 'TEST',
+			'expected'                   => "TEST\n$ai_blocks",
 		);
 
 		yield 'discourage search, discourage AI' => array(
 			'blog_public'                => '0',
 			'wpcom_data_sharing_opt_out' => '1',
-			'expected'                   => 'TEST', // We already discourage all user agents.
+			'expected'                   => "TEST\n$ai_blocks",
 		);
 
 		yield 'private, no discourage AI' => array(


### PR DESCRIPTION
Always add these Disallow blocks when blog_public=0 even if it may be redundant for WP.com.

## Proposed changes:
WP.com and Core differ in robots.txt behavior when blog_public=0.
* WP.com: Disallows all user agents in robots.txt
* Core: Allows all user agents in robots.txt and disallows them in `<meta name="robots">` tag.

Ensure consistency between WP.com and WoA by always outputting Disallow blocks in robots.txt.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
On a WoA site:

0. Set the site's `blog_public` option to `0` (discourage search).
1. Set the site's `wpcom_data_sharing_opt_out` option to `1`.
2. View the site's robots.txt. See the Disallow blocks.
3. Set the site's `wpcom_data_sharing_opt_out` option to `''` (empty string)
4. View the site's robots.txt. Still see the Disallow blocks.

Repeat on a WP.com simple site.