### PR TITLE
Sharing menu: Keep the menu on self-hosted sites in offline mode

### DIFF
--- a/projects/packages/publicize/changelog/fix-sharing-menu-in-offline-mode
+++ b/projects/packages/publicize/changelog/fix-sharing-menu-in-offline-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Deprecate the sharing_menu method of the Publicize_UI class.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.2",
+	"version": "0.42.3-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -52,12 +52,10 @@ class Publicize_UI {
 		}
 
 		// Assets (css, js).
-		add_action( 'load-settings_page_sharing', array( $this, 'load_assets' ) );
 		add_action( 'admin_head-post.php', array( $this, 'post_page_metabox_assets' ) );
 		add_action( 'admin_head-post-new.php', array( $this, 'post_page_metabox_assets' ) );
 
 		// Management of publicize (sharing screen, ajax/lightbox popup, and metabox on post screen).
-		add_action( 'pre_admin_screen_sharing', array( $this, 'admin_page' ) );
 		add_action( 'post_submitbox_misc_actions', array( $this, 'post_page_metabox' ) );
 	}
 
@@ -79,6 +77,8 @@ class Publicize_UI {
 
 	/**
 	 * Add admin page with wrapper.
+	 *
+	 * @deprecated $$next-version$$
 	 */
 	public function wrapper_admin_page() {
 		if ( class_exists( 'Jetpack_Admin_Page' ) ) {
@@ -88,6 +88,8 @@ class Publicize_UI {
 
 	/**
 	 * Management page to load if Sharedaddy is not active so the 'pre_admin_screen_sharing' action exists.
+	 *
+	 * @deprecated $$next-version$$
 	 */
 	public function management_page() {
 		?>
@@ -106,6 +108,8 @@ class Publicize_UI {
 	/**
 	 * Styling for the sharing screen and popups
 	 * JS for the options and switching
+	 *
+	 * @deprecated $$next-version$$
 	 */
 	public function load_assets() {
 		if ( class_exists( 'Jetpack_Admin_Page' ) ) {
@@ -116,6 +120,8 @@ class Publicize_UI {
 	/**
 	 * Lists the current user's publicized accounts for the blog
 	 * looks exactly like Publicize v1 for now, UI and functionality updates will come after the move to keyring
+	 *
+	 * @deprecated $$next-version$$
 	 */
 	public function admin_page() {
 		?>

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -63,6 +63,8 @@ class Publicize_UI {
 
 	/**
 	 * If the ShareDaddy plugin is not active we need to add the sharing settings page to the menu still
+	 *
+	 * @deprecated
 	 */
 	public function sharing_menu() {
 		add_submenu_page(

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -64,7 +64,7 @@ class Publicize_UI {
 	/**
 	 * If the ShareDaddy plugin is not active we need to add the sharing settings page to the menu still
 	 *
-	 * @deprecated
+	 * @deprecated $$next-version$$
 	 */
 	public function sharing_menu() {
 		add_submenu_page(

--- a/projects/plugins/jetpack/changelog/remove-sharedaddy-action-subscription-menu
+++ b/projects/plugins/jetpack/changelog/remove-sharedaddy-action-subscription-menu
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Remove Settings > Sharing menu item registered by Publicize, Sharedaddy, and Likes.
+Remove Settings > Sharing menu item registered by Publicize, and Likes.

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -208,6 +208,8 @@ class Jetpack_Likes_Settings {
 	/**
 	 * Adds the 'sharing' menu to the settings menu.
 	 * Only ran if sharedaddy and publicize are not already active.
+	 *
+	 * @deprecated
 	 */
 	public function sharing_menu() {
 		add_submenu_page( 'options-general.php', esc_html__( 'Sharing Settings', 'jetpack' ), esc_html__( 'Sharing', 'jetpack' ), 'manage_options', 'sharing', array( $this, 'sharing_page' ) );

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -219,6 +219,8 @@ class Jetpack_Likes_Settings {
 	 * Provides a sharing page with the sharing_global_options hook
 	 * so we can display the setting.
 	 * Only ran if sharedaddy and publicize are not already active.
+	 *
+	 * @deprecated $$next-version$$
 	 */
 	public function sharing_page() {
 		$this->updated_message();
@@ -237,6 +239,8 @@ class Jetpack_Likes_Settings {
 
 	/**
 	 * Returns the settings have been saved message.
+	 *
+	 * @deprecated $$next-version$$
 	 */
 	public function updated_message() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- ignoring since we are just displaying that the settings have been saved and not making  any other changes to the site.
@@ -247,6 +251,8 @@ class Jetpack_Likes_Settings {
 
 	/**
 	 * Returns just the "sharing buttons" w/ like option block, so it can be inserted into different sharing page contexts
+	 *
+	 * @deprecated $$next-version$$
 	 */
 	public function sharing_block() {
 		?>

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -209,7 +209,7 @@ class Jetpack_Likes_Settings {
 	 * Adds the 'sharing' menu to the settings menu.
 	 * Only ran if sharedaddy and publicize are not already active.
 	 *
-	 * @deprecated
+	 * @deprecated $$next-version$$
 	 */
 	public function sharing_menu() {
 		add_submenu_page( 'options-general.php', esc_html__( 'Sharing Settings', 'jetpack' ), esc_html__( 'Sharing', 'jetpack' ), 'manage_options', 'sharing', array( $this, 'sharing_page' ) );

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -10,7 +10,6 @@
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 
 if ( ! defined( 'WP_SHARING_PLUGIN_URL' ) ) {
 	define( 'WP_SHARING_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
@@ -123,27 +122,21 @@ class Sharing_Admin {
 	}
 
 	/**
-	 * Register Sharing settings menu page.
-	 *
-	 * We only need to register it on self-hosted sites, in offline mode.
+	 * Register Sharing settings menu page in offline mode.
 	 */
 	public function subscription_menu() {
-		// Hide the menu on the wpcom platform.
-		if ( ( new Host() )->is_wpcom_platform() ) {
+		if ( ! ( new Status() )->is_offline_mode() ) {
 			return;
 		}
 
-		// Register it only on self-hosted sites, in offline mode.
-		if ( Jetpack::is_module_active( 'sharedaddy' ) && ( new Status() )->is_offline_mode() ) {
-			add_submenu_page(
-				'options-general.php',
-				__( 'Sharing Settings', 'jetpack' ),
-				__( 'Sharing', 'jetpack' ),
-				'manage_options',
-				'sharing',
-				array( $this, 'wrapper_admin_page' )
-			);
-		}
+		add_submenu_page(
+			'options-general.php',
+			__( 'Sharing Settings', 'jetpack' ),
+			__( 'Sharing', 'jetpack' ),
+			'manage_options',
+			'sharing',
+			array( $this, 'wrapper_admin_page' )
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -10,6 +10,7 @@
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 
 if ( ! defined( 'WP_SHARING_PLUGIN_URL' ) ) {
 	define( 'WP_SHARING_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
@@ -29,6 +30,7 @@ class Sharing_Admin {
 		require_once WP_SHARING_PLUGIN_DIR . 'sharing-service.php';
 
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
+		add_action( 'admin_menu', array( $this, 'subscription_menu' ) );
 
 		// Insert our CSS and JS
 		add_action( 'load-settings_page_sharing', array( $this, 'sharing_head' ) );
@@ -122,26 +124,26 @@ class Sharing_Admin {
 
 	/**
 	 * Register Sharing settings menu page.
+	 *
+	 * We only need to register it on self-hosted sites, in offline mode.
 	 */
 	public function subscription_menu() {
-		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-			$active = Jetpack::get_active_modules();
-			if (
-				! in_array( 'publicize', $active, true )
-				&& ! current_user_can( 'manage_options' )
-			) {
-				return;
-			}
+		// Hide the menu on the wpcom platform.
+		if ( ( new Host() )->is_wpcom_platform() ) {
+			return;
 		}
 
-		add_submenu_page(
-			'options-general.php',
-			__( 'Sharing Settings', 'jetpack' ),
-			__( 'Sharing', 'jetpack' ),
-			'publish_posts',
-			'sharing',
-			array( $this, 'wrapper_admin_page' )
-		);
+		// Register it only on self-hosted sites, in offline mode.
+		if ( Jetpack::is_module_active( 'sharedaddy' ) && ( new Status() )->is_offline_mode() ) {
+			add_submenu_page(
+				'options-general.php',
+				__( 'Sharing Settings', 'jetpack' ),
+				__( 'Sharing', 'jetpack' ),
+				'manage_options',
+				'sharing',
+				array( $this, 'wrapper_admin_page' )
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/pull/35781/files/b51d3f63196041ca03661aab2f04cf785202f243#r1497118996

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Register the Sharing menu on self-hosted sites in offline mode to address the issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your self-hosted site.
* Enable the [offline mode](https://jetpack.com/support/offline-mode/)
  * If you use Jurassic Ninja, go to Settings > Jetpack Constants to enable that option,
  * if not you can add `define( 'JETPACK_DEV_DEBUG', true );` to your site's wp-config.php file)
* Go to Appearance > Themes and install / activate a classic theme, e.g.: TT1
* Go to Jetpack > Settings > Sharing and enable sharing buttons.
* Click the link to wp-admin sharing settings appear at the bottom of the card as soon as the module is active.
* Make sure you can see the sharing page
