### PR TITLE
Jetpack Boost: Refactor page cache setup and improve error handling

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/health/health.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/health/health.tsx
@@ -1,5 +1,5 @@
 import { Button, Notice } from '@automattic/jetpack-components';
-import { useRunPageCacheSetupAction } from '$lib/stores/page-cache';
+import { usePageCacheSetup } from '$lib/stores/page-cache';
 import getErrorData from './lib/get-error-data';
 import { __ } from '@wordpress/i18n';
 
@@ -8,7 +8,7 @@ type HealthProps = {
 };
 
 const Health = ( { error }: HealthProps ) => {
-	const runPageCacheSetupAction = useRunPageCacheSetupAction();
+	const runPageCacheSetupAction = usePageCacheSetup();
 
 	const requestRunSetup = () => {
 		runPageCacheSetupAction.mutate();

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/health/lib/get-error-data.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/health/lib/get-error-data.tsx
@@ -158,12 +158,14 @@ const messages: { [ key: string ]: { title: string; message: React.ReactNode } }
 			}
 		),
 	},
-	default: {
-		title: __( 'Unknown error', 'jetpack-boost' ),
-		message: __( 'An unknown error ocurred.', 'jetpack-boost' ),
-	},
 };
 
 export default ( status: string ) => {
-	return messages[ status ] || messages.default;
+	if ( status in messages ) {
+		return messages[ status ];
+	}
+	return {
+		title: __( 'Unknown error', 'jetpack-boost' ),
+		message: status,
+	};
 };

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/page-cache.ts
@@ -28,11 +28,11 @@ export function usePageCache() {
 /**
  * Hook which creates a callable action for running Page Cache setup.
  */
-export function useRunPageCacheSetupAction() {
-	const action = 'run-page-cache-setup';
+export function usePageCacheSetup() {
+	const action = 'run-setup';
 	return useDataSyncAction( {
 		namespace: 'jetpack_boost_ds',
-		key: 'page_cache_error',
+		key: 'page_cache',
 		action_name: action,
 		schema: {
 			state: PageCacheError,

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
 
+use Automattic\Jetpack\IdentityCrisis\Exception;
 use Automattic\Jetpack_Boost\Modules\Cache\Pre_WordPress\Filesystem_Utils;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache_Utils;
 
@@ -66,7 +67,7 @@ class Page_Cache_Setup {
 	 *
 	 * Returns true if the files were setup correctly, or WP_Error if there was a problem.
 	 *
-	 * @return bool|WP_Error
+	 * @return bool|\WP_Error
 	 */
 	private static function create_advanced_cache() {
 		$advanced_cache_filename = WP_CONTENT_DIR . '/advanced-cache.php';
@@ -84,12 +85,11 @@ class Page_Cache_Setup {
 			}
 		}
 
-		$boost_cache_filename = WP_CONTENT_DIR . '/plugins/' . basename( dirname( plugin_dir_path( __FILE__ ), 3 ) ) . '/app/modules/cache/pre-wordpress/Boost_Cache.php';
-
+		$plugin_dir_name = untrailingslashit( str_replace( JETPACK_BOOST_PLUGIN_FILENAME, '', JETPACK_BOOST_PLUGIN_BASE ) );
+		$boost_cache_filename = WP_CONTENT_DIR . '/plugins/' . $plugin_dir_name . '/app/modules/cache/pre-wordpress/Boost_Cache.php';
 		if ( ! file_exists( $boost_cache_filename ) ) {
 			return new \WP_Error( 'boost-cache-file-not-found', 'Boost_Cache.php not found' );
 		}
-
 		$contents = '<?php
 // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE . ' - ' . Page_Cache::ADVANCED_CACHE_VERSION . '
 if ( ! file_exists( \'' . $boost_cache_filename . '\' ) ) {

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -85,7 +85,12 @@ class Page_Cache_Setup {
 		}
 
 		$boost_cache_filename = WP_CONTENT_DIR . '/plugins/' . basename( dirname( plugin_dir_path( __FILE__ ), 3 ) ) . '/app/modules/cache/pre-wordpress/Boost_Cache.php';
-		$contents             = '<?php
+
+		if ( ! file_exists( $boost_cache_filename ) ) {
+			return new \WP_Error( 'boost-cache-file-not-found', 'Boost_Cache.php not found' );
+		}
+
+		$contents = '<?php
 // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE . ' - ' . Page_Cache::ADVANCED_CACHE_VERSION . '
 if ( ! file_exists( \'' . $boost_cache_filename . '\' ) ) {
 return;

--- a/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/cache/Page_Cache_Setup.php
@@ -2,7 +2,6 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Page_Cache;
 
-use Automattic\Jetpack\IdentityCrisis\Exception;
 use Automattic\Jetpack_Boost\Modules\Cache\Pre_WordPress\Filesystem_Utils;
 use Automattic\Jetpack_Boost\Modules\Page_Cache\Pre_WordPress\Boost_Cache_Utils;
 
@@ -85,7 +84,7 @@ class Page_Cache_Setup {
 			}
 		}
 
-		$plugin_dir_name = untrailingslashit( str_replace( JETPACK_BOOST_PLUGIN_FILENAME, '', JETPACK_BOOST_PLUGIN_BASE ) );
+		$plugin_dir_name      = untrailingslashit( str_replace( JETPACK_BOOST_PLUGIN_FILENAME, '', JETPACK_BOOST_PLUGIN_BASE ) );
 		$boost_cache_filename = WP_CONTENT_DIR . '/plugins/' . $plugin_dir_name . '/app/modules/cache/pre-wordpress/Boost_Cache.php';
 		if ( ! file_exists( $boost_cache_filename ) ) {
 			return new \WP_Error( 'boost-cache-file-not-found', 'Boost_Cache.php not found' );

--- a/projects/plugins/boost/changelog/fix-boost-cache-setup-errors
+++ b/projects/plugins/boost/changelog/fix-boost-cache-setup-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Boost: Enhanced error handling for page cache setup and refactored related code for clarity.

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -43,7 +43,7 @@ if ( ! defined( 'JETPACK_BOOST_PLUGIN_BASE' ) ) {
 	define( 'JETPACK_BOOST_PLUGIN_BASE', plugin_basename( __FILE__ ) );
 }
 
-if( ! defined('JETPACK_BOOST_PLUGIN_FILENAME') ) {
+if ( ! defined( 'JETPACK_BOOST_PLUGIN_FILENAME' ) ) {
 	define( 'JETPACK_BOOST_PLUGIN_FILENAME', basename( __FILE__ ) );
 }
 

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -43,6 +43,10 @@ if ( ! defined( 'JETPACK_BOOST_PLUGIN_BASE' ) ) {
 	define( 'JETPACK_BOOST_PLUGIN_BASE', plugin_basename( __FILE__ ) );
 }
 
+if( ! defined('JETPACK_BOOST_PLUGIN_FILENAME') ) {
+	define( 'JETPACK_BOOST_PLUGIN_FILENAME', basename( __FILE__ ) );
+}
+
 if ( ! defined( 'JETPACK_BOOST_REST_NAMESPACE' ) ) {
 	define( 'JETPACK_BOOST_REST_NAMESPACE', 'jetpack-boost/v1' );
 }

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Data_Sync_Action;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Data_Sync_Entry;
 use Automattic\Jetpack\WP_JS_Data_Sync\Data_Sync;
 use Automattic\Jetpack\WP_JS_Data_Sync\Data_Sync_Readonly;
@@ -37,7 +38,7 @@ if ( ! defined( 'JETPACK_BOOST_DATASYNC_NAMESPACE' ) ) {
  */
 function jetpack_boost_register_option( $key, $parser, $entry = null ) {
 	Data_Sync::get_instance( JETPACK_BOOST_DATASYNC_NAMESPACE )
-			->register( $key, $parser, $entry );
+	         ->register( $key, $parser, $entry );
 }
 
 /**
@@ -52,7 +53,7 @@ function jetpack_boost_register_option( $key, $parser, $entry = null ) {
 
 function jetpack_boost_register_action( $key, $action_name, $request_schema, $instance ) {
 	Data_Sync::get_instance( JETPACK_BOOST_DATASYNC_NAMESPACE )
-			->register_action( $key, $action_name, $request_schema, $instance );
+	         ->register_action( $key, $action_name, $request_schema, $instance );
 }
 
 /**
@@ -69,8 +70,8 @@ function jetpack_boost_register_readonly_option( $key, $callback ) {
  */
 function jetpack_boost_ds_entry( $key ) {
 	return Data_Sync::get_instance( JETPACK_BOOST_DATASYNC_NAMESPACE )
-					->get_registry()
-					->get_entry( $key );
+	                ->get_registry()
+	                ->get_entry( $key );
 }
 
 function jetpack_boost_ds_get( $key ) {
@@ -355,10 +356,10 @@ jetpack_boost_register_option( 'getting_started', Schema::as_boolean()->fallback
 jetpack_boost_register_option(
 	'page_cache_error',
 	Schema::as_string()
-		->nullable()
+	      ->nullable()
 );
 
-jetpack_boost_register_action( 'page_cache_error', 'run-page-cache-setup', Schema::as_void(), new Run_Setup() );
+jetpack_boost_register_action( 'page_cache', 'run-setup', Schema::as_void(), new Run_Setup() );
 
 jetpack_boost_register_option(
 	'page_cache',

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -1,6 +1,5 @@
 <?php
 
-use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Data_Sync_Action;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Data_Sync_Entry;
 use Automattic\Jetpack\WP_JS_Data_Sync\Data_Sync;
 use Automattic\Jetpack\WP_JS_Data_Sync\Data_Sync_Readonly;
@@ -38,7 +37,7 @@ if ( ! defined( 'JETPACK_BOOST_DATASYNC_NAMESPACE' ) ) {
  */
 function jetpack_boost_register_option( $key, $parser, $entry = null ) {
 	Data_Sync::get_instance( JETPACK_BOOST_DATASYNC_NAMESPACE )
-	         ->register( $key, $parser, $entry );
+			->register( $key, $parser, $entry );
 }
 
 /**
@@ -53,7 +52,7 @@ function jetpack_boost_register_option( $key, $parser, $entry = null ) {
 
 function jetpack_boost_register_action( $key, $action_name, $request_schema, $instance ) {
 	Data_Sync::get_instance( JETPACK_BOOST_DATASYNC_NAMESPACE )
-	         ->register_action( $key, $action_name, $request_schema, $instance );
+			->register_action( $key, $action_name, $request_schema, $instance );
 }
 
 /**
@@ -70,8 +69,8 @@ function jetpack_boost_register_readonly_option( $key, $callback ) {
  */
 function jetpack_boost_ds_entry( $key ) {
 	return Data_Sync::get_instance( JETPACK_BOOST_DATASYNC_NAMESPACE )
-	                ->get_registry()
-	                ->get_entry( $key );
+					->get_registry()
+					->get_entry( $key );
 }
 
 function jetpack_boost_ds_get( $key ) {
@@ -356,7 +355,7 @@ jetpack_boost_register_option( 'getting_started', Schema::as_boolean()->fallback
 jetpack_boost_register_option(
 	'page_cache_error',
 	Schema::as_string()
-	      ->nullable()
+			->nullable()
 );
 
 jetpack_boost_register_action( 'page_cache', 'run-setup', Schema::as_void(), new Run_Setup() );


### PR DESCRIPTION
## Proposed changes:
- Refactor useRunPageCacheSetupAction to usePageCacheSetup for better clarity
- Change action name from 'run-page-cache-setup' to 'run-setup' to align with store naming
- Improve error handling for unknown errors to return the actual error status
- Update the method for resolving the Boost Cache filename
- Define a constant for the Jetpack Boost plugin filename

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Navigate to Jetpack Boost's page cache settings and initiate setup
- Verify that the setup process runs without issues
- Trigger an error and check if the correct error message is displayed
- Ensure that the plugin directory name is resolved correctly for the Boost Cache file
- Confirm that the new constant for the plugin filename is defined and used properly
