### PR TITLE
Add scheduled update body parameter

### DIFF
--- a/projects/packages/scheduled-updates/changelog/update-modify-plugin-endpoint
+++ b/projects/packages/scheduled-updates/changelog/update-modify-plugin-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Pass is_scheduled_updats property in the filter to identify our requests

--- a/projects/packages/scheduled-updates/changelog/update-modify-plugin-endpoint
+++ b/projects/packages/scheduled-updates/changelog/update-modify-plugin-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Pass is_scheduled_updats property in the filter to identify our requests
+Scheduled updates: Change the `jetpack_allowlist_scheduled_plugins` function to include a check for the `SCHEDULED_AUTOUPDATE` constant. This allows us to identify requests coming from scheduled updates and include the relevant plugins when the `auto_update_plugin` hook is triggered.

--- a/projects/packages/scheduled-updates/changelog/update-modify-plugin-endpoint
+++ b/projects/packages/scheduled-updates/changelog/update-modify-plugin-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Scheduled updates: Change the `jetpack_allowlist_scheduled_plugins` function to include a check for the `SCHEDULED_AUTOUPDATE` constant. This allows us to identify requests coming from scheduled updates and include the relevant plugins when the `auto_update_plugin` hook is triggered.
+Scheduled updates: Change the `allowlist_scheduled_plugins` function to include a check for the `SCHEDULED_AUTOUPDATE` constant. This allows us to identify requests coming from scheduled updates and include the relevant plugins when the `auto_update_plugin` hook is triggered.

--- a/projects/packages/scheduled-updates/changelog/update-modify-plugin-endpoint
+++ b/projects/packages/scheduled-updates/changelog/update-modify-plugin-endpoint
@@ -1,4 +1,6 @@
 Significance: minor
 Type: changed
 
-Scheduled updates: Change the `allowlist_scheduled_plugins` function to include a check for the `SCHEDULED_AUTOUPDATE` constant. This allows us to identify requests coming from scheduled updates and include the relevant plugins when the `auto_update_plugin` hook is triggered.
+Scheduled updates: Modified the `allowlist_scheduled_plugins` function to check scheduled update requests.
+
+Change the `allowlist_scheduled_plugins` function to include a check for the `SCHEDULED_AUTOUPDATE` constant. This allows us to identify requests coming from scheduled updates and include the relevant plugins when the `auto_update_plugin` hook is triggered.

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -48,7 +48,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.2.x-dev"
+			"dev-trunk": "0.3.x-dev"
 		},
 		"textdomain": "jetpack-scheduled-updates",
 		"version-constants": {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -89,9 +89,7 @@ class Scheduled_Updates {
 	 * @return bool
 	 */
 	public static function allowlist_scheduled_plugins( $update, $item ) {
-
 		if ( Constants::get_constant( 'SCHEDULED_AUTOUPDATE' ) ) {
-
 			$schedules = get_option( 'jetpack_update_schedules', array() );
 
 			foreach ( $schedules as $plugins ) {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -89,12 +89,14 @@ class Scheduled_Updates {
 	 * @return bool
 	 */
 	public static function allowlist_scheduled_plugins( $update, $item ) {
-		// TODO: Check if we're in a scheduled update request from Jetpack_Autoupdates.
-		$schedules = get_option( 'jetpack_update_schedules', array() );
 
-		foreach ( $schedules as $plugins ) {
-			if ( in_array( $item->slug, $plugins, true ) ) {
-				return true;
+		if ( isset( $item->is_scheduled_updates ) && $item->is_scheduled_updates ) {
+			$schedules = get_option( 'jetpack_update_schedules', array() );
+
+			foreach ( $schedules as $plugins ) {
+				if ( in_array( $item->slug, $plugins, true ) ) {
+					return true;
+				}
 			}
 		}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -90,7 +90,7 @@ class Scheduled_Updates {
 	 */
 	public static function allowlist_scheduled_plugins( $update, $item ) {
 
-		if ( isset( $item->is_scheduled_updates ) && $item->is_scheduled_updates ) {
+		if ( Constants::get_constant( 'SCHEDULED_AUTOUPDATE' ) ) {
 
 			$schedules = get_option( 'jetpack_update_schedules', array() );
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.2.2-alpha';
+	const PACKAGE_VERSION = '0.3.0-alpha';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -91,10 +91,11 @@ class Scheduled_Updates {
 	public static function allowlist_scheduled_plugins( $update, $item ) {
 
 		if ( isset( $item->is_scheduled_updates ) && $item->is_scheduled_updates ) {
+
 			$schedules = get_option( 'jetpack_update_schedules', array() );
 
 			foreach ( $schedules as $plugins ) {
-				if ( in_array( $item->slug, $plugins, true ) ) {
+				if ( isset( $item->plugin ) && in_array( $item->plugin, $plugins, true ) ) {
 					return true;
 				}
 			}

--- a/projects/plugins/jetpack/changelog/update-modify-plugin-endpoint
+++ b/projects/plugins/jetpack/changelog/update-modify-plugin-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Scheduled updates: support scheduled updates for plugin update endpoint
+Scheduled updates: Introduced a new body parameter `is_scheduled_update` to the `POST /sites/%s/plugins/%s` endpoint. When this endpoint is called with the `is_scheduled_update` parameter,  we validate the request and modify the auto-update plugins allowed list to include the ones in the scheduled updates option.

--- a/projects/plugins/jetpack/changelog/update-modify-plugin-endpoint
+++ b/projects/plugins/jetpack/changelog/update-modify-plugin-endpoint
@@ -1,6 +1,6 @@
 Significance: minor
 Type: other
 
-Scheduled updates: Introduced a new body parameter `schedule_update` to the `POST /sites/%s/plugins/%s` endpoint.
+Scheduled updates: Introduced a new body parameter `scheduled_update` to the `POST /sites/%s/plugins/%s` endpoint.
 
-When `POST /sites/%s/plugins/%s` endpoint is called with the `schedule_update` parameter, we validate the request and modify the auto update plugins allowed list to include the ones in the scheduled updates option.
+When `POST /sites/%s/plugins/%s` endpoint is called with the `scheduled_update` parameter, we validate the request and modify the auto update plugins allowed list to include the ones in the scheduled updates option.

--- a/projects/plugins/jetpack/changelog/update-modify-plugin-endpoint
+++ b/projects/plugins/jetpack/changelog/update-modify-plugin-endpoint
@@ -1,6 +1,6 @@
 Significance: minor
 Type: other
 
-Scheduled updates: Introduced a new body parameter `is_scheduled_update` to the `POST /sites/%s/plugins/%s` endpoint.
+Scheduled updates: Introduced a new body parameter `schedule_update` to the `POST /sites/%s/plugins/%s` endpoint.
 
-When `POST /sites/%s/plugins/%s` endpoint is called with the `is_scheduled_update` parameter, we validate the request and modify the auto update plugins allowed list to include the ones in the scheduled updates option.
+When `POST /sites/%s/plugins/%s` endpoint is called with the `schedule_update` parameter, we validate the request and modify the auto update plugins allowed list to include the ones in the scheduled updates option.

--- a/projects/plugins/jetpack/changelog/update-modify-plugin-endpoint
+++ b/projects/plugins/jetpack/changelog/update-modify-plugin-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Scheduled updates: support scheduled updates for plugin update endpoint

--- a/projects/plugins/jetpack/changelog/update-modify-plugin-endpoint
+++ b/projects/plugins/jetpack/changelog/update-modify-plugin-endpoint
@@ -1,4 +1,6 @@
 Significance: minor
 Type: other
 
-Scheduled updates: Introduced a new body parameter `is_scheduled_update` to the `POST /sites/%s/plugins/%s` endpoint. When this endpoint is called with the `is_scheduled_update` parameter,  we validate the request and modify the auto-update plugins allowed list to include the ones in the scheduled updates option.
+Scheduled updates: Introduced a new body parameter `is_scheduled_update` to the `POST /sites/%s/plugins/%s` endpoint.
+
+When `POST /sites/%s/plugins/%s` endpoint is called with the `is_scheduled_update` parameter, we validate the request and modify the auto update plugins allowed list to include the ones in the scheduled updates option.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -445,7 +445,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			if ( Current_Plan::supports( 'scheduled-updates' ) ) {
 				$this->is_scheduled_update = true;
 			} else {
-				return new WP_Error( 'unauthorized', __( 'This user is not authorized to perform a scheduled update event', 'jetpack' ), 403 );
+				return new WP_Error( 'unauthorized', __( 'Scheduled updates are not available on your current plan. Please upgrade to a plan that supports scheduled updates to use this feature.', 'jetpack' ), 403 );
 			}
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -42,7 +42,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	 *
 	 * @var boolean
 	 */
-	protected $schedule_update = false;
+	protected $scheduled_update = false;
 
 	/**
 	 * Response format.
@@ -434,16 +434,16 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	}
 
 	/**
-	 * Validates if scheduled update are allowed based on the current plan.
+	 * Validates if scheduled updates are allowed based on the current plan.
 	 *
-	 * @return bool|WP_Error True if scheduled update are allowed or not provided, WP_Error otherwise.
+	 * @return bool|WP_Error True if scheduled updates are allowed or not provided, WP_Error otherwise.
 	 */
 	protected function validate_scheduled_update() {
 		$args = $this->input();
 
 		if ( isset( $args['schedule_update'] ) && $args['schedule_update'] ) {
 			if ( Current_Plan::supports( 'scheduled-updates' ) ) {
-				$this->schedule_update = true;
+				$this->scheduled_update = true;
 			} else {
 				return new WP_Error( 'unauthorized', __( 'Scheduled updates are not available on your current plan. Please upgrade to a plan that supports scheduled updates to use this feature.', 'jetpack' ), 403 );
 			}

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -42,7 +42,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	 *
 	 * @var boolean
 	 */
-	protected $is_scheduled_updates = false;
+	protected $is_scheduled_update = false;
 
 	/**
 	 * Response format.
@@ -128,7 +128,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			return $error;
 		}
 
-		$error = $this->validate_scheduled_updates();
+		$error = $this->validate_scheduled_update();
 		if ( is_wp_error( $error ) ) {
 			return $error;
 		}
@@ -434,16 +434,16 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	}
 
 	/**
-	 * Validates if scheduled updates are allowed based on the current plan.
+	 * Validates if scheduled update are allowed based on the current plan.
 	 *
-	 * @return bool|WP_Error True if scheduled updates are allowed or not provided, WP_Error otherwise.
+	 * @return bool|WP_Error True if scheduled update are allowed or not provided, WP_Error otherwise.
 	 */
-	protected function validate_scheduled_updates() {
+	protected function validate_scheduled_update() {
 		$args = $this->input();
 
-		if ( isset( $args['is_scheduled_updates'] ) && $args['is_scheduled_updates'] ) {
+		if ( isset( $args['is_scheduled_update'] ) && $args['is_scheduled_update'] ) {
 			if ( Current_Plan::supports( 'scheduled-updates' ) ) {
-				$this->is_scheduled_updates = true;
+				$this->is_scheduled_update = true;
 			} else {
 				return new WP_Error( 'unauthorized', __( 'This user is not authorized to perform a scheduled update event', 'jetpack' ), 403 );
 			}

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -441,7 +441,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	protected function validate_scheduled_update() {
 		$args = $this->input();
 
-		if ( isset( $args['schedule_update'] ) && $args['schedule_update'] ) {
+		if ( isset( $args['scheduled_update'] ) && $args['scheduled_update'] ) {
 			if ( Current_Plan::supports( 'scheduled-updates' ) ) {
 				$this->scheduled_update = true;
 			} else {

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -42,7 +42,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	 *
 	 * @var boolean
 	 */
-	protected $is_scheduled_update = false;
+	protected $schedule_update = false;
 
 	/**
 	 * Response format.
@@ -441,9 +441,9 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	protected function validate_scheduled_update() {
 		$args = $this->input();
 
-		if ( isset( $args['is_scheduled_update'] ) && $args['is_scheduled_update'] ) {
+		if ( isset( $args['schedule_update'] ) && $args['schedule_update'] ) {
 			if ( Current_Plan::supports( 'scheduled-updates' ) ) {
-				$this->is_scheduled_update = true;
+				$this->schedule_update = true;
 			} else {
 				return new WP_Error( 'unauthorized', __( 'Scheduled updates are not available on your current plan. Please upgrade to a plan that supports scheduled updates to use this feature.', 'jetpack' ), 403 );
 			}

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -16,11 +16,11 @@ new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 		),
 		'allow_jetpack_site_auth' => true,
 		'request_format'          => array(
-			'action'              => '(string) Possible values are \'update\'',
-			'autoupdate'          => '(bool) Whether or not to automatically update the plugin',
-			'active'              => '(bool) Activate or deactivate the plugin',
-			'network_wide'        => '(bool) Do action network wide (default value: false)',
-			'is_scheduled_update' => '(bool) If the update is happening as a result of a scheduled update event',
+			'action'          => '(string) Possible values are \'update\'',
+			'autoupdate'      => '(bool) Whether or not to automatically update the plugin',
+			'active'          => '(bool) Activate or deactivate the plugin',
+			'network_wide'    => '(bool) Do action network wide (default value: false)',
+			'schedule_update' => '(bool) If the update is happening as a result of a scheduled update event',
 		),
 		'query_parameters'        => array(
 			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
@@ -383,10 +383,10 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	 */
 	protected function update() {
 		$query_args = $this->query_args();
-		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] || $this->is_scheduled_update ) {
+		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] || $this->schedule_update ) {
 			Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
 		}
-		if ( $this->is_scheduled_update ) {
+		if ( $this->schedule_update ) {
 			Constants::set_constant( 'SCHEDULED_AUTOUPDATE', true );
 		}
 		wp_clean_plugins_cache( false );

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -187,7 +187,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		$args = $this->input();
 
 		if ( isset( $args['autoupdate'] ) && is_bool( $args['autoupdate'] ) ) {
-			if ( $args['autoupdate'] && ! $this->is_scheduled_update ) {
+			if ( $args['autoupdate'] ) {
 				$this->autoupdate_on();
 			} else {
 				$this->autoupdate_off();

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -386,6 +386,9 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] || $this->is_scheduled_updates ) {
 			Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
 		}
+		if ( $this->is_scheduled_updates ) {
+			Constants::set_constant( 'SCHEDULED_AUTOUPDATE', true );
+		}
 		wp_clean_plugins_cache( false );
 		ob_start();
 		wp_update_plugins(); // Check for Plugin updates

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -426,10 +426,6 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				continue;
 			}
 
-			if ( $this->is_scheduled_updates ) {
-				$update_plugins->response[ $plugin ]->is_scheduled_updates = true;
-			}
-
 			// Rely on WP_Automatic_Updater class to check if a plugin item should be updated if it is a Jetpack autoupdate request.
 			if ( Constants::get_constant( 'JETPACK_PLUGIN_AUTOUPDATE' ) && ! ( new WP_Automatic_Updater() )->should_update( 'plugin', $update_plugins->response[ $plugin ], WP_PLUGIN_DIR ) ) {
 				continue;

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -171,7 +171,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 
 		$args = $this->input();
 
-		if ( is_array( $args ) && ( isset( $args['autoupdate'] ) || isset( $args['autoupdate_translations'] ) || isset( $args['is_scheduled_update'] ) ) ) {
+		if ( is_array( $args ) && ( isset( $args['autoupdate'] ) || isset( $args['autoupdate_translations'] ) ) ) {
 			$this->needed_capabilities = 'update_plugins';
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -186,7 +186,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	public function default_action() {
 		$args = $this->input();
 
-		if ( ( isset( $args['autoupdate'] ) && is_bool( $args['autoupdate'] ) ) || $this->is_scheduled_updates ) {
+		if ( isset( $args['autoupdate'] ) && is_bool( $args['autoupdate'] ) ) {
 			if ( $args['autoupdate'] && ! $this->is_scheduled_updates ) {
 				$this->autoupdate_on();
 			} else {

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -16,10 +16,11 @@ new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 		),
 		'allow_jetpack_site_auth' => true,
 		'request_format'          => array(
-			'action'       => '(string) Possible values are \'update\'',
-			'autoupdate'   => '(bool) Whether or not to automatically update the plugin',
-			'active'       => '(bool) Activate or deactivate the plugin',
-			'network_wide' => '(bool) Do action network wide (default value: false)',
+			'action'               => '(string) Possible values are \'update\'',
+			'autoupdate'           => '(bool) Whether or not to automatically update the plugin',
+			'active'               => '(bool) Activate or deactivate the plugin',
+			'network_wide'         => '(bool) Do action network wide (default value: false)',
+			'is_scheduled_updates' => '(bool) If the update is happening as a result of a scheduled update event',
 		),
 		'query_parameters'        => array(
 			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
@@ -381,7 +382,6 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	 * @return bool|WP_Error
 	 */
 	protected function update() {
-
 		$query_args = $this->query_args();
 		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] ) {
 			Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -16,11 +16,11 @@ new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 		),
 		'allow_jetpack_site_auth' => true,
 		'request_format'          => array(
-			'action'               => '(string) Possible values are \'update\'',
-			'autoupdate'           => '(bool) Whether or not to automatically update the plugin',
-			'active'               => '(bool) Activate or deactivate the plugin',
-			'network_wide'         => '(bool) Do action network wide (default value: false)',
-			'is_scheduled_updates' => '(bool) If the update is happening as a result of a scheduled update event',
+			'action'              => '(string) Possible values are \'update\'',
+			'autoupdate'          => '(bool) Whether or not to automatically update the plugin',
+			'active'              => '(bool) Activate or deactivate the plugin',
+			'network_wide'        => '(bool) Do action network wide (default value: false)',
+			'is_scheduled_update' => '(bool) If the update is happening as a result of a scheduled update event',
 		),
 		'query_parameters'        => array(
 			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
@@ -171,7 +171,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 
 		$args = $this->input();
 
-		if ( is_array( $args ) && ( isset( $args['autoupdate'] ) || isset( $args['autoupdate_translations'] ) || isset( $args['is_scheduled_updates'] ) ) ) {
+		if ( is_array( $args ) && ( isset( $args['autoupdate'] ) || isset( $args['autoupdate_translations'] ) || isset( $args['is_scheduled_update'] ) ) ) {
 			$this->needed_capabilities = 'update_plugins';
 		}
 
@@ -187,7 +187,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		$args = $this->input();
 
 		if ( isset( $args['autoupdate'] ) && is_bool( $args['autoupdate'] ) ) {
-			if ( $args['autoupdate'] && ! $this->is_scheduled_updates ) {
+			if ( $args['autoupdate'] && ! $this->is_scheduled_update ) {
 				$this->autoupdate_on();
 			} else {
 				$this->autoupdate_off();
@@ -383,10 +383,10 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	 */
 	protected function update() {
 		$query_args = $this->query_args();
-		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] || $this->is_scheduled_updates ) {
+		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] || $this->is_scheduled_update ) {
 			Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
 		}
-		if ( $this->is_scheduled_updates ) {
+		if ( $this->is_scheduled_update ) {
 			Constants::set_constant( 'SCHEDULED_AUTOUPDATE', true );
 		}
 		wp_clean_plugins_cache( false );

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -16,11 +16,11 @@ new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 		),
 		'allow_jetpack_site_auth' => true,
 		'request_format'          => array(
-			'action'          => '(string) Possible values are \'update\'',
-			'autoupdate'      => '(bool) Whether or not to automatically update the plugin',
-			'active'          => '(bool) Activate or deactivate the plugin',
-			'network_wide'    => '(bool) Do action network wide (default value: false)',
-			'schedule_update' => '(bool) If the update is happening as a result of a scheduled update event',
+			'action'           => '(string) Possible values are \'update\'',
+			'autoupdate'       => '(bool) Whether or not to automatically update the plugin',
+			'active'           => '(bool) Activate or deactivate the plugin',
+			'network_wide'     => '(bool) Do action network wide (default value: false)',
+			'scheduled_update' => '(bool) If the update is happening as a result of a scheduled update event',
 		),
 		'query_parameters'        => array(
 			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
@@ -383,10 +383,10 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	 */
 	protected function update() {
 		$query_args = $this->query_args();
-		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] || $this->schedule_update ) {
+		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] || $this->scheduled_update ) {
 			Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
 		}
-		if ( $this->schedule_update ) {
+		if ( $this->scheduled_update ) {
 			Constants::set_constant( 'SCHEDULED_AUTOUPDATE', true );
 		}
 		wp_clean_plugins_cache( false );
@@ -412,7 +412,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		remove_action( 'upgrader_process_complete', 'wp_update_themes' );
 
 		// Set the lock timeout to 15 minutes if it's scheduled update, otherwise default to one hour.
-		$lock_release_timeout = $this->schedule_update ? 15 * MINUTE_IN_SECONDS : null;
+		$lock_release_timeout = $this->scheduled_update ? 15 * MINUTE_IN_SECONDS : null;
 
 		// Early return if unable to obtain auto_updater lock.
 		// @see https://github.com/WordPress/wordpress-develop/blob/66469efa99e7978c8824e287834135aa9842e84f/src/wp-admin/includes/class-wp-automatic-updater.php#L453.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-modify-plugin-endpoint
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-modify-plugin-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -198,7 +198,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "7e5dcbdcf8977200ccf1201bea501de7c3559348"
+                "reference": "dfd9f527692091535d2959930461894c6c91864c"
             },
             "require": {
                 "php": ">=7.0"

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -198,7 +198,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "9be90d23b55e43e40816ff79dbd2d65b1c392fc8"
+                "reference": "7e5dcbdcf8977200ccf1201bea501de7c3559348"
             },
             "require": {
                 "php": ">=7.0"
@@ -220,7 +220,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "textdomain": "jetpack-scheduled-updates",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/dotcom-forge#5721

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduce a new body parameter `schedule_update` to `Jetpack_JSON_API_Plugins_Modify_Endpoint`. 
* Add conditions to fit the needs for scheduled update requests.
* Update the `jetpack_allowlist_scheduled_plugins` function and make it run the extra check if users are from scheduled updates endpoint.
* Set lock release timeout to 15 minutes if the user if from scheduled updates.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pcmemI-2O3-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Since this PR changes both Jetpack and the scheduled updates package, I'm not sure how well the Jetpack beta plugin can handle this. it's best to test it using the jetpack rsync method here.
* This PR should be tested along with D139642-code.
* jetpack rsync the jetpack and mu-wpcom-plugin following the instructions https://github.com/Automattic/jetpack/pull/35941#issuecomment-1963738571.
* To be able to make the `jetpack_allowlist_scheduled_plugins` work, follow the instructions in https://github.com/Automattic/jetpack/pull/35917 to create an updated schedule.
* If you'd like to test it alone you can also modify the function a little.

```
public static function jetpack_allowlist_scheduled_plugins( $update, $item ) {

	if ( isset( $item->is_scheduled_updates ) && $item->is_scheduled_updates ) {
		return true;
	}

	return $update;
}
```
* Follow pcmemI-2QL-p2 and change a plugin version you want
* Call `https://public-api.wordpress.com/wpcom/v2/sites/<YOUR_SITE_ID>/hosting/scheduled-update` to trigger an update. An example payload can look like this:
```
{
    "plugins": {
            "wpforms-lite/wpforms.php":{
                "id": "w.org/plugins/wpforms-lite",
                "slug": "wpforms-lite",
                "plugin": "wpforms-lite/wpforms.php",
                "new_version": "1.8.6.4",
                "url": "https://wordpress.org/plugins/wpforms-lite/",
                "package": "https://downloads.wordpress.org/plugin/wpforms-lite.1.8.6.4.zip",
                "icons": {
                "1x": "https://ps.w.org/wpforms-lite/assets/icon.svg?rev=2574198",
                "svg": "https://ps.w.org/wpforms-lite/assets/icon.svg?rev=2574198"
                },
                "banners": {
                "2x": "https://ps.w.org/wpforms-lite/assets/banner-1544x500.png?rev=2602491",
                "1x": "https://ps.w.org/wpforms-lite/assets/banner-772x250.png?rev=2602491"
                },
                "banners_rtl": {
                "2x": "https://ps.w.org/wpforms-lite/assets/banner-1544x500-rtl.png?rev=2602491",
                "1x": "https://ps.w.org/wpforms-lite/assets/banner-772x250-rtl.png?rev=2602491"
                },
                "requires": "5.5",
                "tested": "6.4.3",
                "requires_php": "7.0",
                "requires_plugins": [],
                "compatibility": []
            }   
    },
    "schedule": "1"
}
```
* Navigate to `https://<your-woa-site>/wp-admin/plugins.php` and see if the plugin gets updated.