### PR TITLE
Subscribe block: fix disabled input state styles

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-disabled-state
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-disabled-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribe block: improve disabled placeholder state theme colour compatibility

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -32,8 +32,7 @@
 		flex-direction: column;
 	}
 
-	&:not(.wp-block-jetpack-subscriptions__use-newline) 
-	{
+	&:not(.wp-block-jetpack-subscriptions__use-newline) {
 		.is-not-subscriber {
 			.wp-block-jetpack-subscriptions__form-elements {
 				display: flex;
@@ -47,7 +46,7 @@
 	}
 
 	.wp-block-jetpack-subscriptions__form,
-	form  {
+	form {
 		.wp-block-jetpack-subscriptions__textfield .components-text-control__input,
 		.wp-block-jetpack-subscriptions__button,
 		input[type="email"],
@@ -64,7 +63,8 @@
 			cursor: pointer;
 		}
 
-		input[type="email"]::placeholder {
+		input[type="email"]::placeholder,
+		input[type="email"]:disabled::placeholder {
 			color: currentColor;
 			opacity: .5;
 		}
@@ -118,3 +118,4 @@
 		}
 	}
 }
+

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -64,7 +64,7 @@
 		}
 
 		input[type="email"]::placeholder,
-		input[type="email"]:disabled::placeholder {
+		input[type="email"]:disabled {
 			color: currentColor;
 			opacity: .5;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/86451

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds styling for disabled state, better accommodate for different scenarios like dark backgrounds

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

