### PR TITLE
[Boost] invalidate should return true if no cache files were deleted

### DIFF
--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -115,8 +115,10 @@ class File_Storage implements Storage {
 
 		if ( in_array( $type, array( Boost_Cache_Utils::DELETE_FILES, Boost_Cache_Utils::DELETE_ALL ), true ) && is_dir( $normalized_path ) ) {
 			return Boost_Cache_Utils::delete_directory( $normalized_path, $type );
-		} elseif ( $type === Boost_Cache_Utils::DELETE_FILE ) {
+		} elseif ( $type === Boost_Cache_Utils::DELETE_FILE && is_file( $normalized_path ) ) {
 			return Filesystem_Utils::delete_file( $normalized_path );
+		} else {
+			return true; // no cache file or directory to delete.
 		}
 	}
 }

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -118,7 +118,7 @@ class File_Storage implements Storage {
 		} elseif ( $type === Boost_Cache_Utils::DELETE_FILE && is_file( $normalized_path ) ) {
 			return Filesystem_Utils::delete_file( $normalized_path );
 		} else {
-			return true; // no cache file or directory to delete.
+			return new \WP_Error( 'no-cache-files-to-delete', 'No cache files to delete.' );
 		}
 	}
 }

--- a/projects/plugins/boost/changelog/boost-cache-return-true-if-no-cache
+++ b/projects/plugins/boost/changelog/boost-cache-return-true-if-no-cache
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Returns true when deleting cache files and there aren't any. A small fix.
+
+


### PR DESCRIPTION
The invalidate function doesn't return anything if the code is trying to delete a directory and the directory doesn't exist.
I modified the function so it checks for a file, when deleting files and else returns true, to mean that the cache is definitely gone (even though it might not have been there). 

# Proposed changes:
* In the Invalidate function check is_file() when deleting a file
* else return true.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Call File_Storage->invlidate( $dir, Boost_Cache_Utils::DELETE_ALL ) using a non-existant directory.
Check the return value. It should be true.
