### PR TITLE
Changes the locale used in the Blaze Dashboard

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-dashboard-locale
+++ b/projects/packages/blaze/changelog/fix-blaze-dashboard-locale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Changes to use the user's locale to render the dashboard

--- a/projects/packages/blaze/src/class-dashboard-config-data.php
+++ b/projects/packages/blaze/src/class-dashboard-config-data.php
@@ -94,7 +94,7 @@ class Dashboard_Config_Data {
 			return array(
 				'ID'         => 1000,
 				'username'   => 'no-user',
-				'localeSlug' => $this->get_site_locale(),
+				'localeSlug' => $this->get_locale(),
 				'site_count' => 1,
 			);
 		}
@@ -103,7 +103,7 @@ class Dashboard_Config_Data {
 			'ID'         => $user_data['ID'],
 			'username'   => $user_data['login'],
 			'email'      => $user_data['email'],
-			'localeSlug' => $this->get_site_locale(),
+			'localeSlug' => $this->get_locale(),
 			'site_count' => 1,
 		);
 	}
@@ -132,15 +132,15 @@ class Dashboard_Config_Data {
 	}
 
 	/**
-	 * Get locale acceptable by Calypso.
+	 * Get the user's locale acceptable by Calypso.
 	 */
-	protected function get_site_locale() {
+	protected function get_locale() {
 		/**
 		 * In WP, locales are formatted as LANGUAGE_REGION, for example `en`, `en_US`, `es_AR`,
 		 * but Calypso expects language-region, e.g. `en-us`, `en`,  `es-ar`. So we need to convert
 		 * them to lower case and replace the underscore with a dash.
 		 */
-		$locale = strtolower( get_locale() );
+		$locale = strtolower( get_user_locale() );
 		$locale = str_replace( '_', '-', $locale );
 
 		return $locale;


### PR DESCRIPTION
The locale we use to render the Blaze Dashboard is not the correct one. Currently it is taking the site's locale, when the one using the dashboard is the administrator. 

We want to change this and use the administrator's locale instead.

## Proposed changes:
* Change the locale used to render the Blaze Dashboard to be the user's locale

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to your user profile and change you default language
* Go to Tools->Advertising
* Verify that the Blaze Dashboard is rendered in the selected locale

![Screenshot 2024-02-21 at 15 40 48](https://github.com/Automattic/jetpack/assets/1258162/50de32a7-69b1-4b6d-908c-38a93a5d1b8a)
