### PR TITLE
Sharing Block: only inject inline js when needed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-inline-style-when-needed
+++ b/projects/plugins/jetpack/changelog/fix-sharing-inline-style-when-needed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: only enqueue extra JavaScript when a Sharing Block is inserted on the page.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/sharing-buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/sharing-buttons.php
@@ -36,13 +36,8 @@ function render_block( $attr, $content ) {
 	if ( ! jetpack_is_frontend() ) {
 		return '';
 	}
-	return $content;
-}
 
-/**
- * Add the services list to the block
- */
-function add_sharing_buttons_block_data() {
+	// Add the services list to the block.
 	$services = array(
 		'print',
 		'facebook',
@@ -58,11 +53,11 @@ function add_sharing_buttons_block_data() {
 		'x',
 		'nextdoor',
 	);
-
 	wp_add_inline_script(
 		'jetpack-block-sharing-button',
 		'var jetpack_sharing_buttons_services = ' . wp_json_encode( $services, JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
 		'before'
 	);
+
+	return $content;
 }
-add_action( 'enqueue_block_assets', __NAMESPACE__ . '\add_sharing_buttons_block_data' );

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/sharing-buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/sharing-buttons.php
@@ -37,27 +37,5 @@ function render_block( $attr, $content ) {
 		return '';
 	}
 
-	// Add the services list to the block.
-	$services = array(
-		'print',
-		'facebook',
-		'linkedin',
-		'mail',
-		'mastodon',
-		'pinterest',
-		'pocket',
-		'reddit',
-		'telegram',
-		'tumblr',
-		'whatsapp',
-		'x',
-		'nextdoor',
-	);
-	wp_add_inline_script(
-		'jetpack-block-sharing-button',
-		'var jetpack_sharing_buttons_services = ' . wp_json_encode( $services, JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
-		'before'
-	);
-
 	return $content;
 }


### PR DESCRIPTION
## Proposed changes:

The extra JavaScript we need for the Sharing block doesn't have to be hooked on all pages. We can choose to only hook it in when the block is rendered.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a fresh new site.
* Go to Posts > Add New, and insert a sharing block.
* Publish your post, and ensure the sharing buttons are properly displayed on the frontend.
* Open your browser's JavaScript console.
    * `jetpack_sharing_buttons_services` should be an array of available services.
* Go to the home page.
* Open your browser's JavaScript console.
    * `jetpack_sharing_buttons_services` should be undefined.
