### PR TITLE
Remove translation of product names in My Jetpack

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-dont-translate-product-names
+++ b/projects/packages/my-jetpack/changelog/update-dont-translate-product-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove translation of product names

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.11.0",
+	"version": "4.11.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -35,7 +35,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.11.0';
+	const PACKAGE_VERSION = '4.11.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -44,21 +44,21 @@ class Anti_Spam extends Product {
 	public static $requires_user_connection = false;
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Akismet Anti-spam', 'jetpack-my-jetpack' );
+		return 'Akismet Anti-spam';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Akismet Anti-spam', 'jetpack-my-jetpack' );
+		return 'Jetpack Akismet Anti-spam';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -52,21 +52,21 @@ class Backup extends Hybrid_Product {
 	public static $has_standalone_plugin = true;
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'VaultPress Backup', 'jetpack-my-jetpack' );
+		return 'VaultPress Backup';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack VaultPress Backup', 'jetpack-my-jetpack' );
+		return 'Jetpack VaultPress Backup';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -51,21 +51,21 @@ class Boost extends Product {
 	public static $requires_user_connection = false;
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Boost', 'jetpack-my-jetpack' );
+		return 'Boost';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Boost', 'jetpack-my-jetpack' );
+		return 'Jetpack Boost';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-creator.php
+++ b/projects/packages/my-jetpack/src/products/class-creator.php
@@ -50,21 +50,21 @@ class Creator extends Product {
 	public static $requires_user_connection = false;
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Creator', 'jetpack-my-jetpack' );
+		return 'Creator';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Creator', 'jetpack-my-jetpack' );
+		return 'Jetpack Creator';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-crm.php
+++ b/projects/packages/my-jetpack/src/products/class-crm.php
@@ -47,21 +47,21 @@ class Crm extends Product {
 	public static $requires_user_connection = false;
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'CRM', 'jetpack-my-jetpack' );
+		return 'CRM';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack CRM', 'jetpack-my-jetpack' );
+		return 'Jetpack CRM';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-extras.php
+++ b/projects/packages/my-jetpack/src/products/class-extras.php
@@ -38,21 +38,21 @@ class Extras extends Product {
 	public static $requires_user_connection = false;
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Extras', 'jetpack-my-jetpack' );
+		return 'Extras';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Extras', 'jetpack-my-jetpack' );
+		return 'Jetpack Extras';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -58,21 +58,21 @@ class Jetpack_Ai extends Product {
 	}
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'AI', 'jetpack-my-jetpack' );
+		return 'AI';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack AI', 'jetpack-my-jetpack' );
+		return 'Jetpack AI';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -155,14 +155,14 @@ abstract class Product {
 	}
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	abstract public static function get_name();
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -55,21 +55,21 @@ class Protect extends Product {
 	public static $requires_user_connection = false;
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Protect', 'jetpack-my-jetpack' );
+		return 'Protect';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Protect', 'jetpack-my-jetpack' );
+		return 'Jetpack Protect';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -34,21 +34,21 @@ class Scan extends Module_Product {
 	public static $module_name = 'scan';
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Scan', 'jetpack-my-jetpack' );
+		return 'Scan';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Scan', 'jetpack-my-jetpack' );
+		return 'Jetpack Scan';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -66,21 +66,21 @@ class Search extends Hybrid_Product {
 	public static $requires_user_connection = false;
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Search', 'jetpack-my-jetpack' );
+		return 'Search';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Search', 'jetpack-my-jetpack' );
+		return 'Jetpack Search';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-security.php
+++ b/projects/packages/my-jetpack/src/products/class-security.php
@@ -31,21 +31,21 @@ class Security extends Module_Product {
 	public static $module_name = 'security';
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return _x( 'Security', 'Jetpack product name', 'jetpack-my-jetpack' );
+		return 'Security';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return _x( 'Security', 'Jetpack product name', 'jetpack-my-jetpack' );
+		return 'Jetpack Security';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -55,21 +55,21 @@ class Social extends Hybrid_Product {
 	);
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Social', 'jetpack-my-jetpack' );
+		return 'Social';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Social', 'jetpack-my-jetpack' );
+		return 'Jetpack Social';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-starter.php
+++ b/projects/packages/my-jetpack/src/products/class-starter.php
@@ -31,21 +31,21 @@ class Starter extends Module_Product {
 	public static $module_name = 'starter';
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return _x( 'Starter', 'Jetpack product name', 'jetpack-my-jetpack' );
+		return 'Starter';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return _x( 'Jetpack Starter', 'Jetpack product name', 'jetpack-my-jetpack' );
+		return 'Jetpack Starter';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -59,21 +59,21 @@ class Stats extends Module_Product {
 	public static $has_standalone_plugin = false;
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Stats', 'jetpack-my-jetpack' );
+		return 'Stats';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Stats', 'jetpack-my-jetpack' );
+		return 'Jetpack Stats';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -63,21 +63,21 @@ class Videopress extends Hybrid_Product {
 	public static $has_standalone_plugin = true;
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'VideoPress', 'jetpack-my-jetpack' );
+		return 'VideoPress';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack VideoPress', 'jetpack-my-jetpack' );
+		return 'Jetpack VideoPress';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/class-broken-product.php
+++ b/projects/packages/my-jetpack/tests/php/class-broken-product.php
@@ -19,21 +19,21 @@ class Broken_Product extends Module_Product {
 	public static $slug = 'broken';
 
 	/**
-	 * Get the internationalized product name
+	 * Get the product name
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'CRM', 'jetpack-my-jetpack' );
+		return 'CRM';
 	}
 
 	/**
-	 * Get the internationalized product title
+	 * Get the product title
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack CRM', 'jetpack-my-jetpack' );
+		return 'Jetpack CRM';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/class-sample-module-product.php
+++ b/projects/packages/my-jetpack/tests/php/class-sample-module-product.php
@@ -26,21 +26,21 @@ class Sample_Module_Product extends Module_Product {
 	public static $module_name = 'sample-module-product';
 
 	/**
-	 * Get the internationalized product name. Sample data.
+	 * Get the product name. Sample data.
 	 *
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Mock Module Product', 'jetpack-my-jetpack' );
+		return 'Mock Module Product';
 	}
 
 	/**
-	 * Get the internationalized product title. Sample data.
+	 * Get the product title. Sample data.
 	 *
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Mock_Module_Product', 'jetpack-my-jetpack' );
+		return 'Mock_Module_Product';
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Names of products should not be translated
* This PR removes the translations of product names on My Jetpack

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load a Jetpack with this PR applies
* Make sure My Jetpack loads with no errors
* Confirm all unit tests pass
* If you use WordPress in a non-english language, confirm that the product names are not translated

