### PR TITLE
My Jetpack: do not initialize in offline mode

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-offline
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-offline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not initialize My Jetpack when in Offline mode.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -390,6 +390,11 @@ class Initializer {
 			$should = false;
 		}
 
+		// All options presented in My Jetpack require a connection to WordPress.com.
+		if ( ( new Status() )->is_offline_mode() ) {
+			$should = false;
+		}
+
 		/**
 		 * Allows filtering whether My Jetpack should be initialized.
 		 *


### PR DESCRIPTION
## Proposed changes:

The features presented in the My Jetpack screen are not available on sites in offline mode.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start a new JN site with this branch.
* Go to Settings > Jetpack Constants
* Turn Offline mode on
* Check the Jetpack menu
    * You should not see a "My Jetpack" menu item.
