### PR TITLE
Verbum: Improve Disabled Button Colour Contrast 

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-disabled-contrast
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-disabled-contrast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Verbum: Ensure colour contrast for disabled button is a11y-friendly.

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
@@ -446,7 +446,7 @@
 						text-align: center;
 						font-size: 14px;
 						border-radius: 4px;
-						border: none;
+						border: 1px solid transparent;
 						background: var(--wp-components-color-accent,
 								var(--wp-admin-theme-color, #0675c4));
 						color: var(--wp-components-color-accent-inverted, #fff);
@@ -456,7 +456,9 @@
 						cursor: default;
 
 						&:disabled {
-							background-color: #DCDCDE;
+							background-color: white;
+							border: 1px solid var(--verbum-content-background-color);
+							color: #a7aaad;
 						}
 
 						&.is-busy {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
@@ -456,8 +456,8 @@
 						cursor: default;
 
 						&:disabled {
-							background-color: white;
-							border: 1px solid var(--verbum-content-background-color);
+							background-color: var(--verbum-content-background-color);
+							border: 1px solid var(--verbum-border-color);
 							color: #a7aaad;
 						}
 


### PR DESCRIPTION
## Proposed changes:

The current colour contrast for the disabled button in Verbum is 1.36:1, which is really unfriendly. You can find some detailed discussion about this in Automattic/wp-calypso#26982.

TLDR: ideally, the disabled button should have a 2:1 colour contrast (ie. `-studio-gray-20` from Colour Studio) because it still contains information relevant to a user. 

> Disabled button text should be a bit higher contrast. I still feel like the 200 value (against white) is the best balance of not looking enabled, vs looking disabled (but still somewhat readable). I feel confident that our 2.07 contrast (with neutral-200) is in line with strict a11y standards, considering usa.gov, gov.au, and gov.uk all have disabled text contrast ranging from 1.5 – 2.0 (we would be on the high end of the spectrum).

We received a complaint about this in 7732037-zen which is what brought my attention to this, but I think this is a worthy change in itself. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Hoping for some here! cc @heavyweight 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

Here's the changes which I'm proposing that you can test on the Verbum form:

| Before | After |
|--------|--------|
| <img width="706" alt="Screenshot 2024-02-25 at 10 35 54" src="https://github.com/Automattic/jetpack/assets/43215253/7f1fe7e2-e519-4509-9196-9a3282c0d26d"> | <img width="713" alt="Screenshot 2024-02-25 at 10 36 18" src="https://github.com/Automattic/jetpack/assets/43215253/5e78b656-1f6f-48d6-b87d-d6c3daaf0e10"> |
| <img width="715" alt="Screenshot 2024-02-25 at 10 36 39" src="https://github.com/Automattic/jetpack/assets/43215253/52cd8545-ae44-4830-9709-7d1bd6fb2d99"> | <img width="701" alt="Screenshot 2024-02-25 at 10 36 23" src="https://github.com/Automattic/jetpack/assets/43215253/631f037c-8d6d-4015-98bf-88a95d8450d8"> |

This makes it more accessibility-friendly. The ratio goes from **1.36:1** to **2.33:1**, which meets the contrast mentioned in that original discussion. 

The comment form currently turns blue in the active state by the way, so there's definitely a clear distinction between the disabled and active state. 