### PR TITLE
Correct validation error message

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3642,7 +3642,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'invalid_param',
 				sprintf(
 					/* Translators: Placeholder is a parameter name. */
-					esc_html__( '%s must be a object.', 'jetpack' ),
+					esc_html__( '%s must be an object.', 'jetpack' ),
 					$param
 				)
 			);

--- a/projects/plugins/jetpack/changelog/update-validation-message
+++ b/projects/plugins/jetpack/changelog/update-validation-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix spelling error on validation message.


### PR DESCRIPTION
We introduced a spelling error on a validation message at `%s must be a object.`.
So we are updating it with `%s must be an object.` with the `an`.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Just a code review should be fine.
