### PR TITLE
Scheduled Updates: Align responses for 404s

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-schedule-not-found
+++ b/projects/packages/scheduled-updates/changelog/fix-schedule-not-found
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: changed
 
 Aligned handling of schedules that can't be found to return the same error messages.

--- a/projects/packages/scheduled-updates/changelog/fix-schedule-not-found
+++ b/projects/packages/scheduled-updates/changelog/fix-schedule-not-found
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Aligned handling of schedules that can't be found to return the same error messages.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -198,7 +198,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * Returns information about an update schedule.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error The scheduled event or a WP_Error if the schedule could not be found.
 	 */
 	public function get_item( $request ) {
 		$schedules = get_option( 'jetpack_update_schedules', array() );
@@ -209,6 +209,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				$event = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args );
 				break;
 			}
+		}
+
+		if ( empty( $event ) ) {
+			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
 		}
 
 		return rest_ensure_response( $event );
@@ -255,17 +259,14 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * Updates an existing update schedule.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response|WP_Error
+	 * @return WP_REST_Response|WP_Error The updated event or a WP_Error if the schedule could not be found.
 	 */
 	public function update_item( $request ) {
 		$schedules = get_option( 'jetpack_update_schedules', array() );
-		$found     = array();
+		$event     = array();
 
 		foreach ( $schedules as $key => $schedule_args ) {
 			if ( $this->generate_schedule_id( $schedule_args ) === $request['schedule_id'] ) {
-				// We found the schedule to update.
-				$found = true;
-
 				$event  = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args );
 				$result = wp_unschedule_event( $event->timestamp, 'jetpack_scheduled_update', $schedule_args, true );
 				if ( is_wp_error( $result ) ) {
@@ -280,8 +281,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			}
 		}
 
-		if ( ! $found ) {
-			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 400 ) );
+		if ( empty( $event ) ) {
+			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
 		}
 
 		return $this->create_item( $request );

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -306,13 +306,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 */
 	public function delete_item( $request ) {
 		$schedules = get_option( 'jetpack_update_schedules', array() );
-		$found     = array();
+		$event     = array();
 
 		foreach ( $schedules as $key => $schedule_args ) {
 			if ( $this->generate_schedule_id( $schedule_args ) === $request['schedule_id'] ) {
-				// We found the schedule to delete.
-				$found = true;
-
 				$event  = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args );
 				$result = wp_unschedule_event( $event->timestamp, 'jetpack_scheduled_update', $schedule_args, true );
 				if ( is_wp_error( $result ) ) {
@@ -325,8 +322,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			}
 		}
 
-		if ( ! $found ) {
-			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 400 ) );
+		if ( empty( $event ) ) {
+			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
 		}
 
 		update_option( 'jetpack_update_schedules', $schedules );

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -436,6 +436,21 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
+	 * Test delete_item with invalid schedule ID.
+	 *
+	 * @covers ::delete_item
+	 */
+	public function test_delete_invalid_item() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'DELETE', '/wpcom/v2/update-schedules/' . $this->generate_schedule_id( array() ) );
+		$result  = rest_do_request( $request );
+
+		$this->assertSame( 404, $result->get_status() );
+		$this->assertSame( 'rest_invalid_schedule', $result->get_data()['code'] );
+	}
+
+	/**
 	 * Generates a unique schedule ID.
 	 *
 	 * @see wp_schedule_event()

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -310,6 +310,21 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
+	 * Test get_item with invalid schedule ID.
+	 *
+	 * @covers ::get_item
+	 */
+	public function test_get_invalid_item() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules/' . $this->generate_schedule_id( array() ) );
+		$result  = rest_do_request( $request );
+
+		$this->assertSame( 404, $result->get_status() );
+		$this->assertSame( 'rest_invalid_schedule', $result->get_data()['code'] );
+	}
+
+	/**
 	 * Test update item.
 	 *
 	 * @covers ::update_item
@@ -353,6 +368,30 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( $schedule_id, $result->get_data() );
+	}
+
+	/**
+	 * Test update_item with invalid schedule ID.
+	 *
+	 * @covers ::update_item
+	 */
+	public function test_update_invalid_item() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $this->generate_schedule_id( array() ) );
+		$request->set_body_params(
+			array(
+				'plugins'  => array(),
+				'schedule' => array(
+					'timestamp' => strtotime( 'next Tuesday 9:00' ),
+					'interval'  => 'daily',
+				),
+			)
+		);
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 404, $result->get_status() );
+		$this->assertSame( 'rest_invalid_schedule', $result->get_data()['code'] );
 	}
 
 	/**


### PR DESCRIPTION
Makes sure we handle schedules that can't be found in the same way. Adds unit tests as well.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds 404 response when attempting to get a schedule that can't be found.
* Aligns `update_item` handling of schedules that can't be found with `get_item`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unit tests should cover it. No functional changes.

