### PR TITLE
Voice to Content: Support canceling requests

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-support-canceling-requests
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-support-canceling-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: change the way transcription and post processing hooks work, removing callbacks.

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-support-canceling-requests
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-support-canceling-requests
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-AI Client: change the way transcription and post processing hooks work, removing callbacks.
+AI Client: support audio transcription and transcription post-processing canceling.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.8.0",
+	"version": "0.8.1-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/audio-transcription/index.ts
+++ b/projects/js-packages/ai-client/src/audio-transcription/index.ts
@@ -7,10 +7,6 @@ import debugFactory from 'debug';
  */
 import apiFetch from '../api-fetch/index.js';
 import requestJwt from '../jwt/index.js';
-/**
- * Types
- */
-import { CancelablePromise } from '../types.js';
 
 const debug = debugFactory( 'jetpack-ai-client:audio-transcription' );
 
@@ -36,8 +32,7 @@ export default async function transcribeAudio(
 	audio: Blob,
 	feature?: string,
 	requestAbortSignal?: AbortSignal
-	// @ts-expect-error Promises are not cancelable by default
-): CancelablePromise< string > {
+): Promise< string > {
 	debug( 'Transcribing audio: %o. Feature: %o', audio, feature );
 
 	// Get a token to use the transcription service

--- a/projects/js-packages/ai-client/src/audio-transcription/index.ts
+++ b/projects/js-packages/ai-client/src/audio-transcription/index.ts
@@ -29,11 +29,13 @@ type AudioTranscriptionResponse = {
  *
  * @param {Blob} audio - The audio to be transcribed, from a recording or from a file.
  * @param {string} feature - The feature name that is calling the transcription.
+ * @param {AbortSignal} requestAbortSignal - The signal to abort the request.
  * @returns {Promise<string>} - The promise of a string containing the transcribed audio.
  */
 export default async function transcribeAudio(
 	audio: Blob,
-	feature?: string
+	feature?: string,
+	requestAbortSignal?: AbortSignal
 	// @ts-expect-error Promises are not cancelable by default
 ): CancelablePromise< string > {
 	debug( 'Transcribing audio: %o. Feature: %o', audio, feature );
@@ -63,6 +65,7 @@ export default async function transcribeAudio(
 			method: 'POST',
 			body: formData,
 			headers,
+			signal: requestAbortSignal ?? undefined,
 		} );
 
 		debug( 'Transcription response: %o', response );

--- a/projects/js-packages/ai-client/src/hooks/use-audio-transcription/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-audio-transcription/index.ts
@@ -21,11 +21,8 @@ export type UseAudioTranscriptionReturn = {
 	transcriptionResult: string;
 	isTranscribingAudio: boolean;
 	transcriptionError: string;
-	transcribeAudio: (
-		audio: Blob,
-		onReady?: ( transcription: string ) => void,
-		onError?: ( error: string ) => void
-	) => CancelablePromise;
+	isTranscriptionReady: boolean;
+	transcribeAudio: ( audio: Blob ) => CancelablePromise;
 };
 
 /**
@@ -38,20 +35,18 @@ export default function useAudioTranscription( feature: string ): UseAudioTransc
 	const [ transcriptionResult, setTranscriptionResult ] = useState< string >( '' );
 	const [ transcriptionError, setTranscriptionError ] = useState< string >( '' );
 	const [ isTranscribingAudio, setIsTranscribingAudio ] = useState( false );
+	const [ isTranscriptionReady, setIsTranscriptionReady ] = useState( false );
 
 	const handleAudioTranscription = useCallback(
-		(
-			audio: Blob,
-			onReady?: ( transcription: string ) => void,
-			onError?: ( error: string ) => void
-		) => {
+		( audio: Blob ) => {
 			debug( 'Transcribing audio' );
 
 			/**
-			 * Reset the transcription result and error.
+			 * Reset the transcription state.
 			 */
 			setTranscriptionResult( '' );
 			setTranscriptionError( '' );
+			setIsTranscriptionReady( false );
 			setIsTranscribingAudio( true );
 
 			/**
@@ -64,7 +59,7 @@ export default function useAudioTranscription( feature: string ): UseAudioTransc
 					}
 
 					setTranscriptionResult( transcriptionText );
-					onReady?.( transcriptionText );
+					setIsTranscriptionReady( true );
 				} )
 				.catch( error => {
 					if ( promise.canceled ) {
@@ -72,7 +67,6 @@ export default function useAudioTranscription( feature: string ): UseAudioTransc
 					}
 
 					setTranscriptionError( error.message );
-					onError?.( error.message );
 				} )
 				.finally( () => setIsTranscribingAudio( false ) );
 
@@ -84,6 +78,7 @@ export default function useAudioTranscription( feature: string ): UseAudioTransc
 			setTranscriptionResult,
 			setTranscriptionError,
 			setIsTranscribingAudio,
+			setIsTranscriptionReady,
 		]
 	);
 
@@ -91,6 +86,7 @@ export default function useAudioTranscription( feature: string ): UseAudioTransc
 		transcriptionResult,
 		isTranscribingAudio,
 		transcriptionError,
+		isTranscriptionReady,
 		transcribeAudio: handleAudioTranscription,
 	};
 }

--- a/projects/js-packages/ai-client/src/hooks/use-audio-transcription/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-audio-transcription/index.ts
@@ -21,16 +21,11 @@ export type UseAudioTranscriptionReturn = {
 	transcriptionResult: string;
 	isTranscribingAudio: boolean;
 	transcriptionError: string;
-	transcribeAudio: ( audio: Blob ) => CancelablePromise;
-};
-
-/**
- * The props for the audio transcription hook.
- */
-export type UseAudioTranscriptionProps = {
-	feature: string;
-	onReady?: ( transcription: string ) => void;
-	onError?: ( error: string ) => void;
+	transcribeAudio: (
+		audio: Blob,
+		onReady?: ( transcription: string ) => void,
+		onError?: ( error: string ) => void
+	) => CancelablePromise;
 };
 
 /**
@@ -39,17 +34,17 @@ export type UseAudioTranscriptionProps = {
  * @param {string} feature - The feature name that is calling the transcription.
  * @returns {UseAudioTranscriptionReturn} - Object with properties to get the transcription data.
  */
-export default function useAudioTranscription( {
-	feature,
-	onReady,
-	onError,
-}: UseAudioTranscriptionProps ): UseAudioTranscriptionReturn {
+export default function useAudioTranscription( feature: string ): UseAudioTranscriptionReturn {
 	const [ transcriptionResult, setTranscriptionResult ] = useState< string >( '' );
 	const [ transcriptionError, setTranscriptionError ] = useState< string >( '' );
 	const [ isTranscribingAudio, setIsTranscribingAudio ] = useState( false );
 
 	const handleAudioTranscription = useCallback(
-		( audio: Blob ) => {
+		(
+			audio: Blob,
+			onReady?: ( transcription: string ) => void,
+			onError?: ( error: string ) => void
+		) => {
 			debug( 'Transcribing audio' );
 
 			/**
@@ -83,7 +78,13 @@ export default function useAudioTranscription( {
 
 			return promise;
 		},
-		[ transcribeAudio, setTranscriptionResult, setTranscriptionError, setIsTranscribingAudio ]
+		[
+			feature,
+			transcribeAudio,
+			setTranscriptionResult,
+			setTranscriptionError,
+			setIsTranscribingAudio,
+		]
 	);
 
 	return {

--- a/projects/js-packages/ai-client/src/hooks/use-audio-transcription/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-audio-transcription/index.ts
@@ -82,7 +82,7 @@ export default function useAudioTranscription( {
 		[ transcribeAudio, setTranscriptionResult, setTranscriptionError, setIsTranscribingAudio ]
 	);
 
-	const handleAudioTranscriptionCancelled = useCallback( () => {
+	const handleAudioTranscriptionCancel = useCallback( () => {
 		/*
 		 * Cancel the transcription.
 		 */
@@ -100,6 +100,6 @@ export default function useAudioTranscription( {
 		isTranscribingAudio,
 		transcriptionError,
 		transcribeAudio: handleAudioTranscription,
-		cancelTranscription: handleAudioTranscriptionCancelled,
+		cancelTranscription: handleAudioTranscriptionCancel,
 	};
 }

--- a/projects/js-packages/ai-client/src/hooks/use-audio-transcription/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-audio-transcription/index.ts
@@ -7,10 +7,6 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import transcribeAudio from '../../audio-transcription/index.js';
-/**
- * Types
- */
-import type { CancelablePromise } from '../../types.js';
 
 const debug = debugFactory( 'jetpack-ai-client:use-audio-transcription' );
 
@@ -21,7 +17,7 @@ export type UseAudioTranscriptionReturn = {
 	transcriptionResult: string;
 	isTranscribingAudio: boolean;
 	transcriptionError: string;
-	transcribeAudio: ( audio: Blob ) => CancelablePromise;
+	transcribeAudio: ( audio: Blob ) => void;
 	cancelTranscription: () => void;
 };
 
@@ -68,30 +64,16 @@ export default function useAudioTranscription( {
 			/**
 			 * Call the audio transcription library.
 			 */
-			const promise: CancelablePromise = transcribeAudio(
-				audio,
-				feature,
-				abortController.current.signal
-			)
+			transcribeAudio( audio, feature, abortController.current.signal )
 				.then( transcriptionText => {
-					if ( promise.canceled ) {
-						return;
-					}
-
 					setTranscriptionResult( transcriptionText );
 					onReady?.( transcriptionText );
 				} )
 				.catch( error => {
-					if ( promise.canceled ) {
-						return;
-					}
-
 					setTranscriptionError( error.message );
 					onError?.( error.message );
 				} )
 				.finally( () => setIsTranscribingAudio( false ) );
-
-			return promise;
 		},
 		[ transcribeAudio, setTranscriptionResult, setTranscriptionError, setIsTranscribingAudio ]
 	);

--- a/projects/js-packages/ai-client/src/hooks/use-transcription-post-processing/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-transcription-post-processing/index.ts
@@ -25,6 +25,7 @@ export type UseTranscriptionPostProcessingReturn = {
 	isProcessingTranscription: boolean;
 	postProcessingError: string;
 	processTranscription: ( action: PostProcessingAction, transcription: string ) => void;
+	cancelTranscriptionProcessing: () => void;
 };
 
 /**
@@ -81,7 +82,7 @@ export default function useTranscriptionPostProcessing( {
 		[ setPostProcessingError, onError ]
 	);
 
-	const { request } = useAiSuggestions( {
+	const { request, stopSuggestion } = useAiSuggestions( {
 		autoRequest: false,
 		onSuggestion: handleOnSuggestion,
 		onDone: handleOnDone,
@@ -126,10 +127,19 @@ export default function useTranscriptionPostProcessing( {
 		]
 	);
 
+	const handleTranscriptionPostProcessingCancel = useCallback( () => {
+		/*
+		 * Stop the suggestion streaming.
+		 */
+		stopSuggestion();
+		setIsProcessingTranscription( false );
+	}, [ stopSuggestion, setIsProcessingTranscription ] );
+
 	return {
 		postProcessingResult,
 		isProcessingTranscription,
 		postProcessingError,
 		processTranscription: handleTranscriptionPostProcessing,
+		cancelTranscriptionProcessing: handleTranscriptionPostProcessingCancel,
 	};
 }

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-support-canceling-requests
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-support-canceling-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Voice to Content: refactor hook usage and handle request canceling

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -42,7 +42,7 @@ export default function VoiceToContentEdit( { clientId } ) {
 
 	const { upsertTranscription } = useTranscriptionInserter();
 
-	const { processTranscription } = useTranscriptionPostProcessing( {
+	const { processTranscription, cancelTranscriptionProcessing } = useTranscriptionPostProcessing( {
 		feature: 'voice-to-content',
 		onReady: postProcessingResult => {
 			// Insert the content into the editor
@@ -123,8 +123,9 @@ export default function VoiceToContentEdit( { clientId } ) {
 
 	const onCancelHandler = useCallback( () => {
 		cancelTranscription();
+		cancelTranscriptionProcessing();
 		controlReset();
-	}, [ cancelTranscription, controlReset ] );
+	}, [ cancelTranscription, cancelTranscriptionProcessing, controlReset ] );
 
 	const onRecordHandler = useCallback( () => {
 		controlStart( 1000 ); // Stream audio on 1 second intervals

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -87,12 +87,23 @@ export default function VoiceToContentEdit( { clientId } ) {
 
 	const { state, controls, error, onError, onProcessing, duration, analyser } = useMediaRecording( {
 		onDone: lastBlob => {
-			const promise = transcribeAudio( lastBlob );
-			cancelTranscription.current = () => {
-				promise.canceled = true;
-			};
+			// When recording is done, set the audio to be transcribed
+			onAudioHandler( lastBlob );
 		},
 	} );
+
+	const onAudioHandler = useCallback(
+		( audio: Blob ) => {
+			if ( audio ) {
+				onProcessing();
+				const promise = transcribeAudio( audio );
+				cancelTranscription.current = () => {
+					promise.canceled = true;
+				};
+			}
+		},
+		[ transcribeAudio, onProcessing ]
+	);
 
 	// Destructure controls
 	const {
@@ -106,15 +117,11 @@ export default function VoiceToContentEdit( { clientId } ) {
 	const onUploadHandler = useCallback(
 		event => {
 			if ( event.currentTarget.files.length > 0 ) {
-				onProcessing();
 				const file = event.currentTarget.files[ 0 ];
-				const promise = transcribeAudio( file );
-				cancelTranscription.current = () => {
-					promise.canceled = true;
-				};
+				onAudioHandler( file );
 			}
 		},
-		[ onProcessing, transcribeAudio ]
+		[ onAudioHandler ]
 	);
 
 	const onCancelHandler = useCallback( () => {

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -12,7 +12,7 @@ import { ThemeProvider } from '@automattic/jetpack-components';
 import { createBlock } from '@wordpress/blocks';
 import { Button, Modal, Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
 /**
@@ -68,44 +68,29 @@ export default function VoiceToContentEdit( { clientId } ) {
 		},
 	} );
 
-	const {
-		transcribeAudio,
-		isTranscriptionReady,
-		transcriptionResult,
-		transcriptionError,
-	}: UseAudioTranscriptionReturn = useAudioTranscription( 'voice-to-content' );
+	const onTranscriptionReady = ( content: string ) => {
+		// eslint-disable-next-line no-console
+		console.log( 'Transcription ready: ', content );
+		setTranscription( content );
+		processTranscription( TRANSCRIPTION_POST_PROCESSING_ACTION_SIMPLE_DRAFT, content );
+	};
 
-	const { state, controls, error, onProcessing, duration, analyser } = useMediaRecording( {
+	const onTranscriptionError = ( error: string ) => {
+		onError( error );
+	};
+
+	const { transcribeAudio }: UseAudioTranscriptionReturn = useAudioTranscription( {
+		feature: 'voice-to-content',
+		onReady: onTranscriptionReady,
+		onError: onTranscriptionError,
+	} );
+
+	const { state, controls, error, onError, onProcessing, duration, analyser } = useMediaRecording( {
 		onDone: lastBlob => {
 			// When recording is done, set the audio to be transcribed
 			onAudioHandler( lastBlob );
 		},
 	} );
-
-	/*
-	 * React to transcription results
-	 */
-	useEffect( () => {
-		if ( isTranscriptionReady ) {
-			// eslint-disable-next-line no-console
-			console.log( 'Transcription ready: ', transcriptionResult );
-			setTranscription( transcriptionResult );
-			processTranscription(
-				TRANSCRIPTION_POST_PROCESSING_ACTION_SIMPLE_DRAFT,
-				transcriptionResult
-			);
-		}
-	}, [ isTranscriptionReady, transcriptionResult, processTranscription ] );
-
-	/*
-	 * React to transcription errors
-	 */
-	useEffect( () => {
-		if ( transcriptionError ) {
-			// eslint-disable-next-line no-console
-			console.log( 'Transcription error: ', transcriptionError );
-		}
-	}, [ transcriptionError ] );
 
 	const onAudioHandler = useCallback(
 		( audio: Blob ) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35549. Part of #35547.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add support to cancel transcription requests and stop post-processing requests on the respective hooks
* Remove the dependency on the CancelablePromise type
* When the cancel handler is called on the block (because the user clicked the "Cancel" button), cancel a possible transcription and post-processing request that may be going on

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open the browser development console; open the network tab to inspect the requests
* Insert a Voice-to-Content block
* Begin the recording of some audio, just for testing purposes
* Click Done and, as soon as you see the transcription request pop on the network tab, click the Cancel button
   * The UI on the block should return to the initial one, and the request should be canceled on the network tab
   * The same should happen when you pick a file for transcription: as soon as the transcription starts, when you click Cancel, the UI should return to the initial state and the network request should be canceled
* Now let's test canceling after the transcription started to be included on the editor
* Record an audio (or pick a file for upload), wait for the transcription to finish, and when you see that the transcription started to appear on the editor (or on the console logs), click Cancel
   * The transcription should stop, leaving you with the initial UI on the block
* For this last test, it's helpful if the audio is long enough to take some time to be inserted on the editor, giving you time to react to it