### PR TITLE
Untangle: Enable Blaze dashboard on wp-admin without proxy check

### DIFF
--- a/projects/packages/blaze/changelog/untangle-blaze-v2
+++ b/projects/packages/blaze/changelog/untangle-blaze-v2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Untangle: Enable blaze dashboard on wp-admin without proxy check

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -73,11 +73,10 @@ class Blaze {
 	 * @return bool
 	 */
 	public static function is_dashboard_enabled() {
-		$is_dashboard_enabled          = true;
-		$wpcom_is_nav_redesign_enabled = function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled();
+		$is_dashboard_enabled = true;
 
-		// On WordPress.com sites, the dashboard is not needed if the nav redesign is not enabled.
-		if ( ! $wpcom_is_nav_redesign_enabled && ( new Host() )->is_wpcom_platform() ) {
+		// On WordPress.com sites, the dashboard is not needed if the admin interface style is not wp-admin.
+		if ( ( new Host() )->is_wpcom_platform() && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
 			$is_dashboard_enabled = false;
 		}
 
@@ -125,13 +124,16 @@ class Blaze {
 			);
 			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
 		} elseif ( ( new Host() )->is_wpcom_platform() ) {
-			$domain      = ( new Jetpack_Status() )->get_site_suffix();
-			$page_suffix = add_submenu_page(
+			$domain                  = ( new Jetpack_Status() )->get_site_suffix();
+			$uses_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+			$page_suffix             = add_submenu_page(
 				'tools.php',
 				esc_attr__( 'Advertising', 'jetpack-blaze' ),
 				__( 'Advertising', 'jetpack-blaze' ),
 				'manage_options',
-				'https://wordpress.com/advertising/' . $domain,
+				$uses_wp_admin_interface
+					? 'tools.php?page=advertising'
+					: 'https://wordpress.com/advertising/' . $domain,
 				null,
 				1
 			);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to: 

- https://github.com/Automattic/dotcom-forge/issues/5583

## Proposed changes:

We have already enabled the Blaze dashboard on wp-admin but with the proxy check, via https://github.com/Automattic/jetpack/pull/35724. Here, I propose we should just enable it for classic view sites, without proxy check.

This will GREATLY simplify our other PRs that are fixing the Blaze URLs in different parts in dotcom:

- https://github.com/Automattic/wp-calypso/pull/87788
- D139428-code

What do you all think?

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. !!! DO NOT USE A8C PROXY !!!.
1. Patch this branch to your Jetpack Beta Tester.
2. Set the admin interface as Default.
3. Verify Tools -> Advertising point to `wordpress.com/advertising/:siteSlug`.
4. Set the admin interface as Classic.
5. Verify you can still see the Blaze option on `/wp-admin/admin.php?page=jetpack#/traffic`.
    - Verify that the `Manage your campaigns and view your earnings in the Blaze dashboard` point to `/wp-admin/tools.php?page=advertising`.
6. Verify that `Tools -> Advertising` exist and point to `/wp-admin/tools.php?page=advertising`.