### PR TITLE
WPCOM MU: Create new hosting menu for untangling

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-mu-hosting-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-mu-hosting-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update WordPress.com menu item to be a menu of links rather than one link.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -26,8 +26,38 @@ function wpcom_add_wpcom_menu_item() {
 		return;
 	}
 
+	global $menu;
+
 	$parent_slug = 'wpcom-hosting-menu';
 	$domain      = wp_parse_url( home_url(), PHP_URL_HOST );
+
+	add_menu_page(
+		esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		'https://wordpress.com/sites',
+		null,
+		'dashicons-arrow-left-alt2',
+		0
+	);
+
+	// Position a separator below the WordPress.com menu item.
+	// Inspired by https://github.com/Automattic/jetpack/blob/b6b6e86c5491869782857141ca48168dfa195635/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php#L239
+	$separator = array(
+		'',
+		'manage_options',
+		wp_unique_id( 'separator-custom-' ),
+		'',
+		'wp-menu-separator',
+	);
+
+	$position = 0;
+	if ( isset( $menu[ "$position" ] ) ) {
+		$position            = $position + substr( base_convert( md5( $separator[2] . $separator[0] ), 16, 10 ), -5 ) * 0.00001;
+		$menu[ "$position" ] = $separator; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	} else {
+		$menu[ "$position" ] = $separator; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
 
 	add_menu_page(
 		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -152,7 +152,7 @@ add_action( 'admin_menu', 'wpcom_add_wpcom_menu_item' );
 function wpcom_wpcom_menu_item_css() {
 	?>
 	<style>
-		.toplevel_page_wpcom-hosting-menu .wp-submenu .wp-first-item{
+		.toplevel_page_wpcom-hosting-menu .wp-submenu .wp-first-item {
 			display: none;
 		}
 	</style>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -31,7 +31,7 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_menu_page(
 		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ) . ' <span class="dashicons dashicons-external" style="float: right;"></span>',
 		'manage_options',
 		$parent_slug,
 		null,
@@ -41,10 +41,10 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'My Home', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'My Home', 'jetpack-mu-wpcom' ),
 		'manage_options',
-		esc_url( 'https://wordpress.com/sites' ),
+		esc_url( "https://wordpress.com/home/$domain" ),
 		null
 	);
 
@@ -59,6 +59,15 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_submenu_page(
 		$parent_slug,
+		esc_attr__( 'Add-ons', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Add-ons', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/add-ons/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
 		esc_attr__( 'Domains', 'jetpack-mu-wpcom' ),
 		esc_attr__( 'Domains', 'jetpack-mu-wpcom' ),
 		'manage_options',
@@ -68,8 +77,8 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Email', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Email', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Emails', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Emails', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/email/$domain" ),
 		null
@@ -95,8 +104,8 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Site Monitoring', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Site Monitoring', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Monitoring', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Monitoring', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/site-monitoring/$domain" ),
 		null
@@ -104,19 +113,10 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Earn', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Earn', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Monetize', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Monetize', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/earn/$domain" ),
-		null
-	);
-
-	add_submenu_page(
-		$parent_slug,
-		esc_attr__( 'Podcasting', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Podcasting', 'jetpack-mu-wpcom' ),
-		'manage_options',
-		esc_url( "https://wordpress.com/settings/podcasting/$domain" ),
 		null
 	);
 
@@ -145,17 +145,3 @@ function wpcom_add_wpcom_menu_item() {
 	);
 }
 add_action( 'admin_menu', 'wpcom_add_wpcom_menu_item' );
-
-/**
- * Add CSS to hide the first submenu item.
- */
-function wpcom_wpcom_menu_item_css() {
-	?>
-	<style>
-		.toplevel_page_wpcom-hosting-menu .wp-submenu .wp-first-item {
-			display: none;
-		}
-	</style>
-	<?php
-}
-add_action( 'admin_head', 'wpcom_wpcom_menu_item_css' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -11,34 +11,140 @@
  * Add a WordPress.com menu item to the wp-admin sidebar menu.
  */
 function wpcom_add_wpcom_menu_item() {
-	if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
-		add_menu_page(
-			esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
-			esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
-			'manage_options',
-			'https://wordpress.com/sites',
-			null,
-			'dashicons-arrow-left-alt2',
-			0
-		);
-
-		// Position a separator below the WordPress.com menu item.
-		// Inspired by https://github.com/Automattic/jetpack/blob/b6b6e86c5491869782857141ca48168dfa195635/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php#L239
-		global $menu;
-		$separator = array(
-			'',                                  // Menu title (ignored).
-			'manage_options',                    // Required capability.
-			wp_unique_id( 'separator-custom-' ), // URL or file (ignored, but must be unique).
-			'',                                  // Page title (ignored).
-			'wp-menu-separator',                 // CSS class. Identifies this item as a separator.
-		);
-		$position  = 0;
-		if ( isset( $menu[ "$position" ] ) ) {
-			$position            = $position + substr( base_convert( md5( $separator[2] . $separator[0] ), 16, 10 ), -5 ) * 0.00001;
-			$menu[ "$position" ] = $separator; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		} else {
-			$menu[ "$position" ] = $separator; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		}
+	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
+		return;
 	}
+
+	$parent_slug = 'wpcom-hosting-menu';
+	$domain      = wp_parse_url( home_url(), PHP_URL_HOST );
+
+	add_menu_page(
+		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		$parent_slug,
+		null,
+		'dashicons-cloud',
+		3
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( 'https://wordpress.com/sites' ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Plans', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Plans', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/plans/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Domains', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Domains', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/domains/manage/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Email', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Email', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/email/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Purchases', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Purchases', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/purchases/subscriptions/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Configuration', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Configuration', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/hosting-config/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Site Monitoring', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Site Monitoring', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/site-monitoring/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Earn', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Earn', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/earn/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Podcasting', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Podcasting', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/settings/podcasting/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Subscribers', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Subscribers', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/subscribers/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Settings', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Settings', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/settings/general/$domain" ),
+		null
+	);
+
+	// By default, WordPress adds a submenu item for the parent menu item. We don't want that.
+	remove_submenu_page(
+		$parent_slug,
+		$parent_slug
+	);
 }
 add_action( 'admin_menu', 'wpcom_add_wpcom_menu_item' );
+
+/**
+ * Add CSS to hide the first submenu item.
+ */
+function wpcom_wpcom_menu_item_css() {
+	?>
+	<style>
+		.toplevel_page_wpcom-hosting-menu .wp-submenu .wp-first-item{
+			display: none;
+		}
+	</style>
+	<?php
+}
+add_action( 'admin_head', 'wpcom_wpcom_menu_item_css' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -9,6 +9,17 @@
 
 /**
  * Add a WordPress.com menu item to the wp-admin sidebar menu.
+ *
+ * Of note, we need the $parent_slug so that we can link the submenu items to the parent menu item. Using a URL
+ * for the slug doesn't appear to work when registering submenus. Because we use the parent slug in the top
+ * level menu item, we need to find a solution to link that menu out to WordPress.com.
+ *
+ * We accomplish this by:
+ *
+ * - Adding a submenu item that links to /sites.
+ * - Hiding that submenu item with CSS.
+ *
+ * This works because the top level menu item links to wherever the submenu item links to.
  */
 function wpcom_add_wpcom_menu_item() {
 	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
@@ -127,7 +138,7 @@ function wpcom_add_wpcom_menu_item() {
 		null
 	);
 
-	// By default, WordPress adds a submenu item for the parent menu item. We don't want that.
+	// By default, WordPress adds a submenu item for the parent menu item, which we don't want.
 	remove_submenu_page(
 		$parent_slug,
 		$parent_slug


### PR DESCRIPTION
## Proposed changes:

For untangling of Calypso, we previously deployed a link that was in the admin menu that went back to WordPress.com. This is a different approach that adds the full menu with links that go to WordPress.com for managing various parts of a WoA sites's hosting.

<img width="484" alt="Screenshot 2024-02-25 at 8 51 56 AM" src="https://github.com/Automattic/jetpack/assets/1126811/d599fff1-7e56-44cd-ba88-11f6ab183671">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

NA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Check out PR on a WoA site
- On that WoA site, ensure that your are proxied, go to $site.com/wp-admin
- Verify hosting menu item shows
- Ensure that all links are functional