### PR TITLE
Boost: Update cache setup

### DIFF
--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -86,7 +86,6 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 	 * Runs cleanup when the feature is deactivated.
 	 */
 	public static function deactivate() {
-		Page_Cache_Setup::deactivate();
 		Garbage_Collection::deactivate();
 	}
 

--- a/projects/plugins/boost/app/modules/cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache.php
@@ -80,6 +80,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 	public static function activate() {
 		Page_Cache_Setup::run_setup();
 		Garbage_Collection::activate();
+		Boost_Cache_Settings::get_instance()->set( array( 'enabled' => true ) );
 	}
 
 	/**
@@ -87,6 +88,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 	 */
 	public static function deactivate() {
 		Garbage_Collection::deactivate();
+		Boost_Cache_Settings::get_instance()->set( array( 'enabled' => false ) );
 	}
 
 	public static function is_available() {

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -124,7 +124,7 @@ $boost_cache->serve();
 		$content = preg_replace(
 			'#^<\?php#',
 			'<?php
-define( \'WP_CACHE\', true );',
+define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 			$content
 		);
 
@@ -188,7 +188,7 @@ define( \'WP_CACHE\', true );',
 		$lines = file( ABSPATH . 'wp-config.php' );
 		$found = false;
 		foreach ( $lines as $key => $line ) {
-			if ( preg_match( '#define\s*\(\s*[\'"]WP_CACHE[\'"]#', $line ) === 1 ) {
+			if ( preg_match( '#define\s*\(\s*[\'"]WP_CACHE[\'"]#', $line ) === 1 && strpos( $line, Page_Cache::ADVANCED_CACHE_SIGNATURE ) !== false ) {
 				unset( $lines[ $key ] );
 				$found = true;
 			}

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -28,6 +28,8 @@ class Page_Cache_Setup {
 			}
 		}
 
+		opcache_reset(); // Clear the opcode cache to make the file changes take effect.
+
 		jetpack_boost_ds_set( 'page_cache_error', '' );
 
 		return true;
@@ -144,6 +146,8 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 		self::delete_advanced_cache();
 		self::delete_wp_cache_constant();
 
+		opcache_reset(); // Clear the opcode cache to make the file changes take effect.
+
 		return true;
 	}
 
@@ -152,8 +156,7 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 	 * Fired when the plugin is uninstalled.
 	 */
 	public static function uninstall() {
-		self::delete_advanced_cache();
-		self::delete_wp_cache_constant();
+		self::deactivate();
 
 		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::DELETE_ALL );
 		if ( is_wp_error( $result ) ) {

--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -60,7 +60,7 @@ class Boost_Cache {
 	 * Serve the cached page if it exists, otherwise start output buffering.
 	 */
 	public function serve() {
-		if ( ! $this->request->is_cacheable() ) {
+		if ( ! $this->settings->get_enabled() || ! $this->request->is_cacheable() ) {
 			return;
 		}
 

--- a/projects/plugins/boost/changelog/update-cache-setup
+++ b/projects/plugins/boost/changelog/update-cache-setup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Improved the cache setup
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Do not modify advance-cache.php and WP_CACHE constant on module deactivation
* Reset opcache when these files are edited
* Only remove WP_CACHE constant if boost added it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1708574516302629-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
None