### PR TITLE
Backport mu-wpcom-plugin 2.0.25, jetpack 13.2-a.9 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2024-02-26
+### Added
+- Add upgrade message for free tier [#35794]
+
+### Changed
+- Updated package dependencies. [#35793]
+- Voice to Content: Add audio analyser to media recording hook [#35877]
+- Voice to Content: Make transcriptions cancelable and add onProcess callback [#35737]
+
 ## [0.7.0] - 2024-02-19
 ### Added
 - AI Client: add support for audio transcriptions. [#35691]
@@ -220,6 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.8.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.5.1...v0.6.0

--- a/projects/js-packages/ai-client/changelog/add-explicit-export-types
+++ b/projects/js-packages/ai-client/changelog/add-explicit-export-types
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Type updates
-
-

--- a/projects/js-packages/ai-client/changelog/add-tsc-presets
+++ b/projects/js-packages/ai-client/changelog/add-tsc-presets
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use new tsconfig presets. Should be no change to the package itself.
-
-

--- a/projects/js-packages/ai-client/changelog/add-upgrade-block-message
+++ b/projects/js-packages/ai-client/changelog/add-upgrade-block-message
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add upgrade message for free tier

--- a/projects/js-packages/ai-client/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-cancel
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-cancel
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Voice to Content: Make transcriptions cancelable and add onProcess callback

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-oscilloscope
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-oscilloscope
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Voice to Content: Add audio analyser to media recording hook

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.8.0-alpha",
+	"version": "0.8.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.0] - 2024-02-26
+### Added
+- Added toggle to Social admin page for the Social Notes [#35681]
+
+### Changed
+- Added description to social previews for titleless posts [#35728]
+
+### Removed
+- Removed a notice to tell users that instagram is new nad can be connected [#35860]
+
 ## [0.47.1] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -590,6 +600,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.48.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.47.1...v0.48.0
 [0.47.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.47.0...v0.47.1
 [0.47.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.45.2...v0.46.0

--- a/projects/js-packages/publicize-components/changelog/add-social-note-toggle-admin-page
+++ b/projects/js-packages/publicize-components/changelog/add-social-note-toggle-admin-page
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added toggle to Social admin page for the Social Notes

--- a/projects/js-packages/publicize-components/changelog/remove-social-instagram-welcome-notice
+++ b/projects/js-packages/publicize-components/changelog/remove-social-instagram-welcome-notice
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Removed a notice to tell users that instagram is new nad can be connected

--- a/projects/js-packages/publicize-components/changelog/update-social-pass-description-preview
+++ b/projects/js-packages/publicize-components/changelog/update-social-pass-description-preview
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Added description to social previews for titeless posts

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.48.0-alpha",
+	"version": "0.48.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2024-02-26
+### Changed
+- Blaze: Enable the Dashboard behind the feature flag [#35724]
+
+### Fixed
+- added a "use WC_Product" to include this in the post fetching endpoint for blaze [#35870]
+- Changes to use the user's locale to render the dashboard [#35832]
+
 ## [0.17.0] - 2024-02-19
 ### Added
 - Added price in blaze/posts endpoint [#35066]
@@ -293,6 +301,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.18.0]: https://github.com/automattic/jetpack-blaze/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/automattic/jetpack-blaze/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/automattic/jetpack-blaze/compare/v0.15.3...v0.16.0
 [0.15.3]: https://github.com/automattic/jetpack-blaze/compare/v0.15.2...v0.15.3

--- a/projects/packages/blaze/changelog/fix-blaze-dashboard-locale
+++ b/projects/packages/blaze/changelog/fix-blaze-dashboard-locale
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Changes to use the user's locale to render the dashboard

--- a/projects/packages/blaze/changelog/price fix for post in blaze endpoint
+++ b/projects/packages/blaze/changelog/price fix for post in blaze endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-added a "use WC_Product" to include this in the post fetching endpoint for blaze

--- a/projects/packages/blaze/changelog/untangle-unify-blaze-and-advertising
+++ b/projects/packages/blaze/changelog/untangle-unify-blaze-and-advertising
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Blaze: Enable the Dashboard behind the feature flag

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.18.0-alpha",
+	"version": "0.18.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.18.0-alpha';
+	const PACKAGE_VERSION = '0.18.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2024-02-26
+### Removed
+- Remove legacy options that are not needed anymore. [#35873]
+
 ## [2.3.1] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -964,6 +968,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.3.2]: https://github.com/Automattic/jetpack-connection/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/Automattic/jetpack-connection/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/Automattic/jetpack-connection/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/Automattic/jetpack-connection/compare/v2.1.1...v2.2.0

--- a/projects/packages/connection/changelog/update-connection-banner-cleanup
+++ b/projects/packages/connection/changelog/update-connection-banner-cleanup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Remove legacy options that are not needed anymore.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.3.2-alpha';
+	const PACKAGE_VERSION = '2.3.2';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.6] - 2024-02-26
+### Deprecated
+- Deprecate the temporary tmp_grunion_allow_editor_view filter. [#35584]
+
 ## [0.30.5] - 2024-02-13
 ### Changed
 - Updated package dependencies. [#35608]
@@ -490,6 +494,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.6]: https://github.com/automattic/jetpack-forms/compare/v0.30.5...v0.30.6
 [0.30.5]: https://github.com/automattic/jetpack-forms/compare/v0.30.4...v0.30.5
 [0.30.4]: https://github.com/automattic/jetpack-forms/compare/v0.30.3...v0.30.4
 [0.30.3]: https://github.com/automattic/jetpack-forms/compare/v0.30.2...v0.30.3

--- a/projects/packages/forms/changelog/remove-old-filter-contact-form
+++ b/projects/packages/forms/changelog/remove-old-filter-contact-form
@@ -1,4 +1,0 @@
-Significance: patch
-Type: deprecated
-
-Deprecate the temporary tmp_grunion_allow_editor_view filter.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.6-alpha",
+	"version": "0.30.6",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.6-alpha';
+	const PACKAGE_VERSION = '0.30.6';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.14.1] - 2024-02-26
+### Changed
+- Verbum: Ensure colour contrast for disabled button is a11y-friendly. [#35929]
+
+### Fixed
+- Fix comment form login for passwordless users [#35785]
+
 ## [5.14.0] - 2024-02-26
 ### Added
 - Adds a dismissible admin notice to inform users of the hosting menu [#35930]
@@ -604,6 +611,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.14.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.14.0...v5.14.1
 [5.14.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.13.1...v5.14.0
 [5.13.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.13.0...v5.13.1
 [5.13.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.12.2...v5.13.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-comment-login-passwordless
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-comment-login-passwordless
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix comment form login for passwordless users

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-disabled-contrast
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-disabled-contrast
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Verbum: Ensure colour contrast for disabled button is a11y-friendly.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.14.1-alpha",
+	"version": "5.14.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.14.1-alpha';
+	const PACKAGE_VERSION = '5.14.1';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.12.0] - 2024-02-26
+### Changed
+- My Jetpack: decouple Jetpack AI insterstitial component [#35836]
+- Remove translation of product names [#35830]
+- Updating purchases state to use data query instead of redux [#35697]
+
+### Removed
+- Remove kebab menu on My Jetpack cards [#35829]
+
 ## [4.11.0] - 2024-02-22
 ### Added
 - Adding accesible text for external links on connection page and footer [#35733]
@@ -1271,6 +1280,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.12.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.11.0...4.12.0
 [4.11.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.10.0...4.11.0
 [4.10.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.9.2...4.10.0
 [4.9.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.9.1...4.9.2

--- a/projects/packages/my-jetpack/changelog/add-decouple-jetpack-ai-interstitial
+++ b/projects/packages/my-jetpack/changelog/add-decouple-jetpack-ai-interstitial
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: decouple Jetpack AI insterstitial component

--- a/projects/packages/my-jetpack/changelog/remove-my-jetpack-card-menu
+++ b/projects/packages/my-jetpack/changelog/remove-my-jetpack-card-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Remove kebab menu on My Jetpack cards

--- a/projects/packages/my-jetpack/changelog/update-dont-translate-product-names
+++ b/projects/packages/my-jetpack/changelog/update-dont-translate-product-names
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Remove translation of product names

--- a/projects/packages/my-jetpack/changelog/update-purchases-state-management
+++ b/projects/packages/my-jetpack/changelog/update-purchases-state-management
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updating purchases state to use data query instead of redux

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.12.0-alpha",
+	"version": "4.12.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -35,7 +35,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.12.0-alpha';
+	const PACKAGE_VERSION = '4.12.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/post-list/CHANGELOG.md
+++ b/projects/packages/post-list/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-02-26
+### Changed
+- Social Notes: Added the post list enhancements [#35819]
+
 ## [0.5.1] - 2023-11-24
 ### Changed
 - Replaced usage of substr() with str_starts_with() and str_ends_with(). [#34207]
@@ -94,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the default columns displayed on the post and page list screens
 - Refactored thumbnail preview to function server side. All javascript removed.
 
+[0.6.0]: https://github.com/automattic/jetpack-post-list/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/automattic/jetpack-post-list/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/automattic/jetpack-post-list/compare/v0.4.6...v0.5.0
 [0.4.6]: https://github.com/automattic/jetpack-post-list/compare/v0.4.5...v0.4.6

--- a/projects/packages/post-list/changelog/add-social-notes-post-list
+++ b/projects/packages/post-list/changelog/add-social-notes-post-list
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Social Notes: Added the post list enhancements

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Post_List;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.6.0-alpha';
+	const PACKAGE_VERSION = '0.6.0';
 	const FEATURE         = 'enhanced_post_list';
 
 	/**

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.3] - 2024-02-26
+### Fixed
+- Deprecate the sharing_menu method of the Publicize_UI class. [#35810]
+
 ## [0.42.2] - 2024-02-14
 ### Fixed
 - Fixed an issue where on old sites og:image is an array that causes issues [#35688]
@@ -480,6 +484,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.42.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.2...v0.42.3
 [0.42.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.1...v0.42.2
 [0.42.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.0...v0.42.1
 [0.42.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.41.0...v0.42.0

--- a/projects/packages/publicize/changelog/fix-sharing-menu-in-offline-mode
+++ b/projects/packages/publicize/changelog/fix-sharing-menu-in-offline-mode
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Deprecate the sharing_menu method of the Publicize_UI class.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.3-alpha",
+	"version": "0.42.3",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -62,7 +62,7 @@ class Publicize_UI {
 	/**
 	 * If the ShareDaddy plugin is not active we need to add the sharing settings page to the menu still
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 0.42.3
 	 */
 	public function sharing_menu() {
 		add_submenu_page(
@@ -78,7 +78,7 @@ class Publicize_UI {
 	/**
 	 * Add admin page with wrapper.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 0.42.3
 	 */
 	public function wrapper_admin_page() {
 		if ( class_exists( 'Jetpack_Admin_Page' ) ) {
@@ -89,7 +89,7 @@ class Publicize_UI {
 	/**
 	 * Management page to load if Sharedaddy is not active so the 'pre_admin_screen_sharing' action exists.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 0.42.3
 	 */
 	public function management_page() {
 		?>
@@ -109,7 +109,7 @@ class Publicize_UI {
 	 * Styling for the sharing screen and popups
 	 * JS for the options and switching
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 0.42.3
 	 */
 	public function load_assets() {
 		if ( class_exists( 'Jetpack_Admin_Page' ) ) {
@@ -121,7 +121,7 @@ class Publicize_UI {
 	 * Lists the current user's publicized accounts for the blog
 	 * looks exactly like Publicize v1 for now, UI and functionality updates will come after the move to keyring
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 0.42.3
 	 */
 	public function admin_page() {
 		?>

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2024-02-26
+### Added
+- Show schedule information for scheduled plugin updates in wp-admin [#35917]
+
+### Changed
+- Fix up cron callback and schedule generation to make schedule execution work [#35885]
+
 ## 0.1.0 - 2024-02-26
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
+
+[0.2.0]: https://github.com/Automattic/scheduled-updates/compare/v0.1.0...v0.2.0

--- a/projects/packages/scheduled-updates/changelog/add-wp-admin-info
+++ b/projects/packages/scheduled-updates/changelog/add-wp-admin-info
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Show schedule information for scheduled plugin updates in wp-admin

--- a/projects/packages/scheduled-updates/changelog/fix-schedule-args
+++ b/projects/packages/scheduled-updates/changelog/fix-schedule-args
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Fix up cron callback and schedule generation to make schedule execution work

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.2.0-alpha';
+	const PACKAGE_VERSION = '0.2.0';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.1 - 2024-02-26
+### Changed
+- Update dependencies.
+
 ## 0.16.0 - 2024-02-19
 ### Added
 - Stats: added support for Email stats [#35703]

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.16.0",
+	"version": "0.16.1",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.16.0';
+	const VERSION = '0.16.1';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2024-02-26
+### Added
+- Add new method to convert stats data for external consumption. [#35865]
+
 ## [0.10.1] - 2024-02-19
 ### Fixed
 - Avoid Fatal errors when saved stats data is a WP_Error object [#35746]
@@ -133,6 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.11.0]: https://github.com/Automattic/jetpack-stats/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/Automattic/jetpack-stats/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Automattic/jetpack-stats/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Automattic/jetpack-stats/compare/v0.8.0...v0.9.0

--- a/projects/packages/stats/changelog/update-blog-stats-wpcom
+++ b/projects/packages/stats/changelog/update-blog-stats-wpcom
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add new method to convert stats data for external consumption.

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -496,7 +496,7 @@ class WPCOM_Stats {
 	/**
 	 * Convert stats array to object after sanity checking the array is valid.
 	 *
-	 * @since $$next-version$$
+	 * @since 0.11.0
 	 *
 	 * @param  array $stats_array The stats array.
 	 * @return WP_Error|Object|null

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.2-a.9 - 2024-02-26
+### Enhancements
+- Ads Settings: Include option to toggle GDPR Consent Banner [#35205]
+- Blaze: Enable the Dashboard behind the feature flag [#35724]
+- Blog Stats Block: Remove check that prevented testing on WP.com sites. [#35751]
+- Improve SSO send invite hover copy [#35879]
+- Privacy: Add preliminary support for WordAds Consent Management Provider [#35165]
+- Sharing: automatically add the Sharing Buttons block to the single post and page templates on sites using a block-based theme. [#35542]
+- WordAds: Add additional states to US Privacy law opt-out [#35765]
+
+### Improved compatibility
+- General: the plugin is now compatible with the upcoming WordPress release, version 6.5. [#35820]
+
+### Bug fixes
+- Carousel: don't open if no images are found in the gallery. [#35788]
+- Subscribe block: improve disabled placeholder state theme colour compatibility [#35813]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add a button to allow admins to re-send invites [#35833]
+- Add checkbox for opting out of inviting users to WordPress [#35902]
+- Add link to newsletter settings, still under feature flag. [#35825]
+- Add save button to newsletter settings. Still under feature flag. [#35861]
+- Add upgrade message for free tier [#35794]
+- Changed SSO heading tooltip [#35948]
+- Changes newsletter paid subscriber label to nowrap [#35690]
+- Connection flow: remove deprecated files, functions, and images that are not needed anymore now that we do not display connection banners outside of the Jetpack connection screen. [#35873]
+- Connection Screen: make VoiceOver announce lists as such [#35736]
+- Contact Form: deprecate temporary tmp_grunion_allow_editor_view filter. [#35584]
+- ESlint: disable redundant role rule [#35800]
+- Extracted Subscription Welcome Email into its own component [#35774]
+- Fix a bug in showing custom columns in the users table [#35882]
+- Fix spelling error on validation message. [#35909]
+- Google Fonts: Update the implement of print_font_faces as the value of WP_Font_Face_Resolver::get_fonts_from_theme_json may be an indexed array [#35890]
+- Improve SSO invite user error handling [#35850]
+- Interaction on newsletter categories. Work in progress under feature flag. [#35799]
+- Remove Settings > Sharing menu item registered by Publicize, and Likes. [#35810]
+- Remove unstable post editor check in AI Excerpt [#35875]
+- RNMobile: Enable support for editing v5 of the VideoPress block in the Jetpack app. [#35637]
+- Security Monitor: remove link to notifications and add link to wordpress account [#35769]
+- Sharing Block: only hook block on WordPress 6.5+ [#35905]
+- Social: Changed name of the social settings card [#35812]
+- SSO user invitation checkbox css change [#35907]
+- Stats: switch our stats fetching methods to use data conversion method from package. [#35865]
+- Subscriptions: Prevents the HTTP 301 redirection in Paywall block [#35852]
+- Top Posts Block: make available on WordPress.com Simple. [#35866]
+- TreeSelector: Added tree selector component. [#35749]
+- Update SSO users table pending invite icon styling [#35878]
+- Voice to Content: Add hook to handle transcription insertion into the editor. [#35761]
+- Voice to Content: avoid replacing blocks when inserting transcription into editor. [#35790]
+- Voice to Content: Make transcriptions cancelable and link upload button to processing state [#35737]
+- Voice to Content: refactor ActionButtons component to not handle logic on it, relying just on state and events [#35914]
+- Voice to Content: Update oscilloscope component [#35877]
+- WordAds: ensure the new CMP banner can be loaded in production environments. [#35791]
+- Wordpress.com Tools Menu: Update Github Deployments submenu copy [#35759]
+
+## 13.1.3 - 2024-02-20
+### Bug fixes
+- Backup: write helper script to ABSPATH by default to avoid backup failures. [#35508]
+
 ## 13.2-a.7 - 2024-02-19
 ### Enhancements
 - Added custom message textarea to send a message via email when adding new users [#35277]

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -51,7 +51,7 @@ abstract class Jetpack_Admin_Page {
 	 *
 	 * @var bool
 	 *
-	 * @deprecated $$next-version$$ Use `$this->block_page_rendering_for_idc()` instead.
+	 * @deprecated 13.2 Use `$this->block_page_rendering_for_idc()` instead.
 	 */
 	public static $block_page_rendering_for_idc;
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -67,12 +67,12 @@ class Jetpack_Recommendations {
 	 *
 	 * @since 9.3.0
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.2
 	 *
 	 * @return bool
 	 */
 	public static function is_banner_enabled() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'jetpack-13.2' );
 		return false;
 	}
 

--- a/projects/plugins/jetpack/changelog/Add resend invite to user table
+++ b/projects/plugins/jetpack/changelog/Add resend invite to user table
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add a button to allow admins to re-send invites

--- a/projects/plugins/jetpack/changelog/add-cmp-ad-settings
+++ b/projects/plugins/jetpack/changelog/add-cmp-ad-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Ads Settings: Include option to toggle GDPR Consent Banner

--- a/projects/plugins/jetpack/changelog/add-cmp-ad-settings#2
+++ b/projects/plugins/jetpack/changelog/add-cmp-ad-settings#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-hook-sharing-block
+++ b/projects/plugins/jetpack/changelog/add-hook-sharing-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Sharing: automatically add the Sharing Buttons block to the single post and page templates on sites using a block-based theme.

--- a/projects/plugins/jetpack/changelog/add-social-notes-post-list
+++ b/projects/plugins/jetpack/changelog/add-social-notes-post-list
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-tree-dropdown-component
+++ b/projects/plugins/jetpack/changelog/add-tree-dropdown-component
@@ -1,5 +1,0 @@
-Significance: patch
-Type: enhancement
-Comment: Component creation, still under feature flag
-
-

--- a/projects/plugins/jetpack/changelog/add-tree-selector-component
+++ b/projects/plugins/jetpack/changelog/add-tree-selector-component
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-TreeSelector: Added tree selector component.

--- a/projects/plugins/jetpack/changelog/add-upgrade-block-message
+++ b/projects/plugins/jetpack/changelog/add-upgrade-block-message
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add upgrade message for free tier

--- a/projects/plugins/jetpack/changelog/fix-ai-excerpt-simple
+++ b/projects/plugins/jetpack/changelog/fix-ai-excerpt-simple
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Remove unstable post editor check in AI Excerpt

--- a/projects/plugins/jetpack/changelog/fix-carousel-no-images
+++ b/projects/plugins/jetpack/changelog/fix-carousel-no-images
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Carousel: don't open if no images are found in the gallery.

--- a/projects/plugins/jetpack/changelog/fix-comment-password-protected
+++ b/projects/plugins/jetpack/changelog/fix-comment-password-protected
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Bugfix for comment posting on password protect posts
-
-

--- a/projects/plugins/jetpack/changelog/fix-connect-screen-list-for-voice-over
+++ b/projects/plugins/jetpack/changelog/fix-connect-screen-list-for-voice-over
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Connection Screen: make VoiceOver announce lists as such 

--- a/projects/plugins/jetpack/changelog/fix-github-deployments-copy
+++ b/projects/plugins/jetpack/changelog/fix-github-deployments-copy
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Wordpress.com Tools Menu: Update Github Deployments submenu copy

--- a/projects/plugins/jetpack/changelog/fix-http-301-redirection-patwall-block
+++ b/projects/plugins/jetpack/changelog/fix-http-301-redirection-patwall-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Prevents the HTTP 301 redirection in Paywall block

--- a/projects/plugins/jetpack/changelog/fix-idc-safe-mode-leaving
+++ b/projects/plugins/jetpack/changelog/fix-idc-safe-mode-leaving
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Identity Crisis: Show the IDC screen immediately after leaving Safe Mode.
-
-

--- a/projects/plugins/jetpack/changelog/fix-jp-newsletter-access-button-css
+++ b/projects/plugins/jetpack/changelog/fix-jp-newsletter-access-button-css
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Changes newsletter paid subscriber label to nowrap

--- a/projects/plugins/jetpack/changelog/fix-missing-text-on-message-settings
+++ b/projects/plugins/jetpack/changelog/fix-missing-text-on-message-settings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add missing text on Message settings
-
-

--- a/projects/plugins/jetpack/changelog/fix-monitoring-notification-settings-link
+++ b/projects/plugins/jetpack/changelog/fix-monitoring-notification-settings-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Security Monitor: remove link to notifications and add link to wordpress account

--- a/projects/plugins/jetpack/changelog/fix-newsletter-categories-card-position
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-categories-card-position
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Component updates, still under feature flag
-
-

--- a/projects/plugins/jetpack/changelog/fix-sharing-block-hooks-65
+++ b/projects/plugins/jetpack/changelog/fix-sharing-block-hooks-65
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Sharing Block: only hook block on WordPress 6.5+

--- a/projects/plugins/jetpack/changelog/fix-wordads-cmp-post-35165
+++ b/projects/plugins/jetpack/changelog/fix-wordads-cmp-post-35165
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WordAds: ensure the new CMP banner can be loaded in production environments.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.2-a.10
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.2-a.8
-
-

--- a/projects/plugins/jetpack/changelog/lighten-heading-tooltip
+++ b/projects/plugins/jetpack/changelog/lighten-heading-tooltip
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Changed SSO heading tooltip

--- a/projects/plugins/jetpack/changelog/remove-my-jetpack-card-menu
+++ b/projects/plugins/jetpack/changelog/remove-my-jetpack-card-menu
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/remove-old-filter-contact-form
+++ b/projects/plugins/jetpack/changelog/remove-old-filter-contact-form
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Contact Form: deprecate temporary tmp_grunion_allow_editor_view filter.

--- a/projects/plugins/jetpack/changelog/remove-sharedaddy-action-subscription-menu
+++ b/projects/plugins/jetpack/changelog/remove-sharedaddy-action-subscription-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Remove Settings > Sharing menu item registered by Publicize, and Likes.

--- a/projects/plugins/jetpack/changelog/rnmobile-support-for-videopress-v5
+++ b/projects/plugins/jetpack/changelog/rnmobile-support-for-videopress-v5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-RNMobile: Enable support for editing v5 of the VideoPress block in the Jetpack app.

--- a/projects/plugins/jetpack/changelog/sso-add-invite-checkbox
+++ b/projects/plugins/jetpack/changelog/sso-add-invite-checkbox
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add checkbox for opting out of inviting users to WordPress

--- a/projects/plugins/jetpack/changelog/sso-invite-user-error-handling
+++ b/projects/plugins/jetpack/changelog/sso-invite-user-error-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Improve SSO invite user error handling

--- a/projects/plugins/jetpack/changelog/untangle-unify-blaze-and-advertising
+++ b/projects/plugins/jetpack/changelog/untangle-unify-blaze-and-advertising
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Blaze: Enable the Dashboard behind the feature flag

--- a/projects/plugins/jetpack/changelog/update-blog-stats-wpcom
+++ b/projects/plugins/jetpack/changelog/update-blog-stats-wpcom
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Blog Stats Block: Remove check that prevented testing on WP.com sites.

--- a/projects/plugins/jetpack/changelog/update-blog-stats-wpcom#2
+++ b/projects/plugins/jetpack/changelog/update-blog-stats-wpcom#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Stats: switch our stats fetching methods to use data conversion method from package.

--- a/projects/plugins/jetpack/changelog/update-blog-stats-wpcom#3
+++ b/projects/plugins/jetpack/changelog/update-blog-stats-wpcom#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-ccpa-states
+++ b/projects/plugins/jetpack/changelog/update-ccpa-states
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-WordAds: Add additional states to US Privacy law opt-out

--- a/projects/plugins/jetpack/changelog/update-connection-banner-cleanup
+++ b/projects/plugins/jetpack/changelog/update-connection-banner-cleanup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Connection flow: remove deprecated files, functions, and images that are not needed anymore now that we do not display connection banners outside of the Jetpack connection screen.

--- a/projects/plugins/jetpack/changelog/update-email-welcome-message-into-component
+++ b/projects/plugins/jetpack/changelog/update-email-welcome-message-into-component
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Extracted Subscription Welcome Email into its own component

--- a/projects/plugins/jetpack/changelog/update-eslint-disable-redundant-role
+++ b/projects/plugins/jetpack/changelog/update-eslint-disable-redundant-role
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-ESlint: disable redundant role rule

--- a/projects/plugins/jetpack/changelog/update-google-fonts-print-font-faces
+++ b/projects/plugins/jetpack/changelog/update-google-fonts-print-font-faces
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Google Fonts: Update the implement of print_font_faces as the value of WP_Font_Face_Resolver::get_fonts_from_theme_json may be an indexed array

--- a/projects/plugins/jetpack/changelog/update-integrate-categories-tree
+++ b/projects/plugins/jetpack/changelog/update-integrate-categories-tree
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Interaction on newsletter categories. Work in progress under feature flag.

--- a/projects/plugins/jetpack/changelog/update-is-bot-list
+++ b/projects/plugins/jetpack/changelog/update-is-bot-list
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-jetpack-settings-social-settings-name
+++ b/projects/plugins/jetpack/changelog/update-jetpack-settings-social-settings-name
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Social: Changed name of the social settings card

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-interstitial-click-events
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-interstitial-click-events
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-newsletter-categories-enabled-toggle
+++ b/projects/plugins/jetpack/changelog/update-newsletter-categories-enabled-toggle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: In progress, enables categories newsletter settings (under enable-newsletter-categories feature flag )
-
-

--- a/projects/plugins/jetpack/changelog/update-newsletter-categories-link
+++ b/projects/plugins/jetpack/changelog/update-newsletter-categories-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add link to newsletter settings, still under feature flag.

--- a/projects/plugins/jetpack/changelog/update-newsletter-settings-save-button
+++ b/projects/plugins/jetpack/changelog/update-newsletter-settings-save-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add save button to newsletter settings. Still under feature flag.

--- a/projects/plugins/jetpack/changelog/update-purchases-state-management
+++ b/projects/plugins/jetpack/changelog/update-purchases-state-management
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-sso-admin-send-invite-tooltip-copy
+++ b/projects/plugins/jetpack/changelog/update-sso-admin-send-invite-tooltip-copy
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Improve SSO send invite hover copy

--- a/projects/plugins/jetpack/changelog/update-sso-admin-users-send-invite-icon
+++ b/projects/plugins/jetpack/changelog/update-sso-admin-users-send-invite-icon
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Update SSO users table pending invite icon styling

--- a/projects/plugins/jetpack/changelog/update-sso-custom-column
+++ b/projects/plugins/jetpack/changelog/update-sso-custom-column
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix a bug in showing custom columns in the users table

--- a/projects/plugins/jetpack/changelog/update-sso-invitation-checkbox-styling
+++ b/projects/plugins/jetpack/changelog/update-sso-invitation-checkbox-styling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-SSO user invitation checkbox css change

--- a/projects/plugins/jetpack/changelog/update-subscribe-block-disabled-state
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-disabled-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscribe block: improve disabled placeholder state theme colour compatibility

--- a/projects/plugins/jetpack/changelog/update-tested-up-to-65
+++ b/projects/plugins/jetpack/changelog/update-tested-up-to-65
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-General: the plugin is now compatible with the upcoming WordPress release, version 6.5.

--- a/projects/plugins/jetpack/changelog/update-top-posts-availability-wpcom
+++ b/projects/plugins/jetpack/changelog/update-top-posts-availability-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Top Posts Block: make available on WordPress.com Simple.

--- a/projects/plugins/jetpack/changelog/update-tree-dropdown-component
+++ b/projects/plugins/jetpack/changelog/update-tree-dropdown-component
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Component changes, still under feature flag
-
-

--- a/projects/plugins/jetpack/changelog/update-validation-message
+++ b/projects/plugins/jetpack/changelog/update-validation-message
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix spelling error on validation message.

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-action-buttons-refactor
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-action-buttons-refactor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Voice to Content: refactor ActionButtons component to not handle logic on it, relying just on state and events

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-cancel
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-cancel
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Voice to Content: Make transcriptions cancelable and link upload button to processing state

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-handle-editor-content-insertion
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-handle-editor-content-insertion
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Voice to Content: Add hook to handle transcription insertion into the editor.

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-oscilloscope
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-oscilloscope
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Voice to Content: Update oscilloscope component

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-reduce-block-flickering
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-reduce-block-flickering
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Voice to Content: avoid replacing blocks when inserting transcription into editor.

--- a/projects/plugins/jetpack/changelog/wordads-cmp-support
+++ b/projects/plugins/jetpack/changelog/wordads-cmp-support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Privacy: Add preliminary support for WordAds Consent Management Provider

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_9",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_10",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -101,7 +101,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_8",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_2_a_9",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
@@ -78,7 +78,7 @@ function load_assets( $attr, $content ) {
 		/**
 		 * Filters the display of the Cookie-consent Block e.g by GDPR CMP banner on WordAds sites.
 		 *
-		 * @since $$next-version$$
+		 * @since 13.2
 		 *
 		 * @param bool $disable_cookie_consent_block Whether to disable the Cookie-consent Block.
 		 */

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -177,7 +177,7 @@ add_action( 'template_redirect', __NAMESPACE__ . '\sharing_process_requests', 9 
 /**
  * Automatically add the Sharing Buttons block to the end of the Single Posts template.
  *
- * @since $$next-version$$
+ * @since 13.2
  *
  * @param array                   $hooked_block_types The list of hooked block types.
  * @param string                  $relative_position  The relative position of the hooked blocks. Can be one of 'before', 'after', 'first_child', or 'last_child'.
@@ -251,7 +251,7 @@ function add_block_to_single_posts_template( $hooked_block_types, $relative_posi
 /**
  * Add default services to the block we add to the post content by default.
  *
- * @since $$next-version$$
+ * @since 13.2
  *
  * @param array                   $parsed_hooked_block The parsed block array for the given hooked block type.
  * @param string                  $hooked_block_type   The hooked block type name.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.2-a.8
+ * Version: 13.2-a.9
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.2-a.8' );
+define( 'JETPACK__VERSION', '13.2-a.9' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.2-a.9
+ * Version: 13.2-a.10
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.2-a.9' );
+define( 'JETPACK__VERSION', '13.2-a.10' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -209,7 +209,7 @@ class Jetpack_Likes_Settings {
 	 * Adds the 'sharing' menu to the settings menu.
 	 * Only ran if sharedaddy and publicize are not already active.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.2
 	 */
 	public function sharing_menu() {
 		add_submenu_page( 'options-general.php', esc_html__( 'Sharing Settings', 'jetpack' ), esc_html__( 'Sharing', 'jetpack' ), 'manage_options', 'sharing', array( $this, 'sharing_page' ) );
@@ -220,7 +220,7 @@ class Jetpack_Likes_Settings {
 	 * so we can display the setting.
 	 * Only ran if sharedaddy and publicize are not already active.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.2
 	 */
 	public function sharing_page() {
 		$this->updated_message();
@@ -240,7 +240,7 @@ class Jetpack_Likes_Settings {
 	/**
 	 * Returns the settings have been saved message.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.2
 	 */
 	public function updated_message() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- ignoring since we are just displaying that the settings have been saved and not making  any other changes to the site.
@@ -252,7 +252,7 @@ class Jetpack_Likes_Settings {
 	/**
 	 * Returns just the "sharing buttons" w/ like option block, so it can be inserted into different sharing page contexts
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.2
 	 */
 	public function sharing_block() {
 		?>

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1742,7 +1742,7 @@ function filter_stats_array_add_jp_version( $kvs ) {
  * @return WP_Error|Object|null
  */
 function convert_stats_array_to_object( $stats_array ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Stats\WPCOM_Stats->convert_stats_array_to_object' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.2', 'Automattic\Jetpack\Stats\WPCOM_Stats->convert_stats_array_to_object' );
 
 	return ( new WPCOM_Stats() )->convert_stats_array_to_object( $stats_array );
 }

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.2.0-a.9",
+	"version": "13.2.0-a.10",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.2.0-a.8",
+	"version": "13.2.0-a.9",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack - WP Security, Backup, Speed, & Growth ===
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, barry, batmoo, beaulebens, bindlegirl, biskobe, bjorsch, blobaugh, brbrr, cainm, cena, cfinke, cgastrell, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, daniloercoli, davoraltman, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, joen, jblz, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lhkowalski, lschuyler, macmanx, martinremy, matt, mattwiebe, matveb, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, nunyvega, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, renatoagds, retrofox, richardmtl, richardmuscat, robertbpugh, roccotripaldi, ryancowles, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, thehenridev, tmoorewp, tyxla, Viper007Bond, westi, williamvianas, wpkaren, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, performance
-Stable tag: 13.1.2
+Stable tag: 13.1.3
 Requires at least: 6.3
 Requires PHP: 7.0
 Tested up to: 6.5
@@ -326,26 +326,22 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.2-a.7 - 2024-02-19
+### 13.2-a.9 - 2024-02-26
 #### Enhancements
-- Added custom message textarea to send a message via email when adding new users
-- Add images while publishing on the web via the jetpack app
-- Add some extra margin around Stats settings toggles
-- Add support for Email stats
-- Comment: Add Goodreads embed block in Gutenberg.
-- SSO: Add user invite revoke row action in users table
-- SSO: improve messaging and account binding between local and wp.com users
-- SSO: Updated column heading and row background color when invitation is pending.
-- SSO: When creating a new users, mail the users with an invitation to WPCom.
-- We added the Welcome Email Message setting to Newsletter settings
+- Ads Settings: Include option to toggle GDPR Consent Banner
+- Blaze: Enable the Dashboard behind the feature flag
+- Blog Stats Block: Remove check that prevented testing on WP.com sites.
+- Improve SSO send invite hover copy
+- Privacy: Add preliminary support for WordAds Consent Management Provider
+- Sharing: automatically add the Sharing Buttons block to the single post and page templates on sites using a block-based theme.
+- WordAds: Add additional states to US Privacy law opt-out
 
 #### Improved compatibility
-- Add 'if_not_modified_since' to the update post endpoints this will help clients fails if the post has been updated since last retrieved
-- Add support for WP Super Cache and Boost Cache
+- General: the plugin is now compatible with the upcoming WordPress release, version 6.5.
 
 #### Bug fixes
-- Jetpack Google Fonts: Fix some Google fonts aren't displayed correctly on front end
-- Scan: ensure the Admin notice resources are always properly loaded.
+- Carousel: don't open if no images are found in the gallery.
+- Subscribe block: improve disabled placeholder state theme colour compatibility
 
 --------
 

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -5,12 +5,61 @@
 - **At any point during your testing, remember to [check your browser's JavaScript console](https://wordpress.org/support/article/using-your-browser-to-diagnose-javascript-errors/#step-3-diagnosis) and see if there are any errors reported by Jetpack there.**
 - Use the "Debug Bar" or "Query Monitor" WordPress plugins to help make PHP notices and warnings more noticeable and report anything of note you see.
 - You may need to connect Jetpack to a WordPress.com account to test some features, find out how to do that [here](https://jetpack.com/support/getting-started-with-jetpack/).
+- Blocks in beta status require a small change for you to be able to test them. You can do either of the following:
+  - Edit your `wp-config.php` file to include: `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`
+  - Or add the following to something like a code snippet plugin: `add_filter( 'jetpack_blocks_variation', function () { return 'beta'; } );`
 
-### Todo Section Header
+### Stats Blocks
 
-Todo section intro:
+The `Top Posts & Pages` block and the `Blog Stats` block have been added which were previously available as legacy widgets
 
-- Todo testing steps
+Please remember that views are only counted when the Stats module is active and when you're logged out. They are also cached for five minutes.
+
+#### Top Posts and Pages Block
+
+While testing the block, consider the following:
+
+- Enable beta blocks as mentioned at the top of this file, then you can insert the block using the editor.
+- The block should prompt you to activate the Stats module if it's currently disabled.
+- There should be two layouts available from the Block Toolbar: the Grid layout and List layout.
+- The block settings should feel intuitive, and they should all function appropriately:
+  - Number of items: the number of posts displayed in the block.
+  - Stats period: the timeframe for which to check top posts. For example, "7 days" should return the posts with the most views across the last week.
+    - If you do not have enough content that has accumulated views in that timeframe, the block should draw on random posts.
+    - It should not include password-protected or private content.
+  - Items to display: filters out different content types (eg. posts or pages) depending on what you'd like the block to include.
+  - Metadata settings: control what the block shows, such as the date or post author.
+  - Style settings: the block should allow you to choose colours, margin, padding and fonts if your theme has opted in to that feature.
+- Confirm that all these settings work as expected, and that the block displays correctly on the front-end.
+
+#### Blog Stats Block
+
+While testing the block, consider the following:
+
+- Enable beta blocks as mentioned at the top of this file, then you can insert the block using the editor.
+- There are two options to available: Views and Visitors.
+  - These should match the statistics shown in your Dashboard.
+- Unlike the legacy widget, you can now also show stats data for individual posts.
+  - In order to test this, it's recommended that you insert the block into a template within the Site Editor.
+  - Visitor data is not collected for individual posts. As such, you shouldn't be able to select "Visitors" and "This individual post" when adding the block.
+- Confirm that the block correctly loads on the front-end and contains appropriate statistics.
+
+### Jetpack SSO Improvements
+
+There have been various improvements made to the Secure Sign On (SSO) feature. Since there was a considerable amount of refactoring, it's suggested to test the SSO feature overall. When testing, consider:
+
+- Inviting a new user to your site whose email matches an existing WordPress.com account.
+- Inviting a new user to your site whose email address has not been used yet to create a WordPress.com account.
+- If possible, try managing users from both the WP Admin (example.com wp-admin/users.php) view, and the "Calypso" view (wordpress.com/people/team/example.com).
+
+### Goodreads Block
+
+The existing legacy widget for Goodreads is now available as a beta block.
+
+- Enable beta blocks as mentioned at the top of this file, then you can insert the block using the editor.
+- If you don't have a Goodreads account, you can use the following profile to test:
+  - https://www.goodreads.com/author/show/1406384
+- Try the various block settings and verify the results on the front-end of your site.
 
 ### And More!
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.25 - 2024-02-26
+### Changed
+- Internal updates.
+
 ## 2.0.24 - 2024-02-26
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_25_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_25"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.25-alpha
+ * Version: 2.0.25
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.25-alpha",
+	"version": "2.0.25",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Backports changes for mu-wpcom-plugin 2.0.25, jetpack 13.2-a.9
* Backport Jetpack 13.1.3 stable tag and changelog entry
* Updates Jetpack testing instructions for version 13.2, closes #35445

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.