### PR TITLE
override card case can_upgrade to point to product page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -3,7 +3,19 @@ import React from 'react';
 import ProductCard from '../connected-product-card';
 
 const AiCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="jetpack-ai" upgradeInInterstitial={ true } />;
+	const overrides = {
+		can_upgrade: {
+			href: '#/jetpack-ai',
+		},
+	};
+	return (
+		<ProductCard
+			admin={ admin }
+			slug="jetpack-ai"
+			upgradeInInterstitial={ true }
+			primaryActionOverride={ overrides }
+		/>
+	);
 };
 
 AiCard.propTypes = {

--- a/projects/packages/my-jetpack/changelog/change-my-jetpack-point-ai-card-to-product-page
+++ b/projects/packages/my-jetpack/changelog/change-my-jetpack-point-ai-card-to-product-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+My Jetpack: change AI card action button target for upgraded users, point to product page


### PR DESCRIPTION
Card CTA should point to product page for upgraded users

Fixes #35913 

## Proposed changes:
This PR uses the override option on the AI card to add a case for upgradable cases to point to the product page. We might need more tweaking, but this is the first scenario we test.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/35910

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Enable filter to access new features (#35910). Visit My Jetpack and click on AI card CTA button. If you have purchased an upgrade you should land straight into the product page. Any other scenario should get you to the pricing table.