### PR TITLE
RNMobile: Detect and avoid invalid media URLs in VideoPress v5 block

### DIFF
--- a/projects/plugins/jetpack/changelog/rnmobile-detect-invalid-urls
+++ b/projects/plugins/jetpack/changelog/rnmobile-detect-invalid-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+RNMobile: Detect and avoid invalid media URLs in VideoPress v5 block

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.native.js
@@ -206,7 +206,7 @@ class VideoPressEdit extends Component {
 	onSelectURL( url ) {
 		const { createErrorNotice, setAttributes, onReplace } = this.props;
 
-		if ( isURL( url ) ) {
+		if ( isURL( url ) && /^https?:/.test( getProtocol( url ) ) ) {
 			// Check if there's an embed block that handles this URL.
 			const embedBlock = createVideoPressEmbedBlock( {
 				attributes: { url },


### PR DESCRIPTION
At the moment, adding invalid URLs, such as `h://a-path.com`, to the VideoPress v5 block fails silently on mobile. A similar issue has been known to cause the crash in https://github.com/wordpress-mobile/gutenberg-mobile/issues/6233 in similar blocks in the past. Although I could not reproduce the crash, this PR mitigate the risk and also ensures a helpful error message is displayed if a user enters an invalid URL.

## Proposed changes:

* The approach used in https://github.com/WordPress/gutenberg/pull/54834 to fix the issue for Video and Audio blocks has been followed in this PR. That is, logic has been added to ensure URLs like `h://a-path.com` are correctly flagged as invalid.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

* Within the app, select a site that defaults to using VideoPress v5, i.e. a Simple dotcom site, an Atomic site with VideoPress enabled, or a Jetpack-connected site. 
* Navigate to the site's post editor and add a Video block.
* Select "Insert from URL."
* Type an invalid URL, e.g. h://wordpress.org/video.mp4.
* Dismiss the bottom sheet.
* Verify the app does not crash and a helpful message is displayed.
