### PR TITLE
Scheduled Updates: Minor cleanup

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-cleanup
+++ b/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-cleanup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: No functional changes
+
+

--- a/projects/packages/scheduled-updates/phpunit.xml.dist
+++ b/projects/packages/scheduled-updates/phpunit.xml.dist
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <phpunit
 	bootstrap="tests/php/bootstrap.php"
 	backupGlobals="false"
@@ -8,11 +9,4 @@
 			<directory suffix="-test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="false">
-			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
-			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
-			<directory suffix=".php">src</directory>
-		</whitelist>
-	</filter>
 </phpunit>

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -27,10 +27,9 @@ class Scheduled_Updates {
 			return;
 		}
 
-		static::load_rest_api_endpoints();
-
-		add_action( 'jetpack_scheduled_update', array( __CLASS__, 'jetpack_run_scheduled_update' ) );
-		add_filter( 'auto_update_plugin', array( __CLASS__, 'jetpack_allowlist_scheduled_plugins' ), 10, 2 );
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_rest_api_endpoints' ), 20 );
+		add_action( 'jetpack_scheduled_update', array( __CLASS__, 'run_scheduled_update' ) );
+		add_filter( 'auto_update_plugin', array( __CLASS__, 'allowlist_scheduled_plugins' ), 10, 2 );
 		add_filter( 'plugin_auto_update_setting_html', array( __CLASS__, 'show_scheduled_updates' ), 10, 2 );
 	}
 
@@ -50,7 +49,7 @@ class Scheduled_Updates {
 	 *
 	 * @param string ...$plugins List of plugins to update.
 	 */
-	public static function jetpack_run_scheduled_update( ...$plugins ) {
+	public static function run_scheduled_update( ...$plugins ) {
 		$available_updates = get_site_transient( 'update_plugins' );
 		$plugins_to_update = array();
 
@@ -79,7 +78,7 @@ class Scheduled_Updates {
 	 * @param object    $item   The update offer.
 	 * @return bool
 	 */
-	public static function jetpack_allowlist_scheduled_plugins( $update, $item ) {
+	public static function allowlist_scheduled_plugins( $update, $item ) {
 		// TODO: Check if we're in a scheduled update request from Jetpack_Autoupdates.
 		$schedules = get_option( 'jetpack_update_schedules', array() );
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.2.0';
+	const PACKAGE_VERSION = '0.2.1-alpha';
 
 	/**
 	 * Initialize the class.


### PR DESCRIPTION


## Proposed changes:
* Removes unused phpunit filter.
* Removes unneeded `jetpack_` prefixes from when we experimented with a functional approach.
* Moves endpoint loader into an action callback so it can be unhooked if needed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this diff on a test site using the Jetpack Beta plugin.
* Install the REST API Console plugin and activate it.
* Go to `/wp-admin/tools.php?page=rest_api_console` and query `/wpcom/v2/update-schedules`.

