### PR TITLE
Add save button to newsletter categories settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
@@ -68,6 +68,7 @@ const TreeDropdown = props => {
 							onClick={ handleDelete( tag ) }
 							className="tree-dropdown__tag-remove-button"
 							disabled={ disabled }
+							type="button"
 						>
 							<Icon icon={ closeSmall } />
 						</button>

--- a/projects/plugins/jetpack/_inc/client/newsletter/messages-setting.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/messages-setting.jsx
@@ -5,10 +5,12 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
+import { getModule } from 'state/modules';
 import Textarea from '../components/textarea';
+import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
 const MessagesSetting = props => {
-	const { getOptionValue, isSavingAnyOption, moduleName, onOptionChange } = props;
+	const { getOptionValue, isSavingAnyOption, subscriptionsModule, onOptionChange } = props;
 
 	const changeWelcomeMessageState = useCallback(
 		event => {
@@ -26,10 +28,15 @@ const MessagesSetting = props => {
 		<SettingsCard
 			{ ...props }
 			header={ __( 'Messages', 'jetpack' ) }
-			module={ moduleName }
+			module={ SUBSCRIPTIONS_MODULE_NAME }
 			saveDisabled={ isSavingAnyOption( [ 'subscription_options' ] ) }
 		>
-			<SettingsGroup hasChild disableInOfflineMode module={ moduleName }>
+			<SettingsGroup
+				hasChild
+				disableInOfflineMode
+				disableInSiteConnectionMode
+				module={ subscriptionsModule }
+			>
 				<p className="jp-settings-card__email-settings">
 					{ __(
 						'These settings change the emails sent from your site to your readers.',
@@ -54,6 +61,7 @@ const MessagesSetting = props => {
 export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
+			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
 			getOptionValue: ownProps.getOptionValue,
 			isSavingAnyOption: ownProps.isSavingAnyOption,
 			moduleName: ownProps.moduleName,

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -81,6 +81,7 @@ function NewsletterCategories( props ) {
 			{ ...props }
 			header={ __( 'Newsletter categories', 'jetpack' ) }
 			module={ SUBSCRIPTIONS_MODULE_NAME }
+			saveDisabled={ isSavingAnyOption( [ 'subscription_options' ] ) }
 		>
 			<SettingsGroup
 				hasChild

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -41,7 +41,7 @@ function NewsletterCategories( props ) {
 		isUnavailableDueOfflineMode,
 		isUnavailableDueSiteConnectionMode,
 		subscriptionsModule,
-		updateFormStateAndSaveOptionValue,
+		updateFormStateOptionValue,
 		isSavingAnyOption,
 	} = props;
 
@@ -71,16 +71,15 @@ function NewsletterCategories( props ) {
 			} else {
 				newCheckedCategoriesIds = checkedCategoriesIds.filter( category => category !== id );
 			}
-			updateFormStateAndSaveOptionValue( 'wpcom_newsletter_categories', newCheckedCategoriesIds );
+			updateFormStateOptionValue( 'wpcom_newsletter_categories', newCheckedCategoriesIds );
 		},
-		[ checkedCategoriesIds, updateFormStateAndSaveOptionValue ]
+		[ checkedCategoriesIds, updateFormStateOptionValue ]
 	);
 
 	return (
 		<SettingsCard
 			{ ...props }
 			header={ __( 'Newsletter categories', 'jetpack' ) }
-			hideButton
 			module={ SUBSCRIPTIONS_MODULE_NAME }
 		>
 			<SettingsGroup

--- a/projects/plugins/jetpack/changelog/update-newsletter-settings-save-button
+++ b/projects/plugins/jetpack/changelog/update-newsletter-settings-save-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add save button to newsletter settings. Still under feature flag.


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87772

Adds save button to newsletter categories setting.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
To enable the feature flag navigate with **enable-newsletter-categories** query param:
`wp-admin/admin.php?enable-newsletter-categories=true&page=jetpack#/newsletter`

- Check or uncheck a few categories.
- It should not trigger the saving API request.
- Click on the `Save settings` button. It should save the settings.
- Refresh the page and check that the changes persist.

Also, double-check that this does not change the behavior on the enable/disable toggle. Clicking on it should automatically save the setting without clicking the save button. It is not the same behavior we have for this option on calypso, but it is consistent with other settings on jetpack.