### PR TITLE
[Boost] don't cache fatal errors

### DIFF
--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -53,6 +53,7 @@ class Boost_Cache {
 		add_action( 'edit_comment', array( $this, 'delete_on_comment_edit' ), 10, 2 );
 		add_action( 'switch_theme', array( $this, 'delete_cache' ) );
 		add_action( 'wp_trash_post', array( $this, 'delete_on_post_trash' ), 10, 2 );
+		add_filter( 'wp_php_error_message', array( $this, 'disable_caching_on_error' ) );
 	}
 
 	/**
@@ -350,5 +351,13 @@ class Boost_Cache {
 	 */
 	public function delete_cache() {
 		return $this->delete_cache_for_url( home_url() );
+	}
+
+	public function disable_caching_on_error( $message ) {
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
+		}
+		error_log( 'Fatal error detected, caching disabled' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		return $message;
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -357,7 +357,7 @@ class Boost_Cache {
 		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 			define( 'DONOTCACHEPAGE', true );
 		}
-		error_log( 'Fatal error detected, caching disabled' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		Logger::debug( 'Fatal error detected, caching disabled' );
 		return $message;
 	}
 }

--- a/projects/plugins/boost/changelog/boost-cloud-catch-fatal-errors
+++ b/projects/plugins/boost/changelog/boost-cloud-catch-fatal-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Boost - catch fatal errors and don't cache them.


### PR DESCRIPTION
If a fatal error occurs, we don't want to cache the resulting error message.

## Proposed changes:
* add a filter on wp_php_error_message
* If the filter activates, define the constant DONOTCACHEPAGE to disable caching and return the message.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR
* Create an mu-plugin with a fatal error. (call a non-existent function)
* Load the homepage
* Check the page isn't cached in boost-cache/cache/