### PR TITLE
Improve My Jetpack checkout flow consistency

### DIFF
--- a/projects/js-packages/connection/changelog/update-my-jetpack-checkout-flow-consistency
+++ b/projects/js-packages/connection/changelog/update-my-jetpack-checkout-flow-consistency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+allow post-checkout URL to be updated as run-time

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -118,10 +118,14 @@ export default function useProductCheckoutWorkflow( {
 	debug( 'connectAfterCheckout is %s', connectAfterCheckout );
 	debug( 'checkoutUrl is %s', checkoutUrl );
 
-	const handleAfterRegistration = () => {
+	const handleAfterRegistration = ( redirect = null ) => {
 		return Promise.resolve(
 			siteProductAvailabilityHandler && siteProductAvailabilityHandler()
 		).then( siteHasWpcomProduct => {
+			if ( redirect ) {
+				checkoutUrl.searchParams.set( 'redirect_to', redirect );
+			}
+
 			if ( siteHasWpcomProduct ) {
 				debug( 'handleAfterRegistration: Site has a product associated' );
 				return handleConnectUser();
@@ -134,7 +138,11 @@ export default function useProductCheckoutWorkflow( {
 		} );
 	};
 
-	const connectAfterCheckoutFlow = () => {
+	const connectAfterCheckoutFlow = ( redirect = null ) => {
+		if ( redirect ) {
+			checkoutUrl.searchParams.set( 'redirect_to', redirect );
+		}
+
 		debug( 'Redirecting to connectAfterCheckout flow: %s', checkoutUrl );
 
 		window.location.href = checkoutUrl;
@@ -144,19 +152,20 @@ export default function useProductCheckoutWorkflow( {
 	 * Handler to run the checkout workflow.
 	 *
 	 * @param {Event} [event] - Event that dispatched run
+	 * @param {string} redirect - A possible redirect URL to go to after the checkout
 	 * @returns {void}          Nothing.
 	 */
-	const run = event => {
+	const run = ( event, redirect = null ) => {
 		event && event.preventDefault();
 		setCheckoutStarted( true );
 		// By default we will connect first prior to checkout unless `props.connectAfterCheckout`
 		// is set (true), in which we will connect after purchase is completed.
 		if ( connectAfterCheckout ) {
-			return connectAfterCheckoutFlow();
+			return connectAfterCheckoutFlow( redirect );
 		}
 
 		if ( isRegistered ) {
-			return handleAfterRegistration();
+			return handleAfterRegistration( redirect );
 		}
 
 		registerSite( { registrationNonce, redirectUri: redirectUrl } ).then( handleAfterRegistration );

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.32.3",
+	"version": "0.33.0-alpha",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -167,8 +167,10 @@ const ProductDetailCard = ( {
 	const { run: trialCheckoutRedirect, hasCheckoutStarted: hasTrialCheckoutStarted } =
 		useProductCheckoutWorkflow( {
 			productSlug: wpcomFreeProductSlug,
-			redirectUrl: myJetpackCheckoutUri,
+			redirectUrl: checkoutRedirectUrl,
 			siteSuffix,
+			adminUrl,
+			connectAfterCheckout: true,
 			from: 'my-jetpack',
 			quantity,
 			useBlogIdSuffix: true,
@@ -218,9 +220,9 @@ const ProductDetailCard = ( {
 	}, [ onClick, trackButtonClick, mainCheckoutRedirect, detail ] );
 
 	const trialClickHandler = useCallback( () => {
-		trackButtonClick( true, wpcomFreeProductSlug );
-		onClick?.( trialCheckoutRedirect );
-	}, [ onClick, trackButtonClick, trialCheckoutRedirect, wpcomFreeProductSlug ] );
+		trackButtonClick( true, wpcomFreeProductSlug, detail );
+		onClick?.( trialCheckoutRedirect, detail );
+	}, [ onClick, trackButtonClick, trialCheckoutRedirect, wpcomFreeProductSlug, detail ] );
 
 	const disclaimerClickHandler = useCallback(
 		id => {

--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
@@ -16,6 +16,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React, { useCallback, useMemo } from 'react';
 import { useProduct } from '../../hooks/use-product';
+import { useRedirectToReferrer } from '../../hooks/use-redirect-to-referrer';
 
 /**
  * Product Detail Table Column component.
@@ -26,6 +27,7 @@ import { useProduct } from '../../hooks/use-product';
  * @param {boolean}  props.cantInstallPlugin       - True when the plugin cannot be automatically installed.
  * @param {Function} props.onProductButtonClick    - Click handler for the product button.
  * @param {object}   props.detail                  - Product detail object.
+ * @param {boolean}  props.isFetching              - True if there is a pending request to load the product.
  * @param {string}   props.tier                    - Product tier slug, i.e. 'free' or 'upgraded'.
  * @param {Function} props.trackProductButtonClick - Tracks click event for the product button.
  * @returns {object} - ProductDetailTableColumn component.
@@ -34,6 +36,7 @@ const ProductDetailTableColumn = ( {
 	cantInstallPlugin,
 	onProductButtonClick,
 	detail,
+	isFetching,
 	tier,
 	trackProductButtonClick,
 } ) => {
@@ -44,7 +47,7 @@ const ProductDetailTableColumn = ( {
 		featuresByTier = [],
 		pricingForUi: { tiers: tiersPricingForUi },
 		title,
-		postActivationUrl,
+		postCheckoutUrl,
 	} = detail;
 
 	// Extract the pricing details for the provided tier.
@@ -58,11 +61,34 @@ const ProductDetailTableColumn = ( {
 		quantity = null,
 	} = tiersPricingForUi[ tier ];
 
+	// Redirect to the referrer URL when the `redirect_to_referrer` query param is present.
+	const referrerURL = useRedirectToReferrer();
+
+	/*
+	 * Function to handle the redirect URL selection.
+	 * - postCheckoutUrl is the URL provided by the product API and is the preferred URL
+	 * - referrerURL is the referrer URL, in case the redirect_to_referrer flag was provided
+	 * - myJetpackCheckoutUri is the default URL
+	 */
+	const getCheckoutRedirectUrl = useCallback( () => {
+		if ( postCheckoutUrl ) {
+			return postCheckoutUrl;
+		}
+
+		if ( referrerURL ) {
+			return referrerURL;
+		}
+
+		return myJetpackCheckoutUri;
+	}, [ postCheckoutUrl, referrerURL, myJetpackCheckoutUri ] );
+
+	const checkoutRedirectUrl = getCheckoutRedirectUrl();
+
 	// Set up the checkout workflow hook.
 	const { run: runCheckout, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		from: 'my-jetpack',
 		productSlug: wpcomProductSlug,
-		redirectUrl: postActivationUrl.replace( /(^.*\/wp-admin\/)/i, '' ) || myJetpackCheckoutUri,
+		redirectUrl: checkoutRedirectUrl,
 		connectAfterCheckout: true,
 		siteSuffix,
 		useBlogIdSuffix: true,
@@ -126,8 +152,8 @@ const ProductDetailTableColumn = ( {
 					fullWidth
 					variant={ isFree ? 'secondary' : 'primary' }
 					onClick={ onClick }
-					isLoading={ hasCheckoutStarted }
-					disabled={ hasCheckoutStarted || cantInstallPlugin }
+					isLoading={ hasCheckoutStarted || isFetching }
+					disabled={ hasCheckoutStarted || cantInstallPlugin || isFetching }
 				>
 					{ callToAction }
 				</Button>
@@ -192,7 +218,7 @@ ProductDetailTableColumn.propTypes = {
 const ProductDetailTable = ( { slug, onProductButtonClick, trackProductButtonClick } ) => {
 	const { fileSystemWriteAccess } = window?.myJetpackInitialState ?? {};
 
-	const { detail } = useProduct( slug );
+	const { detail, isFetching } = useProduct( slug );
 	const { description, featuresByTier = [], pluginSlug, status, tiers = [], title } = detail;
 
 	// If the plugin can not be installed automatically, the user will have to take extra steps.
@@ -249,6 +275,7 @@ const ProductDetailTable = ( { slug, onProductButtonClick, trackProductButtonCli
 						key={ index }
 						tier={ tier }
 						detail={ detail }
+						isFetching={ isFetching }
 						onProductButtonClick={ onProductButtonClick }
 						trackProductButtonClick={ trackProductButtonClick }
 						primary={ index === 0 }

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -143,7 +143,7 @@ function setIsFetchingProduct( productId, isFetching ) {
  * @param {object}   store.registry - Redux registry.
  * @returns {Promise}               - Promise which resolves when the product status is updated.
  */
-function requestProductStatus( productId, data, { select, dispatch, registry } ) {
+function requestProduct( productId, data, { select, dispatch, registry } ) {
 	return new Promise( ( resolve, reject ) => {
 		// Check valid product.
 		const isValid = select.isValidProduct( productId );
@@ -170,7 +170,7 @@ function requestProductStatus( productId, data, { select, dispatch, registry } )
 				dispatch( setIsFetchingProduct( productId, false ) );
 				dispatch( setProduct( freshProduct ) );
 				registry.dispatch( CONNECTION_STORE_ID ).refreshConnectedPlugins();
-				resolve( freshProduct?.status );
+				resolve( freshProduct );
 			} )
 			.catch( error => {
 				const { name } = select.getProduct( productId );
@@ -196,7 +196,7 @@ function requestProductStatus( productId, data, { select, dispatch, registry } )
  * @returns {Promise}        - Promise which resolves when the product status is activated.
  */
 const activateProduct = productId => async store => {
-	return await requestProductStatus( productId, { activate: true }, store );
+	return await requestProduct( productId, { activate: true }, store );
 };
 
 /**
@@ -207,7 +207,7 @@ const activateProduct = productId => async store => {
  * @returns {Promise}        - Promise which resolves when the product plugin is deactivated.
  */
 const deactivateStandalonePluginForProduct = productId => async store => {
-	return await requestProductStatus( productId, { activate: false }, store );
+	return await requestProduct( productId, { activate: false }, store );
 };
 
 /**

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-checkout-flow-consistency
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-checkout-flow-consistency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Improve consistency and fix bugs in product start and checkout flows

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -203,7 +203,7 @@ class Initializer {
 				),
 				'plugins'                => Plugins_Installer::get_plugins(),
 				'myJetpackUrl'           => admin_url( 'admin.php?page=my-jetpack' ),
-				'myJetpackCheckoutUri'   => 'admin.php?page=my-jetpack',
+				'myJetpackCheckoutUri'   => admin_url( 'admin.php?page=my-jetpack' ),
 				'topJetpackMenuItemUrl'  => Admin_Menu::get_top_level_menu_item_url(),
 				'siteSuffix'             => ( new Status() )->get_site_suffix(),
 				'blogID'                 => Connection_Manager::get_site_id( true ),

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -209,10 +209,12 @@ class Backup extends Hybrid_Product {
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
-		if ( static::is_jetpack_plugin_active() ) {
-			return Redirect::get_url( 'my-jetpack-manage-backup' );
-		} elseif ( static::is_plugin_active() ) {
+		// check standalone first
+		if ( static::is_standalone_plugin_active() ) {
 			return admin_url( 'admin.php?page=jetpack-backup' );
+			// otherwise, check for the main Jetpack plugin
+		} elseif ( static::is_jetpack_plugin_active() ) {
+			return Redirect::get_url( 'my-jetpack-manage-backup' );
 		}
 	}
 
@@ -229,10 +231,6 @@ class Backup extends Hybrid_Product {
 	 * Get the URL where the user should be redirected after checkout
 	 */
 	public static function get_post_checkout_url() {
-		if ( static::is_jetpack_plugin_active() ) {
-			return 'admin.php?page=jetpack#/recommendations';
-		} elseif ( static::is_plugin_active() ) {
-			return 'admin.php?page=jetpack-backup';
-		}
+		self::get_manage_url();
 	}
 }

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -130,6 +130,13 @@ class Backup extends Hybrid_Product {
 	}
 
 	/**
+	 * Get the URL where the user should be redirected after checkout
+	 */
+	public static function get_post_checkout_url() {
+		self::get_manage_url();
+	}
+
+	/**
 	 * Get the product princing details
 	 *
 	 * @return array Pricing details
@@ -225,12 +232,5 @@ class Backup extends Hybrid_Product {
 	 */
 	public static function is_active() {
 		return parent::is_active() && static::has_required_plan();
-	}
-
-	/**
-	 * Get the URL where the user should be redirected after checkout
-	 */
-	public static function get_post_checkout_url() {
-		self::get_manage_url();
 	}
 }

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -133,7 +133,7 @@ class Backup extends Hybrid_Product {
 	 * Get the URL where the user should be redirected after checkout
 	 */
 	public static function get_post_checkout_url() {
-		self::get_manage_url();
+		return self::get_manage_url();
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -238,6 +238,15 @@ class Boost extends Product {
 	}
 
 	/**
+	 * Get the URL the user is taken after purchasing the product through the checkout
+	 *
+	 * @return ?string
+	 */
+	public static function get_post_checkout_url() {
+		return self::get_manage_url();
+	}
+
+	/**
 	 * Get the product princing details
 	 *
 	 * @return array Pricing details

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -118,12 +118,11 @@ abstract class Hybrid_Product extends Product {
 			}
 		}
 
-		if ( ! empty( static::$module_name ) ) {
-			if ( ! static::has_required_plan() ) {
-				// translators: %s is the product name. e.g. Jetpack Search.
-				return new WP_Error( 'not_supported', sprintf( __( 'Your plan does not support %s.', 'jetpack-my-jetpack' ), static::get_title() ) );
-			}
+		// Only activate the module if the plan supports it
+		// We don't want to throw an error for a missing plan here since we try activation before purchase
+		if ( static::has_required_plan() && ! empty( static::$module_name ) ) {
 			$module_activation = ( new Modules() )->activate( static::$module_name, false, false );
+
 			if ( ! $module_activation ) {
 				return new WP_Error( 'module_activation_failed', __( 'Error activating Jetpack module', 'jetpack-my-jetpack' ) );
 			}

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -474,7 +474,8 @@ abstract class Product {
 			return true;
 		}
 
-		if ( ! static::is_plugin_installed() ) {
+		// Default to installing the standalone plugin for the product
+		if ( ! self::is_plugin_installed() ) {
 			$installed = Plugins_Installer::install_plugin( static::get_plugin_slug() );
 			if ( is_wp_error( $installed ) ) {
 				return $installed;

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -261,6 +261,15 @@ class Protect extends Product {
 	}
 
 	/**
+	 * Get the URL the user is taken after purchasing the product through the checkout
+	 *
+	 * @return ?string
+	 */
+	public static function get_post_checkout_url() {
+		return self::get_manage_url();
+	}
+
+	/**
 	 * Get the URL where the user manages the product
 	 *
 	 * @return ?string

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -145,6 +145,15 @@ class Search extends Hybrid_Product {
 	}
 
 	/**
+	 * Get the URL the user is taken after purchasing the product through the checkout
+	 *
+	 * @return ?string
+	 */
+	public static function get_post_checkout_url() {
+		return self::get_manage_url();
+	}
+
+	/**
 	 * Get the WPCOM product slug used to make the purchase
 	 *
 	 * @return ?string

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -119,6 +119,15 @@ class Social extends Hybrid_Product {
 	}
 
 	/**
+	 * Get the URL the user is taken after purchasing the product through the checkout
+	 *
+	 * @return ?string
+	 */
+	public static function get_post_checkout_url() {
+		return self::get_manage_url();
+	}
+
+	/**
 	 * Get the WPCOM product slug used to make the purchase
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -128,6 +128,15 @@ class Videopress extends Hybrid_Product {
 	}
 
 	/**
+	 * Get the URL the user is taken after purchasing the product through the checkout
+	 *
+	 * @return ?string
+	 */
+	public static function get_post_checkout_url() {
+		return self::get_manage_url();
+	}
+
+	/**
 	 * Get the WPCOM product slug used to make the purchase
 	 *
 	 * @return ?string


### PR DESCRIPTION
## Proposed changes:
This PR includes several changes to the product purchase and "start for free" flows in My Jetpack

* Products now all default to installing the standalone plugin if one is available
* All products will go to their individual product page after a purchase, if there is one available
* Bug fixed on the product table views where there was no "loading" state after clicking on start for free
* Enables the "connect after checkout" flow for free purchases that need to go through the cart (Search free)
* Fixes inconsistent post-checkout redirect behavior that was happening between product card and product table interstitial screens
* Fixes bug in free search product activation where errors were returned for no plan as the user was trying to get a free plan

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* It is best to test this PR on a fresh Jetpack install with no standalone plugins installed - the local install already has copies of all plugins installed
* Navigate to My Jetpack, test purchasing different products from My Jetpack. Note that this PR expects that all purchases are started from the My Jetpack screen by clicking on one of the "Learn More" buttons on the product cards.
* Test the "start for free" options for different product (example below).
* ![Screenshot 2024-02-23 at 11 51 12 AM](https://github.com/Automattic/jetpack/assets/18016357/1a7bcd54-9c4f-481b-a4f6-7834eda69e8d)
* Try removing all purchases, deleting all plugins and disconnecting a few times to see what happens when you purchase disconnected or make purchases without plugins installed.

**Expected behaviors while testing**
*  When purchasing a product from My Jetpack (whenever you go through the checkout) - if that product has an available standalone plugin, the standalone should be installed and activated. After the purchase, you should be redirected to the plugin page in wp-admin.
* When choosing a "start for free" option, the standalone plugin should be installed/ activated and you should be redirected to the plugin page.

**Known Issues**
* If your very first "purchase" while Jetpack is disconnected is Jetpack Search Free - you will encounter an error during the checkout process. This is being addressed in this PR: https://github.com/Automattic/wp-calypso/pull/87958
* For initial disconnected purchases, some products will link to the cloud from the license assignment thank you screen (screenshot below). This happens for backup, scan and search. This is out of scope for this PR

![Screenshot 2024-02-27 at 2 55 13 PM](https://github.com/Automattic/jetpack/assets/18016357/523c4956-c262-4c27-9f1b-8dbd98330bfe)

* On the screen pictured above, some products might link to the incorrect page in wp-admin (ex: you might buy Boost and get linked to the Backups plugin page in wp-admin), this is being addressed in this PR: https://github.com/Automattic/wp-calypso/pull/87961
