### PR TITLE
Move Newsletter Categories to Jetpack: Add missing copies

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/tree-selector/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-selector/index.jsx
@@ -1,7 +1,6 @@
 import { CheckboxControl } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
-import { useCallback, useMemo } from 'react';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
 import './style.scss';
 import { createFlatTreeItems } from './utils';
 
@@ -48,25 +47,12 @@ const TreeSelector = props => {
 		</li>
 	) );
 
-	const noResultsMessage = useMemo(
-		() => (
-			<span>
-				{ createInterpolateElement(
-					// translators: %s is the keyword being searched
-					sprintf( __( 'No results found for <b>%s</b>.', 'jetpack' ), keyword ),
-					{
-						b: <b />,
-					}
-				) }
-			</span>
-		),
-		[ keyword ]
-	);
-
 	return (
 		<ul className="jp-tree-items">
 			{ isSearching && filteredTreeItems.length === 0 ? (
-				<li className="jp-tree-item jp-tree-item__no-results">{ noResultsMessage }</li>
+				<li className="jp-tree-item jp-tree-item__no-results">
+					<span>{ __( 'Nothing found', 'jetpack' ) }</span>
+				</li>
 			) : (
 				treeElements
 			) }

--- a/projects/plugins/jetpack/_inc/client/newsletter/messages-setting.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/messages-setting.jsx
@@ -46,6 +46,12 @@ const MessagesSetting = props => {
 						onChange={ changeWelcomeMessageState }
 					/>
 				</FormLabel>
+				<p className="jp-form-setting-explanation">
+					{ __(
+						'You can use plain text or HTML tags in this textarea for formatting.',
+						'jetpack'
+					) }
+				</p>
 			</SettingsGroup>
 		</SettingsCard>
 	);

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -1,4 +1,4 @@
-import { ToggleControl } from '@automattic/jetpack-components';
+import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -88,6 +88,13 @@ function NewsletterCategories( props ) {
 				disableInOfflineMode
 				disableInSiteConnectionMode
 				module={ subscriptionsModule }
+				support={ {
+					text: __(
+						'When you add a new category, your existing subscribers will be automatically subscribed to it.',
+						'jetpack'
+					),
+					link: getRedirectUrl( 'jetpack-support-subscriptions' ),
+				} }
 			>
 				<p>
 					{ __(

--- a/projects/plugins/jetpack/changelog/fix-missing-text-on-message-settings
+++ b/projects/plugins/jetpack/changelog/fix-missing-text-on-message-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add missing text on Message settings
+
+


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/87782

## Proposed changes:
* Add missing text on message settings footer
* Add support message on newsletter categories settings
* Update no results message to match Figma design zmSa53vVqTXOJHQnJ0rqpQ-fi-4561_31090 

<img width="1060" alt="Screenshot 2024-02-22 at 12 52 37" src="https://github.com/Automattic/jetpack/assets/3113712/7729faf2-a9e4-4363-9fdc-cc03fe6d14d6">

<img width="343" alt="Screenshot 2024-02-22 at 14 39 23" src="https://github.com/Automattic/jetpack/assets/3113712/b8c31b43-6959-455c-a7eb-1d81aee76bf7">

<img width="1069" alt="Screenshot 2024-02-22 at 14 51 30" src="https://github.com/Automattic/jetpack/assets/3113712/1948f7c2-098c-4d5d-9e41-f727200a7178">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your JT env
* Navigate to Jetpack > Settings > Newsletter 
* Check if the Message card is displayed with the expected text on the bottom (see Figma file zmSa53vVqTXOJHQnJ0rqpQ-fi-4543_17698)
* Check if the Newsletter Categories card is displayed with the support text and the correct no results message (see Figma file zmSa53vVqTXOJHQnJ0rqpQ-fi-4561_31090)