### PR TITLE
Woo Analytics: fix namespace reference

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-woo-analytics-namespace-error
+++ b/projects/packages/woocommerce-analytics/changelog/fix-woo-analytics-namespace-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix namespace issue with WooCommerce class reference.

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -162,7 +162,9 @@ trait Woo_Analytics_Trait {
 			return;
 		}
 
-		$this->cart_checkout_templates_in_use = wp_is_block_theme() && class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && version_compare( Automattic\WooCommerce\Blocks\Package::get_version(), '10.6.0', '>=' );
+		$this->cart_checkout_templates_in_use = wp_is_block_theme()
+			&& class_exists( '\Automattic\WooCommerce\Blocks\Package' )
+			&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '10.6.0', '>=' );
 
 		// Cart/Checkout *pages* are in use if the templates are not in use. Return their content and do nothing else.
 		if ( ! $this->cart_checkout_templates_in_use ) {


### PR DESCRIPTION
Follow-up from #35756

## Proposed changes:

I missed that class reference in the last PR. It needs to be updated now that the class is in a different namespace.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* N/A

## Testing instructions:

* Not much to test on this one since the package is not required for now (this will happen in #35758)
