### PR TITLE
Boost: Hide Super Cache notice if page cache feature is active

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -24,6 +24,7 @@ const Index = () => {
 
 	const [ isaState ] = useSingleModuleState( 'image_size_analysis' );
 	const [ imageCdn ] = useSingleModuleState( 'image_cdn' );
+	const [ pageCache ] = useSingleModuleState( 'page_cache' );
 
 	const regenerateCssAction = useRegenerateCriticalCssAction();
 	const requestRegenerateCriticalCss = () => {
@@ -286,7 +287,7 @@ const Index = () => {
 				</Module>
 			</div>
 
-			<SuperCacheInfo />
+			{ ! pageCache?.active && <SuperCacheInfo /> }
 		</div>
 	);
 };

--- a/projects/plugins/boost/changelog/hide-super-cache-notice-if-page-cache-active
+++ b/projects/plugins/boost/changelog/hide-super-cache-notice-if-page-cache-active
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Page Cache: Hide Super Cache notice if page cache is enabled.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35869

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hide Super Cache notice if Page Cache is activated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pedxs5-oQ-p2#comment-281

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure Page Cache is not enabled after setting Boost up;
* Install WP Super Cache, but don't activate the plugin yet;
* Make sure the WP Super Cache notice is showing at the bottom of Boost's UI;
* Enable Page Cache and make sure the WP Super Cache notice is not showing up.

![image](https://github.com/Automattic/jetpack/assets/11799079/5936bbf5-a97c-440a-9b07-7d9950e9babb)
