### PR TITLE
Boost: Add cache invalidation on module toggle

### DIFF
--- a/projects/plugins/boost/app/contracts/Changes_Output.php
+++ b/projects/plugins/boost/app/contracts/Changes_Output.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Contracts;
+
+/**
+ * Modules can implement this interface to indicate that they change the HTML output for the site visitor.
+ */
+interface Changes_Output {}

--- a/projects/plugins/boost/app/contracts/Changes_Output.php
+++ b/projects/plugins/boost/app/contracts/Changes_Output.php
@@ -5,4 +5,4 @@ namespace Automattic\Jetpack_Boost\Contracts;
 /**
  * Modules can implement this interface to indicate that they change the HTML output for the site visitor.
  */
-interface Changes_Output {}
+interface Changes_Page_Output {}

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
@@ -34,6 +34,7 @@ class Critical_CSS_Invalidator {
 
 		$state = new Critical_CSS_State();
 		$state->clear();
+		do_action( 'jetpack_boost_critical_css_invalidated' );
 
 		Cloud_CSS_Followup::unschedule();
 	}
@@ -44,8 +45,6 @@ class Critical_CSS_Invalidator {
 	public static function handle_environment_change( $is_major_change ) {
 		if ( $is_major_change ) {
 			self::clear_data();
-
-			do_action( 'critical_css_invalidated' );
 		}
 	}
 

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -133,6 +133,7 @@ class Critical_CSS_State {
 
 		if ( $is_done ) {
 			$this->state['status'] = self::GENERATION_STATES['generated'];
+			do_action( 'jetpack_boost_critical_css_generated' );
 		}
 	}
 

--- a/projects/plugins/boost/app/modules/Modules_Index.php
+++ b/projects/plugins/boost/app/modules/Modules_Index.php
@@ -53,6 +53,24 @@ class Modules_Index {
 		}
 	}
 
+	/**
+	 * Get all modules that implement a specific interface.
+	 *
+	 * @param string $interface - The interface to search for.
+	 * @return array - An array of module classes that implement the interface.
+	 */
+	public function get_modules_implementing( string $interface ): array {
+		$matching_modules = array();
+
+		foreach ( self::MODULES as $module ) {
+			if ( in_array( $interface, class_implements( $module ), true ) ) {
+				$matching_modules[] = $module;
+			}
+		}
+
+		return $matching_modules;
+	}
+
 	public function available_modules() {
 		$forced_disabled_modules = $this->get_disabled_modules();
 

--- a/projects/plugins/boost/app/modules/Modules_Index.php
+++ b/projects/plugins/boost/app/modules/Modules_Index.php
@@ -57,14 +57,14 @@ class Modules_Index {
 	 * Get all modules that implement a specific interface.
 	 *
 	 * @param string $interface - The interface to search for.
-	 * @return array - An array of module classes that implement the interface.
+	 * @return array - An array of module classes indexed by slug that implement the interface.
 	 */
 	public static function get_modules_implementing( string $interface ): array {
 		$matching_modules = array();
 
 		foreach ( self::MODULES as $module ) {
 			if ( in_array( $interface, class_implements( $module ), true ) ) {
-				$matching_modules[] = $module;
+				$matching_modules[ $module::get_slug() ] = $module;
 			}
 		}
 

--- a/projects/plugins/boost/app/modules/Modules_Index.php
+++ b/projects/plugins/boost/app/modules/Modules_Index.php
@@ -59,7 +59,7 @@ class Modules_Index {
 	 * @param string $interface - The interface to search for.
 	 * @return array - An array of module classes that implement the interface.
 	 */
-	public function get_modules_implementing( string $interface ): array {
+	public static function get_modules_implementing( string $interface ): array {
 		$matching_modules = array();
 
 		foreach ( self::MODULES as $module ) {

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
 
-use Automattic\Jetpack_Boost\Contracts\Changes_Output;
+use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Contracts\Has_Activate;
 use Automattic\Jetpack_Boost\Contracts\Has_Deactivate;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
@@ -53,7 +53,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 	 */
 	public function handle_module_status_updated( $module_slug, $status ) {
 		// Get a list of modules that can change the HTML output.
-		$output_changing_modules = Modules_Index::get_modules_implementing( Changes_Output::class );
+		$output_changing_modules = Modules_Index::get_modules_implementing( Changes_Page_Output::class );
 
 		// Special case: don't clear when enabling Critical or Cloud CSS, as they will
 		// be handled after generation.

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -42,6 +42,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 		Garbage_Collection::setup();
 
 		add_action( 'jetpack_boost_module_status_updated', array( $this, 'handle_module_status_updated' ) );
+		add_action( 'jetpack_boost_critical_css_invalidated', array( $this, 'invalidate_cache' ) );
 	}
 
 	/**
@@ -61,9 +62,13 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 		);
 
 		if ( in_array( $module_slug, $slugs, true ) ) {
-			$cache = new Boost_Cache();
-			$cache->get_storage()->invalidate( Boost_Cache_Utils::normalize_request_uri( home_url() ), '*' );
+			$this->invalidate_cache();
 		}
+	}
+
+	public function invalidate_cache() {
+		$cache = new Boost_Cache();
+		$cache->get_storage()->invalidate( Boost_Cache_Utils::normalize_request_uri( home_url() ), '*' );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -43,6 +43,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 
 		add_action( 'jetpack_boost_module_status_updated', array( $this, 'handle_module_status_updated' ) );
 		add_action( 'jetpack_boost_critical_css_invalidated', array( $this, 'invalidate_cache' ) );
+		add_action( 'jetpack_boost_critical_css_generated', array( $this, 'invalidate_cache' ) );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -55,12 +55,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 		// Get a list of modules that can change the HTML output.
 		$modules = Modules_Index::get_modules_implementing( Changes_Output::class );
 
-		$slugs = array_map(
-			function ( $module ) {
-				return $module::get_slug();
-			},
-			$modules
-		);
+		$slugs = array_keys( $modules );
 
 		if ( in_array( $module_slug, $slugs, true ) ) {
 			$this->invalidate_cache();

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -71,7 +71,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 
 	public function invalidate_cache() {
 		$cache = new Boost_Cache();
-		$cache->get_storage()->invalidate( Boost_Cache_Utils::normalize_request_uri( home_url() ), '*' );
+		$cache->get_storage()->invalidate( home_url(), Boost_Cache_Utils::DELETE_ALL );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -89,8 +89,9 @@ if ( ! file_exists( \'' . $boost_cache_filename . '\' ) ) {
 return;
 }
 require_once( \'' . $boost_cache_filename . '\');
-
-( new Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache() )->serve();
+$boost_cache = new Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache();
+$boost_cache->init_actions();
+$boost_cache->serve();
 ';
 
 		$write_advanced_cache = Filesystem_Utils::write_to_file( $advanced_cache_filename, $contents );

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -41,14 +41,12 @@ class Boost_Cache {
 		$home           = isset( $_SERVER['HTTP_HOST'] ) ? strtolower( $_SERVER['HTTP_HOST'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$this->storage  = $storage ?? new Storage\File_Storage( $home );
 		$this->request  = Request::current();
-
-		$this->init_actions();
 	}
 
 	/**
 	 * Initialize the actions for the cache.
 	 */
-	protected function init_actions() {
+	public function init_actions() {
 		add_action( 'transition_post_status', array( $this, 'delete_on_post_transition' ), 10, 3 );
 		add_action( 'transition_comment_status', array( $this, 'delete_on_comment_transition' ), 10, 3 );
 		add_action( 'comment_post', array( $this, 'delete_on_comment_post' ), 10, 3 );

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -3,7 +3,7 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS;
 
 use Automattic\Jetpack\Boost_Core\Lib\Boost_API;
-use Automattic\Jetpack_Boost\Contracts\Changes_Output;
+use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
@@ -16,7 +16,7 @@ use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Update_Cloud_CSS;
 
-class Cloud_CSS implements Pluggable, Has_Endpoints, Changes_Output {
+class Cloud_CSS implements Pluggable, Has_Endpoints, Changes_Page_Output {
 
 	/**
 	 * Critical CSS storage class instance.

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -40,8 +40,8 @@ class Cloud_CSS implements Pluggable, Has_Endpoints, Changes_Output {
 	public function setup() {
 		add_action( 'wp', array( $this, 'display_critical_css' ) );
 		add_action( 'save_post', array( $this, 'handle_save_post' ), 10, 2 );
+		add_action( 'jetpack_boost_critical_css_invalidated', array( $this, 'handle_critical_css_invalidated' ) );
 		add_filter( 'jetpack_boost_total_problem_count', array( $this, 'update_total_problem_count' ) );
-		add_filter( 'critical_css_invalidated', array( $this, 'handle_critical_css_invalidated' ) );
 		add_filter( 'query_vars', array( '\Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator', 'add_generate_query_action_to_list' ) );
 
 		Generator::init();

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS;
 
 use Automattic\Jetpack\Boost_Core\Lib\Boost_API;
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
@@ -15,7 +16,7 @@ use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Update_Cloud_CSS;
 
-class Cloud_CSS implements Pluggable, Has_Endpoints {
+class Cloud_CSS implements Pluggable, Has_Endpoints, Changes_Output {
 
 	/**
 	 * Critical CSS storage class instance.

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS;
 
 use Automattic\Jetpack_Boost\Admin\Regenerate_Admin_Notice;
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
@@ -13,7 +14,7 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 
-class Critical_CSS implements Pluggable {
+class Critical_CSS implements Pluggable, Changes_Output {
 
 	/**
 	 * Critical CSS storage class instance.

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
@@ -3,7 +3,7 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS;
 
 use Automattic\Jetpack_Boost\Admin\Regenerate_Admin_Notice;
-use Automattic\Jetpack_Boost\Contracts\Changes_Output;
+use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
@@ -14,7 +14,7 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 
-class Critical_CSS implements Pluggable, Changes_Output {
+class Critical_CSS implements Pluggable, Changes_Page_Output {
 
 	/**
 	 * Critical CSS storage class instance.

--- a/projects/plugins/boost/app/modules/optimizations/image-cdn/class-image-cdn.php
+++ b/projects/plugins/boost/app/modules/optimizations/image-cdn/class-image-cdn.php
@@ -3,10 +3,11 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Image_CDN;
 
 use Automattic\Jetpack\Image_CDN\Image_CDN_Setup;
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 
-class Image_CDN implements Pluggable {
+class Image_CDN implements Pluggable, Changes_Output {
 
 	public function setup() {
 		Image_CDN_Setup::load();

--- a/projects/plugins/boost/app/modules/optimizations/image-cdn/class-image-cdn.php
+++ b/projects/plugins/boost/app/modules/optimizations/image-cdn/class-image-cdn.php
@@ -3,11 +3,11 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Image_CDN;
 
 use Automattic\Jetpack\Image_CDN\Image_CDN_Setup;
-use Automattic\Jetpack_Boost\Contracts\Changes_Output;
+use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 
-class Image_CDN implements Pluggable, Changes_Output {
+class Image_CDN implements Pluggable, Changes_Page_Output {
 
 	public function setup() {
 		Image_CDN_Setup::load();

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
@@ -2,11 +2,11 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Minify;
 
-use Automattic\Jetpack_Boost\Contracts\Changes_Output;
+use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_CSS;
 
-class Minify_CSS implements Pluggable, Changes_Output {
+class Minify_CSS implements Pluggable, Changes_Page_Output {
 
 	public static $default_excludes = array( 'admin-bar', 'dashicons', 'elementor-app' );
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
@@ -2,10 +2,11 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Minify;
 
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_CSS;
 
-class Minify_CSS implements Pluggable {
+class Minify_CSS implements Pluggable, Changes_Output {
 
 	public static $default_excludes = array( 'admin-bar', 'dashicons', 'elementor-app' );
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
@@ -2,11 +2,11 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Minify;
 
-use Automattic\Jetpack_Boost\Contracts\Changes_Output;
+use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_JS;
 
-class Minify_JS implements Pluggable, Changes_Output {
+class Minify_JS implements Pluggable, Changes_Page_Output {
 
 	public static $default_excludes = array( 'jquery', 'jquery-core', 'underscore', 'backbone' );
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
@@ -2,10 +2,11 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Minify;
 
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_JS;
 
-class Minify_JS implements Pluggable {
+class Minify_JS implements Pluggable, Changes_Output {
 
 	public static $default_excludes = array( 'jquery', 'jquery-core', 'underscore', 'backbone' );
 

--- a/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -9,14 +9,14 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Render_Blocking_JS;
 
-use Automattic\Jetpack_Boost\Contracts\Changes_Output;
+use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Output_Filter;
 
 /**
  * Class Render_Blocking_JS
  */
-class Render_Blocking_JS implements Pluggable, Changes_Output {
+class Render_Blocking_JS implements Pluggable, Changes_Page_Output {
 	/**
 	 * Holds the script tags removed from the output buffer.
 	 *

--- a/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -9,13 +9,14 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Render_Blocking_JS;
 
+use Automattic\Jetpack_Boost\Contracts\Changes_Output;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Output_Filter;
 
 /**
  * Class Render_Blocking_JS
  */
-class Render_Blocking_JS implements Pluggable {
+class Render_Blocking_JS implements Pluggable, Changes_Output {
 	/**
 	 * Holds the script tags removed from the output buffer.
 	 *

--- a/projects/plugins/boost/changelog/boost-cache-module-toggle-invalidation
+++ b/projects/plugins/boost/changelog/boost-cache-module-toggle-invalidation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added cache invalidation on module toggle
+
+

--- a/projects/plugins/boost/compatibility/wp-super-cache.php
+++ b/projects/plugins/boost/compatibility/wp-super-cache.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack_Boost\Compatibility\Super_Cache;
 
-use Automattic\Jetpack_Boost\Contracts\Changes_Output;
+use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Modules\Modules_Index;
 
 /**
@@ -53,7 +53,7 @@ add_action( 'jetpack_boost_critical_css_invalidated', __NAMESPACE__ . '\clear_ca
  */
 function module_status_updated( $module_slug, $status ) {
 	// Get a list of modules that can change the HTML output.
-	$output_changing_modules = Modules_Index::get_modules_implementing( Changes_Output::class );
+	$output_changing_modules = Modules_Index::get_modules_implementing( Changes_Page_Output::class );
 
 	// Special case: don't clear when enabling Critical or Cloud CSS, as they will
 	// be handled after generation.

--- a/projects/plugins/boost/compatibility/wp-super-cache.php
+++ b/projects/plugins/boost/compatibility/wp-super-cache.php
@@ -43,6 +43,7 @@ function clear_cache() {
 	}
 }
 add_action( 'jetpack_boost_critical_css_generated', __NAMESPACE__ . '\clear_cache' );
+add_action( 'jetpack_boost_critical_css_invalidated', __NAMESPACE__ . '\clear_cache' );
 
 /**
  * Clear Super Cache's cache when a module is enabled or disabled.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35748 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Invalidate cache on module toggle
- Invalidate cache on critical CSS generation
- Super Cache compatibility fix:
  - Invalidate cache only on output changing module toggle
  - Invalidate cache on C.CSS invalidation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Create some cache by browsing the site
* Toggle a boost module that might change the HTML output. 
* Make sure all cache got deleted. Special case critical-css is activation doesn't immidately clear cache. It waits until C.CSS generation.

