### PR TITLE
Remove kebab menu from My Jetpack product cards

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -10,18 +10,16 @@ import React, { useCallback, useState } from 'react';
  */
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import { useProduct } from '../../hooks/use-product';
-import ProductCard, { PRODUCT_STATUSES } from '../product-card';
+import ProductCard from '../product-card';
 
 const ConnectedProductCard = ( {
 	admin,
 	slug,
 	children,
 	isDataLoading,
-	showMenu = false,
 	Description = null,
 	additionalActions = null,
 	secondaryAction = null,
-	menuItems = [],
 	upgradeInInterstitial = false,
 	primaryActionOverride,
 } ) => {
@@ -35,39 +33,11 @@ const ConnectedProductCard = ( {
 		installStandalonePlugin,
 		deactivateStandalonePlugin,
 	} = useProduct( slug );
-	const {
-		name,
-		description: defaultDescription,
-		requiresUserConnection,
-		standalonePluginInfo,
-		status,
-	} = detail;
+	const { name, description: defaultDescription, requiresUserConnection, status } = detail;
 	const [ installingStandalone, setInstallingStandalone ] = useState( false );
 	const [ deactivatingStandalone, setDeactivatingStandalone ] = useState( false );
 
 	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
-
-	/* Menu Handling */
-	const hasStandalonePlugin = standalonePluginInfo?.hasStandalonePlugin;
-	const isStandaloneInstalled = standalonePluginInfo?.isStandaloneInstalled;
-	const isStandaloneActive = standalonePluginInfo?.isStandaloneActive;
-	const showActivateOption = hasStandalonePlugin && isStandaloneInstalled && ! isStandaloneActive;
-	const showDeactivateOption = hasStandalonePlugin && isStandaloneInstalled && isStandaloneActive;
-	const showInstallOption = hasStandalonePlugin && ! isStandaloneInstalled;
-	const isConnected = isRegistered && isUserConnected;
-	const isAbsent =
-		status === PRODUCT_STATUSES.ABSENT || status === PRODUCT_STATUSES.ABSENT_WITH_PLAN;
-
-	const menuIsActive =
-		showMenu && // The menu is enabled for the product AND
-		! isAbsent && // product status is not absent AND
-		status !== PRODUCT_STATUSES.ERROR && // product status is not error AND
-		isConnected && // the site is connected AND
-		( menuItems?.length > 0 || // Show custom menus, if present
-			showActivateOption || // Show install | activate options for standalone plugin
-			showDeactivateOption || // Show deactivate option for standalone plugin
-			showInstallOption );
-	/* End Menu Handling */
 
 	/*
 	 * Redirect only if connected
@@ -138,11 +108,6 @@ const ConnectedProductCard = ( {
 			secondaryAction={ secondaryAction }
 			slug={ slug }
 			onActivate={ handleActivate }
-			showMenu={ menuIsActive }
-			menuItems={ menuItems }
-			showActivateOption={ showActivateOption }
-			showDeactivateOption={ showDeactivateOption }
-			showInstallOption={ showInstallOption }
 			onInstallStandalone={ handleInstallStandalone }
 			onActivateStandalone={ handleInstallStandalone }
 			onDeactivateStandalone={ handleDeactivateStandalone }
@@ -158,11 +123,9 @@ ConnectedProductCard.propTypes = {
 	admin: PropTypes.bool.isRequired,
 	slug: PropTypes.string.isRequired,
 	isDataLoading: PropTypes.bool,
-	showMenu: PropTypes.bool,
 	additionalActions: PropTypes.array,
 	primaryActionOverride: PropTypes.object,
 	secondaryAction: PropTypes.object,
-	menuItems: PropTypes.array,
 };
 
 export default ConnectedProductCard;

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -162,6 +162,7 @@ const ProductCard = props => {
 	/**
 	 * Use a Tracks event to count a standalone plugin activation request
 	 */
+	// eslint-disable-next-line no-unused-vars
 	const activateStandaloneHandler = useCallback(
 		event => {
 			event.preventDefault();
@@ -176,6 +177,7 @@ const ProductCard = props => {
 	/**
 	 * Use a Tracks event to count a standalone plugin deactivation click
 	 */
+	// eslint-disable-next-line no-unused-vars
 	const deactivateStandaloneHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_product_card_deactivate_standalone_plugin_click', {
 			product: slug,

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -1,7 +1,5 @@
 import { Button } from '@automattic/jetpack-components';
-import { Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { moreVertical, download } from '@wordpress/icons';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
@@ -21,115 +19,6 @@ export const PRODUCT_STATUSES_LABELS = {
 	[ PRODUCT_STATUSES.ABSENT_WITH_PLAN ]: __( 'Needs Plugin', 'jetpack-my-jetpack' ),
 	[ PRODUCT_STATUSES.ERROR ]: __( 'Needs connection', 'jetpack-my-jetpack' ),
 	[ PRODUCT_STATUSES.CAN_UPGRADE ]: __( 'Active', 'jetpack-my-jetpack' ),
-};
-
-/* eslint-disable react/jsx-no-bind */
-// Menu component
-const Menu = ( {
-	items = [],
-	showInstall = false,
-	onInstall,
-	showActivate = false,
-	showDeactivate = false,
-	onActivate,
-	onDeactivate,
-} ) => {
-	return (
-		<Dropdown
-			popoverProps={ { noArrow: false, placement: 'bottom-end' } }
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					variant="tertiary"
-					size="small"
-					icon={ moreVertical }
-					onClick={ onToggle }
-					aria-expanded={ isOpen }
-				/>
-			) }
-			renderContent={ ( { onClose } ) => (
-				<>
-					{ items.map( item => (
-						<Button
-							weight="regular"
-							fullWidth
-							variant="tertiary"
-							icon={ item?.icon }
-							onClick={ () => {
-								onClose();
-								item?.onClick?.();
-							} }
-						>
-							{ item?.label }
-						</Button>
-					) ) }
-					{ showInstall && (
-						<Button
-							weight="regular"
-							fullWidth
-							variant="tertiary"
-							icon={ download }
-							onClick={ () => {
-								onClose();
-								onInstall?.();
-							} }
-						>
-							{ __( 'Install Plugin', 'jetpack-my-jetpack' ) }
-						</Button>
-					) }
-					{ showActivate && (
-						<Button
-							weight="regular"
-							fullWidth
-							variant="tertiary"
-							onClick={ () => {
-								onClose();
-								onActivate?.();
-							} }
-						>
-							{ __( 'Activate Plugin', 'jetpack-my-jetpack' ) }
-						</Button>
-					) }
-					{ showDeactivate && (
-						<Button
-							weight="regular"
-							fullWidth
-							variant="tertiary"
-							onClick={ () => {
-								onClose();
-								onDeactivate?.();
-							} }
-						>
-							{ __( 'Deactivate Plugin', 'jetpack-my-jetpack' ) }
-						</Button>
-					) }
-				</>
-			) }
-		/>
-	);
-};
-/* eslint-enable react/jsx-no-bind */
-
-Menu.propTypes = {
-	onActivate: PropTypes.func,
-	onDeactivate: PropTypes.func,
-	showActivate: PropTypes.bool,
-	showDeactivate: PropTypes.bool,
-	showInstall: PropTypes.bool,
-	items: PropTypes.arrayOf(
-		PropTypes.shape( {
-			label: PropTypes.string,
-			icon: PropTypes.node,
-			onClick: PropTypes.func,
-		} )
-	),
-	onInstall: PropTypes.func,
-};
-
-Menu.defaultProps = {
-	onActivate: () => {},
-	onDeactivate: () => {},
-	showActivate: false,
-	showDeactivate: false,
 };
 
 // SecondaryButton component
@@ -185,12 +74,6 @@ const ProductCard = props => {
 		primaryActionOverride,
 		secondaryAction,
 		children,
-		// Menu Related
-		showMenu = false,
-		showActivateOption = false,
-		showDeactivateOption = false,
-		showInstallOption = false,
-		menuItems = [],
 		onInstallStandalone,
 		onActivateStandalone,
 		onDeactivateStandalone,
@@ -291,7 +174,7 @@ const ProductCard = props => {
 	);
 
 	/**
-	 * Use a Tracks event to count a standalone plugin deactivation menu click
+	 * Use a Tracks event to count a standalone plugin deactivation click
 	 */
 	const deactivateStandaloneHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_product_card_deactivate_standalone_plugin_click', {
@@ -304,19 +187,7 @@ const ProductCard = props => {
 		<Card
 			title={ name }
 			className={ classNames( styles.container, containerClassName ) }
-			headerRightContent={
-				showMenu && (
-					<Menu
-						items={ menuItems }
-						showActivate={ showActivateOption }
-						showDeactivate={ showDeactivateOption }
-						onActivate={ activateStandaloneHandler }
-						onDeactivate={ deactivateStandaloneHandler }
-						showInstall={ showInstallOption }
-						onInstall={ installStandaloneHandler }
-					/>
-				)
-			}
+			headerRightContent={ null }
 		>
 			<Description />
 
@@ -369,17 +240,6 @@ ProductCard.propTypes = {
 	isManageDisabled: PropTypes.bool,
 	onActivate: PropTypes.func,
 	slug: PropTypes.string.isRequired,
-	showMenu: PropTypes.bool,
-	showActivateOption: PropTypes.bool,
-	showDeactivateOption: PropTypes.bool,
-	showInstallOption: PropTypes.bool,
-	menuItems: PropTypes.arrayOf(
-		PropTypes.shape( {
-			label: PropTypes.string,
-			icon: PropTypes.node,
-			onClick: PropTypes.func,
-		} )
-	),
 	additionalActions: PropTypes.array,
 	primaryActionOverride: PropTypes.object,
 	secondaryAction: PropTypes.object,
@@ -403,11 +263,6 @@ ProductCard.defaultProps = {
 	isInstallingStandalone: false,
 	isDeactivatingStandalone: false,
 	onActivate: () => {},
-	showMenu: false,
-	showActivateOption: false,
-	showDeactivateOption: false,
-	showInstallOption: false,
-	menuItems: [],
 };
 
 export { PRODUCT_STATUSES };

--- a/projects/packages/my-jetpack/changelog/remove-my-jetpack-card-menu
+++ b/projects/packages/my-jetpack/changelog/remove-my-jetpack-card-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove kebab menu on My Jetpack cards

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -77,7 +77,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.11.x-dev"
+			"dev-trunk": "4.12.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.11.1-alpha",
+	"version": "4.12.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -35,7 +35,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.11.1-alpha';
+	const PACKAGE_VERSION = '4.12.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/backup/changelog/remove-my-jetpack-card-menu
+++ b/projects/plugins/backup/changelog/remove-my-jetpack-card-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1122,7 +1122,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4e4d80fad9ed05a5c58c20611b75b3488313a318"
+                "reference": "cd2abb7246ef3cbccfdfe5ca4b68a4581f0c8586"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1155,7 +1155,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.11.x-dev"
+                    "dev-trunk": "4.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/remove-my-jetpack-card-menu
+++ b/projects/plugins/boost/changelog/remove-my-jetpack-card-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1047,7 +1047,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4e4d80fad9ed05a5c58c20611b75b3488313a318"
+                "reference": "cd2abb7246ef3cbccfdfe5ca4b68a4581f0c8586"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1080,7 +1080,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.11.x-dev"
+                    "dev-trunk": "4.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/remove-my-jetpack-card-menu
+++ b/projects/plugins/jetpack/changelog/remove-my-jetpack-card-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1681,7 +1681,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "4e4d80fad9ed05a5c58c20611b75b3488313a318"
+				"reference": "cd2abb7246ef3cbccfdfe5ca4b68a4581f0c8586"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1714,7 +1714,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.11.x-dev"
+					"dev-trunk": "4.12.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/remove-my-jetpack-card-menu
+++ b/projects/plugins/migration/changelog/remove-my-jetpack-card-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1122,7 +1122,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4e4d80fad9ed05a5c58c20611b75b3488313a318"
+                "reference": "cd2abb7246ef3cbccfdfe5ca4b68a4581f0c8586"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1155,7 +1155,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.11.x-dev"
+                    "dev-trunk": "4.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/remove-my-jetpack-card-menu
+++ b/projects/plugins/protect/changelog/remove-my-jetpack-card-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1035,7 +1035,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4e4d80fad9ed05a5c58c20611b75b3488313a318"
+                "reference": "cd2abb7246ef3cbccfdfe5ca4b68a4581f0c8586"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1068,7 +1068,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.11.x-dev"
+                    "dev-trunk": "4.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/remove-my-jetpack-card-menu
+++ b/projects/plugins/search/changelog/remove-my-jetpack-card-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4e4d80fad9ed05a5c58c20611b75b3488313a318"
+                "reference": "cd2abb7246ef3cbccfdfe5ca4b68a4581f0c8586"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1011,7 +1011,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.11.x-dev"
+                    "dev-trunk": "4.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/remove-my-jetpack-card-menu
+++ b/projects/plugins/social/changelog/remove-my-jetpack-card-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -978,7 +978,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "4e4d80fad9ed05a5c58c20611b75b3488313a318"
+				"reference": "cd2abb7246ef3cbccfdfe5ca4b68a4581f0c8586"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1011,7 +1011,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.11.x-dev"
+					"dev-trunk": "4.12.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/remove-my-jetpack-card-menu
+++ b/projects/plugins/starter-plugin/changelog/remove-my-jetpack-card-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4e4d80fad9ed05a5c58c20611b75b3488313a318"
+                "reference": "cd2abb7246ef3cbccfdfe5ca4b68a4581f0c8586"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1011,7 +1011,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.11.x-dev"
+                    "dev-trunk": "4.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/remove-my-jetpack-card-menu
+++ b/projects/plugins/videopress/changelog/remove-my-jetpack-card-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4e4d80fad9ed05a5c58c20611b75b3488313a318"
+                "reference": "cd2abb7246ef3cbccfdfe5ca4b68a4581f0c8586"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1011,7 +1011,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.11.x-dev"
+                    "dev-trunk": "4.12.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Because product cards install standalone plugins when needed on purchase or trying the product for free, we are removing the additional menu that was being used for standalone plugin management. Standalone plugin installation is becoming more transparent and does not need a separate control.
* Removing this menu also simplifies the available actions on the cards. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without this PR applied, visit My Jetpack on a site with active products
* Notice the kebab menu that shows in the upper-right-hand corner of some product cards
![Screenshot 2024-02-21 at 11 25 43 AM](https://github.com/Automattic/jetpack/assets/18016357/fb7f7327-7818-4553-820d-bb5e90d374f9)
* Now with this PR applied, you should see those menu icons are gone
![Screenshot 2024-02-21 at 11 26 33 AM](https://github.com/Automattic/jetpack/assets/18016357/70dbb76c-6daf-46ee-a860-f44777546b9b)
* Confirm there are no JS errors in the console as a result of this change

