### PR TITLE
Handle tree dropdown visible area click

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/index.jsx
@@ -29,7 +29,13 @@ const TreeDropdown = props => {
 
 	const removeTag = useCallback( tag => onChange( tag.id, false ), [ onChange ] );
 
-	const handleDelete = useCallback( tag => () => removeTag( tag ), [ removeTag ] );
+	const handleDelete = useCallback(
+		tag => e => {
+			e.stopPropagation();
+			removeTag( tag );
+		},
+		[ removeTag ]
+	);
 
 	const handleInputKeyDown = useCallback(
 		e => {
@@ -57,9 +63,15 @@ const TreeDropdown = props => {
 		};
 	}, [ handleClickOutside ] );
 
+	const onVisibleAreaClick = useCallback( () => {
+		showDropdown();
+		inputRef.current.focus();
+	}, [ showDropdown, inputRef ] );
+
 	return (
 		<div className="tree-dropdown" ref={ dropdownRef }>
-			<div className={ className }>
+			{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */ }
+			<div className={ className } onClick={ onVisibleAreaClick }>
 				<Icon icon={ search } />
 				{ tags.map( ( tag, index ) => (
 					<span key={ index } className="tree-dropdown__tag">

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -104,12 +104,14 @@ function NewsletterCategories( props ) {
 						'jetpack'
 					) }
 				</p>
-				<ToggleControl
-					disabled={ isUnavailableDueOfflineMode || isUnavailableDueSiteConnectionMode }
-					checked={ isNewsletterCategoriesEnabled }
-					onChange={ handleEnableNewsletterCategoriesToggleChange }
-					label={ __( 'Enable newsletter categories', 'jetpack' ) }
-				/>
+				<div className="newsletter-categories-toggle-wrapper">
+					<ToggleControl
+						disabled={ isUnavailableDueOfflineMode || isUnavailableDueSiteConnectionMode }
+						checked={ isNewsletterCategoriesEnabled }
+						onChange={ handleEnableNewsletterCategoriesToggleChange }
+						label={ __( 'Enable newsletter categories', 'jetpack' ) }
+					/>
+				</div>
 				<div
 					className={ classNames( 'newsletter-colapsable', {
 						hide: ! isNewsletterCategoriesEnabled,

--- a/projects/plugins/jetpack/_inc/client/newsletter/style.scss
+++ b/projects/plugins/jetpack/_inc/client/newsletter/style.scss
@@ -49,3 +49,8 @@
         overflow: hidden;
     }
 }
+
+.newsletter-categories-toggle-wrapper {
+	display: flex;
+	margin-bottom: 16px;
+}

--- a/projects/plugins/jetpack/changelog/update-handle-tree-dropdown-visible-area-click
+++ b/projects/plugins/jetpack/changelog/update-handle-tree-dropdown-visible-area-click
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Better handle categories input click/focus.


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5798

On the `TreeDropdown` component, only the text input is clickable.

![image](https://github.com/Automattic/jetpack/assets/33497086/646d23ed-2cd2-4163-a230-b54561a8953b)

But the intent behavior is that the yellow area below also expands the categories tree and focuses on the input:
![image](https://github.com/Automattic/jetpack/assets/33497086/b2bff02a-f275-45f6-82c5-d399ad9e3216)

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
To enable the feature flag navigate with **enable-newsletter-categories** query param:
`wp-admin/admin.php?enable-newsletter-categories=true&page=jetpack#/newsletter`

- Enable the newsletter categories toggle.
- Click on any part of the `TreeDropdown` represented as yellow in the image above. It should expand the categories tree and focus the input.
- Clicking on the close X icon of the categories pill should remove the category, but not trigger the focus of the input element..