### PR TITLE
Vdimitrakis/price fix for blaze post fetch

### DIFF
--- a/projects/packages/blaze/changelog/price fix for post in blaze endpoint
+++ b/projects/packages/blaze/changelog/price fix for post in blaze endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+added a "use WC_Product" to include this in the post fetching endpoint for blaze

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -11,6 +11,7 @@ namespace Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status\Host;
+use WC_Product;
 use WP_Error;
 use WP_REST_Server;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

Added a use WC_Product in blaze endpoint to fetch the posts correclty

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
This is a minor fix.
when testing out the prices of posts (products) in the new blaze marketing page we realised that the price was empty,

we needed to include the WC_Product entity in order for the condition to work correctly

checkout this branch and navigate to marketing blaze for woo commerce (or tools-> advertising) open the network tab and filter by posts

check the response of the call that it includes the formated price for product posts 



