### PR TITLE
Stats: introduce new shared method in Stats package

### DIFF
--- a/projects/packages/stats/changelog/update-blog-stats-wpcom
+++ b/projects/packages/stats/changelog/update-blog-stats-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new method to convert stats data for external consumption.

--- a/projects/packages/stats/composer.json
+++ b/projects/packages/stats/composer.json
@@ -50,7 +50,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.10.x-dev"
+			"dev-trunk": "0.11.x-dev"
 		},
 		"textdomain": "jetpack-stats"
 	},

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -492,4 +492,24 @@ class WPCOM_Stats {
 
 		return json_decode( $response_body, true );
 	}
+
+	/**
+	 * Convert stats array to object after sanity checking the array is valid.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param  array $stats_array The stats array.
+	 * @return WP_Error|Object|null
+	 */
+	public function convert_stats_array_to_object( $stats_array ) {
+
+		if ( is_wp_error( $stats_array ) ) {
+			return $stats_array;
+		}
+		$encoded_array = wp_json_encode( $stats_array );
+		if ( ! $encoded_array ) {
+			return new WP_Error( 'stats_encoding_error', 'Failed to encode stats array' );
+		}
+		return json_decode( $encoded_array );
+	}
 }

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1622,16 +1622,12 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 			$range = 'day';
 		}
 
-		if ( ! function_exists( 'convert_stats_array_to_object' ) ) {
-			require_once JETPACK__PLUGIN_DIR . 'modules/stats.php';
-		}
-
 		$wpcom_stats = new WPCOM_Stats();
 		switch ( $range ) {
 
 			// This is always called first on page load.
 			case 'day':
-				$initial_stats = convert_stats_array_to_object( $wpcom_stats->get_stats() );
+				$initial_stats = $wpcom_stats->convert_stats_array_to_object( $wpcom_stats->get_stats() );
 				return rest_ensure_response(
 					array(
 						'general' => $initial_stats,
@@ -1645,7 +1641,7 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 			case 'week':
 				return rest_ensure_response(
 					array(
-						'week' => convert_stats_array_to_object(
+						'week' => $wpcom_stats->convert_stats_array_to_object(
 							$wpcom_stats->get_visits(
 								array(
 									'unit'     => 'week',
@@ -1658,7 +1654,7 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 			case 'month':
 				return rest_ensure_response(
 					array(
-						'month' => convert_stats_array_to_object(
+						'month' => $wpcom_stats->convert_stats_array_to_object(
 							$wpcom_stats->get_visits(
 								array(
 									'unit'     => 'month',

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -150,13 +150,11 @@ class Jetpack_Core_API_Site_Endpoint {
 		 * - Followers (only if subs module is active)
 		 * - Sharing counts (not currently supported in Jetpack -- https://github.com/Automattic/jetpack/issues/844 )
 		 */
-		$stats = null;
-		if ( function_exists( 'convert_stats_array_to_object' ) ) {
-				$stats = convert_stats_array_to_object(
-					( new WPCOM_Stats() )->get_stats( array( 'fields' => 'stats' ) )
-				);
-		}
-		$has_stats = null !== $stats && ! is_wp_error( $stats );
+		$wpcom_stats = new WPCOM_Stats();
+		$stats       = $wpcom_stats->convert_stats_array_to_object(
+			$wpcom_stats->get_stats( array( 'fields' => 'stats' ) )
+		);
+		$has_stats   = null !== $stats && ! is_wp_error( $stats );
 
 		// Yearly visitors.
 		if ( $has_stats && $stats->stats->visitors > 0 ) {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-blog-stats.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-blog-stats.php
@@ -55,12 +55,13 @@ class WPCOM_REST_API_V2_Endpoint_Blog_Stats extends WP_REST_Controller {
 	 * @return array Blog stats.
 	 */
 	public function get_blog_stats( $request ) {
-		$post_id   = $request->get_param( 'post_id' );
-		$post_data = convert_stats_array_to_object(
-			( new WPCOM_Stats() )->get_post_views( $post_id, array( 'fields' => 'views' ) )
+		$wpcom_stats = new WPCOM_Stats();
+		$post_id     = $request->get_param( 'post_id' );
+		$post_data   = $wpcom_stats->convert_stats_array_to_object(
+			$wpcom_stats->get_post_views( $post_id, array( 'fields' => 'views' ) )
 		);
-		$blog_data = convert_stats_array_to_object(
-			( new WPCOM_Stats() )->get_stats( array( 'fields' => 'stats' ) )
+		$blog_data   = $wpcom_stats->convert_stats_array_to_object(
+			$wpcom_stats->get_stats( array( 'fields' => 'stats' ) )
 		);
 
 		if ( ! isset( $blog_data->stats->views ) || ! isset( $blog_data->stats->visitors ) ) {

--- a/projects/plugins/jetpack/changelog/update-blog-stats-wpcom#2
+++ b/projects/plugins/jetpack/changelog/update-blog-stats-wpcom#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Stats: switch our stats fetching methods to use data conversion method from package.

--- a/projects/plugins/jetpack/changelog/update-blog-stats-wpcom#3
+++ b/projects/plugins/jetpack/changelog/update-blog-stats-wpcom#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2272,7 +2272,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/stats",
-				"reference": "7d8c7c0e9eb0169ecad36746b757e49e36296588"
+				"reference": "0caaec1a8b9f18edd8f963374de1fdf91e5dafe1"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2296,7 +2296,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.10.x-dev"
+					"dev-trunk": "0.11.x-dev"
 				},
 				"textdomain": "jetpack-stats"
 			},

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
@@ -58,12 +58,14 @@ function load_assets( $attributes ) {
 		return;
 	}
 
+	$wpcom_stats = new WPCOM_Stats();
+
 	if ( $attributes['statsOption'] === 'post' ) {
 		// Cache in post meta to prevent wp_options blowing up when retrieving views
 		// for multiple posts simultaneously (eg. when inserted into template).
 		$cache_in_meta = true;
-		$data          = convert_stats_array_to_object(
-			( new WPCOM_Stats() )->get_post_views(
+		$data          = $wpcom_stats->convert_stats_array_to_object(
+			$wpcom_stats->get_post_views(
 				get_the_ID(),
 				array( 'fields' => 'views' ),
 				$cache_in_meta
@@ -74,8 +76,8 @@ function load_assets( $attributes ) {
 			$stats = $data->views;
 		}
 	} else {
-		$data = convert_stats_array_to_object(
-			( new WPCOM_Stats() )->get_stats( array( 'fields' => 'stats' ) )
+		$data = $wpcom_stats->convert_stats_array_to_object(
+			$wpcom_stats->get_stats( array( 'fields' => 'stats' ) )
 		);
 
 		if ( $attributes['statsData'] === 'views' && isset( $data->stats->views ) ) {

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -22,6 +22,7 @@ use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Stats\Main as Stats;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Stats\Tracking_Pixel as Stats_Tracking_Pixel;
+use Automattic\Jetpack\Stats\WPCOM_Stats;
 use Automattic\Jetpack\Stats\XMLRPC_Provider as Stats_XMLRPC;
 use Automattic\Jetpack\Stats_Admin\Dashboard as Stats_Dashboard;
 use Automattic\Jetpack\Stats_Admin\Main as Stats_Main;
@@ -1741,13 +1742,7 @@ function filter_stats_array_add_jp_version( $kvs ) {
  * @return WP_Error|Object|null
  */
 function convert_stats_array_to_object( $stats_array ) {
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Stats\WPCOM_Stats->convert_stats_array_to_object' );
 
-	if ( is_wp_error( $stats_array ) ) {
-		return $stats_array;
-	}
-	$encoded_array = wp_json_encode( $stats_array );
-	if ( ! $encoded_array ) {
-		return new WP_Error( 'stats_encoding_error', 'Failed to encode stats array' );
-	}
-	return json_decode( $encoded_array );
+	return ( new WPCOM_Stats() )->convert_stats_array_to_object( $stats_array );
 }

--- a/projects/plugins/jetpack/modules/widgets/blog-stats.php
+++ b/projects/plugins/jetpack/modules/widgets/blog-stats.php
@@ -81,8 +81,9 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
 	 * @return string|false $views All Time Stats for that blog.
 	 */
 	public function get_stats() {
+		$wpcom_stats = new WPCOM_Stats();
 		// Get data from the WordPress.com Stats REST API endpoint.
-		$stats = convert_stats_array_to_object( ( new WPCOM_Stats() )->get_stats( array( 'fields' => 'stats' ) ) );
+		$stats = $wpcom_stats->convert_stats_array_to_object( $wpcom_stats->get_stats( array( 'fields' => 'stats' ) ) );
 
 		if ( isset( $stats->stats->views ) ) {
 			return $stats->stats->views;

--- a/projects/plugins/jetpack/modules/widgets/top-posts.php
+++ b/projects/plugins/jetpack/modules/widgets/top-posts.php
@@ -710,7 +710,10 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			'summarize' => 1,
 			'num'       => (int) $days,
 		);
-		$post_view_posts = convert_stats_array_to_object( ( new WPCOM_Stats() )->get_top_posts( $query_args ) );
+		$wpcom_stats     = new WPCOM_Stats();
+		$post_view_posts = $wpcom_stats->convert_stats_array_to_object(
+			$wpcom_stats->get_top_posts( $query_args )
+		);
 
 		if ( ! isset( $post_view_posts->summary ) || empty( $post_view_posts->summary->postviews ) ) {
 			return array();

--- a/projects/plugins/search/changelog/update-blog-stats-wpcom
+++ b/projects/plugins/search/changelog/update-blog-stats-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1430,7 +1430,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "7d8c7c0e9eb0169ecad36746b757e49e36296588"
+                "reference": "0caaec1a8b9f18edd8f963374de1fdf91e5dafe1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1454,7 +1454,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
+                    "dev-trunk": "0.11.x-dev"
                 },
                 "textdomain": "jetpack-stats"
             },


### PR DESCRIPTION
> [!NOTE]
> This PR was originally created off #35751. It is necessary for that PR.

## Proposed changes:

It will allow us to use the `convert_stats_array_to_object` utility in environments that do not load `modules/stats.php` where that utility was previously defined. WordPress.com Simple is such an environment.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site where you have enabled the Stats module.
* Enable Beta blocks (`add_filter( 'jetpack_blocks_variation', function () { return 'beta'; } );`)
* Go to Posts > Add New
* Insert a Blog Stats block
* Watch your logs; you should see no errors.
