### PR TITLE
Boost: Add cache to getting-started feature list

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/boost-pricing-table.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/boost-pricing-table.tsx
@@ -1,108 +1,13 @@
 import { type PricingSchema, usePricing } from '$lib/stores/pricing';
 import {
 	Button,
-	getRedirectUrl,
 	PricingTable,
 	PricingTableColumn,
 	PricingTableHeader,
-	PricingTableItem,
 	ProductPrice,
 } from '@automattic/jetpack-components';
-import { createInterpolateElement } from '@wordpress/element';
+import { boostFeatureList } from './lib/features';
 import { __ } from '@wordpress/i18n';
-
-const cssOptimizationContext = __(
-	'Move important styling information to the start of the page, which helps pages display your content sooner, so your users don’t have to wait for the entire page to load. Commonly referred to as Critical CSS.',
-	'jetpack-boost'
-);
-
-const deferJSContextTemplate = __(
-	'Run non-essential JavaScript after the page has loaded so that styles and images can load more quickly. Read more on <link>web.dev</link>.',
-	'jetpack-boost'
-);
-const deferJSContext = createInterpolateElement( deferJSContextTemplate, {
-	// eslint-disable-next-line jsx-a11y/anchor-has-content
-	link: <a href={ getRedirectUrl( 'jetpack-boost-defer-js' ) } target="_blank" rel="noreferrer" />,
-} );
-
-const imageGuideContext = __(
-	'Discover and fix images with a suboptimal resolution, aspect ratio, or file size, improving user experience and page speed.',
-	'jetpack-boost'
-);
-
-const supportContext = __(
-	`Paid customers get dedicated email support from our world-class Happiness Engineers to help with any issue.<br><br>All other questions are handled by our team as quickly as we are able to go through the WordPress support forum.`,
-	'jetpack-boost'
-);
-
-const automaticallyUpdatedContext = (
-	<span>
-		{ __(
-			'It’s essential to regenerate Critical CSS to optimize your site speed whenever your HTML or CSS structure changes. Being on top of this can be tedious and time-consuming.',
-			'jetpack-boost'
-		) }
-		<br />
-		<br />
-		{ __(
-			'Boost’s cloud service can automatically detect when your site needs the Critical CSS regenerated, and perform this function behind the scenes without requiring you to monitor it manually.',
-			'jetpack-boost'
-		) }
-	</span>
-);
-
-const imageCdnContext = __(
-	`Deliver images from Jetpack's Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.`,
-	'jetpack-boost'
-);
-
-const manuallyUpdatedContext = (
-	<span>
-		{ __(
-			'To enhance the speed of your site, with this plan you will need to optimize CSS by using the Manual Critical CSS generation feature whenever you:',
-			'jetpack-boost'
-		) }
-		<br />
-		<br />
-		<ul>
-			<li>{ __( 'Make theme changes.', 'jetpack-boost' ) }</li>
-			<li>{ __( 'Write a new post/page.', 'jetpack-boost' ) }</li>
-			<li>{ __( 'Edit a post/page.', 'jetpack-boost' ) }</li>
-			<li>
-				{ __(
-					'Activate, deactivate, or update plugins that impact your site layout or HTML structure.',
-					'jetpack-boost'
-				) }
-			</li>
-			<li>
-				{ __(
-					'Change settings of plugins that impact your site layout or HTML structure.',
-					'jetpack-boost'
-				) }
-			</li>
-			<li>
-				{ __(
-					'Upgrade your WordPress version if the new release includes core CSS changes.',
-					'jetpack-boost'
-				) }
-			</li>
-		</ul>
-	</span>
-);
-
-const concatenateContext = __(
-	'Boost your website performance by merging and compressing JavaScript and CSS files, reducing site loading time and number of requests.',
-	'jetpack-boost'
-);
-
-const performanceHistoryContext = __(
-	'Get access to your historical performance scores and see advanced Core Web Vitals data.',
-	'jetpack-boost'
-);
-
-const isaContext = __(
-	"Scan your site for images that aren't properly sized for the device they're being viewed on.",
-	'jetpack-boost'
-);
 
 type BoostPricingTableProps = {
 	pricing: PricingSchema;
@@ -130,118 +35,51 @@ export const BoostPricingTable = ( {
 	return (
 		<PricingTable
 			title={ __( 'The easiest speed optimization plugin for WordPress', 'jetpack-boost' ) }
-			items={ [
-				{
-					name: __( 'Optimize CSS Loading', 'jetpack-boost' ),
-					tooltipInfo: cssOptimizationContext,
-					tooltipPlacement: 'bottom-start',
-				},
-				{
-					name: __( 'Image CDN', 'jetpack-boost' ),
-					tooltipInfo: imageCdnContext,
-					tooltipPlacement: 'bottom-start',
-				},
-				{
-					name: __( 'Automatic image size analysis', 'jetpack-boost' ),
-					tooltipInfo: isaContext,
-					tooltipPlacement: 'bottom-start',
-				},
-				{
-					name: __( 'Historical performance scores', 'jetpack-boost' ),
-					tooltipInfo: performanceHistoryContext,
-					tooltipPlacement: 'bottom-start',
-				},
-				{
-					name: __( 'Defer non-essential JavaScript', 'jetpack-boost' ),
-					tooltipInfo: deferJSContext,
-					tooltipPlacement: 'bottom-start',
-				},
-				{
-					name: __( 'Image guide', 'jetpack-boost' ),
-					tooltipInfo: imageGuideContext,
-					tooltipPlacement: 'bottom-start',
-				},
-				{
-					name: __( 'Concatenate JS and CSS', 'jetpack-boost' ),
-					tooltipInfo: concatenateContext,
-					tooltipPlacement: 'bottom-start',
-				},
-				{
-					name: __( 'Dedicated email support', 'jetpack-boost' ),
-					tooltipInfo: <span dangerouslySetInnerHTML={ { __html: supportContext } }></span>,
-					tooltipPlacement: 'bottom-start',
-				},
-			] }
+			items={ boostFeatureList.map( feature => feature.description ) }
 		>
 			<PricingTableColumn primary>
-				<PricingTableHeader>
-					<ProductPrice
-						price={ ( pricing?.priceBefore ?? 0 ) / 12 }
-						offPrice={ isDiscounted ? ( pricing?.priceAfter ?? 0 ) / 12 : undefined }
-						currency={ pricing?.currencyCode }
-						hideDiscountLabel={ false }
-						legend={ legend }
-					/>
-					<Button
-						onClick={ onPremiumCTA }
-						isLoading={ chosenPaidPlan }
-						disabled={ chosenFreePlan || chosenPaidPlan }
-						fullWidth
-					>
-						{ __( 'Get Boost', 'jetpack-boost' ) }
-					</Button>
-				</PricingTableHeader>
-				<PricingTableItem
-					isIncluded={ true }
-					label={ <strong>{ __( 'Automatically updated', 'jetpack-boost' ) }</strong> }
-					tooltipTitle={ __( 'Automatic Critical CSS regeneration', 'jetpack-boost' ) }
-					tooltipInfo={ automaticallyUpdatedContext }
-					tooltipClassName="wide-tooltip"
-				/>
-				<PricingTableItem
-					isIncluded={ true }
-					label={ <strong>{ __( 'Included + quality settings', 'jetpack-boost' ) }</strong> }
-					tooltipInfo={ __( 'Fine-tune image quality settings to your liking.', 'jetpack-boost' ) }
-				/>
-				<PricingTableItem isIncluded={ true } />
-				<PricingTableItem isIncluded={ true } />
-				<PricingTableItem isIncluded={ true } />
-				<PricingTableItem isIncluded={ true } />
-				<PricingTableItem isIncluded={ true } />
-				<PricingTableItem isIncluded={ true } />
+				{ [
+					<PricingTableHeader key="premium-header">
+						<ProductPrice
+							price={ ( pricing?.priceBefore ?? 0 ) / 12 }
+							offPrice={ isDiscounted ? ( pricing?.priceAfter ?? 0 ) / 12 : undefined }
+							currency={ pricing?.currencyCode }
+							hideDiscountLabel={ false }
+							legend={ legend }
+						/>
+						<Button
+							onClick={ onPremiumCTA }
+							isLoading={ chosenPaidPlan }
+							disabled={ chosenFreePlan || chosenPaidPlan }
+							fullWidth
+						>
+							{ __( 'Get Boost', 'jetpack-boost' ) }
+						</Button>
+					</PricingTableHeader>,
+					...boostFeatureList.map( feature => feature.premium ),
+				] }
 			</PricingTableColumn>
 			<PricingTableColumn>
-				<PricingTableHeader>
-					<ProductPrice
-						price={ 0 }
-						legend=""
-						currency={ pricing?.currencyCode }
-						hidePriceFraction
-					/>
-					<Button
-						onClick={ onFreeCTA }
-						isLoading={ chosenFreePlan }
-						disabled={ chosenFreePlan || chosenPaidPlan }
-						fullWidth
-						variant="secondary"
-					>
-						{ __( 'Start for free', 'jetpack-boost' ) }
-					</Button>
-				</PricingTableHeader>
-				<PricingTableItem
-					isIncluded={ true }
-					label={ __( 'Must be done manually', 'jetpack-boost' ) }
-					tooltipTitle={ __( 'Manual Critical CSS regeneration', 'jetpack-boost' ) }
-					tooltipInfo={ manuallyUpdatedContext }
-					tooltipClassName="wide-tooltip"
-				/>
-				<PricingTableItem isIncluded={ true } />
-				<PricingTableItem isIncluded={ false } label={ __( 'Not included', 'jetpack-boost' ) } />
-				<PricingTableItem isIncluded={ false } label={ __( 'Not included', 'jetpack-boost' ) } />
-				<PricingTableItem isIncluded={ true } />
-				<PricingTableItem isIncluded={ true } />
-				<PricingTableItem isIncluded={ true } />
-				<PricingTableItem isIncluded={ false } label={ __( 'Not included', 'jetpack-boost' ) } />
+				{ [
+					<PricingTableHeader key="free-header">
+						<ProductPrice
+							price={ 0 }
+							legend=""
+							currency={ pricing?.currencyCode }
+							hidePriceFraction
+						/>
+						<Button
+							onClick={ onFreeCTA }
+							isLoading={ chosenFreePlan }
+							disabled={ chosenFreePlan || chosenPaidPlan }
+							fullWidth
+							variant="secondary"
+						>
+							{ __( 'Start for free', 'jetpack-boost' ) }
+						</Button>
+					</PricingTableHeader>,
+					...boostFeatureList.map( feature => feature.free ),
+				] }
 			</PricingTableColumn>
 		</PricingTable>
 	);

--- a/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/lib/features.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/lib/features.tsx
@@ -1,0 +1,204 @@
+import { PricingTableItem, getRedirectUrl } from '@automattic/jetpack-components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	PricingTableItemProps,
+	PricingTableProps,
+} from '../../../../../../../../../js-packages/components/components/pricing-table/types';
+import { ReactElement } from 'react';
+const cssOptimizationContext = __(
+	'Move important styling information to the start of the page, which helps pages display your content sooner, so your users don’t have to wait for the entire page to load. Commonly referred to as Critical CSS.',
+	'jetpack-boost'
+);
+
+const manuallyUpdatedContext = (
+	<span>
+		{ __(
+			'To enhance the speed of your site, with this plan you will need to optimize CSS by using the Manual Critical CSS generation feature whenever you:',
+			'jetpack-boost'
+		) }
+		<br />
+		<br />
+		<ul>
+			<li>{ __( 'Make theme changes.', 'jetpack-boost' ) }</li>
+			<li>{ __( 'Write a new post/page.', 'jetpack-boost' ) }</li>
+			<li>{ __( 'Edit a post/page.', 'jetpack-boost' ) }</li>
+			<li>
+				{ __(
+					'Activate, deactivate, or update plugins that impact your site layout or HTML structure.',
+					'jetpack-boost'
+				) }
+			</li>
+			<li>
+				{ __(
+					'Change settings of plugins that impact your site layout or HTML structure.',
+					'jetpack-boost'
+				) }
+			</li>
+			<li>
+				{ __(
+					'Upgrade your WordPress version if the new release includes core CSS changes.',
+					'jetpack-boost'
+				) }
+			</li>
+		</ul>
+	</span>
+);
+
+const automaticallyUpdatedContext = (
+	<span>
+		{ __(
+			'It’s essential to regenerate Critical CSS to optimize your site speed whenever your HTML or CSS structure changes. Being on top of this can be tedious and time-consuming.',
+			'jetpack-boost'
+		) }
+		<br />
+		<br />
+		{ __(
+			'Boost’s cloud service can automatically detect when your site needs the Critical CSS regenerated, and perform this function behind the scenes without requiring you to monitor it manually.',
+			'jetpack-boost'
+		) }
+	</span>
+);
+
+const imageCdnContext = __(
+	`Deliver images from Jetpack's Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.`,
+	'jetpack-boost'
+);
+
+const isaContext = __(
+	"Scan your site for images that aren't properly sized for the device they're being viewed on.",
+	'jetpack-boost'
+);
+
+const performanceHistoryContext = __(
+	'Get access to your historical performance scores and see advanced Core Web Vitals data.',
+	'jetpack-boost'
+);
+
+const deferJSContextTemplate = __(
+	'Run non-essential JavaScript after the page has loaded so that styles and images can load more quickly. Read more on <link>web.dev</link>.',
+	'jetpack-boost'
+);
+
+const deferJSContext = createInterpolateElement( deferJSContextTemplate, {
+	// eslint-disable-next-line jsx-a11y/anchor-has-content
+	link: <a href={ getRedirectUrl( 'jetpack-boost-defer-js' ) } target="_blank" rel="noreferrer" />,
+} );
+
+const imageGuideContext = __(
+	'Discover and fix images with a suboptimal resolution, aspect ratio, or file size, improving user experience and page speed.',
+	'jetpack-boost'
+);
+
+const supportContext = __(
+	`Paid customers get dedicated email support from our world-class Happiness Engineers to help with any issue.<br><br>All other questions are handled by our team as quickly as we are able to go through the WordPress support forum.`,
+	'jetpack-boost'
+);
+
+const concatenateContext = __(
+	'Boost your website performance by merging and compressing JavaScript and CSS files, reducing site loading time and number of requests.',
+	'jetpack-boost'
+);
+
+type FeatureItem = {
+	description: PricingTableProps[ 'items' ][ number ];
+	free: ReactElement< PricingTableItemProps >;
+	premium: ReactElement< PricingTableItemProps >;
+};
+
+export const boostFeatureList: FeatureItem[] = [
+	{
+		description: {
+			name: __( 'Optimize CSS Loading', 'jetpack-boost' ),
+			tooltipInfo: cssOptimizationContext,
+			tooltipPlacement: 'bottom-start',
+		},
+		free: (
+			<PricingTableItem
+				isIncluded={ true }
+				label={ __( 'Must be done manually', 'jetpack-boost' ) }
+				tooltipTitle={ __( 'Manual Critical CSS regeneration', 'jetpack-boost' ) }
+				tooltipInfo={ manuallyUpdatedContext }
+				tooltipClassName="wide-tooltip"
+			/>
+		),
+		premium: (
+			<PricingTableItem
+				isIncluded={ true }
+				label={ <strong>{ __( 'Automatically updated', 'jetpack-boost' ) }</strong> }
+				tooltipTitle={ __( 'Automatic Critical CSS regeneration', 'jetpack-boost' ) }
+				tooltipInfo={ automaticallyUpdatedContext }
+				tooltipClassName="wide-tooltip"
+			/>
+		),
+	},
+	{
+		description: {
+			name: __( 'Image CDN', 'jetpack-boost' ),
+			tooltipInfo: imageCdnContext,
+			tooltipPlacement: 'bottom-start',
+		},
+		free: <PricingTableItem isIncluded={ true } />,
+		premium: (
+			<PricingTableItem
+				isIncluded={ true }
+				label={ <strong>{ __( 'Included + quality settings', 'jetpack-boost' ) }</strong> }
+				tooltipInfo={ __( 'Fine-tune image quality settings to your liking.', 'jetpack-boost' ) }
+			/>
+		),
+	},
+	{
+		description: {
+			name: __( 'Automatic image size analysis', 'jetpack-boost' ),
+			tooltipInfo: isaContext,
+			tooltipPlacement: 'bottom-start',
+		},
+		free: <PricingTableItem isIncluded={ false } label={ __( 'Not included', 'jetpack-boost' ) } />,
+		premium: <PricingTableItem isIncluded={ true } />,
+	},
+	{
+		description: {
+			name: __( 'Historical performance scores', 'jetpack-boost' ),
+			tooltipInfo: performanceHistoryContext,
+			tooltipPlacement: 'bottom-start',
+		},
+		free: <PricingTableItem isIncluded={ false } label={ __( 'Not included', 'jetpack-boost' ) } />,
+		premium: <PricingTableItem isIncluded={ true } />,
+	},
+	{
+		description: {
+			name: __( 'Defer non-essential JavaScript', 'jetpack-boost' ),
+			tooltipInfo: deferJSContext,
+			tooltipPlacement: 'bottom-start',
+		},
+		free: <PricingTableItem isIncluded={ true } />,
+		premium: <PricingTableItem isIncluded={ true } />,
+	},
+	{
+		description: {
+			name: __( 'Image guide', 'jetpack-boost' ),
+			tooltipInfo: imageGuideContext,
+			tooltipPlacement: 'bottom-start',
+		},
+		free: <PricingTableItem isIncluded={ true } />,
+		premium: <PricingTableItem isIncluded={ true } />,
+	},
+	{
+		description: {
+			name: __( 'Concatenate JS and CSS', 'jetpack-boost' ),
+			tooltipInfo: concatenateContext,
+			tooltipPlacement: 'bottom-start',
+		},
+		free: <PricingTableItem isIncluded={ true } />,
+		premium: <PricingTableItem isIncluded={ true } />,
+	},
+	{
+		description: {
+			name: __( 'Dedicated email support', 'jetpack-boost' ),
+			tooltipInfo: <span dangerouslySetInnerHTML={ { __html: supportContext } }></span>,
+			tooltipPlacement: 'bottom-start',
+		},
+		free: <PricingTableItem isIncluded={ false } label={ __( 'Not included', 'jetpack-boost' ) } />,
+		premium: <PricingTableItem isIncluded={ true } />,
+	},
+];

--- a/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/lib/features.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/lib/features.tsx
@@ -1,11 +1,11 @@
-import { PricingTableItem, getRedirectUrl } from '@automattic/jetpack-components';
+import { PricingTable, PricingTableItem, getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import {
-	PricingTableItemProps,
-	PricingTableProps,
-} from '../../../../../../../../../js-packages/components/components/pricing-table/types';
-import { ReactElement } from 'react';
+import React, { ReactElement } from 'react';
+
+type PricingTableItemProps = React.ComponentProps< typeof PricingTableItem >;
+type PricingTableProps = React.ComponentProps< typeof PricingTable >;
+
 const cssOptimizationContext = __(
 	'Move important styling information to the start of the page, which helps pages display your content sooner, so your users don’t have to wait for the entire page to load. Commonly referred to as Critical CSS.',
 	'jetpack-boost'

--- a/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/lib/features.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/lib/features.tsx
@@ -60,6 +60,11 @@ const automaticallyUpdatedContext = (
 	</span>
 );
 
+const pageCacheContext = __(
+	'Page caching speeds up load times by storing a copy of each web page on the first visit, allowing subsequent visits to be served instantly. This reduces server load and improves user experience by delivering content faster, without waiting for the page to be generated again.',
+	'jetpack-boost'
+);
+
 const imageCdnContext = __(
 	`Deliver images from Jetpack's Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.`,
 	'jetpack-boost'
@@ -146,6 +151,15 @@ export const boostFeatureList: FeatureItem[] = [
 				tooltipInfo={ __( 'Fine-tune image quality settings to your liking.', 'jetpack-boost' ) }
 			/>
 		),
+	},
+	{
+		description: {
+			name: __( 'Page Cache', 'jetpack-boost' ),
+			tooltipInfo: pageCacheContext,
+			tooltipPlacement: 'bottom-start',
+		},
+		free: <PricingTableItem isIncluded={ true } />,
+		premium: <PricingTableItem isIncluded={ true } />,
 	},
 	{
 		description: {

--- a/projects/plugins/boost/changelog/update-getting-started
+++ b/projects/plugins/boost/changelog/update-getting-started
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Cache: Added page-cache to the feature list in getting-started page.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35868

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refactor feature list in getting-started page so they are easier to manage
* Add "Page Cache" to the list

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Check the getting-started page and ensure Page Cache is listed.

![image](https://github.com/Automattic/jetpack/assets/3737780/9032eabd-7474-4a60-941d-d5124d2d1a97)
