### PR TITLE
Add/newsletter categories animation

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import TreeSelector from '../tree-selector';
 
 const TreeDropdown = props => {
-	const { items, onChange, selectedItems, disabled } = props;
+	const { items, onChange, selectedItems, disabled, hidden } = props;
 	const [ inputValue, setInputValue ] = useState( '' );
 	const [ isDropdownVisible, setIsDropdownVisible ] = useState( false );
 	const dropdownRef = useRef( null );
@@ -57,8 +57,10 @@ const TreeDropdown = props => {
 		};
 	}, [ handleClickOutside ] );
 
+	const treeDropdownClass = `tree-dropdown ${ hidden ? 'tree-dropdown--hidden' : '' }`;
+
 	return (
-		<div className="tree-dropdown" ref={ dropdownRef }>
+		<div className={ treeDropdownClass } ref={ dropdownRef }>
 			<div className={ className }>
 				<Icon icon={ search } />
 				{ tags.map( ( tag, index ) => (

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
@@ -1,6 +1,16 @@
 @import '../../scss/calypso-colors';
 
 .tree-dropdown {
+	opacity: 1;
+  max-height: none;
+  transition: opacity 0.3s, max-height 0.3s ease-in-out;
+
+	&--hidden {
+		opacity: 0;
+    max-height: 0;
+    transition: opacity 0.3s, max-height 0.3s ease-in-out;
+	}
+
 	.tree-dropdown__input-container {
 		display: flex;
 		flex-wrap: wrap;

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -106,6 +106,7 @@ function NewsletterCategories( props ) {
 					selectedItems={ checkedCategoriesIds }
 					onChange={ onSelectedCategoryChange }
 					disabled={ isSavingAnyOption( [ 'wpcom_newsletter_categories' ] ) }
+					hidden={ ! isNewsletterCategoriesEnabled }
 				/>
 			</SettingsGroup>
 			<Card

--- a/projects/plugins/jetpack/changelog/add-newsletter-categories-animation
+++ b/projects/plugins/jetpack/changelog/add-newsletter-categories-animation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Added animation to enabling and disabling newsletter categories


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87662

## Proposed changes:
Added animation at the time of enabling and disabling newsletter categories. This animation includes hiding and showing the TreeDropdown component.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Apply these changes to your JT site.
* Go to `/wp-admin/admin.php?enable-newsletter-categories=true&page=jetpack#/newsletter`.
* Click on the `Enable newsletter categories` switch. See how the categories box appears and disappears with a subtle animation.

