### PR TITLE
My Jetpack: pass quantity to checkout process

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
@@ -55,6 +55,7 @@ const ProductDetailTableColumn = ( {
 		introductoryOffer,
 		isFree,
 		wpcomProductSlug,
+		quantity = null,
 	} = tiersPricingForUi[ tier ];
 
 	// Set up the checkout workflow hook.
@@ -65,6 +66,7 @@ const ProductDetailTableColumn = ( {
 		connectAfterCheckout: true,
 		siteSuffix,
 		useBlogIdSuffix: true,
+		quantity,
 	} );
 
 	// Register the click handler for the product button.

--- a/projects/packages/my-jetpack/changelog/add-support-quantity-checkout-process
+++ b/projects/packages/my-jetpack/changelog/add-support-quantity-checkout-process
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: let tier data pass on quantity data to checkout process for proper checkout URL crafting


### PR DESCRIPTION
While tiered plans have the capability of indicating a quantity and the checkout process considers it at the time of building the checkout URL, the value was never being passed from the pricing tables.

## Proposed changes:
Add `quantity`, when available, to the props passed on to the checkout process. The value should be present on the `pricingForUi` prop sent by the product class.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
There's currently no easy way to test this, I'll put up another PR to test. Meanwhile, all checkout processes should continue to work normally:
- go to My Jetpack screen and visit the products, the pricing tables should look as usual
- purchase as many products as you can, see that the checkout process finishes without hiccups