### PR TITLE
[Boost] do not cache non-html or incomplete html pages

### DIFF
--- a/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/cache/pre-wordpress/Boost_Cache.php
@@ -120,6 +120,12 @@ class Boost_Cache {
 	 */
 	public function ob_callback( $buffer ) {
 		if ( strlen( $buffer ) > 0 && $this->request->is_cacheable() ) {
+
+			if ( false === stripos( $buffer, '</html>' ) ) {
+				Logger::debug( 'Closing HTML tag not found, not caching' );
+				return $buffer;
+			}
+
 			$result = $this->storage->write( $this->request->get_uri(), $this->request->get_parameters(), $buffer );
 
 			if ( is_wp_error( $result ) ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf

--- a/projects/plugins/boost/changelog/boost-cache-skip-caching-incomplete-pages
+++ b/projects/plugins/boost/changelog/boost-cache-skip-caching-incomplete-pages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Boost - only caching html pages so we should make sure we're only caching html pages
+
+

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "3.1.0-beta",
+	"version": "3.1.1-alpha",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -73,7 +73,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_1_0_beta",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_1_1_alpha",
 		"allow-plugins": {
 			"roots/wordpress-core-installer": true,
 			"automattic/jetpack-autoloader": true,

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e395d446534864de7e296f1767316ac3",
+    "content-hash": "a7b6bd17499f483713f0eefbd83317d2",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 3.1.0-beta
+ * Version: 3.1.1-alpha
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'JETPACK_BOOST_VERSION', '3.1.0-beta' );
+define( 'JETPACK_BOOST_VERSION', '3.1.1-alpha' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-boost",
-	"version": "3.1.0-beta",
+	"version": "3.1.1-alpha",
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"directories": {
 		"test": "tests"


### PR DESCRIPTION
The caching module only caches HTML pages, so we should make sure that the data being cached is an HTML page. The page should also be complete because we don't want to cache broken pages.

A simple way to do this is to search for a closing HTML tag before saving the cache file.

Fixes [#35859](https://github.com/Automattic/jetpack/issues/35859)

## Proposed changes:
* In the ob_callback function check if the buffer contains the text "</html>".
* do not write the buffer to a file if it's not found.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Apply this PR.
Create an mu-plugin with this code in it:
```
function stop_footer() {
        die();
}
add_action( 'wp_footer', 'stop_footer' );
```
Load an uncached page in a private window.
Verify that a cached file was not created. If you have logging enabled, you'll see a message say "Closing HTML tag not found, not caching"
