### PR TITLE
Jetpack Boost: Add MutationNotice for status feedback

### DIFF
--- a/projects/js-packages/react-data-sync-client/changelog/update-boost-toggle-toasts
+++ b/projects/js-packages/react-data-sync-client/changelog/update-boost-toggle-toasts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+DataSync: Add `useDataSyncSubset`

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -348,21 +348,21 @@ export function useDataSyncAction<
 	} );
 }
 
-type PickedMutation< T > = UseMutationResult< T > & {
+type SubsetMutation< T > = UseMutationResult< T > & {
 	mutate: ( newValue: T ) => void;
 };
 export function useDataSyncSubset<
 	Schema extends z.ZodSchema,
 	Value extends z.infer< Schema >,
 	K extends keyof Value,
->( key: K, hook: DataSyncHook< Schema, Value > ): [ Value[ K ], PickedMutation< Value[ K ] > ] {
+>( key: K, hook: DataSyncHook< Schema, Value > ): [ Value[ K ], SubsetMutation< Value[ K ] > ] {
 	const [ query, mutation ] = hook;
 	const [ isPending, setIsPending ] = React.useState( false );
 	const [ isError, setIsError ] = React.useState( false );
 	const [ isActive, setIsActive ] = React.useState( false );
 	const [ isSuccess, setIsSuccess ] = React.useState( false );
 
-	const set = ( newValue: Value[ K ] ) => {
+	const mutate = ( newValue: Value[ K ] ) => {
 		if ( ! query.data ) {
 			return;
 		}
@@ -392,7 +392,7 @@ export function useDataSyncSubset<
 			isSuccess,
 			isPending,
 			isError,
-			mutate: set,
+			mutate,
 		},
 	];
 }

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -347,3 +347,31 @@ export function useDataSyncAction<
 		...mutationOptions,
 	} );
 }
+
+type PickedMutation< T > = UseMutationResult< T > & {
+	mutate: ( newValue: T ) => void;
+};
+export function useDataSyncPick<
+	Schema extends z.ZodSchema,
+	Value extends z.infer< Schema >,
+	K extends keyof Value,
+>( key: K, hook: DataSyncHook< Schema, Value > ): [ Value[ K ], PickedMutation< Value[ K ] > ] {
+	const [ query, mutation ] = hook;
+	const set = ( newValue: Value[ K ] ) => {
+		if ( ! query.data ) {
+			return;
+		}
+		mutation.mutate( {
+			...query.data,
+			[ key ]: newValue,
+		} );
+	};
+
+	return [
+		query.data?.[ key ],
+		{
+			...mutation,
+			mutate: set,
+		},
+	];
+}

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -348,9 +348,14 @@ export function useDataSyncAction<
 	} );
 }
 
-type SubsetMutation< T > = UseMutationResult< T > & {
+type SubsetMutation< T > = {
 	mutate: ( newValue: T ) => void;
+	isSuccess: boolean;
+	isPending: boolean;
+	isError: boolean;
+	error: Error | null;
 };
+
 export function useDataSyncSubset<
 	Schema extends z.ZodSchema,
 	Value extends z.infer< Schema >,
@@ -361,6 +366,7 @@ export function useDataSyncSubset<
 	const [ isError, setIsError ] = React.useState( false );
 	const [ isActive, setIsActive ] = React.useState( false );
 	const [ isSuccess, setIsSuccess ] = React.useState( false );
+	const [ error, setError ] = React.useState< unknown >( null );
 
 	const mutate = ( newValue: Value[ K ] ) => {
 		if ( ! query.data ) {
@@ -380,6 +386,7 @@ export function useDataSyncSubset<
 		setIsError( mutation.isError );
 		setIsPending( mutation.isPending );
 		setIsSuccess( mutation.isSuccess );
+		setError( mutation.error );
 		if ( mutation.isSuccess || mutation.isError ) {
 			setIsActive( false );
 		}
@@ -388,10 +395,10 @@ export function useDataSyncSubset<
 	return [
 		query.data?.[ key ],
 		{
-			...mutation,
 			isSuccess,
 			isPending,
 			isError,
+			error,
 			mutate,
 		},
 	];

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -360,7 +360,7 @@ export function useDataSyncSubset<
 	Schema extends z.ZodSchema,
 	Value extends z.infer< Schema >,
 	K extends keyof Value,
->( key: K, hook: DataSyncHook< Schema, Value > ): [ Value[ K ], SubsetMutation< Value[ K ] > ] {
+>( hook: DataSyncHook< Schema, Value >, key: K ): [ Value[ K ], SubsetMutation< Value[ K ] > ] {
 	const [ query, mutation ] = hook;
 	const [ isPending, setIsPending ] = React.useState( false );
 	const [ isError, setIsError ] = React.useState( false );

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -357,7 +357,10 @@ export function useDataSyncSubset<
 	K extends keyof Value,
 >( key: K, hook: DataSyncHook< Schema, Value > ): [ Value[ K ], SubsetMutation< Value[ K ] > ] {
 	const [ query, mutation ] = hook;
+	const [ isPending, setIsPending ] = React.useState( false );
+	const [ isError, setIsError ] = React.useState( false );
 	const [ isActive, setIsActive ] = React.useState( false );
+	const [ isSuccess, setIsSuccess ] = React.useState( false );
 
 	const mutate = ( newValue: Value[ K ] ) => {
 		if ( ! query.data ) {
@@ -371,25 +374,24 @@ export function useDataSyncSubset<
 	};
 
 	useEffect( () => {
+		if ( ! isActive ) {
+			return;
+		}
+		setIsError( mutation.isError );
+		setIsPending( mutation.isPending );
+		setIsSuccess( mutation.isSuccess );
 		if ( mutation.isSuccess || mutation.isError ) {
 			setIsActive( false );
 		}
-	}, [ mutation.isSuccess, mutation.isError ] );
-
-	const mutationProxy = new Proxy( mutation, {
-		get( target, prop, receiver ) {
-			// If not active, return undefined for all except the mutate function
-			if ( ! isActive && prop !== 'mutate' ) {
-				return undefined;
-			}
-			return Reflect.get( target, prop, receiver );
-		},
-	} );
+	}, [ mutation.isError, mutation.isPending, isActive ] );
 
 	return [
 		query.data?.[ key ],
 		{
-			...mutationProxy,
+			...mutation,
+			isSuccess,
+			isPending,
+			isError,
 			mutate,
 		},
 	];

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -380,7 +380,7 @@ export function useDataSyncSubset<
 		setIsError( mutation.isError );
 		setIsPending( mutation.isPending );
 		setIsSuccess( mutation.isSuccess );
-		if ( ! mutation.isError && ! mutation.isPending ) {
+		if ( mutation.isSuccess || mutation.isError ) {
 			setIsActive( false );
 		}
 	}, [ mutation.isError, mutation.isPending, isActive ] );

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -364,7 +364,6 @@ export function useDataSyncSubset<
 	const [ query, mutation ] = hook;
 	const [ isPending, setIsPending ] = React.useState( false );
 	const [ isError, setIsError ] = React.useState( false );
-	const [ isActive, setIsActive ] = React.useState( false );
 	const [ isSuccess, setIsSuccess ] = React.useState( false );
 	const [ error, setError ] = React.useState< unknown >( null );
 
@@ -372,7 +371,7 @@ export function useDataSyncSubset<
 		if ( ! query.data ) {
 			return;
 		}
-		setIsActive( true );
+		setIsPending( true );
 		mutation.mutate( {
 			...query.data,
 			[ key ]: newValue,
@@ -380,17 +379,16 @@ export function useDataSyncSubset<
 	};
 
 	useEffect( () => {
-		if ( ! isActive ) {
+		if ( ! isPending ) {
 			return;
 		}
 		setIsError( mutation.isError );
-		setIsPending( mutation.isPending );
 		setIsSuccess( mutation.isSuccess );
 		setError( mutation.error );
 		if ( mutation.isSuccess || mutation.isError ) {
-			setIsActive( false );
+			setIsPending( false );
 		}
-	}, [ mutation.isError, mutation.isPending, isActive ] );
+	}, [ mutation.isError, mutation.error, mutation.isSuccess, isPending ] );
 
 	return [
 		query.data?.[ key ],

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -11,10 +11,13 @@ import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import { Snackbar } from '@wordpress/components';
 
-const SettingsStatusNotice = ( mutation: {
+const MutationNotice = ( mutation: {
 	isSuccess: boolean;
 	isError: boolean;
 	isPending: boolean;
+	savingMessage?: string;
+	errorMessage?: string;
+	successMessage?: string;
 } ) => {
 	const [ showSnackbar, setShowSnackbar ] = useState( false );
 	const [ snackbarContent, setSnackbarContent ] = useState( '' );
@@ -28,20 +31,30 @@ const SettingsStatusNotice = ( mutation: {
 		if ( mutation.isPending && ! mutation.isSuccess ) {
 			timeoutId = setTimeout( () => {
 				setShowSnackbar( true );
-				setSnackbarContent( __( 'Saving…', 'jetpack-boost' ) );
+				setSnackbarContent( mutation.savingMessage || __( 'Saving…', 'jetpack-boost' ) );
 				setSnackbarType( 'success' );
 			}, 50 );
 		} else if ( mutation.isSuccess ) {
 			setShowSnackbar( true );
-			setSnackbarContent( __( 'Settings saved successfully.', 'jetpack-boost' ) );
+			setSnackbarContent( mutation.successMessage || __( 'Changes saved.', 'jetpack-boost' ) );
 			setSnackbarType( 'success' );
 		} else if ( mutation.isError ) {
 			setShowSnackbar( true );
-			setSnackbarContent( __( 'Failed to save settings.', 'jetpack-boost' ) );
+			setSnackbarContent(
+				mutation.errorMessage ||
+					__( 'An error occurred while saving changes. Please, try again.', 'jetpack-boost' )
+			);
 			setSnackbarType( 'error' );
 		}
 		return () => clearTimeout( timeoutId );
-	}, [ mutation.isSuccess, mutation.isError, mutation.isPending ] );
+	}, [
+		mutation.isSuccess,
+		mutation.isError,
+		mutation.isPending,
+		mutation.savingMessage,
+		mutation.errorMessage,
+		mutation.successMessage,
+	] );
 
 	return (
 		<>
@@ -87,7 +100,7 @@ const Meta = () => {
 
 	return (
 		<div className={ styles.wrapper }>
-			<SettingsStatusNotice { ...mutation } />
+			<MutationNotice { ...mutation } />
 			<div className={ styles.head }>
 				<div className={ styles.summary }>
 					{ totalBypassPatterns === 0 && ! settings?.logging ? (

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -16,11 +16,12 @@ const Meta = () => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const pageCache = usePageCache();
 
-	const [ logging, mutateLogging ] = useDataSyncSubset( 'logging', pageCache );
+	const [ logging, mutateLogging ] = useDataSyncSubset( pageCache, 'logging' );
 	const [ bypassPatterns, mutateBypassPatterns ] = useDataSyncSubset(
-		'bypass_patterns',
-		pageCache
+		pageCache,
+		'bypass_patterns'
 	);
+
 	const totalBypassPatterns = bypassPatterns?.length || 0;
 	return (
 		<div className={ styles.wrapper }>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -9,63 +9,7 @@ import { useEffect, useState } from 'react';
 import { usePageCache } from '$lib/stores/page-cache';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
-import { Snackbar } from '@wordpress/components';
-
-const MutationNotice = ( mutation: {
-	isSuccess: boolean;
-	isError: boolean;
-	isPending: boolean;
-	savingMessage?: string;
-	errorMessage?: string;
-	successMessage?: string;
-} ) => {
-	const [ showSnackbar, setShowSnackbar ] = useState( false );
-	const [ snackbarContent, setSnackbarContent ] = useState( '' );
-	const [ snackbarType, setSnackbarType ] = useState< 'success' | 'error' >( 'success' );
-
-	useEffect( () => {
-		let timeoutId: ReturnType< typeof setTimeout >;
-
-		// If mutation is pending, show a "Saving…" message.
-		// But only if saving takes more than 50ms to avoid FOLC(Flash of Loading Content).
-		if ( mutation.isPending && ! mutation.isSuccess ) {
-			timeoutId = setTimeout( () => {
-				setShowSnackbar( true );
-				setSnackbarContent( mutation.savingMessage || __( 'Saving…', 'jetpack-boost' ) );
-				setSnackbarType( 'success' );
-			}, 50 );
-		} else if ( mutation.isSuccess ) {
-			setShowSnackbar( true );
-			setSnackbarContent( mutation.successMessage || __( 'Changes saved.', 'jetpack-boost' ) );
-			setSnackbarType( 'success' );
-		} else if ( mutation.isError ) {
-			setShowSnackbar( true );
-			setSnackbarContent(
-				mutation.errorMessage ||
-					__( 'An error occurred while saving changes. Please, try again.', 'jetpack-boost' )
-			);
-			setSnackbarType( 'error' );
-		}
-		return () => clearTimeout( timeoutId );
-	}, [
-		mutation.isSuccess,
-		mutation.isError,
-		mutation.isPending,
-		mutation.savingMessage,
-		mutation.errorMessage,
-		mutation.successMessage,
-	] );
-
-	return (
-		<>
-			{ showSnackbar && (
-				<Snackbar type={ snackbarType } onDismiss={ () => setShowSnackbar( false ) }>
-					{ snackbarContent }
-				</Snackbar>
-			) }
-		</>
-	);
-};
+import { MutationNotice } from '$features/ui';
 
 const Meta = () => {
 	const [ isExpanded, setIsExpanded ] = useState( false );

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -10,44 +10,24 @@ import { usePageCache } from '$lib/stores/page-cache';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import { MutationNotice } from '$features/ui';
+import { useDataSyncSubset } from '@automattic/jetpack-react-data-sync-client';
 
 const Meta = () => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
-	const [ query, mutation ] = usePageCache();
+	const pageCache = usePageCache();
 
-	const settings = query?.data;
-	const setSettings = mutation.mutate;
-
-	const setLogging = ( newValue: boolean ) => {
-		if ( ! setSettings || ! settings ) {
-			return;
-		}
-
-		setSettings( {
-			...settings,
-			logging: newValue,
-		} );
-	};
-
-	const setBypassPatterns = ( newValue: string ) => {
-		if ( ! setSettings || ! settings ) {
-			return;
-		}
-
-		setSettings( {
-			...settings,
-			bypass_patterns: newValue.split( '\n' ).map( item => item.trim() ),
-		} );
-	};
-
-	const totalBypassPatterns = settings?.bypass_patterns.length || 0;
-
+	const [ logging, mutateLogging ] = useDataSyncSubset( 'logging', pageCache );
+	const [ bypassPatterns, mutateBypassPatterns ] = useDataSyncSubset(
+		'bypass_patterns',
+		pageCache
+	);
+	const totalBypassPatterns = bypassPatterns?.length || 0;
 	return (
 		<div className={ styles.wrapper }>
-			<MutationNotice { ...mutation } />
+			<MutationNotice { ...mutateBypassPatterns } />
 			<div className={ styles.head }>
 				<div className={ styles.summary }>
-					{ totalBypassPatterns === 0 && ! settings?.logging ? (
+					{ totalBypassPatterns === 0 && ! logging ? (
 						__( 'No exceptions or logging.', 'jetpack-boost' )
 					) : (
 						<>
@@ -62,8 +42,8 @@ const Meta = () => {
 							) : (
 								__( 'No exceptions.', 'jetpack-boost' )
 							) }{ ' ' }
-							{ settings?.logging && __( 'Logging activated.', 'jetpack-boost' ) }
-							{ ! settings?.logging && __( 'No logging.', 'jetpack-boost' ) }
+							{ logging && __( 'Logging activated.', 'jetpack-boost' ) }
+							{ ! logging && __( 'No logging.', 'jetpack-boost' ) }
 						</>
 					) }
 				</div>
@@ -91,33 +71,33 @@ const Meta = () => {
 			</div>
 			{ isExpanded && (
 				<div className={ styles.body }>
-					{ settings && (
-						<>
-							<BypassPatterns
-								patterns={ settings.bypass_patterns.join( '\n' ) }
-								setPatterns={ setBypassPatterns }
-								showErrorNotice={ mutation.isError }
-							/>
-							<div className={ styles.section }>
-								<div className={ styles.title }>{ __( 'Logging', 'jetpack-boost' ) }</div>
-								<label htmlFor="cache-logging">
-									<input
-										type="checkbox"
-										id="cache-logging"
-										checked={ settings.logging }
-										onChange={ event => setLogging( event.target.checked ) }
-									/>{ ' ' }
-									{ __( 'Activate logging to track all your cache events.', 'jetpack-boost' ) }
-									{ settings.logging && (
-										<>
-											{ ' ' }
-											<Link to="/cache-debug-log">{ __( 'See Logs', 'jetpack-boost' ) }</Link>
-										</>
-									) }
-								</label>
-							</div>
-						</>
-					) }
+					<>
+						<BypassPatterns
+							patterns={ bypassPatterns.join( '\n' ) }
+							setPatterns={ patterns =>
+								mutateBypassPatterns.mutate( patterns.split( '\n' ).map( item => item.trim() ) )
+							}
+							showErrorNotice={ mutateBypassPatterns.isError }
+						/>
+						<div className={ styles.section }>
+							<div className={ styles.title }>{ __( 'Logging', 'jetpack-boost' ) }</div>
+							<label htmlFor="cache-logging">
+								<input
+									type="checkbox"
+									id="cache-logging"
+									checked={ logging }
+									onChange={ event => mutateLogging.mutate( event.target.checked ) }
+								/>{ ' ' }
+								{ __( 'Activate logging to track all your cache events.', 'jetpack-boost' ) }
+								{ logging && (
+									<>
+										{ ' ' }
+										<Link to="/cache-debug-log">{ __( 'See Logs', 'jetpack-boost' ) }</Link>
+									</>
+								) }
+							</label>
+						</div>
+					</>
 				</div>
 			) }
 		</div>

--- a/projects/plugins/boost/app/assets/src/js/features/ui/index.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/index.ts
@@ -1,3 +1,4 @@
 export { default as BackButton } from './back-button/back-button';
 export { default as CloseButton } from './close-button/close-button';
 export { default as Spinner } from './spinner/spinner';
+export { default as MutationNotice } from './mutation-notice/mutation-notice';

--- a/projects/plugins/boost/app/assets/src/js/features/ui/mutation-notice/mutation-notice.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/mutation-notice/mutation-notice.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { Snackbar } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Mutation Notice: A component that shows a notice when a mutation is pending, successful or failed.
+ *
+ * Usage:
+ * ```tsx
+ *	 <MutationNotice
+ *		 isSuccess={ mutation.isSuccess }
+ *		 isError={ mutation.isError }
+ *		 isPending={ mutation.isPending }
+ *		 savingMessage={ __( 'Saving…', 'jetpack-boost' ) }
+ *		 errorMessage={ __(
+ *		 'An error occurred while saving changes. Please, try again.',
+ *		 'jetpack-boost'
+ *		 ) }
+ *		 successMessage={ __( 'Changes saved.', 'jetpack-boost' ) }
+ *		 />
+ * ```
+ *
+ * Usage when you don't need to customize the messages:
+ *
+ * ```tsx
+ * 	const [ data, mutation ] = useDataSync(...);
+ * 	<MutationNotice { ...mutation } />
+ * ```
+ *
+ * @param props.isSuccess      Whether the mutation was successful.
+ * @param props.isError        Whether the mutation failed.
+ * @param props.isPending      Whether the mutation is pending.
+ * @param props.savingMessage  The message to show when the mutation is pending.
+ * @param props.errorMessage   The message to show when the mutation failed.
+ * @param props.successMessage The message to show when the mutation was successful.
+ * @param props
+ */
+export const MutationNotice = ( props: {
+	isSuccess: boolean;
+	isError: boolean;
+	isPending: boolean;
+	savingMessage?: string;
+	errorMessage?: string;
+	successMessage?: string;
+} ) => {
+	const [ showSnackbar, setShowSnackbar ] = useState( false );
+	const [ snackbarContent, setSnackbarContent ] = useState( '' );
+	const [ snackbarType, setSnackbarType ] = useState< 'success' | 'error' >( 'success' );
+
+	const savingMessage = props.savingMessage || __( 'Saving…', 'jetpack-boost' );
+	const errorMessage =
+		props.errorMessage ||
+		__( 'An error occurred while saving changes.', 'jetpack-boost' );
+	const successMessage = props.successMessage || __( 'Changes saved.', 'jetpack-boost' );
+
+	useEffect( () => {
+		let timeoutId: ReturnType< typeof setTimeout >;
+
+		// If mutation is pending, show a "Saving…" message.
+		// But only if saving takes more than 50ms to avoid FOLC(Flash of Loading Content).
+		if ( props.isPending && ! props.isSuccess ) {
+			timeoutId = setTimeout( () => {
+				setShowSnackbar( true );
+				setSnackbarContent( savingMessage );
+			}, 50 );
+			setSnackbarType( 'success' );
+		} else if ( props.isSuccess ) {
+			setShowSnackbar( true );
+			setSnackbarContent( successMessage );
+			setSnackbarType( 'success' );
+		} else if ( props.isError ) {
+			setShowSnackbar( true );
+			setSnackbarContent( errorMessage );
+			setSnackbarType( 'error' );
+		}
+		return () => clearTimeout( timeoutId );
+	}, [
+		props.isSuccess,
+		props.isError,
+		props.isPending,
+		savingMessage,
+		errorMessage,
+		successMessage,
+	] );
+
+	return (
+		<>
+			{ showSnackbar && (
+				<Snackbar type={ snackbarType } onDismiss={ () => setShowSnackbar( false ) }>
+					{ snackbarContent }
+				</Snackbar>
+			) }
+		</>
+	);
+};
+
+
+// This is a pure component, so we can use React.memo to avoid unnecessary re-renders.
+export default React.memo(MutationNotice);

--- a/projects/plugins/boost/app/assets/src/js/features/ui/mutation-notice/mutation-notice.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/mutation-notice/mutation-notice.tsx
@@ -26,14 +26,13 @@ import { __ } from '@wordpress/i18n';
  * 	const [ data, mutation ] = useDataSync(...);
  * 	<MutationNotice { ...mutation } />
  * ```
- *
+ * @param props
  * @param props.isSuccess      Whether the mutation was successful.
  * @param props.isError        Whether the mutation failed.
  * @param props.isPending      Whether the mutation is pending.
  * @param props.savingMessage  The message to show when the mutation is pending.
  * @param props.errorMessage   The message to show when the mutation failed.
  * @param props.successMessage The message to show when the mutation was successful.
- * @param props
  */
 export const MutationNotice = ( props: {
 	isSuccess: boolean;
@@ -49,8 +48,7 @@ export const MutationNotice = ( props: {
 
 	const savingMessage = props.savingMessage || __( 'Saving…', 'jetpack-boost' );
 	const errorMessage =
-		props.errorMessage ||
-		__( 'An error occurred while saving changes.', 'jetpack-boost' );
+		props.errorMessage || __( 'An error occurred while saving changes.', 'jetpack-boost' );
 	const successMessage = props.successMessage || __( 'Changes saved.', 'jetpack-boost' );
 
 	useEffect( () => {
@@ -94,6 +92,5 @@ export const MutationNotice = ( props: {
 	);
 };
 
-
 // This is a pure component, so we can use React.memo to avoid unnecessary re-renders.
-export default React.memo(MutationNotice);
+export default React.memo( MutationNotice );

--- a/projects/plugins/boost/changelog/update-boost-toggle-toasts
+++ b/projects/plugins/boost/changelog/update-boost-toggle-toasts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Boost: Implemented a customizable Notice.


### PR DESCRIPTION
## Proposed changes:
- Import and utilize the MutationNotice component within the Page Cache meta component.
- Make the MutationNotice component available by exporting it from the features/ui index.
- Implement a new MutationNotice component to display status messages for mutations.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Navigate to the Page Cache section of the Jetpack Boost dashboard.
- Perform actions that trigger mutations such as saving settings.
- Observe the MutationNotice component displaying the status of the action (e.g., 'Saving...', 'Changes saved.', or 'An error occurred...').
- Ensure the MutationNotice component is properly styled and dismissible.
