### PR TITLE
SSO: Fixes users table custom columns

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sso-custom-column
+++ b/projects/plugins/jetpack/changelog/update-sso-custom-column
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix a bug in showing custom columns in the users table

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -644,39 +644,41 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		 * @return string
 		 */
 		public function jetpack_show_connection_status( $val, $col, $user_id ) {
-			if ( 'user_jetpack' === $col && Jetpack::connection()->is_user_connected( $user_id ) ) {
-				$connection_html = sprintf(
-					'<span title="%1$s" class="jetpack-sso-invitation">%2$s</span>',
-					esc_attr__( 'This user is connected and can log-in to this site.', 'jetpack' ),
-					esc_html__( 'Connected', 'jetpack' )
-				);
-				return $connection_html;
-			} else {
-				$has_pending_invite = self::has_pending_wpcom_invite( $user_id );
-				if ( $has_pending_invite ) {
+			if ( 'user_jetpack' === $col ) {
+				if ( Jetpack::connection()->is_user_connected( $user_id ) ) {
 					$connection_html = sprintf(
-						'<span title="%1$s" class="jetpack-sso-invitation sso-pending-invite">%2$s</span>',
-						esc_attr__( 'This user didn&#8217;t accept the invitation to join this site yet.', 'jetpack' ),
-						esc_html__( 'Pending invite', 'jetpack' )
+						'<span title="%1$s" class="jetpack-sso-invitation">%2$s</span>',
+						esc_attr__( 'This user is connected and can log-in to this site.', 'jetpack' ),
+						esc_html__( 'Connected', 'jetpack' )
+					);
+					return $connection_html;
+				} else {
+					$has_pending_invite = self::has_pending_wpcom_invite( $user_id );
+					if ( $has_pending_invite ) {
+						$connection_html = sprintf(
+							'<span title="%1$s" class="jetpack-sso-invitation sso-pending-invite">%2$s</span>',
+							esc_attr__( 'This user didn&#8217;t accept the invitation to join this site yet.', 'jetpack' ),
+							esc_html__( 'Pending invite', 'jetpack' )
+						);
+						return $connection_html;
+					}
+					$nonce           = wp_create_nonce( 'jetpack-sso-invite-user' );
+					$connection_html = sprintf(
+					// Using formmethod and formaction because we can't nest forms and have to submit using the main form.
+						'<a href="%1$s" class="jetpack-sso-invitation sso-disconnected-user">%2$s</a><span title="%3$s" class="sso-disconnected-user-icon dashicons dashicons-warning"></span>',
+						add_query_arg(
+							array(
+								'user_id'      => $user_id,
+								'invite_nonce' => $nonce,
+								'action'       => 'jetpack_invite_user_to_wpcom',
+							),
+							admin_url( 'admin-post.php' )
+						),
+						esc_html__( 'Send invite', 'jetpack' ),
+						esc_attr__( 'This user doesn&#8217;t have a WP.com account and, with your current site settings, won&#8217;t be able to log in. Request them to create a WP.com account to be able to function normally.', 'jetpack' )
 					);
 					return $connection_html;
 				}
-				$nonce           = wp_create_nonce( 'jetpack-sso-invite-user' );
-				$connection_html = sprintf(
-				// Using formmethod and formaction because we can't nest forms and have to submit using the main form.
-					'<a href="%1$s" class="jetpack-sso-invitation sso-disconnected-user">%2$s</a><span title="%3$s" class="sso-disconnected-user-icon dashicons dashicons-warning"></span>',
-					add_query_arg(
-						array(
-							'user_id'      => $user_id,
-							'invite_nonce' => $nonce,
-							'action'       => 'jetpack_invite_user_to_wpcom',
-						),
-						admin_url( 'admin-post.php' )
-					),
-					esc_html__( 'Send invite', 'jetpack' ),
-					esc_attr__( 'This user doesn&#8217;t have a WP.com account and, with your current site settings, won&#8217;t be able to log in. Request them to create a WP.com account to be able to function normally.', 'jetpack' )
-				);
-				return $connection_html;
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Fixes the users table in users.php to not override custom columns made by the users.

Before: 

<img width="631" alt="CleanShot 2024-02-22 at 17 06 17@2x" src="https://github.com/Automattic/jetpack/assets/10482592/5b1c4090-3154-4641-9f6f-1ae9315d378a">


After: 

<img width="563" alt="CleanShot 2024-02-22 at 17 24 22@2x" src="https://github.com/Automattic/jetpack/assets/10482592/3e6e410c-aeeb-4519-92aa-723f95141670">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout branch
* Add custom columns in `jetpack_user_connected_th` method.
* Sync to WoA
* Verify the SSO Status column is still visible.
* Verify the added custom columns do not contain the send invite link and icon.

