### PR TITLE
Boost: Implement "Clear Cache" UI

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -50,14 +50,16 @@ const Meta = () => {
 	};
 
 	useEffect( () => {
-		if (
-			clearingCache &&
-			( runClearPageCacheAction.isSuccess || runClearPageCacheAction.isError )
-		) {
+		if ( clearingCache ) {
 			setClearingCache( false );
-			setSnackbarMessage( __( 'Cache Cleared.', 'jetpack-boost' ) );
 		}
-	}, [ clearingCache, runClearPageCacheAction ] );
+
+		if ( runClearPageCacheAction.isSuccess ) {
+			setSnackbarMessage( __( 'Cache Cleared.', 'jetpack-boost' ) );
+		} else if ( runClearPageCacheAction.isError ) {
+			setSnackbarMessage( __( 'Unable to clear cache.', 'jetpack-boost' ) );
+		}
+	}, [ clearingCache, runClearPageCacheAction.isSuccess, runClearPageCacheAction.isError ] );
 
 	const totalBypassPatterns = settings?.bypass_patterns.length || 0;
 

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -21,8 +21,7 @@ const Meta = () => {
 		pageCache,
 		'bypass_patterns'
 	);
-
-	const runClearPageCacheAction = useClearPageCacheAction();
+	const [ clearedCacheMessage, runClearPageCacheAction ] = useClearPageCacheAction();
 
 	const clearPageCache = () => {
 		runClearPageCacheAction.mutate();
@@ -65,7 +64,7 @@ const Meta = () => {
 				{ ...runClearPageCacheAction }
 				savingMessage={ __( 'Clearing cache…', 'jetpack-boost' ) }
 				errorMessage={ __( 'Unable to clear cache.', 'jetpack-boost' ) }
-				successMessage={ __( 'Cache cleared.', 'jetpack-boost' ) }
+				successMessage={ clearedCacheMessage || __( 'Cache cleared.', 'jetpack-boost' ) }
 			/>
 			<div className={ styles.head }>
 				<div className={ styles.summary }>{ getSummary() }</div>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -1,6 +1,5 @@
 import { Button, Notice } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
-import { Snackbar } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import ChevronDown from '$svg/chevron-down';
 import ChevronUp from '$svg/chevron-up';
@@ -23,32 +22,16 @@ const Meta = () => {
 		'bypass_patterns'
 	);
 
-	const [ clearingCache, setClearingCache ] = useState( false );
-	const [ snackbarMessage, setSnackbarMessage ] = useState< string >( '' );
 	const runClearPageCacheAction = useClearPageCacheAction();
 
 	const clearPageCache = () => {
-		setClearingCache( true );
-		setSnackbarMessage( '' ); // Hide any previous snackbar message.
 		runClearPageCacheAction.mutate();
 	};
-
-	useEffect( () => {
-		if ( clearingCache ) {
-			setClearingCache( false );
-		}
-
-		if ( runClearPageCacheAction.isSuccess ) {
-			setSnackbarMessage( __( 'Cache Cleared.', 'jetpack-boost' ) );
-		} else if ( runClearPageCacheAction.isError ) {
-			setSnackbarMessage( __( 'Unable to clear cache.', 'jetpack-boost' ) );
-		}
-	}, [ clearingCache, runClearPageCacheAction.isSuccess, runClearPageCacheAction.isError ] );
 
 	const totalBypassPatterns = bypassPatterns?.length || 0;
 
 	const getSummary = () => {
-		if ( clearingCache ) {
+		if ( runClearPageCacheAction.isPending ) {
 			return __( 'Clearing cache…', 'jetpack-boost' );
 		}
 
@@ -78,6 +61,12 @@ const Meta = () => {
 	return (
 		<div className={ styles.wrapper }>
 			<MutationNotice { ...mutateBypassPatterns } />
+			<MutationNotice
+				{ ...runClearPageCacheAction }
+				savingMessage={ __( 'Clearing cache…', 'jetpack-boost' ) }
+				errorMessage={ __( 'Unable to clear cache.', 'jetpack-boost' ) }
+				successMessage={ __( 'Cache cleared.', 'jetpack-boost' ) }
+			/>
 			<div className={ styles.head }>
 				<div className={ styles.summary }>{ getSummary() }</div>
 				<div className={ styles.actions }>
@@ -88,7 +77,7 @@ const Meta = () => {
 						iconSize={ 16 }
 						icon={ <Lightning /> }
 						onClick={ clearPageCache }
-						disabled={ clearingCache }
+						disabled={ runClearPageCacheAction.isPending }
 					>
 						{ __( 'Clear Cache', 'jetpack-boost' ) }
 					</Button>{ ' ' }
@@ -134,9 +123,6 @@ const Meta = () => {
 						</div>
 					</>
 				</div>
-			) }
-			{ snackbarMessage !== '' && (
-				<Snackbar children={ snackbarMessage } onDismiss={ () => setSnackbarMessage( '' ) } />
 			) }
 		</div>
 	);

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -1,12 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import Meta from '$features/page-cache/meta/meta';
 import Health from '$features/page-cache/health/health';
-import { usePageCacheErrorDS } from '$lib/stores/page-cache';
+import { usePageCacheError } from '$lib/stores/page-cache';
 import ErrorBoundary from '$features/error-boundary/error-boundary';
 import ErrorNotice from '$features/error-notice/error-notice';
 
 const PageCache = () => {
-	const pageCacheError = usePageCacheErrorDS();
+	const pageCacheError = usePageCacheError();
 
 	return <>{ pageCacheError ? <Health error={ pageCacheError } /> : <Meta /> }</>;
 };

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
@@ -28,6 +28,13 @@ export function useRunPageCacheSetupAction() {
 	return usePageCacheErrorAction( 'run-page-cache-setup', z.void() );
 }
 
+/**
+ * Hook which creates a callable action for clearing Page Cache.
+ */
+export function useClearPageCacheAction() {
+	return usePageCacheAction( 'clear-page-cache', z.void() );
+}
+
 function usePageCacheErrorAction<
 	ActionSchema extends z.ZodSchema,
 	ActionRequestData extends z.infer< ActionSchema >,
@@ -40,6 +47,24 @@ function usePageCacheErrorAction<
 		action_name: action,
 		schema: {
 			state: PageCacheError,
+			action_request: schema,
+			action_response: responseSchema,
+		},
+	} );
+}
+
+function usePageCacheAction<
+	ActionSchema extends z.ZodSchema,
+	ActionRequestData extends z.infer< ActionSchema >,
+>( action: string, schema: ActionRequestData ) {
+	const responseSchema = z.boolean();
+
+	return useDataSyncAction( {
+		namespace: 'jetpack_boost_ds',
+		key: 'page_cache',
+		action_name: action,
+		schema: {
+			state: PageCache,
 			action_request: schema,
 			action_response: responseSchema,
 		},

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
@@ -10,6 +10,9 @@ export const PageCache = z.object( {
 	bypass_patterns: z.array( z.string() ),
 	logging: z.boolean(),
 } );
+const PageCacheClear = z.object( {
+	message: z.string(),
+} );
 
 export function usePageCacheErrorDS() {
 	const [ { data } ] = useDataSync( 'jetpack_boost_ds', 'page_cache_error', PageCacheError );
@@ -57,8 +60,6 @@ function usePageCacheAction<
 	ActionSchema extends z.ZodSchema,
 	ActionRequestData extends z.infer< ActionSchema >,
 >( action: string, schema: ActionRequestData ) {
-	const responseSchema = z.boolean();
-
 	return useDataSyncAction( {
 		namespace: 'jetpack_boost_ds',
 		key: 'page_cache',
@@ -66,7 +67,7 @@ function usePageCacheAction<
 		schema: {
 			state: PageCache,
 			action_request: schema,
-			action_response: responseSchema,
+			action_response: PageCacheClear,
 		},
 	} );
 }

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
@@ -3,6 +3,7 @@ import {
 	useDataSync,
 	useDataSyncAction,
 } from '@automattic/jetpack-react-data-sync-client';
+import { useState } from 'react';
 import { z } from 'zod';
 
 export const PageCacheError = z.string();
@@ -45,7 +46,8 @@ export function useRunPageCacheSetupAction() {
  * Hook which creates a callable action for clearing Page Cache.
  */
 export function useClearPageCacheAction() {
-	return useDataSyncAction( {
+	const [ message, setMessage ] = useState( '' );
+	const action = useDataSyncAction( {
 		namespace: 'jetpack_boost_ds',
 		key: 'page_cache',
 		action_name: 'clear-page-cache',
@@ -54,7 +56,16 @@ export function useClearPageCacheAction() {
 			action_request: z.void(),
 			action_response: PageCacheClear,
 		},
+		callbacks: {
+			onResult: result => {
+				if ( result.message ) {
+					setMessage( result.message );
+				}
+			},
+		},
 	} );
+
+	return [ message, action ] as const;
 }
 
 // When page cache is enabled, page cache error needs to be invalidated,

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
@@ -14,7 +14,7 @@ const PageCacheClear = z.object( {
 	message: z.string(),
 } );
 
-export function usePageCacheErrorDS() {
+export function usePageCacheError() {
 	const [ { data } ] = useDataSync( 'jetpack_boost_ds', 'page_cache_error', PageCacheError );
 
 	return data;
@@ -28,45 +28,30 @@ export function usePageCache() {
  * Hook which creates a callable action for running Page Cache setup.
  */
 export function useRunPageCacheSetupAction() {
-	return usePageCacheErrorAction( 'run-page-cache-setup', z.void() );
-}
-
-/**
- * Hook which creates a callable action for clearing Page Cache.
- */
-export function useClearPageCacheAction() {
-	return usePageCacheAction( 'clear-page-cache', z.void() );
-}
-
-function usePageCacheErrorAction<
-	ActionSchema extends z.ZodSchema,
-	ActionRequestData extends z.infer< ActionSchema >,
->( action: string, schema: ActionRequestData ) {
-	const responseSchema = z.void();
-
+	const action = 'run-page-cache-setup';
 	return useDataSyncAction( {
 		namespace: 'jetpack_boost_ds',
 		key: 'page_cache_error',
 		action_name: action,
 		schema: {
 			state: PageCacheError,
-			action_request: schema,
-			action_response: responseSchema,
+			action_request: z.void(),
+			action_response: z.void(),
 		},
 	} );
 }
 
-function usePageCacheAction<
-	ActionSchema extends z.ZodSchema,
-	ActionRequestData extends z.infer< ActionSchema >,
->( action: string, schema: ActionRequestData ) {
+/**
+ * Hook which creates a callable action for clearing Page Cache.
+ */
+export function useClearPageCacheAction() {
 	return useDataSyncAction( {
 		namespace: 'jetpack_boost_ds',
 		key: 'page_cache',
-		action_name: action,
+		action_name: 'clear-page-cache',
 		schema: {
 			state: PageCache,
-			action_request: schema,
+			action_request: z.void(),
 			action_response: PageCacheClear,
 		},
 	} );

--- a/projects/plugins/boost/app/modules/cache/data-sync-actions/clear-page-cache.php
+++ b/projects/plugins/boost/app/modules/cache/data-sync-actions/clear-page-cache.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Modules\Page_Cache\Data_Sync_Actions;
+
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Data_Sync_Action;
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache;
+
+/**
+ * Page Cache: Clear page cache
+ */
+class Clear_Page_Cache implements Data_Sync_Action {
+
+	/**
+	 * Handles the action logic.
+	 *
+	 * @param mixed            $_data    JSON Data passed to the action.
+	 * @param \WP_REST_Request $_request The request object.
+	 */
+	public function handle( $_data, $_request ) {
+		$cache = new Boost_Cache();
+		return $cache->delete_cache();
+	}
+}

--- a/projects/plugins/boost/app/modules/cache/data-sync-actions/clear-page-cache.php
+++ b/projects/plugins/boost/app/modules/cache/data-sync-actions/clear-page-cache.php
@@ -17,7 +17,21 @@ class Clear_Page_Cache implements Data_Sync_Action {
 	 * @param \WP_REST_Request $_request The request object.
 	 */
 	public function handle( $_data, $_request ) {
-		$cache = new Boost_Cache();
-		return $cache->delete_cache();
+		$cache  = new Boost_Cache();
+		$delete = $cache->delete_cache();
+
+		if ( is_wp_error( $delete ) ) {
+			return array(
+				'message' => __( 'Cache already cleared.', 'jetpack-boost' ),
+			);
+		}
+
+		if ( $delete ) {
+			return array(
+				'message' => __( 'Cache cleared.', 'jetpack-boost' ),
+			);
+		}
+
+		return new \WP_Error( 'unable-to-clear-cache', __( 'Unable to clear cache.', 'jetpack-boost' ) );
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/data-sync-actions/clear-page-cache.php
+++ b/projects/plugins/boost/app/modules/cache/data-sync-actions/clear-page-cache.php
@@ -20,7 +20,7 @@ class Clear_Page_Cache implements Data_Sync_Action {
 		$cache  = new Boost_Cache();
 		$delete = $cache->delete_cache();
 
-		if ( is_wp_error( $delete ) ) {
+		if ( $delete === null || is_wp_error( $delete ) ) {
 			return array(
 				'message' => __( 'Cache already cleared.', 'jetpack-boost' ),
 			);

--- a/projects/plugins/boost/changelog/implement-clear-cache-ui
+++ b/projects/plugins/boost/changelog/implement-clear-cache-ui
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Implement Clear Cache UI.
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -20,6 +20,7 @@ use Automattic\Jetpack_Boost\Lib\Super_Cache_Info;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_CSS;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_JS;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Data_Sync\Page_Cache_Entry;
+use Automattic\Jetpack_Boost\Modules\Page_Cache\Data_Sync_Actions\Clear_Page_Cache;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Data_Sync_Actions\Run_Setup;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Logger;
 
@@ -369,3 +370,5 @@ jetpack_boost_register_option(
 	),
 	new Page_Cache_Entry( JETPACK_BOOST_DATASYNC_NAMESPACE . '_page_cache' )
 );
+
+jetpack_boost_register_action( 'page_cache', 'clear-page-cache', Schema::as_void(), new Clear_Page_Cache() );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35783

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Clear page cache when clicking the "Clear Cache" button;
* Disable "Clear Cache" button during cleanup;
* Update the Page Cache summary during cleanup;
* Add snackbar message after cleanup is done.

Currently, when cleaning the cache, the "clean cache" PHP side of things returns an error that the cache directory doesn't exist. This is why the snackbar message shows on success and error.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-2rA-p2

pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have some cached pages;
* Click the "Clear Cache" button and make sure cache is deleted (and that the message shows up).