### PR TITLE
Add 'Add New Category' link to the Newsletter categories card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -10,6 +10,7 @@ import {
 	requiresConnection,
 } from 'state/connection';
 import { getModule } from 'state/modules';
+import Card from '../components/card';
 import { withModuleSettingsFormHelpers } from '../components/module-settings/with-module-settings-form-helpers';
 import TreeSelector from '../components/tree-selector';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
@@ -106,8 +107,15 @@ function NewsletterCategories( props ) {
 					onChange={ onSelectedCategoryChange }
 					disabled={ isSavingAnyOption( [ 'wpcom_newsletter_categories' ] ) }
 				/>
-				<p>{ __( 'Add New Category', 'jetpack' ) }</p>
 			</SettingsGroup>
+			<Card
+				compact
+				className="jp-settings-card__configure-link"
+				href="/wp-admin/edit-tags.php?taxonomy=category"
+				target="_blank"
+			>
+				{ __( 'Add New Category', 'jetpack' ) }
+			</Card>
 		</SettingsCard>
 	);
 }

--- a/projects/plugins/jetpack/changelog/update-newsletter-categories-link
+++ b/projects/plugins/jetpack/changelog/update-newsletter-categories-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add link to newsletter settings, still under feature flag.


### PR DESCRIPTION
![image](https://github.com/Automattic/jetpack/assets/33497086/90f0d08c-11fd-4250-88cb-5fe2b0ddea1c)

Just adds `Add New Category` link to the Newsletter categories card.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
To enable the feature flag navigate with **enable-newsletter-categories** query param:
`wp-admin/admin.php?enable-newsletter-categories=true&page=jetpack#/newsletter`

Just click on the link, and you should navigate to a new tab on for categories pages.