### PR TITLE
TreeDropdown: Update tree dropdown component

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
@@ -35,6 +35,10 @@ const TreeDropdown = props => {
 		e => {
 			if ( e.key === 'Backspace' && ! inputValue ) {
 				removeTag( tags[ tags.length - 1 ] );
+			} else if ( e.key === 'Escape' ) {
+				setIsDropdownVisible( false );
+				setInputValue( '' );
+				inputRef.current.blur();
 			}
 		},
 		[ inputValue, removeTag, tags ]

--- a/projects/plugins/jetpack/_inc/client/components/tree-selector/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-selector/index.jsx
@@ -1,5 +1,7 @@
 import { CheckboxControl } from '@wordpress/components';
-import { useCallback } from 'react';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useCallback, useMemo } from 'react';
 import './style.scss';
 import { createFlatTreeItems } from './utils';
 
@@ -46,7 +48,30 @@ const TreeSelector = props => {
 		</li>
 	) );
 
-	return <ul className="jp-tree-items">{ treeElements }</ul>;
+	const noResultsMessage = useMemo(
+		() => (
+			<span>
+				{ createInterpolateElement(
+					// translators: %s is the keyword being searched
+					sprintf( __( 'No results found for <b>%s</b>.', 'jetpack' ), keyword ),
+					{
+						b: <b />,
+					}
+				) }
+			</span>
+		),
+		[ keyword ]
+	);
+
+	return (
+		<ul className="jp-tree-items">
+			{ isSearching && filteredTreeItems.length === 0 ? (
+				<li className="jp-tree-item jp-tree-item__no-results">{ noResultsMessage }</li>
+			) : (
+				treeElements
+			) }
+		</ul>
+	);
 };
 
 export default TreeSelector;

--- a/projects/plugins/jetpack/changelog/update-tree-dropdown-component
+++ b/projects/plugins/jetpack/changelog/update-tree-dropdown-component
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Component changes, still under feature flag
+
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87666

## Proposed changes:

* Close dropdown on ESC
* Display no results message

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Apply this PR to your JT env
* Navigate to Jetpack > Settings > Newsletter with the feature flag enabled: `wp-admin/admin.php?enable-newsletter-categories=true&page=jetpack#/newsletter`
* Search for categories, check if the no results message is displayed
* Press ESC and check if the dropdown closes
