### PR TITLE
Boost: Delete cached files for /author/ when a post is updated

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -279,6 +279,7 @@ class Boost_Cache {
 		$this->delete_cache_for_post( $post );
 		$this->delete_cache_for_post_terms( $post );
 		$this->delete_cache_for_front_page();
+		$this->delete_cache_for_author( $post->post_author );
 	}
 
 	/**
@@ -293,6 +294,7 @@ class Boost_Cache {
 			$this->delete_cache_for_post( $post );
 			$this->delete_cache_for_post_terms( $post );
 			$this->delete_cache_for_front_page();
+			$this->delete_cache_for_author( $post->post_author );
 		}
 	}
 
@@ -347,6 +349,22 @@ class Boost_Cache {
 				$this->delete_cache_for_url( $link );
 			}
 		}
+	}
+
+	/**
+	 * Delete the entire cache for the author's archive page.
+	 *
+	 * @param int $author_id - The id of the author.
+	 * @return bool|WP_Error - True if the cache was deleted, WP_Error otherwise.
+	 */
+	public function delete_cache_for_author( $author_id ) {
+		$author = get_userdata( $author_id );
+		if ( ! $author ) {
+			return;
+		}
+
+		$author_link = get_author_posts_url( $author_id, $author->user_nicename );
+		return $this->delete_cache_for_url( $author_link );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/boost-cache-delete-cache-for-author
+++ b/projects/plugins/boost/changelog/boost-cache-delete-cache-for-author
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Boost: delete cached Author pages when pages are edited


### PR DESCRIPTION
When a post is updated, we should delete the author's cached files in /author/[username]/ along with paged archives.

Fixes [#35939](https://github.com/Automattic/jetpack/issues/35939)

## Proposed changes:
* Adds a new function, delete_cache_for_author( $author_id ) to delete the cached pages.
* Call the function from trash and post transition functions.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR and make sure logging is enabled
* Edit a post
* Check Logger logs for this entry: "invalidate: http://domain.tld/author/wordpress/ delete-all"