### PR TITLE
Untangle: make release toggle consistent

### DIFF
--- a/projects/plugins/jetpack/changelog/prepare-nav-redesign
+++ b/projects/plugins/jetpack/changelog/prepare-nav-redesign
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Untangle: always use the wpcom_is_nav_redesign_enabled() function as release toggle

--- a/projects/plugins/jetpack/modules/masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar.php
@@ -22,11 +22,7 @@ require __DIR__ . '/masterbar/masterbar/class-masterbar.php';
 require __DIR__ . '/masterbar/admin-color-schemes/class-admin-color-schemes.php';
 require __DIR__ . '/masterbar/inline-help/class-inline-help.php';
 
-$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] )
-			? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) )
-			: defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
-
-$should_use_nav_redesign = apply_filters( 'is_nav_redesign_enabled', $is_proxied && get_option( 'wpcom_admin_interface' ) === 'wp-admin' );
+$should_use_nav_redesign = function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled();
 
 if ( ! $should_use_nav_redesign ) {
 	new Masterbar();


### PR DESCRIPTION
Part of:

- https://github.com/Automattic/dotcom-forge/issues/5858

## Proposed changes:

Currently, in Jetpack side we have 2 ways of checking the nav redesign flag:

1. Uses wpcomsh helper function
   - `function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled()`
      - `wpcom_is_nav_redesign_enabled()` currently calls `apply_filter( 'is_nav_redesign_enabled' )`
2. Uses the filter directly
   - `apply_filter( 'is_nav_redesign_enabled' )`

Now, we are adding a third check which checks the early-access blog option here in wpcomsh: https://github.com/Automattic/wpcomsh/pull/1714. As such, this PR proposes to update all checks in Jetpack to use `wpcom_is_nav_redesign_enabled()` to:

- be consistent
- avoid future confusion

Read more details of the discussion in:
   - https://github.com/Automattic/dotcom-forge/issues/5712
   - https://github.com/Automattic/dotcom-forge/issues/5718

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Use Jepack Beta Tester to apply this branch.
2. Follow instructions in https://github.com/Automattic/wpcomsh/pull/1714