### PR TITLE
[Boost] Remove BOOST_CACHE flag 

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -91,9 +91,6 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 	}
 
 	public static function is_available() {
-		if ( ! defined( 'BOOST_CACHE' ) ) {
-			return false;
-		}
 		return true;
 	}
 

--- a/projects/plugins/boost/changelog/fix-boost-cache-gate
+++ b/projects/plugins/boost/changelog/fix-boost-cache-gate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Removed BOOST_CACHE gate. No changelog needed, as the same fix is going into 3.1.0
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Remove check for BOOST_CACHE flag on Boost Cache.

Note that I have also applied the same fix to the 3.1.0 branch as well, so there is no need to cherry-pick this.

## Proposed changes:
* Allow use of the Boost Cache module without the BOOST_CACHE flag.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Make sure you can use Boost Cache without the BOOST_CACHE flag defined.

