### PR TITLE
VideoPress: Update card styles in Jetpack plugin

### DIFF
--- a/projects/js-packages/components/changelog/update-jetpack-videopress-card-styles
+++ b/projects/js-packages/components/changelog/update-jetpack-videopress-card-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update ProgressBar styles.

--- a/projects/js-packages/components/components/progress-bar/style.module.scss
+++ b/projects/js-packages/components/components/progress-bar/style.module.scss
@@ -8,10 +8,11 @@
 	&.small {
 		height: 3px;
 	}
-	
+
 	.progress {
 		height: 100%;
 		border-radius: calc( var( --spacing-base ) * 3 );
-		background-color: var(--jp-green-50 );
+		background-color: var( --jp-black );
+		min-width: 12px;
 	}
 }

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.48.4",
+	"version": "0.48.5-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -575,7 +575,11 @@
 }
 
 .jp-dash-item__videopress-storage {
-	margin-top: 1em;
+	margin-top: rem( 16px );
+	span {
+		margin-top: rem( 10px );
+		display: block;
+	}
 }
 
 .jp-dash-item__action-links {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -1,6 +1,6 @@
 import { ProgressBar, getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import Button from 'components/button';
 import DashItem from 'components/dash-item';
 import JetpackBanner from 'components/jetpack-banner';
@@ -94,8 +94,17 @@ class DashVideoPress extends Component {
 								</p>
 								{ shouldDisplayStorage && (
 									<div className="jp-dash-item__videopress-storage">
-										<span>{ __( 'Video storage used out of 1TB:', 'jetpack' ) }</span>
 										<ProgressBar progress={ videoPressStorageUsed / 1000000 } />
+										<span>
+											{ createInterpolateElement(
+												sprintf(
+													/* translators: %s is a number (disk space used) */
+													__( 'Using <strong>%dGB</strong> of 1TB', 'jetpack' ),
+													Math.round( videoPressStorageUsed / 1024 )
+												),
+												{ strong: <strong /> }
+											) }
+										</span>
 									</div>
 								) }
 							</div>

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -1,5 +1,6 @@
 import { ProgressBar, ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
-import { __, _x } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { FormLegend, FormFieldset } from 'components/forms';
 import JetpackBanner from 'components/jetpack-banner';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
@@ -85,8 +86,17 @@ class Media extends React.Component {
 				</p>
 				{ shouldDisplayStorage && (
 					<div className="media__videopress-storage">
-						<span>{ __( 'Video storage used out of 1TB:', 'jetpack' ) }</span>
 						<ProgressBar progress={ videoPressStorageUsed / 1000000 } />
+						<span>
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %d is a number (disk space used) */
+									__( 'Using <strong>%dGB</strong> of 1TB', 'jetpack' ),
+									Math.round( videoPressStorageUsed / 1024 )
+								),
+								{ strong: <strong /> }
+							) }
+						</span>
 					</div>
 				) }
 				{ hasConnectedOwner && (

--- a/projects/plugins/jetpack/_inc/client/performance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/performance/style.scss
@@ -8,6 +8,11 @@
 .media__videopress-storage {
 	margin-bottom: 1.5rem;
 	max-width: 50%;
+
+	span {
+		margin-top: rem( 10px );
+		display: block;
+	}
 }
 
 

--- a/projects/plugins/jetpack/changelog/update-jetpack-videopress-card-styles
+++ b/projects/plugins/jetpack/changelog/update-jetpack-videopress-card-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update VideoPress card styles.


### PR DESCRIPTION
## Proposed changes:
* Update styles of the VideoPress cards (Dashboard and Settings) according to the new design.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1705068320776989-slack-C0D96691V

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack.
2. Go to Jetpack Dashboard, activate VideoPress, and purchase the VideoPress plan.
3. Go back to Jetpack Dashboard, confirm the VideoPress card looks like on the screenshot below.
4. Go to "Settings -> Performance", confirm that "Media" card looks like on the screenshot below.
5. Go to WordPress.com and upload a video (at least 1GB), confirm that the "Using 0GB" no longer shows "0GB" in both cards (steps 3 and 4).

<img width="527" alt="Screenshot 2024-02-26 at 20 00 04" src="https://github.com/Automattic/jetpack/assets/1341249/6b0070c7-d0f4-4ea7-9d5f-ecc30b86ba33">
<img width="1053" alt="Screenshot 2024-02-26 at 20 00 17" src="https://github.com/Automattic/jetpack/assets/1341249/5eb11a27-1987-4f26-9af9-bd3e631de176">
