### PR TITLE
[Boost] Clear cache on template edit.

### DIFF
--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -244,6 +244,12 @@ class Boost_Cache {
 	 * @param WP_Post $post - The post that transitioned.
 	 */
 	public function delete_on_post_transition( $new_status, $old_status, $post ) {
+		// Special case: edits to wp_template can affect the whole site.
+		if ( $post->post_type === 'wp_template' ) {
+			$this->delete_cache();
+			return;
+		}
+
 		if ( ! Boost_Cache_Utils::is_visible_post_type( $post ) ) {
 			return;
 		}

--- a/projects/plugins/boost/changelog/boost-fix-template-edits
+++ b/projects/plugins/boost/changelog/boost-fix-template-edits
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix for unreleased feature
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Clear the whole cache when the user updates their templates. 

## Proposed changes:
* Clear the whole cache when the user updates their templates. 

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Edit your template via Appearance -> Editor in the WP admin menu.
* Make sure that your edits are immediately visible on the front of your site (and that your cache is being cleared appropriately).

