### PR TITLE
Google Fonts: Update the implementation of the print_font_faces

### DIFF
--- a/projects/plugins/jetpack/changelog/update-google-fonts-print-font-faces
+++ b/projects/plugins/jetpack/changelog/update-google-fonts-print-font-faces
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Google Fonts: Update the implement of print_font_faces as the value of WP_Font_Face_Resolver::get_fonts_from_theme_json may be an indexed array

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -54,13 +54,21 @@ class Jetpack_Google_Font_Face {
 	 * Print fonts that are used in global styles or block-level settings.
 	 */
 	public function print_font_faces() {
-		$fonts          = $this->get_fonts();
-		$fonts_to_print = array();
+		$fonts             = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+		$font_slug_aliases = $this->get_font_slug_aliases();
+		$fonts_to_print    = array();
 
 		$this->collect_global_styles_fonts();
-		$this->fonts_in_use = array_values( array_unique( $this->fonts_in_use, SORT_STRING ) );
+		$fonts_in_use = array_values( array_unique( $this->fonts_in_use, SORT_STRING ) );
+		$fonts_in_use = array_map(
+			function ( $font_slug ) use ( $font_slug_aliases ) {
+				return $font_slug_aliases[ $font_slug ] ?? $font_slug;
+			},
+			$this->fonts_in_use
+		);
+
 		foreach ( $fonts as $font_family => $font_faces ) {
-			if ( in_array( $this->format_font( $font_family ), $this->fonts_in_use, true ) ) {
+			if ( in_array( $this->format_font( $font_family ), $fonts_in_use, true ) ) {
 				$fonts_to_print[ $font_family ] = $font_faces;
 			}
 		}
@@ -141,26 +149,27 @@ class Jetpack_Google_Font_Face {
 	}
 
 	/**
-	 * Get all font definitions from theme json.
+	 * Get the font slug aliases that maps the font slug to the font family if they are different.
+	 *
+	 * The font definition may define an alias slug name, so we have to add the map from the slug name to the font family.
+	 * See https://github.com/WordPress/twentytwentyfour/blob/df92472089ede6fae5924c124a93c843b84e8cbd/theme.json#L215.
 	 */
-	public function get_fonts() {
-		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+	public function get_font_slug_aliases() {
+		$font_slug_aliases = array();
 
-		// The font definition might define an alias slug name, so we have to add the map from the slug name to font faces.
-		// See https://github.com/WordPress/twentytwentyfour/blob/df92472089ede6fae5924c124a93c843b84e8cbd/theme.json#L215.
 		$theme_json = WP_Theme_JSON_Resolver::get_theme_data();
 		$raw_data   = $theme_json->get_data();
 		if ( ! empty( $raw_data['settings']['typography']['fontFamilies'] ) ) {
 			foreach ( $raw_data['settings']['typography']['fontFamilies'] as $font ) {
 				$font_family_name = $this->get_font_family_name( $font );
 				$font_slug        = $font['slug'] ?? '';
-				if ( $font_slug && ! array_key_exists( $font_slug, $fonts ) && array_key_exists( $font_family_name, $fonts ) ) {
-					$fonts[ $font_slug ] = $fonts[ $font_family_name ];
+				if ( $font_slug && $font_slug !== $font_family_name && ! array_key_exists( $font_slug, $font_slug_aliases ) ) {
+					$font_slug_aliases[ $font_slug ] = $font_family_name;
 				}
 			}
 		}
 
-		return $fonts;
+		return $font_slug_aliases;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/WordPress/wordpress-develop/pull/6161

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* The returned value of the `WP_Font_Face_Resolver::get_fonts_from_theme_json()` is changing to an indexed array ([here](https://github.com/WordPress/wordpress-develop/pull/6161)), so we cannot rely on the key of the returned value. As a result, this PR avoids using the key from the value and just loops the array to collect the fonts to print.
* Moreover, we added the key of the font slug alias to the returned value of that function as well (See https://github.com/Automattic/jetpack/pull/34157/commits/c472144347077d742458839aa1088e5f8145d604). Now we change to get the font slug aliases array first and then map the `$fonts_in_use` to its actual font family to get rid of using the key from the returned value of the `WP_Font_Face_Resolver::get_fonts_from_theme_json()`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your WoA site via Jetpack Beta Tester
* Active TT4
* Go to your homepage
* Make sure the font looks correct
