### PR TITLE
Voice to Content: refactor ActionButtons component to simplify event handling on the block code

### DIFF
--- a/projects/plugins/jetpack/changelog/update-voice-to-content-action-buttons-refactor
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-action-buttons-refactor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Voice to Content: refactor ActionButtons component to not handle logic on it, relying just on state and events

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -3,28 +3,17 @@
  */
 import { micIcon, playerPauseIcon } from '@automattic/jetpack-ai-client';
 import { Button, FormFileUpload } from '@wordpress/components';
-import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 export default function ActionButtons( {
 	state,
-	mediaControls,
 	onUpload,
-	onCancelRecording,
+	onCancel,
 	onRecord,
 	onPause,
 	onResume,
 	onDone,
 } ) {
-	const { reset } = mediaControls ?? {};
-	const cancelUpload = useRef( () => {} );
-
-	const onCancel = () => {
-		cancelUpload.current?.();
-		onCancelRecording?.();
-		reset?.();
-	};
-
 	return (
 		<div className="jetpack-ai-voice-to-content__action-buttons">
 			{ [ 'inactive', 'error' ].includes( state ) && (

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -41,23 +41,36 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 		};
 	};
 
-	let buttonLabel = __( 'Begin recording', 'jetpack' );
-	if ( state === 'recording' ) {
-		buttonLabel = __( 'Pause recording', 'jetpack' );
-	} else if ( state === 'paused' ) {
-		buttonLabel = __( 'Resume recording', 'jetpack' );
-	}
-
 	return (
 		<div className="jetpack-ai-voice-to-content__action-buttons">
-			{ [ 'inactive', 'recording', 'paused', 'error' ].includes( state ) && (
+			{ [ 'inactive', 'error' ].includes( state ) && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
-					icon={ state === 'recording' ? playerPauseIcon : micIcon }
+					icon={ micIcon }
 					variant="secondary"
 					onClick={ recordingHandler }
 				>
-					{ buttonLabel }
+					{ __( 'Begin recording', 'jetpack' ) }
+				</Button>
+			) }
+			{ [ 'recording' ].includes( state ) && (
+				<Button
+					className="jetpack-ai-voice-to-content__button"
+					icon={ playerPauseIcon }
+					variant="secondary"
+					onClick={ recordingHandler }
+				>
+					{ __( 'Pause recording', 'jetpack' ) }
+				</Button>
+			) }
+			{ [ 'paused' ].includes( state ) && (
+				<Button
+					className="jetpack-ai-voice-to-content__button"
+					icon={ micIcon }
+					variant="secondary"
+					onClick={ recordingHandler }
+				>
+					{ __( 'Resume recording', 'jetpack' ) }
 				</Button>
 			) }
 			{ [ 'inactive', 'error' ].includes( state ) && (

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { micIcon, playerPauseIcon } from '@automattic/jetpack-ai-client';
+import { Button, FormFileUpload } from '@wordpress/components';
+import { useCallback, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Types
+ */
+import type { CancelablePromise } from '@automattic/jetpack-ai-client';
+
+export default function ActionButtons( { state, mediaControls, onUpload, onCancelRecording } ) {
+	const { start, pause, resume, stop, reset } = mediaControls ?? {};
+	const cancelUpload = useRef( () => {} );
+
+	const recordingHandler = useCallback( () => {
+		if ( [ 'inactive', 'error' ].includes( state ) ) {
+			start?.( 1000 ); // Stream audio on 1 second intervals
+		} else if ( state === 'recording' ) {
+			pause?.();
+		} else if ( state === 'paused' ) {
+			resume?.();
+		}
+	}, [ state, start, pause, resume ] );
+
+	const doneHandler = useCallback( () => {
+		stop?.();
+	}, [ stop ] );
+
+	const cancelHandler = () => {
+		cancelUpload.current?.();
+		onCancelRecording?.();
+		reset?.();
+	};
+
+	const handleUpload = event => {
+		const transcriptionProcess: CancelablePromise = onUpload( event );
+		cancelUpload.current = () => {
+			transcriptionProcess.canceled = true;
+		};
+	};
+
+	let buttonLabel = __( 'Begin recording', 'jetpack' );
+	if ( state === 'recording' ) {
+		buttonLabel = __( 'Pause recording', 'jetpack' );
+	} else if ( state === 'paused' ) {
+		buttonLabel = __( 'Resume recording', 'jetpack' );
+	}
+
+	return (
+		<div className="jetpack-ai-voice-to-content__action-buttons">
+			{ [ 'inactive', 'recording', 'paused', 'error' ].includes( state ) && (
+				<Button
+					className="jetpack-ai-voice-to-content__button"
+					icon={ state === 'recording' ? playerPauseIcon : micIcon }
+					variant="secondary"
+					onClick={ recordingHandler }
+				>
+					{ buttonLabel }
+				</Button>
+			) }
+			{ [ 'inactive', 'error' ].includes( state ) && (
+				<FormFileUpload
+					accept="audio/*"
+					onChange={ handleUpload }
+					variant="secondary"
+					className="jetpack-ai-voice-to-content__button"
+				>
+					{ __( 'Upload audio', 'jetpack' ) }
+				</FormFileUpload>
+			) }
+			{ [ 'recording', 'paused' ].includes( state ) && (
+				<Button
+					className="jetpack-ai-voice-to-content__button"
+					variant="primary"
+					onClick={ doneHandler }
+				>
+					{ __( 'Done', 'jetpack' ) }
+				</Button>
+			) }
+			{ [ 'recording', 'paused', 'processing' ].includes( state ) && (
+				<Button
+					className="jetpack-ai-voice-to-content__button"
+					variant="secondary"
+					onClick={ cancelHandler }
+				>
+					{ __( 'Cancel', 'jetpack' ) }
+				</Button>
+			) }
+		</div>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -3,7 +3,7 @@
  */
 import { micIcon, playerPauseIcon } from '@automattic/jetpack-ai-client';
 import { Button, FormFileUpload } from '@wordpress/components';
-import { useCallback, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Types
@@ -18,13 +18,10 @@ export default function ActionButtons( {
 	onRecord,
 	onPause,
 	onResume,
+	onDone,
 } ) {
-	const { stop, reset } = mediaControls ?? {};
+	const { reset } = mediaControls ?? {};
 	const cancelUpload = useRef( () => {} );
-
-	const onDone = useCallback( () => {
-		stop?.();
-	}, [ stop ] );
 
 	const onCancel = () => {
 		cancelUpload.current?.();

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -30,7 +30,7 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 		stop?.();
 	}, [ stop ] );
 
-	const cancelHandler = () => {
+	const onCancel = () => {
 		cancelUpload.current?.();
 		onCancelRecording?.();
 		reset?.();
@@ -98,7 +98,7 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					variant="secondary"
-					onClick={ cancelHandler }
+					onClick={ onCancel }
 				>
 					{ __( 'Cancel', 'jetpack' ) }
 				</Button>

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -5,10 +5,6 @@ import { micIcon, playerPauseIcon } from '@automattic/jetpack-ai-client';
 import { Button, FormFileUpload } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-/**
- * Types
- */
-import type { CancelablePromise } from '@automattic/jetpack-ai-client';
 
 export default function ActionButtons( {
 	state,
@@ -27,13 +23,6 @@ export default function ActionButtons( {
 		cancelUpload.current?.();
 		onCancelRecording?.();
 		reset?.();
-	};
-
-	const handleUpload = event => {
-		const transcriptionProcess: CancelablePromise = onUpload( event );
-		cancelUpload.current = () => {
-			transcriptionProcess.canceled = true;
-		};
 	};
 
 	return (
@@ -71,7 +60,7 @@ export default function ActionButtons( {
 			{ [ 'inactive', 'error' ].includes( state ) && (
 				<FormFileUpload
 					accept="audio/*"
-					onChange={ handleUpload }
+					onChange={ onUpload }
 					variant="secondary"
 					className="jetpack-ai-voice-to-content__button"
 				>

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -17,13 +17,10 @@ export default function ActionButtons( {
 	onCancelRecording,
 	onRecord,
 	onPause,
+	onResume,
 } ) {
-	const { resume, stop, reset } = mediaControls ?? {};
+	const { stop, reset } = mediaControls ?? {};
 	const cancelUpload = useRef( () => {} );
-
-	const onResume = useCallback( () => {
-		resume?.();
-	}, [ resume ] );
 
 	const onDone = useCallback( () => {
 		stop?.();

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -14,12 +14,6 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 	const { start, pause, resume, stop, reset } = mediaControls ?? {};
 	const cancelUpload = useRef( () => {} );
 
-	const recordingHandler = useCallback( () => {
-		if ( state === 'paused' ) {
-			resume?.();
-		}
-	}, [ state, resume ] );
-
 	const onRecord = useCallback( () => {
 		start?.( 1000 ); // Stream audio on 1 second intervals
 	}, [ start ] );
@@ -27,6 +21,10 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 	const onPause = useCallback( () => {
 		pause?.();
 	}, [ pause ] );
+
+	const onResume = useCallback( () => {
+		resume?.();
+	}, [ resume ] );
 
 	const doneHandler = useCallback( () => {
 		stop?.();
@@ -72,7 +70,7 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 					className="jetpack-ai-voice-to-content__button"
 					icon={ micIcon }
 					variant="secondary"
-					onClick={ recordingHandler }
+					onClick={ onResume }
 				>
 					{ __( 'Resume recording', 'jetpack' ) }
 				</Button>

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -10,13 +10,15 @@ import { __ } from '@wordpress/i18n';
  */
 import type { CancelablePromise } from '@automattic/jetpack-ai-client';
 
-export default function ActionButtons( { state, mediaControls, onUpload, onCancelRecording } ) {
-	const { start, pause, resume, stop, reset } = mediaControls ?? {};
+export default function ActionButtons( {
+	state,
+	mediaControls,
+	onUpload,
+	onCancelRecording,
+	onRecord,
+} ) {
+	const { pause, resume, stop, reset } = mediaControls ?? {};
 	const cancelUpload = useRef( () => {} );
-
-	const onRecord = useCallback( () => {
-		start?.( 1000 ); // Stream audio on 1 second intervals
-	}, [ start ] );
 
 	const onPause = useCallback( () => {
 		pause?.();

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -16,13 +16,10 @@ export default function ActionButtons( {
 	onUpload,
 	onCancelRecording,
 	onRecord,
+	onPause,
 } ) {
-	const { pause, resume, stop, reset } = mediaControls ?? {};
+	const { resume, stop, reset } = mediaControls ?? {};
 	const cancelUpload = useRef( () => {} );
-
-	const onPause = useCallback( () => {
-		pause?.();
-	}, [ pause ] );
 
 	const onResume = useCallback( () => {
 		resume?.();

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -15,14 +15,16 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 	const cancelUpload = useRef( () => {} );
 
 	const recordingHandler = useCallback( () => {
-		if ( [ 'inactive', 'error' ].includes( state ) ) {
-			start?.( 1000 ); // Stream audio on 1 second intervals
-		} else if ( state === 'recording' ) {
+		if ( state === 'recording' ) {
 			pause?.();
 		} else if ( state === 'paused' ) {
 			resume?.();
 		}
-	}, [ state, start, pause, resume ] );
+	}, [ state, pause, resume ] );
+
+	const onRecord = useCallback( () => {
+		start?.( 1000 ); // Stream audio on 1 second intervals
+	}, [ start ] );
 
 	const doneHandler = useCallback( () => {
 		stop?.();
@@ -48,7 +50,7 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 					className="jetpack-ai-voice-to-content__button"
 					icon={ micIcon }
 					variant="secondary"
-					onClick={ recordingHandler }
+					onClick={ onRecord }
 				>
 					{ __( 'Begin recording', 'jetpack' ) }
 				</Button>

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -26,7 +26,7 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 		resume?.();
 	}, [ resume ] );
 
-	const doneHandler = useCallback( () => {
+	const onDone = useCallback( () => {
 		stop?.();
 	}, [ stop ] );
 
@@ -89,7 +89,7 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					variant="primary"
-					onClick={ doneHandler }
+					onClick={ onDone }
 				>
 					{ __( 'Done', 'jetpack' ) }
 				</Button>

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -15,16 +15,18 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 	const cancelUpload = useRef( () => {} );
 
 	const recordingHandler = useCallback( () => {
-		if ( state === 'recording' ) {
-			pause?.();
-		} else if ( state === 'paused' ) {
+		if ( state === 'paused' ) {
 			resume?.();
 		}
-	}, [ state, pause, resume ] );
+	}, [ state, resume ] );
 
 	const onRecord = useCallback( () => {
 		start?.( 1000 ); // Stream audio on 1 second intervals
 	}, [ start ] );
+
+	const onPause = useCallback( () => {
+		pause?.();
+	}, [ pause ] );
 
 	const doneHandler = useCallback( () => {
 		stop?.();
@@ -60,7 +62,7 @@ export default function ActionButtons( { state, mediaControls, onUpload, onCance
 					className="jetpack-ai-voice-to-content__button"
 					icon={ playerPauseIcon }
 					variant="secondary"
-					onClick={ recordingHandler }
+					onClick={ onPause }
 				>
 					{ __( 'Pause recording', 'jetpack' ) }
 				</Button>

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/audio-status-panel.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/audio-status-panel.tsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { AudioDurationDisplay } from '@automattic/jetpack-ai-client';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import Oscilloscope from './oscilloscope';
+/**
+ * Types
+ */
+import type { RecordingState } from '@automattic/jetpack-ai-client';
+
+export default function AudioStatusPanel( {
+	state,
+	error = null,
+	analyser,
+	duration = 0,
+}: {
+	state: RecordingState;
+	error: string;
+	analyser: AnalyserNode;
+	duration: number;
+} ) {
+	if ( state === 'inactive' ) {
+		return (
+			<div className="jetpack-ai-voice-to-content__information">
+				{ __( 'File size limit: 25MB. Recording time limit: 25 minutes.', 'jetpack' ) }
+			</div>
+		);
+	}
+
+	if ( state === 'recording' ) {
+		return (
+			<div className="jetpack-ai-voice-to-content__audio">
+				<AudioDurationDisplay
+					className="jetpack-ai-voice-to-content__audio--duration"
+					duration={ duration }
+				/>
+				<Oscilloscope analyser={ analyser } paused={ false } />
+				<span className="jetpack-ai-voice-to-content__information">
+					{ __( 'Recording…', 'jetpack' ) }
+				</span>
+			</div>
+		);
+	}
+
+	if ( state === 'paused' ) {
+		return (
+			<div className="jetpack-ai-voice-to-content__audio">
+				<AudioDurationDisplay
+					className="jetpack-ai-voice-to-content__audio--duration"
+					duration={ duration }
+				/>
+				<Oscilloscope analyser={ analyser } paused={ true } />
+				<span className="jetpack-ai-voice-to-content__information">
+					{ __( 'Paused', 'jetpack' ) }
+				</span>
+			</div>
+		);
+	}
+
+	if ( state === 'processing' ) {
+		return (
+			<div className="jetpack-ai-voice-to-content__information">
+				{ __( 'Uploading and transcribing audio…', 'jetpack' ) }
+			</div>
+		);
+	}
+
+	if ( state === 'error' ) {
+		return <div className="jetpack-ai-voice-to-content__information--error">{ error }</div>;
+	}
+
+	return null;
+}

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -106,6 +106,10 @@ export default function VoiceToContentEdit( { clientId } ) {
 		controls.start( 1000 ); // Stream audio on 1 second intervals
 	}, [ controls ] );
 
+	const onPauseHandler = useCallback( () => {
+		controls.pause();
+	}, [ controls ] );
+
 	// To avoid a wrong TS warning
 	const iconProps = { className: 'icon' };
 
@@ -138,6 +142,7 @@ export default function VoiceToContentEdit( { clientId } ) {
 							onUpload={ uploadHandler }
 							onCancelRecording={ cancelRecording.current }
 							onRecord={ onRecordHandler }
+							onPause={ onPauseHandler }
 						/>
 					</div>
 					<div className="jetpack-ai-voice-to-content__footer">

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -102,6 +102,10 @@ export default function VoiceToContentEdit( { clientId } ) {
 		}
 	};
 
+	const onRecordHandler = useCallback( () => {
+		controls.start( 1000 ); // Stream audio on 1 second intervals
+	}, [ controls ] );
+
 	// To avoid a wrong TS warning
 	const iconProps = { className: 'icon' };
 
@@ -133,6 +137,7 @@ export default function VoiceToContentEdit( { clientId } ) {
 							mediaControls={ controls }
 							onUpload={ uploadHandler }
 							onCancelRecording={ cancelRecording.current }
+							onRecord={ onRecordHandler }
 						/>
 					</div>
 					<div className="jetpack-ai-voice-to-content__footer">

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -114,6 +114,10 @@ export default function VoiceToContentEdit( { clientId } ) {
 		controls.resume();
 	}, [ controls ] );
 
+	const onDoneHandler = useCallback( () => {
+		controls.stop();
+	}, [ controls ] );
+
 	// To avoid a wrong TS warning
 	const iconProps = { className: 'icon' };
 
@@ -148,6 +152,7 @@ export default function VoiceToContentEdit( { clientId } ) {
 							onRecord={ onRecordHandler }
 							onPause={ onPauseHandler }
 							onResume={ onResumeHandler }
+							onDone={ onDoneHandler }
 						/>
 					</div>
 					<div className="jetpack-ai-voice-to-content__footer">

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -110,6 +110,10 @@ export default function VoiceToContentEdit( { clientId } ) {
 		controls.pause();
 	}, [ controls ] );
 
+	const onResumeHandler = useCallback( () => {
+		controls.resume();
+	}, [ controls ] );
+
 	// To avoid a wrong TS warning
 	const iconProps = { className: 'icon' };
 
@@ -143,6 +147,7 @@ export default function VoiceToContentEdit( { clientId } ) {
 							onCancelRecording={ cancelRecording.current }
 							onRecord={ onRecordHandler }
 							onPause={ onPauseHandler }
+							onResume={ onResumeHandler }
 						/>
 					</div>
 					<div className="jetpack-ai-voice-to-content__footer">

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -94,13 +94,16 @@ export default function VoiceToContentEdit( { clientId } ) {
 		},
 	} );
 
-	const uploadHandler = event => {
-		if ( event.currentTarget.files.length > 0 ) {
-			onProcessing();
-			const file = event.currentTarget.files[ 0 ];
-			return transcribeAudio( file );
-		}
-	};
+	const onUploadHandler = useCallback(
+		event => {
+			if ( event.currentTarget.files.length > 0 ) {
+				onProcessing();
+				const file = event.currentTarget.files[ 0 ];
+				return transcribeAudio( file );
+			}
+		},
+		[ onProcessing, transcribeAudio ]
+	);
 
 	const onRecordHandler = useCallback( () => {
 		controls.start( 1000 ); // Stream audio on 1 second intervals
@@ -147,7 +150,7 @@ export default function VoiceToContentEdit( { clientId } ) {
 						<ActionButtons
 							state={ state }
 							mediaControls={ controls }
-							onUpload={ uploadHandler }
+							onUpload={ onUploadHandler }
 							onCancelRecording={ cancelRecording.current }
 							onRecord={ onRecordHandler }
 							onPause={ onPauseHandler }

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -94,6 +94,15 @@ export default function VoiceToContentEdit( { clientId } ) {
 		},
 	} );
 
+	// Destructure controls
+	const {
+		start: controlStart,
+		pause: controlPause,
+		resume: controlResume,
+		stop: controlStop,
+		reset: controlReset,
+	} = controls;
+
 	const onUploadHandler = useCallback(
 		event => {
 			if ( event.currentTarget.files.length > 0 ) {
@@ -110,24 +119,24 @@ export default function VoiceToContentEdit( { clientId } ) {
 
 	const onCancelHandler = useCallback( () => {
 		cancelTranscription.current?.();
-		controls.reset();
-	}, [ controls ] );
+		controlReset();
+	}, [ controlReset ] );
 
 	const onRecordHandler = useCallback( () => {
-		controls.start( 1000 ); // Stream audio on 1 second intervals
-	}, [ controls ] );
+		controlStart( 1000 ); // Stream audio on 1 second intervals
+	}, [ controlStart ] );
 
 	const onPauseHandler = useCallback( () => {
-		controls.pause();
-	}, [ controls ] );
+		controlPause();
+	}, [ controlPause ] );
 
 	const onResumeHandler = useCallback( () => {
-		controls.resume();
-	}, [ controls ] );
+		controlResume();
+	}, [ controlResume ] );
 
 	const onDoneHandler = useCallback( () => {
-		controls.stop();
-	}, [ controls ] );
+		controlStop();
+	}, [ controlStop ] );
 
 	// To avoid a wrong TS warning
 	const iconProps = { className: 'icon' };

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import {
-	micIcon,
-	playerPauseIcon,
 	useMediaRecording,
 	useAudioTranscription,
 	UseAudioTranscriptionReturn,
@@ -12,7 +10,7 @@ import {
 } from '@automattic/jetpack-ai-client';
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { createBlock } from '@wordpress/blocks';
-import { Button, Modal, Icon, FormFileUpload } from '@wordpress/components';
+import { Button, Modal, Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -20,94 +18,9 @@ import { external } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import ActionButtons from './components/action-buttons';
 import AudioStatusPanel from './components/audio-status-panel';
 import useTranscriptionInserter from './hooks/use-transcription-inserter';
-/**
- * Types
- */
-import type { CancelablePromise } from '@automattic/jetpack-ai-client';
-
-function ActionButtons( { state, mediaControls, onUpload, onCancelRecording } ) {
-	const { start, pause, resume, stop, reset } = mediaControls ?? {};
-	const cancelUpload = useRef( () => {} );
-
-	const recordingHandler = useCallback( () => {
-		if ( [ 'inactive', 'error' ].includes( state ) ) {
-			start?.( 1000 ); // Stream audio on 1 second intervals
-		} else if ( state === 'recording' ) {
-			pause?.();
-		} else if ( state === 'paused' ) {
-			resume?.();
-		}
-	}, [ state, start, pause, resume ] );
-
-	const doneHandler = useCallback( () => {
-		stop?.();
-	}, [ stop ] );
-
-	const cancelHandler = () => {
-		cancelUpload.current?.();
-		onCancelRecording?.();
-		reset?.();
-	};
-
-	const handleUpload = event => {
-		const transcriptionProcess: CancelablePromise = onUpload( event );
-		cancelUpload.current = () => {
-			transcriptionProcess.canceled = true;
-		};
-	};
-
-	let buttonLabel = __( 'Begin recording', 'jetpack' );
-	if ( state === 'recording' ) {
-		buttonLabel = __( 'Pause recording', 'jetpack' );
-	} else if ( state === 'paused' ) {
-		buttonLabel = __( 'Resume recording', 'jetpack' );
-	}
-
-	return (
-		<div className="jetpack-ai-voice-to-content__action-buttons">
-			{ [ 'inactive', 'recording', 'paused', 'error' ].includes( state ) && (
-				<Button
-					className="jetpack-ai-voice-to-content__button"
-					icon={ state === 'recording' ? playerPauseIcon : micIcon }
-					variant="secondary"
-					onClick={ recordingHandler }
-				>
-					{ buttonLabel }
-				</Button>
-			) }
-			{ [ 'inactive', 'error' ].includes( state ) && (
-				<FormFileUpload
-					accept="audio/*"
-					onChange={ handleUpload }
-					variant="secondary"
-					className="jetpack-ai-voice-to-content__button"
-				>
-					{ __( 'Upload audio', 'jetpack' ) }
-				</FormFileUpload>
-			) }
-			{ [ 'recording', 'paused' ].includes( state ) && (
-				<Button
-					className="jetpack-ai-voice-to-content__button"
-					variant="primary"
-					onClick={ doneHandler }
-				>
-					{ __( 'Done', 'jetpack' ) }
-				</Button>
-			) }
-			{ [ 'recording', 'paused', 'processing' ].includes( state ) && (
-				<Button
-					className="jetpack-ai-voice-to-content__button"
-					variant="secondary"
-					onClick={ cancelHandler }
-				>
-					{ __( 'Cancel', 'jetpack' ) }
-				</Button>
-			) }
-		</div>
-	);
-}
 
 export default function VoiceToContentEdit( { clientId } ) {
 	const dispatch: {

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	AudioDurationDisplay,
 	micIcon,
 	playerPauseIcon,
 	useMediaRecording,
@@ -21,76 +20,12 @@ import { external } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import Oscilloscope from './components/oscilloscope';
+import AudioStatusPanel from './components/audio-status-panel';
 import useTranscriptionInserter from './hooks/use-transcription-inserter';
 /**
  * Types
  */
-import type { CancelablePromise, RecordingState } from '@automattic/jetpack-ai-client';
-
-function AudioStatusPanel( {
-	state,
-	error = null,
-	analyser,
-	duration = 0,
-}: {
-	state: RecordingState;
-	error: string;
-	analyser: AnalyserNode;
-	duration: number;
-} ) {
-	if ( state === 'inactive' ) {
-		return (
-			<div className="jetpack-ai-voice-to-content__information">
-				{ __( 'File size limit: 25MB. Recording time limit: 25 minutes.', 'jetpack' ) }
-			</div>
-		);
-	}
-
-	if ( state === 'recording' ) {
-		return (
-			<div className="jetpack-ai-voice-to-content__audio">
-				<AudioDurationDisplay
-					className="jetpack-ai-voice-to-content__audio--duration"
-					duration={ duration }
-				/>
-				<Oscilloscope analyser={ analyser } paused={ false } />
-				<span className="jetpack-ai-voice-to-content__information">
-					{ __( 'Recording…', 'jetpack' ) }
-				</span>
-			</div>
-		);
-	}
-
-	if ( state === 'paused' ) {
-		return (
-			<div className="jetpack-ai-voice-to-content__audio">
-				<AudioDurationDisplay
-					className="jetpack-ai-voice-to-content__audio--duration"
-					duration={ duration }
-				/>
-				<Oscilloscope analyser={ analyser } paused={ true } />
-				<span className="jetpack-ai-voice-to-content__information">
-					{ __( 'Paused', 'jetpack' ) }
-				</span>
-			</div>
-		);
-	}
-
-	if ( state === 'processing' ) {
-		return (
-			<div className="jetpack-ai-voice-to-content__information">
-				{ __( 'Uploading and transcribing audio…', 'jetpack' ) }
-			</div>
-		);
-	}
-
-	if ( state === 'error' ) {
-		return <div className="jetpack-ai-voice-to-content__information--error">{ error }</div>;
-	}
-
-	return null;
-}
+import type { CancelablePromise } from '@automattic/jetpack-ai-client';
 
 function ActionButtons( { state, mediaControls, onUpload, onCancelRecording } ) {
 	const { start, pause, resume, stop, reset } = mediaControls ?? {};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #35547.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This is a refactor to help include request cancelation and error handling to the code base. The changes are:

* Move `AudioStatusPanel` component to it's own file
* Move `ActionButtons` component to it's onw file
* Remove logic from `ActionButtons` component, so every actions is handled outside of it
* Move all button handlers outside of `ActionButtons` component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open the browser console to watch for messages and errors
* Insert a Voice-to-Content block
* Use the block and make sure there is no regressions from previous state; you should be able to:
   * start recording an audio, pause and resume it how many times you see fit, and then click done to get a transcription
   * upload an audio to get a transcription
   * the cancel button should bring the block back to it's initial state (but will not cancel the transcription/post-processing requests yet, as expected)
   * the processing state should work as before, showing a message related to processing going on
   * error messages/handling is not in place yet, as before
* Check the browser console for any error or extraneous message