### PR TITLE
WPCOM MU: Add admin notice to know about hosting menu

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add-site-menu-banner
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add-site-menu-banner
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds a dismissible admin notice to inform users of the hosting menu

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -44,10 +44,24 @@ function wpcom_add_wpcom_menu_item() {
 add_action( 'admin_menu', 'wpcom_add_wpcom_menu_item' );
 
 /**
+ * Helper function to determine if the admin notice should be shown.
+ *
+ * @return bool
+ */
+function wpcom_site_menu_should_show_notice() {
+	if ( get_option( 'wpcom_site_menu_notice_dismisses' ) ) {
+		return false;
+	}
+
+	$screen = get_current_screen();
+	return 'dashboard' === $screen->id;
+}
+
+/**
  * Add a notice to the admin menu to inform users about the new WordPress.com menu item.
  */
 function wpcom_add_hosting_menu_intro_notice() {
-	if ( get_option( 'wpcom_site_menu_notice_dismisses' ) ) {
+	if ( ! wpcom_site_menu_should_show_notice() ) {
 		return;
 	}
 	?>
@@ -108,7 +122,7 @@ add_action( 'admin_notices', 'wpcom_add_hosting_menu_intro_notice' );
  * Handles the AJAX request to dismiss the admin notice.
  */
 function wpcom_add_hosting_menu_intro_notice_dismiss() {
-	if ( get_option( 'wpcom_site_menu_notice_dismisses' ) ) {
+	if ( ! wpcom_site_menu_should_show_notice() ) {
 		return;
 	}
 	?>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -49,7 +49,10 @@ add_action( 'admin_menu', 'wpcom_add_wpcom_menu_item' );
  * @return bool
  */
 function wpcom_site_menu_should_show_notice() {
-	if ( get_option( 'wpcom_site_menu_notice_dismisses' ) ) {
+	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
+		return false;
+	}
+	if ( get_option( 'wpcom_site_menu_notice_dismissed' ) ) {
 		return false;
 	}
 
@@ -61,7 +64,7 @@ function wpcom_site_menu_should_show_notice() {
  * Add a notice to the admin menu to inform users about the new WordPress.com menu item.
  */
 function wpcom_add_hosting_menu_intro_notice() {
-	if ( ! wpcom_site_menu_should_show_notice() ) {
+	if ( ! wpcom_site_menu_should_show_notice() || ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 		return;
 	}
 	?>
@@ -150,7 +153,7 @@ add_action( 'admin_footer', 'wpcom_add_hosting_menu_intro_notice_dismiss' );
  * Acts as the AJAX callback to set an option for dismissing the admin notice.
  */
 function wpcom_site_menu_handle_dismiss_notice() {
-	update_option( 'wpcom_site_menu_notice_dismisses', 1 );
+	update_option( 'wpcom_site_menu_notice_dismissed', 1 );
 	wp_die();
 }
 add_action( 'wp_ajax_dismiss_wpcom_site_menu_intro_notice', 'wpcom_site_menu_handle_dismiss_notice' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -42,3 +42,94 @@ function wpcom_add_wpcom_menu_item() {
 	}
 }
 add_action( 'admin_menu', 'wpcom_add_wpcom_menu_item' );
+
+/**
+ * Add a notice to the admin menu to inform users about the new WordPress.com menu item.
+ */
+function wpcom_add_hosting_menu_intro_notice() {
+	if ( get_option( 'wpcom_site_menu_notice_dismisses' ) ) {
+		return;
+	}
+	?>
+	<style>
+		.wpcom-site-menu-intro-notice {
+			padding: 8px 12px;
+			width: 100%;
+		}
+
+		.wpcom-site-menu-intro-notice.notice.notice-info {
+			border-left-color: #3858e9;
+			display: flex;
+			align-items: center;
+			gap: 12px;
+		}
+
+		.wpcom-site-menu-intro-notice .dashicons-wordpress-alt {
+			color: #3858e9;
+			font-size: 32px;
+			width: 32px;
+			height: 32px;
+		}
+
+		.wpcom-site-menu-intro-notice span.title {
+			font-size: 14px;
+			font-weight: 600;
+		}
+
+		.wpcom-site-menu-intro-notice span {
+			color: rgb(29, 35, 39);
+			font-size: 14px;
+		}
+
+		.wpcom-site-menu-intro-notice a.close-button {
+			height: 16px;
+			margin-left: auto;
+		}
+	</style>
+	<div class="wpcom-site-menu-intro-notice notice notice-info" role="alert">
+		<div class="banner-icon">
+			<span class="dashicons dashicons-wordpress-alt"></span>
+		</div>
+		<div>
+			<span class="title"><?php esc_html_e( 'WordPress.com', 'jetpack-mu-wpcom' ); ?></span><br />
+			<span>
+				<?php esc_html_e( 'To access settings for plans, domains, subscribers, etc., click "Hosting" in the sidebar.', 'jetpack-mu-wpcom' ); ?>
+			</span>
+		</div>
+		<a href="#" class="close-button" aria-label=<?php echo esc_attr__( 'Dismiss', 'jetpack-mu-wpcom' ); ?>>
+			<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="12.7019" y="2.35547" width="1.53333" height="15.287" rx="0.766667" transform="rotate(45 12.7019 2.35547)" fill="#646970"></rect><rect x="13.6445" y="13.165" width="1.53333" height="15.287" rx="0.766667" transform="rotate(135 13.6445 13.165)" fill="#646970"></rect></svg>
+		</a>
+	</div>
+	<?php
+}
+add_action( 'admin_notices', 'wpcom_add_hosting_menu_intro_notice' );
+
+/**
+ * Handles the AJAX request to dismiss the admin notice.
+ */
+function wpcom_add_hosting_menu_intro_notice_dismiss() {
+	if ( get_option( 'wpcom_site_menu_notice_dismisses' ) ) {
+		return;
+	}
+	?>
+	<script>
+		document.addEventListener( 'DOMContentLoaded', function() {
+			document.querySelector( '.wpcom-site-menu-intro-notice a.close-button' ).addEventListener( 'click', function( event ) {
+				event.preventDefault();
+				this.closest( '.wpcom-site-menu-intro-notice' ).remove();
+				wp.ajax.post( 'dismiss_wpcom_site_menu_intro_notice' );
+			} );
+		} );
+	</script>
+	<?php
+}
+add_action( 'admin_footer', 'wpcom_add_hosting_menu_intro_notice_dismiss' );
+
+/**
+ * Acts as the AJAX callback to set an option for dismissing the admin notice.
+ */
+function wpcom_site_menu_handle_dismiss_notice() {
+	update_option( 'wpcom_site_menu_notice_dismisses', 1 );
+	wp_die();
+}
+add_action( 'wp_ajax_dismiss_wpcom_site_menu_intro_notice', 'wpcom_site_menu_handle_dismiss_notice' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -66,11 +66,18 @@ function wpcom_add_hosting_menu_intro_notice() {
 	}
 	?>
 	<style>
+
+		body.no-js .wpcom-site-menu-intro-notice {
+			display: none !important;
+		}
 		.wpcom-site-menu-intro-notice {
+			display: none !important;
 			padding: 8px 12px;
-			width: 100%;
 		}
 
+		.wrap > .wpcom-site-menu-intro-notice {
+			display: flex !important;
+		}
 		.wpcom-site-menu-intro-notice.notice.notice-info {
 			border-left-color: #3858e9;
 			display: flex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
Adds a dismissible admin notice to inform users of new hosting menu.

<img width="1405" alt="Screenshot 2024-02-25 at 7 19 54 PM" src="https://github.com/Automattic/jetpack/assets/1126811/69d6cb12-8306-4e4d-95ac-5429b0449394">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Checkout PR on site
- Ensure site has classic view enabled
- Ensure you are proxied
- Go to `$site.com/wp-admin`
- Verify you see notice
- Dismiss notice
- Reload page
- Verify no notice
- Go to `$site.com/wp-admin/options.php` and set `wpcom_site_menu_notice_dismisses` to `0`
- Reload dashboard
- Ensure notice shows
- Set view mode to `Default`
- Ensure notice doesn't show

