### PR TITLE
[Boost] Change error_log to using the plugin Logger::debug

### DIFF
--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -141,17 +141,17 @@ class Boost_Cache {
 		if ( get_option( 'show_on_front' ) === 'page' ) {
 			$front_page_id = get_option( 'page_on_front' ); // static page
 			if ( $front_page_id ) {
-				error_log( 'delete_cache_for_front_page: deleting front page cache' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				Logger::debug( 'delete_cache_for_front_page: deleting front page cache' );
 				$this->delete_cache_for_post( get_post( $front_page_id ) );
 			}
 			$posts_page_id = get_option( 'page_for_posts' ); // posts page
 			if ( $posts_page_id ) {
-				error_log( 'delete_cache_for_front_page: deleting posts page cache' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				Logger::debug( 'delete_cache_for_front_page: deleting posts page cache' );
 				$this->delete_cache_for_post( get_post( $posts_page_id ) );
 			}
 		} else {
 			$this->storage->invalidate( home_url(), Boost_Cache_Utils::DELETE_FILES );
-			error_log( 'delete front page cache ' . Boost_Cache_Utils::normalize_request_uri( home_url() ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			Logger::debug( 'delete front page cache ' . Boost_Cache_Utils::normalize_request_uri( home_url() ) );
 		}
 	}
 
@@ -166,10 +166,10 @@ class Boost_Cache {
 		if ( $new_status === $old_status ) {
 			return;
 		}
-		error_log( "delete_on_comment_transition: $new_status, $old_status" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		Logger::debug( "delete_on_comment_transition: $new_status, $old_status" );
 
 		if ( $new_status !== 'approved' && $old_status !== 'approved' ) {
-			error_log( 'delete_on_comment_transition: comment not approved' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			Logger::debug( 'delete_on_comment_transition: comment not approved' );
 			return;
 		}
 
@@ -202,7 +202,7 @@ class Boost_Cache {
 	 */
 	public function delete_on_comment_post( $comment_id, $comment_approved, $commentdata ) {
 		$post = get_post( $commentdata['comment_post_ID'] );
-		error_Log( "delete_on_comment_post: $comment_id, $comment_approved, {$post->ID}" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		Logger::debug( "delete_on_comment_post: $comment_id, $comment_approved, {$post->ID}" );
 		/**
 		 * If a comment is not approved, we only need to delete the cache for
 		 * this post for this visitor so the unmoderated comment is shown to them.
@@ -251,15 +251,15 @@ class Boost_Cache {
 			return;
 		}
 
-		error_log( "delete_on_post_transition: $new_status, $old_status, {$post->ID}" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		Logger::debug( "delete_on_post_transition: $new_status, $old_status, {$post->ID}" );
 
 		// Don't delete the cache for posts that weren't published and aren't published now
 		if ( ! $this->is_published( $new_status ) && ! $this->is_published( $old_status ) ) {
-			error_log( 'delete_on_post_transition: not published' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			Logger::debug( 'delete_on_post_transition: not published' );
 			return;
 		}
 
-		error_log( "delete_on_post_transition: deleting post {$post->ID}" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		Logger::debug( "delete_on_post_transition: deleting post {$post->ID}" );
 
 		$this->delete_cache_for_post( $post );
 		$this->delete_cache_for_post_terms( $post );
@@ -307,7 +307,7 @@ class Boost_Cache {
 		 * the post name. We need to get the post name from the post object.
 		 */
 		$permalink = get_permalink( $post->ID );
-		error_log( "delete_cache_for_post: $permalink" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		Logger::debug( "delete_cache_for_post: $permalink" );
 		$this->delete_cache_for_url( $permalink );
 	}
 
@@ -340,7 +340,7 @@ class Boost_Cache {
 	 * @param string $url - The url to delete the cache for.
 	 */
 	public function delete_cache_for_url( $url ) {
-		error_log( 'delete_cache_for_url: ' . $url ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		Logger::debug( 'delete_cache_for_url: ' . $url );
 
 		return $this->storage->invalidate( $url, Boost_Cache_Utils::DELETE_ALL );
 	}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache_Utils.php
@@ -18,7 +18,7 @@ class Boost_Cache_Utils {
 	 * @return bool|WP_Error
 	 */
 	public static function delete_directory( $path, $type ) {
-		error_log( "delete directory: $path $type" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		Logger::debug( "delete directory: $path $type" );
 		$path = realpath( $path );
 		if ( ! $path ) {
 			// translators: %s is the directory that does not exist.
@@ -40,10 +40,10 @@ class Boost_Cache_Utils {
 				$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \RecursiveDirectoryIterator::SKIP_DOTS ) );
 				foreach ( $iterator as $file ) {
 					if ( $file->isDir() ) {
-						error_log( 'rmdir: ' . $file->getPathname() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+						Logger::debug( 'rmdir: ' . $file->getPathname() );
 						@rmdir( $file->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
 					} else {
-						error_log( 'unlink: ' . $file->getPathname() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+						Logger::debug( 'unlink: ' . $file->getPathname() );
 						@unlink( $file->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink, WordPress.PHP.NoSilencedErrors.Discouraged
 					}
 				}
@@ -54,7 +54,7 @@ class Boost_Cache_Utils {
 				foreach ( $files as $file ) {
 					$file = $path . '/' . $file;
 					if ( is_file( $file ) ) {
-						error_log( "unlink: $file" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+						Logger::debug( "unlink: $file" );
 						@unlink( $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
 					}
 				}

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/storage/File_Storage.php
@@ -110,7 +110,7 @@ class File_Storage implements Storage {
 	 * @param string $type - defines what files/directories are deleted: DELETE_FILE, DELETE_FILES, DELETE_ALL.
 	 */
 	public function invalidate( $path, $type ) {
-		error_log( "invalidate: $path $type" ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		Logger::debug( "invalidate: $path $type" );
 		$normalized_path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $path );
 
 		if ( in_array( $type, array( Boost_Cache_Utils::DELETE_FILES, Boost_Cache_Utils::DELETE_ALL ), true ) && is_dir( $normalized_path ) ) {

--- a/projects/plugins/boost/changelog/boost-cache-error-log-logger
+++ b/projects/plugins/boost/changelog/boost-cache-error-log-logger
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Boost - changed logging to plugin logging
+
+


### PR DESCRIPTION
Many error_log statements were added to my PRs when testing. I changed them to use Logger::debug but it's probably too noisy.
We can fix them up next week.


## Proposed changes:
* Replace error_log() with Logger::debug() all over the place

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Try the PR.
Use your test site
Tail the log file boost-cache/logs or look at it through the settings page.
