### PR TITLE
Boost: Purge on special post status change

### DIFF
--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -244,8 +244,10 @@ class Boost_Cache {
 	 * @param WP_Post $post - The post that transitioned.
 	 */
 	public function delete_on_post_transition( $new_status, $old_status, $post ) {
-		// Special case: edits to wp_template can affect the whole site.
-		if ( $post->post_type === 'wp_template' ) {
+		// Special case: Delete cache if the post type can effect the whole site.
+		$special_post_types = array( 'wp_template', 'wp_template_part', 'wp_global_styles' );
+		if ( in_array( $post->post_type, $special_post_types, true ) ) {
+			Logger::debug( 'delete_on_post_transition: special post type ' . $post->post_type );
 			$this->delete_cache();
 			return;
 		}

--- a/projects/plugins/boost/changelog/update-purge-on-special-post
+++ b/projects/plugins/boost/changelog/update-purge-on-special-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Purge cache on special post type change
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* If a post type that can impact the whole site is being updated, purge cache for the whole site

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1708582084621249/1708580774.280269-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Change blog header or any other template part in a block theme
* Check to make sure cache is purged
* Change any styles through the visual editor, e.g. text color.
* Check again and see the cache is purged again