### PR TITLE
Repo Gardening: Fix Boost feature tagging

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-boost-feature-tagging
+++ b/projects/github-actions/repo-gardening/changelog/fix-boost-feature-tagging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Boost: Fix [Boost Feature] labels

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -210,9 +210,9 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			keywords.add( `[mu wpcom Feature] ${ cleanName( muWpcomFeatureName ) }` );
 		}
 
-		// Boost Critical CSS.
+		// Boost Features
 		const boostModules = file.match(
-			/^projects\/plugins\/boost\/app\/(?:modules|features)\/(?<boostModule>[^/]*)\//
+			/^projects\/plugins\/boost\/app\/(?:modules|features)\/(?:optimizations\/)?(?<boostModule>[^/]*)\//
 		);
 		const boostModuleName = boostModules && boostModules.groups.boostModule;
 		if ( boostModuleName ) {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Boost modules can be in either `app/modules/<module>` or  `app/modules/optimizations/<module>`. This is resulting in some of the labels to be applied incorrectly. Example: #35946. This PR should fix it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Create a PR that changes a boost optimization module
* Ensure that the labels are applied correctly

