### PR TITLE
Update/premium content custom domain token fix

### DIFF
--- a/projects/plugins/jetpack/changelog/update-premium-content-custom-domain-token-fix
+++ b/projects/plugins/jetpack/changelog/update-premium-content-custom-domain-token-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Fix the premium content cookie domain

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -444,7 +444,12 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 		}
 
 		if ( ! empty( $token ) && false === headers_sent() ) {
-			setcookie( self::JWT_AUTH_TOKEN_COOKIE_NAME, $token, 0, '/', COOKIE_DOMAIN, is_ssl(), true ); // httponly -- used by visitor_can_view_content() within the PHP context.
+			$cookie_domain = COOKIE_DOMAIN;
+			if ( empty( $cookie_domain ) && ! empty( $_SERVER['HTTP_HOST'] ) ) {
+				$cookie_domain = '.' . wp_unslash( $_SERVER['HTTP_HOST'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			}
+
+			setcookie( self::JWT_AUTH_TOKEN_COOKIE_NAME, $token, 0, '/', $cookie_domain, is_ssl(), false ); // phpcs:ignore Jetpack.Functions.SetCookie.FoundNonHTTPOnlyFalse
 		}
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1065,7 +1065,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 			'site_id'      => intval( \Jetpack_Options::get_option( 'id' ) ),
 			'redirect_url' => rawurlencode( $redirect_url ),
 		),
-		'https://subscribe.wordpress.com/memberships/jwt'
+		'https://subscribe.wordpress.com/memberships/jwt/'
 	);
 	if ( is_user_auth() ) {
 		if ( ( new Host() )->is_wpcom_simple() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes this scenario: p1708467751975069/1708362991.873199-slack-C052XEUUBL4

> the problem is we have two cookies on different domain
> <img width="1046" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/10e8e2c0-d857-4a8f-85e7-d9bc10a55d37">
> and that is because the `COOKIE_DOMAIN` is set to `false` in some cases
> the better way would be to define this constant somewhere if not defined
> another problem is that this cookie is HTTP only, and it’s not accessible by js
> 
> https://github.com/Automattic/jetpack/pull/35680
> https://github.com/Automattic/gold/issues/326


## Proposed changes:
* makes the premium content cookie not HTTP only since we are reading it on frontend here https://github.com/Automattic/jetpack/blob/3cf4ae640be8cf9cb53f37e8445bed7b62519a53/projects/plugins/jetpack/extensions/shared/memberships.js#L51
* sets the premium content cookie domain when it's not set (the `COOKIE_DOMAIN` constant is set to `false` when I test the above scenario in Jurrasic Tube
* prevents HTTP 301 redirections after "Already a subscriber?" link is clicked (not related to the bug but decided to fix it here)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*