### PR TITLE
User management: Update pending invite icon styling

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sso-admin-users-send-invite-icon
+++ b/projects/plugins/jetpack/changelog/update-sso-admin-users-send-invite-icon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update SSO users table pending invite icon styling

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -728,12 +728,20 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 			}
 
 			.sso-disconnected-user-icon {
-				margin-left: 5px;
+				margin-left: 4px;
 				cursor: pointer;
 				background: gray;
 				border-radius: 10px;
-				color: white;
 			}
+
+			.sso-disconnected-user-icon.dashicons {
+				font-size: 1rem;
+				height: 1rem;
+				width: 1rem;
+				background-color: #9D6E00;
+				color: #F5F1E1;
+			}
+
 		</style>
 			<?php
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/87766

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Updates pending invite icon to match design changes:

![image](https://github.com/Automattic/jetpack/assets/10482592/ec3cc782-10f0-462c-bcd5-921e7e5565cb)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync to WoA
* Compare icon changes to design

