### PR TITLE
Components: Add Jetpack AI icon

### DIFF
--- a/projects/js-packages/components/changelog/add-jetpack-icon-ai
+++ b/projects/js-packages/components/changelog/add-jetpack-icon-ai
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Components: add AI icon

--- a/projects/js-packages/components/components/icons/README.md
+++ b/projects/js-packages/components/components/icons/README.md
@@ -16,6 +16,7 @@ Available slugs are:
 * star
 * videopress
 * jetpack
+* ai
 
 ```es6
 import {
@@ -43,6 +44,7 @@ return (
 * VideopressIcon
 * JetpackIcon
 * ShareIcon
+* AiIcon
 
 ```es6
 import {
@@ -57,6 +59,7 @@ import {
 	VideoPressIcon,
 	JetpackIcon,
 	ShareIcon,
+	AiIcon,
 } from '@automattic/jetpack-components';
 
 return (
@@ -72,6 +75,7 @@ return (
 		<VideoPressIcon />
 		<JetpackIcon />
 		<ShareIcon />
+		<AiIcon />
 	</div>
 )
 ```

--- a/projects/js-packages/components/components/icons/index.tsx
+++ b/projects/js-packages/components/components/icons/index.tsx
@@ -212,6 +212,28 @@ export const ShareIcon: React.FC< BaseIconProps > = ( { size = 16, className, co
 	);
 };
 
+export const AiIcon: React.FC< BaseIconProps > = ( {
+	size = 24,
+	color = '#069e08', // JP green
+} ) => {
+	return (
+		<IconWrapper color={ color } size={ size } viewBox={ '0 0 32 32' }>
+			<Path
+				className="spark-first"
+				d="M9.33301 5.33325L10.4644 8.20188L13.333 9.33325L10.4644 10.4646L9.33301 13.3333L8.20164 10.4646L5.33301 9.33325L8.20164 8.20188L9.33301 5.33325Z"
+			/>
+			<Path
+				className="spark-second"
+				d="M21.3333 5.33333L22.8418 9.15817L26.6667 10.6667L22.8418 12.1752L21.3333 16L19.8248 12.1752L16 10.6667L19.8248 9.15817L21.3333 5.33333Z"
+			/>
+			<Path
+				className="spark-third"
+				d="M14.6667 13.3333L16.5523 18.1144L21.3333 20L16.5523 21.8856L14.6667 26.6667L12.781 21.8856L8 20L12.781 18.1144L14.6667 13.3333Z"
+			/>
+		</IconWrapper>
+	);
+};
+
 const jetpackIcons = {
 	'anti-spam': AntiSpamIcon,
 	backup: BackupIcon,
@@ -226,6 +248,7 @@ const jetpackIcons = {
 	videopress: VideopressIcon,
 	jetpack: JetpackIcon,
 	share: ShareIcon,
+	ai: AiIcon,
 };
 
 const iconsMap = {

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.48.4",
+	"version": "0.49.0-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
The AI icon remains as part of the AI Client package but not available as part of components

## Proposed changes:
This PR adds the AI icon to the components to availability and ease of use

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Checkout the branch and change directory to `projects/js-packages/storybook`, then run: `pnpm storybook:dev`. The browser will open and you should be able to see the new icon.