### PR TITLE
[Boost] Reduce log noise

### DIFF
--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
@@ -123,11 +123,6 @@ class Request {
 			return false;
 		}
 
-		if ( $this->is_url_excluded() ) {
-			Logger::debug( 'Url excluded, not cached!' ); // phpcs:ignore -- This is a debug message
-			return false;
-		}
-
 		if ( function_exists( 'is_user_logged_in' ) && is_user_logged_in() ) {
 			return false;
 		}
@@ -145,6 +140,11 @@ class Request {
 		}
 
 		if ( isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] !== 'GET' ) {
+			return false;
+		}
+
+		if ( $this->is_url_excluded() ) {
+			Logger::debug( 'Url excluded, not cached!' ); // phpcs:ignore -- This is a debug message
 			return false;
 		}
 

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Request.php
@@ -144,7 +144,7 @@ class Request {
 		}
 
 		if ( $this->is_url_excluded() ) {
-			Logger::debug( 'Url excluded, not cached!' ); // phpcs:ignore -- This is a debug message
+			Logger::debug( 'Url excluded, not cached!' );
 			return false;
 		}
 

--- a/projects/plugins/boost/changelog/boost-fix-cache-loud-notice
+++ b/projects/plugins/boost/changelog/boost-fix-cache-loud-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Check Boost Cache exclusions after excluding wp-admin
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We log a message when an exclusion rule excludes a page-load. However, the exclusion rules automatically include any wp- URLs. So as you browse wp-admin you get a bunch of noise in the logs.

This fixes it by making sure the other exclusions are respected before the exclude-list.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check the exclusion list *after* checking it's not a back end page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Load pages in wp-admin
* Make sure they don't get entries in the logs.
