### PR TITLE
Sharing: only hook block to single post template on WP 6.5+

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-block-hooks-65
+++ b/projects/plugins/jetpack/changelog/fix-sharing-block-hooks-65
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sharing Block: only hook block on WordPress 6.5+

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -30,6 +30,17 @@ function register_block() {
 		__DIR__,
 		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
 	);
+
+	/*
+	 * Automatically add the sharing block to the end of single posts
+	 * only when running WordPress 6.5 or later.
+	 * @todo: remove when WordPress 6.5 is the minimum required version.
+	 */
+	global $wp_version;
+	if ( version_compare( $wp_version, '6.5', '>=' ) ) {
+		add_filter( 'hooked_block_types', __NAMESPACE__ . '\add_block_to_single_posts_template', 10, 4 );
+		add_filter( 'hooked_block_' . PARENT_BLOCK_NAME, __NAMESPACE__ . '\add_default_services_to_block', 10, 5 );
+	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
@@ -236,7 +247,6 @@ function add_block_to_single_posts_template( $hooked_block_types, $relative_posi
 
 	return $hooked_block_types;
 }
-add_filter( 'hooked_block_types', __NAMESPACE__ . '\add_block_to_single_posts_template', 10, 4 );
 
 /**
  * Add default services to the block we add to the post content by default.
@@ -312,4 +322,3 @@ function add_default_services_to_block( $parsed_hooked_block, $hooked_block_type
 		),
 	);
 }
-add_filter( 'hooked_block_' . PARENT_BLOCK_NAME, __NAMESPACE__ . '\add_default_services_to_block', 10, 5 );

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -37,7 +37,7 @@ function register_block() {
 	 * @todo: remove when WordPress 6.5 is the minimum required version.
 	 */
 	global $wp_version;
-	if ( version_compare( $wp_version, '6.5', '>=' ) ) {
+	if ( version_compare( $wp_version, '6.5-beta2', '>=' ) ) {
 		add_filter( 'hooked_block_types', __NAMESPACE__ . '\add_block_to_single_posts_template', 10, 4 );
 		add_filter( 'hooked_block_' . PARENT_BLOCK_NAME, __NAMESPACE__ . '\add_default_services_to_block', 10, 5 );
 	}


### PR DESCRIPTION
## Proposed changes:

Follow-up to #35542

Core recently changed the definition of the filter we're using to automatically add the sharing block to post templates. As a result, our code is not compatible with WordPress 6.4 anymore:

```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Automattic\Jetpack\Extensions\Sharing_Button_Block\add_default_services_to_block(), 4 passed in /var/www/html/wp-includes/class-wp-hook.php on line 324 and exactly 5 expected in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php:254
```

Let's gate that functionality to WordPress 6.5+ to avoid that error.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* On a site running WordPress 6.4, go to Appearance > Site Editor
* You should not get any Fatal error in your logs.
* Using WP CLI, enable auto addition to the sharing buttons: `wp option update jetpack_sharing_buttons_auto_add true`
* Using the WordPress Beta tester plugin, update your site to the current Bleeding edge version of WordPress
* Go to Appearance > Site Editor > Template > Single Posts
* See the sharing buttons at the bottom of the template.