### PR TITLE
Update/newsletter slide up/down animations

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
@@ -91,7 +91,11 @@ const TreeDropdown = props => {
 						visible: isDropdownVisible,
 					} ) }
 				>
-					<div className={ `tree-dropdown-colapsable ${ ! isDropdownVisible ? 'hide' : '' }` }>
+					<div
+						className={ classNames( 'tree-dropdown-colapsable', {
+							hide: ! isDropdownVisible,
+						} ) }
+					>
 						<TreeSelector
 							items={ items }
 							selectedItems={ selectedItems }

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
@@ -85,10 +85,9 @@ const TreeDropdown = props => {
 					disabled={ disabled }
 				/>
 			</div>
-
-			{ isDropdownVisible && (
-				<div className="tree-dropdown__dropdown-container">
-					<div className="tree-dropdown__dropdown">
+			<div className="tree-dropdown__dropdown-container">
+				<div className="tree-dropdown__dropdown">
+					<div className={ `tree-dropdown-colapsable ${ ! isDropdownVisible ? 'hide' : '' }` }>
 						<TreeSelector
 							items={ items }
 							selectedItems={ selectedItems }
@@ -98,7 +97,7 @@ const TreeDropdown = props => {
 						/>
 					</div>
 				</div>
-			) }
+			</div>
 		</div>
 	);
 };

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
@@ -86,7 +86,11 @@ const TreeDropdown = props => {
 				/>
 			</div>
 			<div className="tree-dropdown__dropdown-container">
-				<div className="tree-dropdown__dropdown">
+				<div
+					className={ classNames( 'tree-dropdown__dropdown', {
+						visible: isDropdownVisible,
+					} ) }
+				>
 					<div className={ `tree-dropdown-colapsable ${ ! isDropdownVisible ? 'hide' : '' }` }>
 						<TreeSelector
 							items={ items }

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
@@ -1,7 +1,57 @@
 @import '../../scss/calypso-colors';
 
+
+@keyframes dropdown-slide-down {
+	from {
+		border: solid 1px $gray-5;
+	}
+	to {
+		border: solid 1px var(--jp-green);
+	}
+}
+
+@keyframes dropdown-slide-up {
+	0% {
+		border: solid 1px $gray-5;
+		border-top: none;
+	}
+	99% {
+		border: solid 1px $gray-5;
+		border-top: none;
+	}
+	100% {
+		border: none;
+	}
+}
+
+@keyframes input-container-slide-up {
+	from {
+		border-bottom: none;
+		border-bottom-left-radius: 0;
+		border-bottom-right-radius: 0;
+	}
+	to {
+		border-bottom: unset;
+		border-bottom-left-radius: unset;
+		border-bottom-right-radius: unset;
+	}
+}
+
+@keyframes jp-tree-items-slide-down {
+	0% {
+		overflow-y: hidden;
+	}
+	99% {
+		overflow-y: hidden;
+	}
+	100% {
+		overflow-y: auto;
+	}
+}
+
 .tree-dropdown {
 	.tree-dropdown__input-container {
+		animation: input-container-slide-up 500ms;
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
@@ -10,8 +60,8 @@
 		border-radius: 4px;
 		min-height: 40px;
 		padding: 4px 8px;
-
 		&.active {
+			animation: unset;
 			border-color: var(--jp-green);
 			box-shadow: 0px 0px 0px 2px var(--jp-green-5), 0px 7px 15px 0px #00000026;
 			border-radius: 4px 4px 0 0;
@@ -59,34 +109,55 @@
 	}
 
 	.tree-dropdown__dropdown-container {
-		position: relative;
+		.tree-dropdown-colapsable {
+			display: grid;
+			grid-template-rows: 1fr;
+			transition: grid-template-rows 500ms;
+			  
+			&.hide {
+				grid-template-rows: 0fr;
+			}
+		}
 
 		.tree-dropdown__dropdown {
+			animation: dropdown-slide-up 500ms;
+			border: none;
 			position: absolute;
 			top: 100%;
 			width: 100%;
-			background-color: $white;
-			border: solid 1px var(--jp-green);
-			border-top: none;
-			border-radius: 0 0 4px 4px;
-			box-shadow: 0px 0px 0px 2px var(--jp-green-5), 0px 10px 15px 0px #00000026;
+			background-color: $white;	
 			z-index: 1000;
 
-			&::before {
-				content: '';
-				position: absolute;
-				top: -5px;
-				left: -1px;
-				right: -1px;
-				height: 5px;
-				background-color: $white;
-				border-left: solid 1px var(--jp-green);
-				border-right: solid 1px var(--jp-green);
+			&.visible {
+				animation: dropdown-slide-down 500ms;
+				border: solid 1px var(--jp-green);
+				border-top: none;
+				border-radius: 0 0 4px 4px;
+				box-shadow: 0px 0px 0px 2px var(--jp-green-5), 0px 10px 15px 0px #00000026;
+				&::before {
+					content: '';
+					position: absolute;
+					top: -5px;
+					left: -1px;
+					right: -1px;
+					height: 5px;
+					background-color: $white;
+					border-left: solid 1px var(--jp-green);
+					border-right: solid 1px var(--jp-green);
+				}
+
+				ul.jp-tree-items {
+					animation: jp-tree-items-slide-down 500ms;
+					overflow-y: auto;
+				}
+			}
+			
+			ul.jp-tree-items {
+				overflow-y: hidden;
 			}
 
 			ul.jp-tree-items {
 				max-height: 370px;
-				overflow-y: auto;
 			}
 
 			li.jp-tree-item {

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
@@ -127,6 +127,7 @@
 			width: 100%;
 			background-color: $white;	
 			z-index: 1000;
+			padding: 8px;
 
 			&.visible {
 				animation: dropdown-slide-down 500ms;

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
@@ -65,7 +65,6 @@
 			position: absolute;
 			top: 100%;
 			width: 100%;
-			padding: 8px;
 			background-color: $white;
 			border: solid 1px var(--jp-green);
 			border-top: none;

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -1,3 +1,4 @@
+import './style.scss';
 import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import SettingsCard from 'components/settings-card';
@@ -108,21 +109,27 @@ function NewsletterCategories( props ) {
 					onChange={ handleEnableNewsletterCategoriesToggleChange }
 					label={ __( 'Enable newsletter categories', 'jetpack' ) }
 				/>
-				<TreeDropdown
-					items={ mappedCategories }
-					selectedItems={ checkedCategoriesIds }
-					onChange={ onSelectedCategoryChange }
-					disabled={ isSavingAnyOption( [ 'wpcom_newsletter_categories' ] ) }
-				/>
+				<div
+					className={ `newsletter-colapsable ${ ! isNewsletterCategoriesEnabled ? 'hide' : '' }` }
+				>
+					<TreeDropdown
+						items={ mappedCategories }
+						selectedItems={ checkedCategoriesIds }
+						onChange={ onSelectedCategoryChange }
+						disabled={ isSavingAnyOption( [ 'wpcom_newsletter_categories' ] ) }
+					/>
+				</div>
 			</SettingsGroup>
-			<Card
-				compact
-				className="jp-settings-card__configure-link"
-				href="/wp-admin/edit-tags.php?taxonomy=category"
-				target="_blank"
-			>
-				{ __( 'Add New Category', 'jetpack' ) }
-			</Card>
+			<div className={ `newsletter-colapsable ${ ! isNewsletterCategoriesEnabled ? 'hide' : '' }` }>
+				<Card
+					compact
+					className="jp-settings-card__configure-link"
+					href="/wp-admin/edit-tags.php?taxonomy=category"
+					target="_blank"
+				>
+					{ __( 'Add New Category', 'jetpack' ) }
+				</Card>
+			</div>
 		</SettingsCard>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -1,6 +1,7 @@
 import './style.scss';
 import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import React, { useCallback, useMemo } from 'react';
@@ -110,7 +111,9 @@ function NewsletterCategories( props ) {
 					label={ __( 'Enable newsletter categories', 'jetpack' ) }
 				/>
 				<div
-					className={ `newsletter-colapsable ${ ! isNewsletterCategoriesEnabled ? 'hide' : '' }` }
+					className={ classNames( 'newsletter-colapsable', {
+						hide: ! isNewsletterCategoriesEnabled,
+					} ) }
 				>
 					<TreeDropdown
 						items={ mappedCategories }
@@ -120,7 +123,11 @@ function NewsletterCategories( props ) {
 					/>
 				</div>
 			</SettingsGroup>
-			<div className={ `newsletter-colapsable ${ ! isNewsletterCategoriesEnabled ? 'hide' : '' }` }>
+			<div
+				className={ classNames( 'newsletter-card-colapsable', {
+					hide: ! isNewsletterCategoriesEnabled,
+				} ) }
+			>
 				<Card
 					compact
 					className="jp-settings-card__configure-link"

--- a/projects/plugins/jetpack/_inc/client/newsletter/style.scss
+++ b/projects/plugins/jetpack/_inc/client/newsletter/style.scss
@@ -1,4 +1,46 @@
+@keyframes categories-slide-down {
+	0% {
+		overflow: hidden;
+	}
+	99% {
+		overflow: hidden;
+	}
+	100% {
+		overflow: unset;
+	}
+}
+
+@keyframes categories-slide-up {
+	0% {
+		overflow: unset;
+	}
+	1% {
+		overflow: hidden;
+	}
+	100% {
+		overflow: hidden;
+	}
+}
+  
 .newsletter-colapsable {
+	grid-template-rows: 1fr;
+	transition: grid-template-rows 500ms;
+	display: grid;
+	position: relative;
+	.tree-dropdown {
+		animation: categories-slide-down 500ms;
+		overflow: unset;
+	}
+	&.hide {
+		.tree-dropdown {
+			animation: categories-slide-up 500ms;
+			overflow: hidden;
+		}
+		grid-template-rows: 0fr;
+    }
+}
+
+.newsletter-card-colapsable {
     transition: max-height 500ms;
     max-height: 60px;
         
@@ -6,23 +48,4 @@
         max-height: 0px;
         overflow: hidden;
     }
-}
-
-.tree-dropdown-colapsable {
-	grid-template-rows: 1fr;
-	transition: grid-template-rows 500ms;
-	display: grid;
-	  
-	&.hide {
-		grid-template-rows: 0fr;
-		opacity: 1;
-	}
-
-	ul {
-		overflow: hidden;
-	  }
-
-	  &.tree-dropdown {
-		overflow: hidden;
-	}
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/style.scss
+++ b/projects/plugins/jetpack/_inc/client/newsletter/style.scss
@@ -1,0 +1,28 @@
+.newsletter-colapsable {
+    transition: max-height 500ms;
+    max-height: 60px;
+        
+    &.hide {
+        max-height: 0px;
+        overflow: hidden;
+    }
+}
+
+.tree-dropdown-colapsable {
+	grid-template-rows: 1fr;
+	transition: grid-template-rows 500ms;
+	display: grid;
+	  
+	&.hide {
+		grid-template-rows: 0fr;
+		opacity: 1;
+	}
+
+	ul {
+		overflow: hidden;
+	  }
+
+	  &.tree-dropdown {
+		overflow: hidden;
+	}
+}

--- a/projects/plugins/jetpack/changelog/update-newsletter-slidedown-animations
+++ b/projects/plugins/jetpack/changelog/update-newsletter-slidedown-animations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add slide up/down animation to categories.


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87662

Introduces the animation to show/hide categories on newsletter settings.

![gif](https://github.com/Automattic/jetpack/assets/33497086/50eb3fe9-fc58-49f9-8e8b-a5e684fc2bcb)

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
To enable the feature flag navigate with **enable-newsletter-categories** query param:
`wp-admin/admin.php?enable-newsletter-categories=true&page=jetpack#/newsletter`

- Toggle the setting on/off.
- Open/close the categories input.
- The animation should work like the gif above.