### PR TITLE
Boost: Move filesystem methods

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache.php
@@ -10,7 +10,7 @@ use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Modules\Modules_Index;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
-use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache_Utils;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Filesystem_Utils;
 
 class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 	/*
@@ -70,7 +70,7 @@ class Page_Cache implements Pluggable, Has_Activate, Has_Deactivate {
 
 	public function invalidate_cache() {
 		$cache = new Boost_Cache();
-		$cache->get_storage()->invalidate( home_url(), Boost_Cache_Utils::DELETE_ALL );
+		$cache->get_storage()->invalidate( home_url(), Filesystem_Utils::DELETE_ALL );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -2,7 +2,6 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache;
 
-use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache_Utils;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Filesystem_Utils;
 
 class Page_Cache_Setup {
@@ -163,7 +162,7 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 	public static function uninstall() {
 		self::deactivate();
 
-		$result = Boost_Cache_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', Boost_Cache_Utils::DELETE_ALL );
+		$result = Filesystem_Utils::delete_directory( WP_CONTENT_DIR . '/boost-cache', Filesystem_Utils::DELETE_ALL );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -157,7 +157,7 @@ class Boost_Cache {
 				$this->delete_cache_for_post( get_post( $posts_page_id ) );
 			}
 		} else {
-			$this->storage->invalidate( home_url(), Boost_Cache_Utils::DELETE_FILES );
+			$this->storage->invalidate( home_url(), Filesystem_Utils::DELETE_FILES );
 			Logger::debug( 'delete front page cache ' . Boost_Cache_Utils::normalize_request_uri( home_url() ) );
 		}
 	}
@@ -223,8 +223,8 @@ class Boost_Cache {
 			 * message.
 			 */
 			if ( isset( $parameters['cookies'] ) && ! empty( $parameters['cookies'] ) ) {
-				$filename = trailingslashit( get_permalink( $post->ID ) ) . Boost_Cache_Utils::get_request_filename( $parameters );
-				$this->storage->invalidate( $filename, Boost_Cache_Utils::DELETE_FILE );
+				$filename = trailingslashit( get_permalink( $post->ID ) ) . Filesystem_Utils::get_request_filename( $parameters );
+				$this->storage->invalidate( $filename, Filesystem_Utils::DELETE_FILE );
 			}
 			return;
 		}
@@ -357,7 +357,7 @@ class Boost_Cache {
 	public function delete_cache_for_url( $url ) {
 		Logger::debug( 'delete_cache_for_url: ' . $url );
 
-		return $this->storage->invalidate( $url, Boost_Cache_Utils::DELETE_ALL );
+		return $this->storage->invalidate( $url, Filesystem_Utils::DELETE_ALL );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
@@ -3,6 +3,84 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress;
 
 class Filesystem_Utils {
+
+	const DELETE_ALL   = 'delete-all'; // delete all files and directories in a given directory, recursively.
+	const DELETE_FILE  = 'delete-single'; // delete a single file or recursively delete a single directory in a given directory.
+	const DELETE_FILES = 'delete-files'; // delete all files in a given directory.
+
+	/**
+	 * Recursively delete a directory.
+	 * @param string $path - The directory to delete.
+	 * @param bool   $type - The type of delete. DELETE_FILES to delete all files in the given directory. DELETE_ALL to delete everything in the given directory, recursively.
+	 * @return bool|WP_Error
+	 */
+	public static function delete_directory( $path, $type ) {
+		Logger::debug( "delete directory: $path $type" );
+		$path = realpath( $path );
+		if ( ! $path ) {
+			// translators: %s is the directory that does not exist.
+			return new \WP_Error( 'directory-missing', sprintf( __( 'Directory does not exist: %s', 'jetpack-boost' ), $path ) ); // realpath returns false if a file does not exist.
+		}
+
+		// make sure that $dir is a directory inside WP_CONTENT . '/boost-cache/';
+		if ( self::is_boost_cache_directory( $path ) === false ) {
+			// translators: %s is the directory that is invalid.
+			return new \WP_Error( 'invalid-directory', sprintf( __( 'Invalid directory %s', 'jetpack-boost' ), $path ) );
+		}
+
+		if ( ! is_dir( $path ) ) {
+			return new \WP_Error( 'not-a-directory', __( 'Not a directory', 'jetpack-boost' ) );
+		}
+
+		switch ( $type ) {
+			case self::DELETE_ALL: // delete all files and directories in the given directory.
+				$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \RecursiveDirectoryIterator::SKIP_DOTS ) );
+				foreach ( $iterator as $file ) {
+					if ( $file->isDir() ) {
+						Logger::debug( 'rmdir: ' . $file->getPathname() );
+						@rmdir( $file->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
+					} else {
+						Logger::debug( 'unlink: ' . $file->getPathname() );
+						@unlink( $file->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink, WordPress.PHP.NoSilencedErrors.Discouraged
+					}
+				}
+				@rmdir( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged,
+				break;
+			case self::DELETE_FILES: // delete all files in the given directory.
+				$files = array_diff( scandir( $path ), array( '.', '..' ) );
+				foreach ( $files as $file ) {
+					$file = $path . '/' . $file;
+					if ( is_file( $file ) ) {
+						Logger::debug( "unlink: $file" );
+						@unlink( $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+					}
+				}
+				break;
+		}
+		return true;
+	}
+
+	/**
+	 * Returns true if the given directory is inside the boost-cache directory.
+	 * @param string $dir - The directory to check.
+	 * @return bool
+	 */
+	public static function is_boost_cache_directory( $dir ) {
+		$dir = self::sanitize_file_path( $dir );
+		return strpos( $dir, WP_CONTENT_DIR . '/boost-cache' ) !== false;
+	}
+
+	/**
+	 * Given a request_uri and its parameters, return the filename to use for this cached data. Does not include the file path.
+	 *
+	 * @param array  $parameters  - An associative array of all the things that make this request special/different. Includes GET parameters and COOKIEs normally.
+	 */
+	public static function get_request_filename( $parameters ) {
+
+		$key_components = apply_filters( 'boost_cache_key_components', $parameters );
+
+		return md5( json_encode( $key_components ) ) . '.html'; // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+	}
 	/**
 	 * Recursively garbage collect a directory.
 	 *

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
@@ -66,7 +66,7 @@ class Filesystem_Utils {
 	 * @return bool
 	 */
 	public static function is_boost_cache_directory( $dir ) {
-		$dir = self::sanitize_file_path( $dir );
+		$dir = Boost_Cache_Utils::sanitize_file_path( $dir );
 		return strpos( $dir, WP_CONTENT_DIR . '/boost-cache' ) !== false;
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/storage/File_Storage.php
@@ -32,7 +32,7 @@ class File_Storage implements Storage {
 	 */
 	public function write( $request_uri, $parameters, $data ) {
 		$directory = self::get_uri_directory( $request_uri );
-		$filename  = Boost_Cache_Utils::get_request_filename( $parameters );
+		$filename  = Filesystem_Utils::get_request_filename( $parameters );
 
 		if ( ! Filesystem_Utils::create_directory( $directory ) ) {
 			return new \WP_Error( 'Could not create cache directory' );
@@ -49,7 +49,7 @@ class File_Storage implements Storage {
 	 */
 	public function read( $request_uri, $parameters ) {
 		$directory = self::get_uri_directory( $request_uri );
-		$filename  = Boost_Cache_Utils::get_request_filename( $parameters );
+		$filename  = Filesystem_Utils::get_request_filename( $parameters );
 		$hash_path = $directory . $filename;
 
 		if ( file_exists( $hash_path ) ) {
@@ -113,9 +113,9 @@ class File_Storage implements Storage {
 		Logger::debug( "invalidate: $path $type" );
 		$normalized_path = $this->root_path . Boost_Cache_Utils::normalize_request_uri( $path );
 
-		if ( in_array( $type, array( Boost_Cache_Utils::DELETE_FILES, Boost_Cache_Utils::DELETE_ALL ), true ) && is_dir( $normalized_path ) ) {
-			return Boost_Cache_Utils::delete_directory( $normalized_path, $type );
-		} elseif ( $type === Boost_Cache_Utils::DELETE_FILE && is_file( $normalized_path ) ) {
+		if ( in_array( $type, array( Filesystem_Utils::DELETE_FILES, Filesystem_Utils::DELETE_ALL ), true ) && is_dir( $normalized_path ) ) {
+			return Filesystem_Utils::delete_directory( $normalized_path, $type );
+		} elseif ( $type === Filesystem_Utils::DELETE_FILE && is_file( $normalized_path ) ) {
 			return Filesystem_Utils::delete_file( $normalized_path );
 		} else {
 			return new \WP_Error( 'no-cache-files-to-delete', 'No cache files to delete.' );

--- a/projects/plugins/boost/changelog/boost-cache-move-delete
+++ b/projects/plugins/boost/changelog/boost-cache-move-delete
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Move filesystem related methods and const from Boost_Cache_Utils.php
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35805

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move filesystem related methods and const from Boost_Cache_Utils.php

> [!NOTE]  
> Merge after #35892

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Make sure caching functionalities still work