### PR TITLE
Boost: Add tooltip for cache exceptions UI

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
@@ -106,6 +106,9 @@
 		top: 0;
 		left: -10px;
 		z-index: 9;
+
+		.tooltip :global(.icon-tooltip-container .components-popover__content) {
+			width: 150px;
+		}
 	}
 }
-

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
@@ -91,3 +91,21 @@
 		}
 	}
 }
+
+.example-wrapper {
+	position: relative;
+	display: inline;
+
+	.example-button {
+		position: relative;
+		z-index: 10;
+	}
+
+	.tooltip-wrapper {
+		position: absolute;
+		top: 0;
+		left: -10px;
+		z-index: 9;
+	}
+}
+

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -1,4 +1,4 @@
-import { Button, Notice } from '@automattic/jetpack-components';
+import { Button, IconTooltip, Notice } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import ChevronDown from '$svg/chevron-down';
@@ -179,7 +179,7 @@ const BypassPatterns = ( {
 			<p className={ classNames( styles.description, styles[ 'error-message' ] ) }>
 				{ __( 'Error: Invalid format', 'jetpack-boost' ) }
 			</p>
-			<p className={ styles.description }>
+			<div className={ styles.description }>
 				{ __(
 					'Use (.*) to address multiple URLs under a given path. Be sure each URL path is in its own line.',
 					'jetpack-boost'
@@ -188,13 +188,12 @@ const BypassPatterns = ( {
 				{ createInterpolateElement(
 					__( '<help>See an example</help> or <link>learn more</link>.', 'jetpack-boost' ),
 					{
-						// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
-						help: <a href="#" target="_blank" rel="noreferrer" />,
+						help: <BypassPatternsExample />,
 						// eslint-disable-next-line jsx-a11y/anchor-has-content
 						link: <a href={ exclusionsLink } target="_blank" rel="noreferrer" />,
 					}
 				) }
-			</p>
+			</div>
 			{ showNotice && (
 				<Notice
 					level="error"
@@ -207,6 +206,43 @@ const BypassPatterns = ( {
 			<Button disabled={ patterns === inputValue } onClick={ save } className={ styles.button }>
 				{ __( 'Save', 'jetpack-boost' ) }
 			</Button>
+		</div>
+	);
+};
+
+const BypassPatternsExample = () => {
+	const [ show, setShow ] = useState( false );
+
+	return (
+		<div className={ styles[ 'example-wrapper' ] }>
+			{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+			<a
+				href="#"
+				className={ styles[ 'example-button' ] }
+				onClick={ e => {
+					e.preventDefault();
+					setShow( ! show );
+				} }
+			>
+				{ __( 'See an example', 'jetpack-boost' ) }
+			</a>
+			<div className={ styles[ 'tooltip-wrapper' ] }>
+				<IconTooltip
+					placement="bottom-start"
+					popoverAnchorStyle="wrapper"
+					forceShow={ show }
+					offset={ -10 }
+					className={ styles.tooltip }
+				>
+					<strong>{ __( 'Example:', 'jetpack-boost' ) }</strong>
+					<br />
+					checkout
+					<br />
+					gallery/.*
+					<br />
+					specific-page
+				</IconTooltip>
+			</div>
 		</div>
 	);
 };

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -188,7 +188,7 @@ const BypassPatterns = ( {
 				{ createInterpolateElement(
 					__( '<help>See an example</help> or <link>learn more</link>.', 'jetpack-boost' ),
 					{
-						help: <BypassPatternsExample />,
+						help: <BypassPatternsExample children={ null } />, // children are passed after the interpolation.
 						// eslint-disable-next-line jsx-a11y/anchor-has-content
 						link: <a href={ exclusionsLink } target="_blank" rel="noreferrer" />,
 					}
@@ -210,7 +210,11 @@ const BypassPatterns = ( {
 	);
 };
 
-const BypassPatternsExample = () => {
+type BypassPatternsExampleProps = {
+	children: React.ReactNode;
+};
+
+const BypassPatternsExample = ( { children }: BypassPatternsExampleProps ) => {
 	const [ show, setShow ] = useState( false );
 
 	return (
@@ -224,7 +228,7 @@ const BypassPatternsExample = () => {
 					setShow( ! show );
 				} }
 			>
-				{ __( 'See an example', 'jetpack-boost' ) }
+				{ children }
 			</a>
 			<div className={ styles[ 'tooltip-wrapper' ] }>
 				<IconTooltip

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -188,7 +188,7 @@ const BypassPatterns = ( {
 				{ createInterpolateElement(
 					__( '<help>See an example</help> or <link>learn more</link>.', 'jetpack-boost' ),
 					{
-						help: <BypassPatternsExample children={ null } />, // children are passed after the interpolation.
+						help: <BypassPatternsExample />, // children are passed after the interpolation.
 						// eslint-disable-next-line jsx-a11y/anchor-has-content
 						link: <a href={ exclusionsLink } target="_blank" rel="noreferrer" />,
 					}
@@ -211,7 +211,7 @@ const BypassPatterns = ( {
 };
 
 type BypassPatternsExampleProps = {
-	children: React.ReactNode;
+	children?: React.ReactNode;
 };
 
 const BypassPatternsExample = ( { children }: BypassPatternsExampleProps ) => {

--- a/projects/plugins/boost/changelog/update-exceptions-ui
+++ b/projects/plugins/boost/changelog/update-exceptions-ui
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Update cache exceptions UI to include an example tooltip.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/35768

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make the `See an example` link show an actual tooltip with an example.

![CleanShot 2024-02-23 at 13 54 53](https://github.com/Automattic/jetpack/assets/11799079/2e0814dd-4502-469a-9a59-987b95defd95)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the `See an example` link is clickable and shows the tooltip accordingly.