### PR TITLE
Move Newsletter Categories to Jetpack: Switch cards position

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -48,8 +48,8 @@ function Subscriptions( props ) {
 			{ foundSubscriptions && (
 				<SubscriptionsSettings siteRawUrl={ siteRawUrl } blogID={ blogID } />
 			) }
-			<MessagesSetting { ...props } />
 			{ isNewsletterCategoriesEnabled && <NewsletterCategories /> }
+			<MessagesSetting { ...props } />
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/changelog/fix-newsletter-categories-card-position
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-categories-card-position
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Component updates, still under feature flag
+
+


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/87777

## Proposed changes:

* Switch Messages and Newsletter Categories cards position

<img width="1077" alt="Screenshot 2024-02-22 at 11 30 14" src="https://github.com/Automattic/jetpack/assets/3113712/ba37766d-8a30-4503-8eb7-f972b39ad2aa">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Apply this PR to your JT env
* Navigate to Jetpack > Settings > Newsletter with the feature flag enabled: `wp-admin/admin.php?enable-newsletter-categories=true&page=jetpack#/newsletter`
* Check if the cards are displayed in the expected position (see on Figma zmSa53vVqTXOJHQnJ0rqpQ-fi-4454_13500)