### PR TITLE
SSO Invite Users: Improve error handling when inviting users

### DIFF
--- a/projects/plugins/jetpack/changelog/sso-invite-user-error-handling
+++ b/projects/plugins/jetpack/changelog/sso-invite-user-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Improve SSO invite user error handling

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -163,7 +163,9 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 					'wpcom'
 				);
 
-				if ( isset( $response['response']['code'] ) && 200 !== $response['response']['code'] ) {
+				$response_code = $response['response']['code'];
+
+				if ( isset( $response_code ) && 200 !== $response_code ) {
 					$query_params = array(
 						'jetpack-sso-invite-user'  => 'failed',
 						'jetpack-sso-invite-error' => 'invalid_request',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

When an error occurs with the invite user API, the errors are not handled correctly and are throwing a critical error on /wp-admin.
These changes will handle API response errors gracefully when inviting users and will display a error notice instead of a critical error screen.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync to WoA
* Add `define('JETPACK__SANDBOX_DOMAIN', 'SANDBOX_HOST_NAME') ;` to your atomic site wp-config.php
* Test error scenarios when inviting users by modifying the backend. You can force throw `new WP_ERROR('random_text', 'some message');` on WPCOM.
* Try to break this ( critical error on frontend)

