### PR TITLE
Subscriptions: Prevents the HTTP 301 redirection in Paywall block for Atomic sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-http-301-redirection-patwall-block
+++ b/projects/plugins/jetpack/changelog/fix-http-301-redirection-patwall-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Prevents the HTTP 301 redirection in Paywall block

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1065,7 +1065,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 			'site_id'      => intval( \Jetpack_Options::get_option( 'id' ) ),
 			'redirect_url' => rawurlencode( $redirect_url ),
 		),
-		'https://subscribe.wordpress.com/memberships/jwt'
+		'https://subscribe.wordpress.com/memberships/jwt/'
 	);
 	if ( is_user_auth() ) {
 		if ( ( new Host() )->is_wpcom_simple() ) {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* adds the `/` at the end of the URL to prevent HTTP 301 redirection

#### Before

<img width="713" alt="Screenshot 2024-02-22 at 09 01 22" src="https://github.com/Automattic/jetpack/assets/4068554/eb28bd27-3b03-4bf1-a5b4-574c774a0f77">

#### After

<img width="713" alt="Screenshot 2024-02-22 at 09 00 58" src="https://github.com/Automattic/jetpack/assets/4068554/deb7635a-794b-4c97-bc67-62bbf1ae725b">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* open the Atomic site post with the Paywall block in incognito
* open the Browser Dev Tools Network tab
* click the "Already a subscriber?" link
* make sure there is no HTTP 301 redirect for `https://subscribe.wordpress.com/memberships/jwt/` URL

