### PR TITLE
Boost/fix missing function

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
@@ -48,7 +48,7 @@ class Logger {
 	}
 
 	private function __construct() {
-		if ( function_exists( 'getmyxpid' ) ) {
+		if ( function_exists( 'getmypid' ) ) {
 			$this->pid = getmypid();
 		} else {
 			// Where PID is not available, use the microtime of the first log of the session.

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
@@ -48,11 +48,11 @@ class Logger {
 	}
 
 	private function __construct() {
-		// If we cannot query the real process_id, use the timestamp of the request / first log of the request instead.
-		if ( function_exists( 'getmypid' ) ) {
+		if ( function_exists( 'getmyxpid' ) ) {
 			$this->pid = getmypid();
 		} else {
-			$this->pid = time();
+			// Where PID is not available, use the microtime of the first log of the session.
+			$this->pid = microtime( true );
 		}
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
@@ -25,6 +25,11 @@ class Logger {
 	const LOG_DIRECTORY = WP_CONTENT_DIR . '/boost-cache/logs';
 
 	/**
+	 * The Process Identifier used by this Logger instance.
+	 */
+	private static $pid = null;
+
+	/**
 	 * Get the singleton instance of the logger.
 	 */
 	public static function get_instance() {
@@ -40,6 +45,15 @@ class Logger {
 
 		self::$instance = $instance;
 		return $instance;
+	}
+
+	private function __construct() {
+		// If we cannot query the real process_id, use the timestamp of the request / first log of the request instead.
+		if ( function_exists( 'getmypid' ) ) {
+			$this->pid = getmypid();
+		} else {
+			$this->pid = time();
+		}
 	}
 
 	/**
@@ -85,7 +99,7 @@ class Logger {
 	public function log( $message ) {
 		$request     = Request::current();
 		$request_uri = htmlspecialchars( $request->get_uri(), ENT_QUOTES, 'UTF-8' );
-		$line        = gmdate( 'H:i:s' ) . ' ' . getmypid() . "\t{$request_uri}\t\t{$message}" . PHP_EOL;
+		$line        = gmdate( 'H:i:s' ) . " {$this->pid}\t{$request_uri}\t\t{$message}" . PHP_EOL;
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		error_log( $line, 3, $this->get_log_file() );
 	}
@@ -95,8 +109,9 @@ class Logger {
 	 *
 	 * @return string
 	 */
-	public function read() {
-		$log_file = $this->get_log_file();
+	public static function read() {
+		$instance = self::get_instance();
+		$log_file = $instance->get_log_file();
 
 		if ( ! file_exists( $log_file ) ) {
 			return '';

--- a/projects/plugins/boost/changelog/boost-fix-missing-function
+++ b/projects/plugins/boost/changelog/boost-fix-missing-function
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Avoid errors if getmypid unavailable
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -347,7 +347,7 @@ jetpack_boost_register_readonly_option( 'connection', array( new Connection(), '
 jetpack_boost_register_readonly_option( 'pricing', array( Premium_Pricing::class, 'get_yearly_pricing' ) );
 jetpack_boost_register_readonly_option( 'premium_features', array( Premium_Features::class, 'get_features' ) );
 jetpack_boost_register_readonly_option( 'super_cache', array( Super_Cache_Info::class, 'get_info' ) );
-jetpack_boost_register_readonly_option( 'cache_debug_log', array( new Logger(), 'read' ) );
+jetpack_boost_register_readonly_option( 'cache_debug_log', array( Logger::class, 'read' ) );
 
 jetpack_boost_register_option( 'getting_started', Schema::as_boolean()->fallback( false ), new Getting_Started_Entry() );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes pedxs5-oQ-p2#comment-307

`getmypid` is not available on all platforms. This PR addresses this problem by checking if it exists and adding a fallback if not: instead, the microtime of the first log message of the PHP session is used. That way, all messages from the same PHP session can be identified.

## Proposed changes:
* Add a fallback where microtime is unavailable
* Don't instantiate the `Logger` singleton in the DataSync setup layer.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Test this on a server without getmypid, and verify it works properly.
* Alternately, change the function_exists check in Logger::__construct to force it down the other path.