### PR TITLE
Subscriptions: Fix subscribing to Atomic sites when already logged in

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-premium-content-cookie-duplication-atomic
+++ b/projects/plugins/jetpack/changelog/update-fix-premium-content-cookie-duplication-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Fix subscribing to Atomic sites when already logged in

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -444,7 +444,7 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 		}
 
 		if ( ! empty( $token ) && false === headers_sent() ) {
-			setcookie( self::JWT_AUTH_TOKEN_COOKIE_NAME, $token, 0, '/', COOKIE_DOMAIN, is_ssl(), true ); // httponly -- used by visitor_can_view_content() within the PHP context.
+			setcookie( self::JWT_AUTH_TOKEN_COOKIE_NAME, $token, 0, '/', COOKIE_DOMAIN, is_ssl(), false ); // phpcs:ignore Jetpack.Functions.SetCookie.FoundNonHTTPOnlyFalse
 		}
 	}
 

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -112,6 +112,8 @@ const updateQueryStringParameter = function ( uri, key, value ) {
 export const setPurchaseResultCookie = function ( premiumContentJWTToken ) {
 	// We will set this in a cookie  - just in case. This will be reloaded in the refresh, when user clicks OK.
 	// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
+	const date = new Date();
+	date.setTime( date.getTime() + 365 * 24 * 60 * 60 * 1000 );
 	const hostname = window.location.hostname;
 	const isSimpleSite = hostname.endsWith( '.wordpress.com' );
 	const domain = isSimpleSite ? '.' + hostname : '';
@@ -121,7 +123,7 @@ export const setPurchaseResultCookie = function ( premiumContentJWTToken ) {
 		'=' +
 		premiumContentJWTToken +
 		'; expires=' +
-		0 +
+		date.toGMTString() +
 		'; path=/' +
 		'; domain=' +
 		domain;

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -113,7 +113,8 @@ export const setPurchaseResultCookie = function ( premiumContentJWTToken ) {
 	// We will set this in a cookie  - just in case. This will be reloaded in the refresh, when user clicks OK.
 	// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
 	const hostname = window.location.hostname;
-	const domain = '.' + hostname;
+	const isSimpleSite = hostname.endsWith( '.wordpress.com' );
+	const domain = isSimpleSite ? '.' + hostname : '';
 
 	document.cookie =
 		'wp-jp-premium-content-session' +

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -118,15 +118,7 @@ export const setPurchaseResultCookie = function ( premiumContentJWTToken ) {
 	const isSimpleSite = hostname.endsWith( '.wordpress.com' );
 	const domain = isSimpleSite ? '.' + hostname : '';
 
-	document.cookie =
-		'wp-jp-premium-content-session' +
-		'=' +
-		premiumContentJWTToken +
-		'; expires=' +
-		date.toGMTString() +
-		'; path=/' +
-		'; domain=' +
-		domain;
+	document.cookie = `wp-jp-premium-content-session=${ premiumContentJWTToken }; expires=${ date.toGMTString() }; path=/; domain=${ domain }`;
 };
 
 export const reloadPageWithPremiumContentQueryString = function (


### PR DESCRIPTION
Fixes this scenario: p1708467751975069/1708362991.873199-slack-C052XEUUBL4

## Proposed changes:

* makes the premium content cookie not HTTP only since we are reading it on frontend here https://github.com/Automattic/jetpack/blob/3cf4ae640be8cf9cb53f37e8445bed7b62519a53/projects/plugins/jetpack/extensions/shared/memberships.js#L51
* sets the cookie expiration date so it's not for the current session only
* adds the leading dot for a premium cookie domain only on Simple

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* open the Atomic site post with the Paywall block in incognito
* log in to wp.com in another tab
* get back to the post and click "Already a subscriber?"
* make sure the premium cookie you get is not HTTP only
* make sure the Paywall block email input is filled up with your email address
* click "Subscribe"
* make sure you are subscribed to the blog and can read the content behind the paywall

