### PR TITLE
Boost: Fix cache logging label

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
@@ -90,4 +90,13 @@
 			margin-top: 16px;
 		}
 	}
+
+	.logging-toggle {
+		margin-right: 1em;
+		float: left;
+	}
+	
+	.clearfix {
+		clear: both;
+	}
 }

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
@@ -91,6 +91,11 @@
 		}
 	}
 
+	.see-logs-link {
+		font-size: 16px;
+		line-height: 1.5;
+	}
+
 	.logging-toggle {
 		margin-right: 1em;
 		float: left;

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -104,7 +104,7 @@ const Meta = () => {
 						/>
 						<div className={ styles.section }>
 							<div className={ styles.title }>{ __( 'Logging', 'jetpack-boost' ) }</div>
-							<label htmlFor="cache-logging">
+							<label htmlFor="cache-logging" className={ styles[ 'logging-toggle' ] }>
 								<input
 									type="checkbox"
 									id="cache-logging"
@@ -112,13 +112,11 @@ const Meta = () => {
 									onChange={ event => mutateLogging.mutate( event.target.checked ) }
 								/>{ ' ' }
 								{ __( 'Activate logging to track all your cache events.', 'jetpack-boost' ) }
-								{ logging && (
-									<>
-										{ ' ' }
-										<Link to="/cache-debug-log">{ __( 'See Logs', 'jetpack-boost' ) }</Link>
-									</>
-								) }
 							</label>
+							{ logging && (
+								<Link to="/cache-debug-log">{ __( 'See Logs', 'jetpack-boost' ) }</Link>
+							) }
+							<div className={ styles.clearfix } />
 						</div>
 					</>
 				</div>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -114,7 +114,9 @@ const Meta = () => {
 								{ __( 'Activate logging to track all your cache events.', 'jetpack-boost' ) }
 							</label>
 							{ logging && (
-								<Link to="/cache-debug-log">{ __( 'See Logs', 'jetpack-boost' ) }</Link>
+								<Link className={ styles[ 'see-logs-link' ] } to="/cache-debug-log">
+									{ __( 'See Logs', 'jetpack-boost' ) }
+								</Link>
 							) }
 							<div className={ styles.clearfix } />
 						</div>

--- a/projects/plugins/boost/changelog/fix-cache-logging-label
+++ b/projects/plugins/boost/changelog/fix-cache-logging-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+


### PR DESCRIPTION
## Proposed changes:
The link to "See Logs" was inside the label, which toggles logging. This would trigger the logging to toggle each time someone tried to see logs. Thought, this didn't disable logging since it would immediately change the page. I fixed it to correct the behaviour.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable cache
* Enable logging
* Make sure the "See Logs" link behaves and looks correct

