### PR TITLE
Top Posts Block: make available on WordPress.com.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-top-posts-availability-wpcom
+++ b/projects/plugins/jetpack/changelog/update-top-posts-availability-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Top Posts Block: make available on WordPress.com Simple.

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
@@ -12,6 +12,7 @@ namespace Automattic\Jetpack\Extensions\Top_Posts;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 use Jetpack_Top_Posts_Helper;
 
@@ -26,9 +27,11 @@ if ( ! class_exists( 'Jetpack_Top_Posts_Helper' ) ) {
  */
 function register_block() {
 	if (
-		! defined( 'IS_WPCOM' )
-		&& ( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner()
-		&& ! ( new Status() )->is_offline_mode() )
+		( new Host() )->is_wpcom_simple()
+		|| (
+			( new Connection_Manager( 'jetpack' ) )->has_connected_owner()
+			&& ! ( new Status() )->is_offline_mode()
+		)
 	) {
 		Blocks::jetpack_register_block(
 			__DIR__,


### PR DESCRIPTION
See #34506

## Proposed changes:

Make the block available on WordPress.com Simple as well, so we can use it there once we take the block out of beta.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* On a self-hosted site, enable Beta blocks
* Go to Posts > Add New
    * You should see the Top Posts block available there.
* On a WordPress.com simple site, apply this patch
* Go to Posts > Add New
    * You should see the Top Posts block available.
