### PR TITLE
jetpack-mu-wpcom: wrap wpcom URL with localized_wpcom_url

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-site-menu-localize-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-site-menu-localize-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use localized_wpcom_url per PHPCS-CHANGED WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl
+
+

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.14.1",
+	"version": "5.14.2-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.14.1';
+	const PACKAGE_VERSION = '5.14.2-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -35,7 +35,7 @@ function wpcom_add_wpcom_menu_item() {
 		esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
 		esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
 		'manage_options',
-		'https://wordpress.com/sites',
+		localized_wpcom_url( 'https://wordpress.com/sites' ),
 		null,
 		'dashicons-arrow-left-alt2',
 		0


### PR DESCRIPTION
## Proposed changes:

Wrap wpcom URL with `localized_wpcom_url` per lint: PHPCS-CHANGED WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl

Follow-up to #35925

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1708985722121349-slack-C01U2KGS2PQ

```
>>> Lint for wp-content/mu-plugins/jetpack-mu-wpcom-plugin/sun/vendor/automattic/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php:


   Error  (PHPCS-CHANGED WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl) The URL string 'https://wordpress.com/sites' should be wrapped in the `localized_wpcom_url` function call.
    The URL string 'https://wordpress.com/sites' should be wrapped in the
    `localized_wpcom_url` function call.

              35 		esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
              36 		esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
              37 		'manage_options',
    >>>       38 		'https://wordpress.com/sites',
                   ^
              39 		null,
              40 		'dashicons-arrow-left-alt2',
              41 		0
```

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Test via bot instructions posted to PR.