### PR TITLE
Social: Add the post list enhancements to Social Notes

### DIFF
--- a/projects/packages/post-list/changelog/add-social-notes-post-list
+++ b/projects/packages/post-list/changelog/add-social-notes-post-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Social Notes: Added the post list enhancements

--- a/projects/packages/post-list/composer.json
+++ b/projects/packages/post-list/composer.json
@@ -52,7 +52,7 @@
 			"link-template": "https://github.com/automattic/jetpack-post-list/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.5.x-dev"
+			"dev-trunk": "0.6.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -17,21 +17,26 @@ class Post_List {
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.
+	 *
+	 * @return Post_List Post_List instance.
 	 */
 	public static function configure() {
 		add_post_type_support( 'post', self::FEATURE );
 		add_post_type_support( 'page', self::FEATURE );
-		self::setup();
+		return self::setup();
 	}
 
 	/**
 	 * Convenience function to create an instance of the class and register the
 	 * filters and actions. It allows for the feature to be set up without adding
 	 * support for posts and pages.
+	 *
+	 * @return Post_List Post_List instance.
 	 */
 	public static function setup() {
 		$post_list = self::get_instance();
 		$post_list->register();
+		return $post_list;
 	}
 
 	/**

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Post_List;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.5.1';
+	const PACKAGE_VERSION = '0.6.0-alpha';
 	const FEATURE         = 'enhanced_post_list';
 
 	/**

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -13,11 +13,23 @@ namespace Automattic\Jetpack\Post_List;
 class Post_List {
 
 	const PACKAGE_VERSION = '0.5.1';
+	const FEATURE         = 'enhanced_post_list';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.
 	 */
 	public static function configure() {
+		add_post_type_support( 'post', self::FEATURE );
+		add_post_type_support( 'page', self::FEATURE );
+		self::setup();
+	}
+
+	/**
+	 * Convenience function to create an instance of the class and register the
+	 * filters and actions. It allows for the feature to be set up without adding
+	 * support for posts and pages.
+	 */
+	public static function setup() {
 		$post_list = self::get_instance();
 		$post_list->register();
 	}
@@ -82,7 +94,7 @@ class Post_List {
 	 */
 	public function maybe_customize_columns( $post_type ) {
 		// Add the thumbnail column if this is specifically "Posts" or "Pages".
-		if ( in_array( $post_type, array( 'post', 'page' ), true ) ) {
+		if ( post_type_supports( $post_type, self::FEATURE ) ) {
 			// Add the thumbnail column to the "Posts" admin table.
 			add_filter( 'manage_posts_columns', array( $this, 'add_thumbnail_column' ), 10, 2 );
 			add_action( 'manage_posts_custom_column', array( $this, 'populate_thumbnail_rows' ), 10, 2 );
@@ -229,7 +241,7 @@ class Post_List {
 	 * @return array    The columns to hide by default.
 	 */
 	public function adjust_default_columns( $cols, $screen ) {
-		if ( ! ( 'edit' === $screen->base && in_array( $screen->post_type, array( 'post', 'page' ), true ) ) ) {
+		if ( ! ( 'edit' === $screen->base && post_type_supports( $screen->post_type, self::FEATURE ) ) ) {
 			return $cols;
 		}
 

--- a/projects/packages/post-list/tests/php/test-post-list.php
+++ b/projects/packages/post-list/tests/php/test-post-list.php
@@ -20,16 +20,17 @@ use WorDBless\BaseTestCase;
 class Test_Post_List extends BaseTestCase {
 
 	/**
-	 * Post_List::get_instance() should return and instance of the Post_List class.
+	 * Post_List::configure() should return and instance of the Post_List class.
 	 */
-	public function test_get_instance() {
-		$this->assertInstanceOf( Post_List::class, Post_List::get_instance() );
+	public function test_configure() {
+		$this->assertInstanceOf( Post_List::class, Post_List::configure() );
 	}
 
 	/**
 	 * Test the register() method.
 	 */
 	public function test_register() {
+		// We use get_instance() here because we're specifically testing register()
 		$post_list = Post_List::get_instance();
 
 		// did_action() Retrieves the number of times an action has been fired during the current request.
@@ -56,7 +57,7 @@ class Test_Post_List extends BaseTestCase {
 	 * Test the enqueue_scripts() method.
 	 */
 	public function test_enqueue_scripts() {
-		$post_list = Post_List::get_instance();
+		$post_list = Post_List::configure();
 
 		// Confirm that our style, filter, and action have not been added before the enqueue_scripts() method call.
 		$this->assertFalse( wp_style_is( 'jetpack_posts_list_ui_style' ) );
@@ -84,9 +85,9 @@ class Test_Post_List extends BaseTestCase {
 	 * Thumbnail should show up on "Pages", but Share should not, because 'publicize' is not supported on "Pages".
 	 */
 	public function test_add_filters_and_actions_for_screen_thumbnail() {
-		$post_list = Post_List::get_instance();
-
 		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
+
+		$post_list = Post_List::configure();
 
 		$current_screen = (object) array(
 			'base'      => 'edit',
@@ -113,9 +114,8 @@ class Test_Post_List extends BaseTestCase {
 	 * types that support publicize and the block editor.
 	 */
 	public function test_add_filters_and_actions_for_screen_share() {
-		$post_list = Post_List::get_instance();
-
 		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
+		$post_list = Post_List::configure();
 
 		// Create a custom post type.
 		register_post_type(
@@ -151,9 +151,8 @@ class Test_Post_List extends BaseTestCase {
 	 * The thumbnail and Share action should be available on "Posts".
 	 */
 	public function test_add_filters_and_actions_for_screen_thumbnail_and_share() {
-		$post_list = Post_List::get_instance();
-
 		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
+		$post_list = Post_List::configure();
 
 		$current_screen = (object) array(
 			'base'      => 'edit',
@@ -181,9 +180,9 @@ class Test_Post_List extends BaseTestCase {
 	 * thumbnails show up.
 	 */
 	public function test_add_filters_and_actions_for_screen_share_flag_disabled() {
-		$post_list = Post_List::get_instance();
 
 		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
+		$post_list = Post_List::configure();
 
 		$current_screen = (object) array(
 			'base'      => 'edit',
@@ -206,7 +205,7 @@ class Test_Post_List extends BaseTestCase {
 	 * Test the add_filters_and_actions_for_screen() method doesn't add thumbnails or Share if screen not 'edit' base.
 	 */
 	public function test_add_filters_and_actions_for_screen_wrong_screen() {
-		$post_list      = Post_List::get_instance();
+		$post_list      = Post_List::configure();
 		$current_screen = (object) array(
 			'base'      => 'edit-tags',
 			'post_type' => 'post',
@@ -246,7 +245,7 @@ class Test_Post_List extends BaseTestCase {
 			'date'       => 'Date',
 		);
 
-		$post_list       = Post_List::get_instance();
+		$post_list       = Post_List::configure();
 		$columns_results = $post_list->add_thumbnail_column( $columns );
 
 		$this->assertSame( $columns_results, $columns_expected );
@@ -265,7 +264,7 @@ class Test_Post_List extends BaseTestCase {
 			'date'       => 'Date',
 		);
 
-		$post_list       = Post_List::get_instance();
+		$post_list       = Post_List::configure();
 		$columns_results = $post_list->add_thumbnail_column( $columns );
 
 		$this->assertSame( $columns_results, $columns );

--- a/projects/plugins/jetpack/changelog/add-social-notes-post-list
+++ b/projects/plugins/jetpack/changelog/add-social-notes-post-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1946,7 +1946,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/post-list",
-				"reference": "9ae1d7e7fc798fbdc910960aa1d2d18e88e3bf56"
+				"reference": "d163b29e9f11af83ba2995fcec0106df86345c7e"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1972,7 +1972,7 @@
 					"link-template": "https://github.com/automattic/jetpack-post-list/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.5.x-dev"
+					"dev-trunk": "0.6.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/social/changelog/add-social-notes-post-list
+++ b/projects/plugins/social/changelog/add-social-notes-post-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Social Notes: Added the post list enhancements

--- a/projects/plugins/social/changelog/add-social-notes-post-list#2
+++ b/projects/plugins/social/changelog/add-social-notes-post-list#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -16,7 +16,7 @@
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-plans": "@dev",
-		"automattic/jetpack-post-list": "^0.5.0@dev"
+		"automattic/jetpack-post-list": "@dev"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -15,7 +15,8 @@
 		"automattic/jetpack-my-jetpack": "@dev",
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-status": "@dev",
-		"automattic/jetpack-plans": "@dev"
+		"automattic/jetpack-plans": "@dev",
+		"automattic/jetpack-post-list": "^0.5.0@dev"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "bc5fc11b3cbc875c514274f46b8d2139",
+	"content-hash": "b98bf01030a3fbc12d58f32238f79820",
 	"packages": [
 		{
 			"name": "automattic/jetpack-a8c-mc-stats",
@@ -1233,6 +1233,68 @@
 				"GPL-2.0-or-later"
 			],
 			"description": "Handle installation of plugins from WP.org",
+			"transport-options": {
+				"relative": true
+			}
+		},
+		{
+			"name": "automattic/jetpack-post-list",
+			"version": "dev-trunk",
+			"dist": {
+				"type": "path",
+				"url": "../../packages/post-list",
+				"reference": "9ae1d7e7fc798fbdc910960aa1d2d18e88e3bf56"
+			},
+			"require": {
+				"automattic/jetpack-assets": "@dev",
+				"php": ">=7.0"
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "@dev",
+				"automattic/wordbless": "@dev",
+				"yoast/phpunit-polyfills": "1.1.0"
+			},
+			"suggest": {
+				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+			},
+			"type": "jetpack-library",
+			"extra": {
+				"autotagger": true,
+				"mirror-repo": "Automattic/jetpack-post-list",
+				"textdomain": "jetpack-post-list",
+				"version-constants": {
+					"::PACKAGE_VERSION": "src/class-post-list.php"
+				},
+				"changelogger": {
+					"link-template": "https://github.com/automattic/jetpack-post-list/compare/v${old}...v${new}"
+				},
+				"branch-alias": {
+					"dev-trunk": "0.5.x-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"scripts": {
+				"phpunit": [
+					"./vendor/phpunit/phpunit/phpunit --colors=always"
+				],
+				"test-php": [
+					"@composer phpunit"
+				],
+				"post-install-cmd": [
+					"WorDBless\\Composer\\InstallDropin::copy"
+				],
+				"post-update-cmd": [
+					"WorDBless\\Composer\\InstallDropin::copy"
+				]
+			},
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "Enhance the classic view of the Admin section of your WordPress site",
 			"transport-options": {
 				"relative": true
 			}

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "b98bf01030a3fbc12d58f32238f79820",
+	"content-hash": "0dd6601ce5d17fc926d4f0e587c5d9f3",
 	"packages": [
 		{
 			"name": "automattic/jetpack-a8c-mc-stats",
@@ -1243,7 +1243,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/post-list",
-				"reference": "9ae1d7e7fc798fbdc910960aa1d2d18e88e3bf56"
+				"reference": "d163b29e9f11af83ba2995fcec0106df86345c7e"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1269,7 +1269,7 @@
 					"link-template": "https://github.com/automattic/jetpack-post-list/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.5.x-dev"
+					"dev-trunk": "0.6.x-dev"
 				}
 			},
 			"autoload": {
@@ -4728,6 +4728,7 @@
 		"automattic/jetpack-sync": 20,
 		"automattic/jetpack-status": 20,
 		"automattic/jetpack-plans": 20,
+		"automattic/jetpack-post-list": 20,
 		"automattic/jetpack-changelogger": 20
 	},
 	"prefer-stable": true,

--- a/projects/plugins/social/src/class-note.php
+++ b/projects/plugins/social/src/class-note.php
@@ -37,7 +37,8 @@ class Note {
 	 * Things to do on admin_init.
 	 */
 	public function admin_init_actions() {
-		add_action( 'current_screen', array( $this, 'add_filters_and_actions_for_screen' ) );
+		\Automattic\Jetpack\Post_List\Post_List::setup();
+		add_action( 'current_screen', array( $this, 'add_filters_and_actions_for_screen' ), 5 );
 	}
 
 	/**
@@ -51,6 +52,18 @@ class Note {
 		}
 
 		add_filter( 'the_title', array( $this, 'override_empty_title' ), 10, 2 );
+		add_filter( 'jetpack_post_list_display_share_action', array( $this, 'show_share_action' ), 10, 2 );
+	}
+
+	/**
+	 * Used as a filter to determine if we should show the share action on the post list screen.
+	 *
+	 * @param bool   $show_share The current filter value.
+	 * @param string $post_type The current post type on the post list screen.
+	 * @return bool Whether to show the share action.
+	 */
+	public function show_share_action( $show_share, $post_type ) {
+		return self::JETPACK_SOCIAL_NOTE_CPT === $post_type || $show_share;
 	}
 
 	/**
@@ -96,7 +109,7 @@ class Note {
 			),
 			'show_in_rest'  => true,
 			'has_archive'   => true,
-			'supports'      => array( 'editor', 'thumbnail', 'publicize', 'activitypub' ),
+			'supports'      => array( 'editor', 'thumbnail', 'publicize', 'enhanced_post_list', 'activitypub' ),
 			'menu_icon'     => 'dashicons-welcome-write-blog',
 			'rewrite'       => array( 'slug' => 'sn' ),
 			'template'      => array(

--- a/projects/plugins/social/src/js/editor.js
+++ b/projects/plugins/social/src/js/editor.js
@@ -35,7 +35,7 @@ domReady( () => {
 	if ( getQueryArg( window.location.search, 'jetpackSidebarIsOpen' ) === 'true' ) {
 		dispatch( 'core/interface' ).enableComplementaryArea(
 			'core/edit-post',
-			'jetpack-social-sidebar/jetpack-social'
+			'jetpack-social/jetpack-social'
 		);
 	}
 } );


### PR DESCRIPTION
## Proposed changes:

This change updates the post list package so support for the changes to the post list screen can be added to a post type. It also fixes a bug which meant the Social sidebar wasn't opened when required, as the editor loads from the 'Share' quick link.

The post list enhancements are enabled for Social Notes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the Jetpack Social plugin, and enable the Social Notes feature
* Go to the Social Notes post list screen. You should see a modified display with the post thumbnail, and an added link in the post actions to 'Share'
* Click the 'Share' link and check that the editor loads with the Jetpack or Social sidebar open
* Check that this doesn't make the same changes to the Posts or Pages post list

We also need to check that this doesn't modify the behaviour on WPCOM, which has these enhancements enabled for Posts and Pages.

![CleanShot 2024-02-21 at 14 15 39@2x](https://github.com/Automattic/jetpack/assets/96462/53a92982-002f-46d0-9d8e-6b7f56543d44)

