### PR TITLE
Boost: Fix learn-more links for boost cache issues

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/health/lib/get-error-data.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/health/lib/get-error-data.tsx
@@ -1,8 +1,11 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import styles from '../health.module.scss';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 
-const cacheIssuesLink = 'TBD'; // @todo - add proper link here.
+const cacheIssuesLink = ( issue: string ) => {
+	return getRedirectUrl( `jb-cache-issue-${ issue }` );
+};
 
 const messages: { [ key: string ]: { title: string; message: React.ReactNode } } = {
 	'wp-content-not-writable': {
@@ -18,8 +21,14 @@ const messages: { [ key: string ]: { title: string; message: React.ReactNode } }
 			),
 			{
 				code: <code className={ styles.nowrap } />,
-				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				link: <a href={ cacheIssuesLink } target="_blank" rel="noopener noreferrer" />,
+				link: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href={ cacheIssuesLink( 'wp-content-not-writable' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
 			}
 		),
 	},
@@ -31,8 +40,14 @@ const messages: { [ key: string ]: { title: string; message: React.ReactNode } }
 				'jetpack-boost'
 			),
 			{
-				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				link: <a href={ cacheIssuesLink } target="_blank" rel="noopener noreferrer" />,
+				link: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href={ cacheIssuesLink( 'not-using-permalinks' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
 			}
 		),
 	},
@@ -49,8 +64,14 @@ const messages: { [ key: string ]: { title: string; message: React.ReactNode } }
 			),
 			{
 				code: <code className={ styles.nowrap } />,
-				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				link: <a href={ cacheIssuesLink } target="_blank" rel="noopener noreferrer" />,
+				link: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href={ cacheIssuesLink( 'advanced-cache-incompatible' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
 			}
 		),
 	},
@@ -67,8 +88,14 @@ const messages: { [ key: string ]: { title: string; message: React.ReactNode } }
 			),
 			{
 				code: <code className={ styles.nowrap } />,
-				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				link: <a href={ cacheIssuesLink } target="_blank" rel="noopener noreferrer" />,
+				link: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href={ cacheIssuesLink( 'unable-to-write-to-advanced-cache' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
 			}
 		),
 	},
@@ -88,8 +115,14 @@ const messages: { [ key: string ]: { title: string; message: React.ReactNode } }
 			),
 			{
 				code: <code className={ styles.nowrap } />,
-				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				link: <a href={ cacheIssuesLink } target="_blank" rel="noopener noreferrer" />,
+				link: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href={ cacheIssuesLink( 'wp-cache-defined-not-true' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
 			}
 		),
 	},

--- a/projects/plugins/boost/changelog/boost-cache-fix-learnmore-links
+++ b/projects/plugins/boost/changelog/boost-cache-fix-learnmore-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35677

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use jetpack redirects for cache issue learn more links

> [!NOTE]  
> Currently they redirect to `jb-cache-issue-${ issue }` while assuming `wp-content-not-writable` and `not-using-permalinks` redirect to their hash anchors on `https://jetpack.com/support/jetpack-boost/jetpack-boost-cache`. I later decided to not use redirects for the rest until the actual URL is up.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Reproduce the cache issues
* Click the learn more links and make sure they go to `https://jetpack.com/redirect/?source=jb-cache-issue-${issue}`.