### PR TITLE
Social: Added endpoint to sync post meta

### DIFF
--- a/projects/plugins/social/changelog/add-sync-cpt-post-meta
+++ b/projects/plugins/social/changelog/add-sync-cpt-post-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added endpoint to update post meta

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -110,6 +110,7 @@ class Jetpack_Social {
 
 		// Add REST routes
 		add_action( 'rest_api_init', array( new Automattic\Jetpack\Social\REST_Settings_Controller(), 'register_rest_routes' ) );
+		add_action( 'rest_api_init', array( new Automattic\Jetpack\Social\REST_Social_Note_Controller(), 'register_rest_routes' ) );
 
 		// Add block editor assets
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_editor_scripts' ) );

--- a/projects/plugins/social/src/class-rest-social-note-controller.php
+++ b/projects/plugins/social/src/class-rest-social-note-controller.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * The Social Note Controller class.
+ * Registers the REST routes for Social.
+ *
+ * @package automattic/jetpack-social-plugin
+ */
+
+namespace Automattic\Jetpack\Social;
+
+use Automattic\Jetpack\Connection\Rest_Authentication;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Server;
+
+/**
+ * Registers the REST routes for Social.
+ */
+class REST_Social_Note_Controller extends WP_REST_Controller {
+	/**
+	 * Registers the REST routes for Social.
+	 *
+	 * @access public
+	 * @static
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			'jetpack/v4',
+			'/social/update-post-meta',
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_post_meta' ),
+					'permission_callback' => array( $this, 'update_post_meta_permission_callback' ),
+					'args'                => array(
+						'post_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'meta'    => array(
+							'type'       => 'object',
+							'required'   => true,
+							'properties' => array(
+								'_publicize_done_external' => array(
+									'type'     => 'object',
+									'required' => true,
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Update the post meta
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 */
+	public function update_post_meta( $request ) {
+		$request_body = $request->get_json_params();
+
+		$post_id   = $request_body['post_id'];
+		$post_meta = (array) $request_body['meta'];
+		$post      = get_post( $post_id );
+
+		if ( $post && $post->post_type === Note::JETPACK_SOCIAL_NOTE_CPT && $post->post_status === 'publish' ) {
+			if ( isset( $post_meta['_publicize_done_external'] ) ) {
+				update_post_meta( $post_id, '_publicize_done_external', $post_meta['_publicize_done_external'] );
+			}
+			return rest_ensure_response( new \WP_REST_Response() );
+
+		}
+
+		return new WP_Error(
+			'rest_cannot_edit',
+			__( 'Failed to update the post meta', 'jetpack-social' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	/**
+	 * Permissions callback.
+	 */
+	public function update_post_meta_permission_callback() {
+		if ( Rest_Authentication::is_signed_with_blog_token() ) {
+			return true;
+		}
+
+		$error_msg = esc_html__(
+			'You are not allowed to perform this action.',
+			'jetpack-social'
+		);
+
+		return new WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );
+	}
+}

--- a/projects/plugins/social/src/class-rest-social-note-controller.php
+++ b/projects/plugins/social/src/class-rest-social-note-controller.php
@@ -27,18 +27,14 @@ class REST_Social_Note_Controller extends WP_REST_Controller {
 	public function register_rest_routes() {
 		register_rest_route(
 			'jetpack/v4',
-			'/social/update-post-meta',
+			'/social/shares/post/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
-					'callback'            => array( $this, 'update_post_shares_meta' ),
-					'permission_callback' => array( $this, 'update_post_shares_meta_permission_callback' ),
+					'callback'            => array( $this, 'update_post_shares' ),
+					'permission_callback' => array( $this, 'update_post_shares_permission_callback' ),
 					'args'                => array(
-						'post_id' => array(
-							'type'     => 'integer',
-							'required' => true,
-						),
-						'meta'    => array(
+						'meta' => array(
 							'type'       => 'object',
 							'required'   => true,
 							'properties' => array(
@@ -55,14 +51,14 @@ class REST_Social_Note_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Update the post meta
+	 * Update the post with information about shares.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 */
-	public function update_post_shares_meta( $request ) {
+	public function update_post_shares( $request ) {
 		$request_body = $request->get_json_params();
 
-		$post_id   = $request_body['post_id'];
+		$post_id   = $request->get_param( 'id' );
 		$post_meta = $request_body['meta'];
 		$post      = get_post( $post_id );
 
@@ -81,7 +77,7 @@ class REST_Social_Note_Controller extends WP_REST_Controller {
 	/**
 	 * Permissions callback.
 	 */
-	public function update_post_shares_meta_permission_callback() {
+	public function update_post_shares_permission_callback() {
 		if ( Rest_Authentication::is_signed_with_blog_token() ) {
 			return true;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Added endpoint to sync the newly added post-meta key after publicizing. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added an endpoint that will accept a signed Jetpack request. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdrWKz-156-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*  See D139318-code