### PR TITLE
CLI: Mock connection

### DIFF
--- a/projects/plugins/jetpack/changelog/try-cli-mock-connection
+++ b/projects/plugins/jetpack/changelog/try-cli-mock-connection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack CLI: add connection mocking commands.

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -198,6 +198,30 @@ class Jetpack_CLI extends WP_CLI_Command {
 		}
 	}
 
+	public function connect_mock( $args ) {
+		$action = isset( $args[0] ) ? $args[0] : null;
+		if ( ! in_array( $action, array( 'blog', 'user', 'clear' ), true ) ) {
+			/* translators: %s is a command like "prompt" */
+			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
+		}
+
+		switch ( $action ) {
+			case 'blog':
+				Jetpack_Options::update_option( 'id', '12345' );
+				( new Connection_Manager( 'jetpack' ) )->get_tokens()->update_blog_token( 'blog.token' );
+				break;
+			case 'user':
+				( new Connection_Manager( 'jetpack' ) )->get_tokens()->update_user_token( 1, 'user.token.1', true );
+				break;
+			case 'clear':
+				Jetpack_Options::delete_option( 'id' );
+				Jetpack_Options::delete_option( 'master_user' );
+				Jetpack_Options::delete_option( 'user_tokens' );
+				Jetpack_Options::delete_option( 'blog_token' );
+				break;
+		}
+	}
+
 	/**
 	 * Disconnect Jetpack Blogs or Users
 	 *


### PR DESCRIPTION
## Proposed changes:
Create CLI commands to mock Jetpack connection:
* `jetpack connect_mock blog`
* `jetpack connect_mock user`
* `jetpack connect_mock clear`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1705092068241859-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
TBD