### PR TITLE
[Boost] Move debug log store to the proper place

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/lib/stores.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/lib/stores.ts
@@ -1,0 +1,14 @@
+import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
+import { z } from 'zod';
+
+/**
+ * Hook for reading Debug Logs. Is automatically kept up-to-date with 10 second refreshes.
+ */
+export function useDebugLog() {
+	return useDataSync( 'jetpack_boost_ds', 'cache_debug_log', z.string(), {
+		query: {
+			// Keep refreshing the logs every 10 seconds
+			refetchInterval: 10000,
+		},
+	} );
+}

--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
@@ -1,19 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import Header from '$layout/header/header';
-import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
-import { z } from 'zod';
 import Footer from '$layout/footer/footer';
 import styles from './cache-debug-log.module.scss';
 import classNames from 'classnames';
 import { CopyToClipboard } from '@automattic/jetpack-components';
+import { useDebugLog } from '$features/page-cache/lib/stores';
 
 const CacheDebugLog = () => {
-	const [ { data: debugLog } ] = useDataSync( 'jetpack_boost_ds', 'cache_debug_log', z.string(), {
-		query: {
-			// Keep refreshing the logs every 10 seconds
-			refetchInterval: 10000,
-		},
-	} );
+	const [ { data: debugLog } ] = useDebugLog();
 
 	return (
 		<div id="jb-dashboard" className="jb-dashboard jb-dashboard--main">

--- a/projects/plugins/boost/changelog/boost-fix-code-layout
+++ b/projects/plugins/boost/changelog/boost-fix-code-layout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal code cleanup
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #35618, @dilirity pointed out that the data-store hook for debug-log didn't belong inline in the page. I made a mistake when I glossed over that detail; he's right. It's in a `/page` and not in the feature directory. It belongs in the feature dir in the store file - just like all other stores.

This fixes that.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Shift debug log hook to the right place

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Verify debug logger still works

