### PR TITLE
Memberships: Fix double premium content cookies

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-memberships-double-cookie-issue
+++ b/projects/plugins/jetpack/changelog/fix-memberships-double-cookie-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Assign premium content cookie to subdomain only on wordpress.com

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -114,8 +114,8 @@ export const setPurchaseResultCookie = function ( premiumContentJWTToken ) {
 	// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
 	const hostname = window.location.hostname;
 	let domain = hostname;
-	if ( 'wordpress.com' === hostname ) {
-		domain = '.wordpress.com';
+	if ( hostname.indexOf( 'wordpress.com' ) !== -1 ) {
+		domain = '.' + hostname;
 	}
 
 	document.cookie =

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -112,11 +112,7 @@ const updateQueryStringParameter = function ( uri, key, value ) {
 export const setPurchaseResultCookie = function ( premiumContentJWTToken ) {
 	// We will set this in a cookie  - just in case. This will be reloaded in the refresh, when user clicks OK.
 	// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
-	const hostname = window.location.hostname;
-	let domain = hostname;
-	if ( hostname.indexOf( 'wordpress.com' ) !== -1 ) {
-		domain = '.' + hostname;
-	}
+	const domain = window.location.hostname;
 
 	document.cookie =
 		'wp-jp-premium-content-session' +

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -112,17 +112,8 @@ const updateQueryStringParameter = function ( uri, key, value ) {
 export const setPurchaseResultCookie = function ( premiumContentJWTToken ) {
 	// We will set this in a cookie  - just in case. This will be reloaded in the refresh, when user clicks OK.
 	// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
-	const domain = window.location.hostname;
-
 	document.cookie =
-		'wp-jp-premium-content-session' +
-		'=' +
-		premiumContentJWTToken +
-		'; expires=' +
-		0 +
-		'; path=/' +
-		'; domain=' +
-		domain;
+		'wp-jp-premium-content-session' + '=' + premiumContentJWTToken + '; expires=' + 0 + '; path=/';
 };
 
 export const reloadPageWithPremiumContentQueryString = function (

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -113,7 +113,10 @@ export const setPurchaseResultCookie = function ( premiumContentJWTToken ) {
 	// We will set this in a cookie  - just in case. This will be reloaded in the refresh, when user clicks OK.
 	// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
 	const hostname = window.location.hostname;
-	const domain = '.' + hostname;
+	let domain = hostname;
+	if ( 'wordpress.com' === hostname ) {
+		domain = '.wordpress.com';
+	}
 
 	document.cookie =
 		'wp-jp-premium-content-session' +

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -112,8 +112,7 @@ const updateQueryStringParameter = function ( uri, key, value ) {
 export const setPurchaseResultCookie = function ( premiumContentJWTToken ) {
 	// We will set this in a cookie  - just in case. This will be reloaded in the refresh, when user clicks OK.
 	// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
-	document.cookie =
-		'wp-jp-premium-content-session' + '=' + premiumContentJWTToken + '; expires=' + 0 + '; path=/';
+	document.cookie = `wp-jp-premium-content-session=${ premiumContentJWTToken }; expires=0; path=/`;
 };
 
 export const reloadPageWithPremiumContentQueryString = function (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1708539779094679/1708362991.873199-slack-C052XEUUBL4

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets the premium content cookie domain to the hostname, unless the hostname is `wordpress.com`, in which case it sets it to `.wordpress.com`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN test site with this patch or apply this patch to an atomic site with premium content
* Setup paid content blocks on the site if not already setup.
* Subscribe to a plan on the site if not already subscribed (as a non a11n subscriber account)
* In a private window, login to access the paid content.
* Open developer tools and confirm there is only one `wp-jp-premium-content-session` cookie