### PR TITLE
[Boost] Remove type casting

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
@@ -25,7 +25,7 @@ const CacheDebugLog = () => {
 						<CopyToClipboard
 							buttonStyle="icon-text"
 							className={ styles[ 'copy-button' ] }
-							textToCopy={ debugLog as string }
+							textToCopy={ debugLog || '' }
 							variant="link"
 							weight="regular"
 						>

--- a/projects/plugins/boost/changelog/boost-remove-type-casting
+++ b/projects/plugins/boost/changelog/boost-remove-type-casting
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Not user-facing
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Any time `as` appears in new code, we should ask if it's the right solution. Here it can be used to cram an undefined value into a component that expects text.

pc9hqz-2wT-p2

## Proposed changes:
* Don't use `as` to force incorrect value types.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-2wT-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
n/a