### PR TITLE
Update Schedules: Show scheduled updates in WP Admin

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-wp-admin-info
+++ b/projects/packages/scheduled-updates/changelog/add-wp-admin-info
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Show schedule information for scheduled plugin updates in wp-admin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5679

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Overwrites auto-updates column in the plugins screen with scheduled updates information

<img width="1398" alt="image" src="https://github.com/Automattic/jetpack/assets/1398304/d75bffce-6423-4c98-9663-61a66df1cefe">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this diff on a test site using the Jetpack Beta plugin
* Install the REST API Console plugin and activate it.
* Go to `/wp-admin/tools.php?page=rest_api_console` and query `/wpcom/v2/update-schedules`
* Create an update schedule by sending a POST request with the following body: `plugins=rest-api-console/rest-api-console.php&schedule[interval]=weekly&schedule[timestamp]=1709044413`
* Go to the plugin list screen and make sure it shows the correct schedule information.

