### PR TITLE
Scheduled Updates: Make schedule execution work

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-schedule-args
+++ b/projects/packages/scheduled-updates/changelog/fix-schedule-args
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Fix up cron callback and schedule generation to make schedule execution work

--- a/projects/packages/scheduled-updates/changelog/fix-schedule-args
+++ b/projects/packages/scheduled-updates/changelog/fix-schedule-args
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fix up cron callback and schedule generation to make schedule execution work

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -47,7 +47,7 @@ class Scheduled_Updates {
 	/**
 	 * Run the scheduled update.
 	 *
-	 * @param string ...$plugins The plugins to update.
+	 * @param string ...$plugins List of plugins to update.
 	 */
 	public static function jetpack_run_scheduled_update( ...$plugins ) {
 		$available_updates = get_site_transient( 'update_plugins' );

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -47,9 +47,9 @@ class Scheduled_Updates {
 	/**
 	 * Run the scheduled update.
 	 *
-	 * @param array $plugins List of plugins to update.
+	 * @param string ...$plugins The plugins to update.
 	 */
-	public static function jetpack_run_scheduled_update( $plugins = array() ) {
+	public static function jetpack_run_scheduled_update( ...$plugins ) {
 		$available_updates = get_site_transient( 'update_plugins' );
 		$plugins_to_update = array();
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -61,18 +61,11 @@ class Scheduled_Updates {
 		}
 
 		if ( ! empty( $plugins_to_update ) ) {
-			$endpoint_url = sprintf(
-				'https://public-api.wordpress.com/wpcom/v2/sites/%d/hosting/scheduled-update',
-				\Jetpack_Options::get_option( 'id' )
-			);
-
-			wp_remote_post(
-				$endpoint_url,
-				array(
-					'body' => array(
-						'plugins' => $plugins_to_update,
-					),
-				)
+			( new Connection\Client() )->wpcom_json_api_request_as_user(
+				sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
+				'2',
+				array( 'method' => 'POST' ),
+				array( 'plugins' => $plugins_to_update )
 			);
 		}
 	}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -150,7 +150,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same time as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 
-			if ( $this->generate_schedule_id( $schedule_args ) === $this->generate_schedule_id( $request['plugins'] ) ) {
+			if ( $this->generate_schedule_id( $schedule_args ) === $this->generate_schedule_id( array( $request['plugins'] ) ) ) {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same plugins as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 		}
@@ -172,7 +172,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$schedule = $request['schedule'];
 		$plugins  = $request['plugins'];
 
-		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], 'jetpack_scheduled_update', $plugins, true );
+		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], 'jetpack_scheduled_update', array( $plugins ), true );
 		if ( is_wp_error( $event ) ) {
 			return $event;
 		}
@@ -239,7 +239,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same time as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 
-			if ( $this->generate_schedule_id( $schedule_args ) === $this->generate_schedule_id( $request['plugins'] ) ) {
+			if ( $this->generate_schedule_id( $schedule_args ) === $this->generate_schedule_id( array( $request['plugins'] ) ) ) {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same plugins as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 		}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -150,7 +150,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same time as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 
-			if ( $this->generate_schedule_id( $schedule_args ) === $this->generate_schedule_id( array( $request['plugins'] ) ) ) {
+			if ( $this->generate_schedule_id( $schedule_args ) === $this->generate_schedule_id( $request['plugins'] ) ) {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same plugins as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 		}
@@ -172,7 +172,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$schedule = $request['schedule'];
 		$plugins  = $request['plugins'];
 
-		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], 'jetpack_scheduled_update', array( $plugins ), true );
+		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], 'jetpack_scheduled_update', $plugins, true );
 		if ( is_wp_error( $event ) ) {
 			return $event;
 		}
@@ -239,7 +239,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same time as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 
-			if ( $this->generate_schedule_id( $schedule_args ) === $this->generate_schedule_id( array( $request['plugins'] ) ) ) {
+			if ( $this->generate_schedule_id( $schedule_args ) === $this->generate_schedule_id( $request['plugins'] ) ) {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same plugins as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5653

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Cron passes each plugin slug in a separate parameter. We now capture them all.
* Now uses authenticated requests when triggering updates.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the Jetpack beta tester plugin to activate this branch on your WoA site.
* Find a place to execute the following call on a page load (replace the plugin slug with one that you intend to update) `Automattic\Jetpack\Scheduled_Updates::jetpack_run_scheduled_update('wordpress-importer/wordpress-importer.php');`
* Change the version of the plugin you want to update and reload `wp-admin/plugins.php` to trigger an update check.
* Execute the call above to trigger the schedule.