### PR TITLE
mu-wpcom - Update wpcom site menu url to go to my sites page

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-mu-wpcom-site-menu-to-my-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-mu-wpcom-site-menu-to-my-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Change wpcom menu item to go to my sites instead of global site view.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -12,12 +12,11 @@
  */
 function wpcom_add_wpcom_menu_item() {
 	if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
-		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 		add_menu_page(
 			esc_attr__( 'WordPress.com', 'jetpack-mu-wpcom' ),
 			esc_attr__( 'WordPress.com', 'jetpack-mu-wpcom' ),
 			'manage_options',
-			"https://wordpress.com/home/$domain",
+			'https://wordpress.com/sites',
 			null,
 			'dashicons-arrow-left-alt2',
 			0

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -13,8 +13,8 @@
 function wpcom_add_wpcom_menu_item() {
 	if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
 		add_menu_page(
-			esc_attr__( 'WordPress.com', 'jetpack-mu-wpcom' ),
-			esc_attr__( 'WordPress.com', 'jetpack-mu-wpcom' ),
+			esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
+			esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
 			'manage_options',
 			'https://wordpress.com/sites',
 			null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

related to # pfsHM7-gH-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* updates the wpcom menu item url to go to my sites as per requested.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this branch from jetpack-beta-plugin
* have up to date wpcomsh version on WoA site
* with 'classic' view enabled, visit wp-admin
* verify the  `< WordPress.com` button has been replaced with a link to all sites.