### PR TITLE
[Boost] Use wp_trash_post to clear cache files when a post is trashed

### DIFF
--- a/projects/plugins/boost/changelog/Boost - use wp_trash_post when clearing the cache so the permalink is preserved and cache files cleared.
+++ b/projects/plugins/boost/changelog/Boost - use wp_trash_post when clearing the cache so the permalink is preserved and cache files cleared.
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Boost - use wp_trash_post when clearing the cache so the permalink is preserved and cache files cleared.


### PR DESCRIPTION
When a post is deleted (trashed) the permalink is deleted, even though the post data is still preserved. By using wp_trash_post we can delete the cache data before the permalink is modified and delete the cache files belonging to that post.

## Proposed changes:
* Add wp_trash_post action and a function to delete the cache if the post was previously published.
* Stop the transition function if new_status is trash and remove the "sample_permalink" code that was supposed to deal with this.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR to your test site
* run `jetpack docker tail` or tail your debug log.
* Trash a post and make sure it deletes the cache for the page, tags, categories and the homepage, but not every cached file.


