### PR TITLE
WPCOM API: add hook to log data about post imports

### DIFF
--- a/projects/plugins/jetpack/changelog/add-logging-fb-imports
+++ b/projects/plugins/jetpack/changelog/add-logging-fb-imports
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Imports: add filter to log import data on WordPress.com.
+
+

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -560,6 +560,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		 * @since $$next-version$$
 		 *
 		 * @param bool  $is_dtp_fb_post Is this for a Facebook import?
+		 * @param array $input          Whole input.
 		 * @param array $media_files    File upload data.
 		 * @param array $media_urls     URLs to fetch.
 		 * @param array $media_attrs    Attributes corresponding to each entry in `$media_files`/`$media_urls`.
@@ -567,7 +568,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		 *  - media_ids: IDs created, by index in `$media_files`/`$media_urls`.
 		 *  - errors: Errors encountered, by index in `$media_files`/`$media_urls`.
 		 */
-		do_action( 'jetpack_dtp_fb_media', $is_dtp_fb_post, $media_files, $media_urls, $media_attrs, $media_results );
+		do_action( 'jetpack_dtp_fb_media', $is_dtp_fb_post, $input, $media_files, $media_urls, $media_attrs, $media_results );
 
 		if ( $new ) {
 			if ( isset( $input['content'] ) && ! has_shortcode( $input['content'], 'gallery' ) && ( $has_media || $has_media_by_url ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -560,6 +560,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		 * @since $$next-version$$
 		 *
 		 * @param bool  $is_dtp_fb_post Is this for a Facebook import?
+		 * @param int   $blog_id        Blog ID.
 		 * @param array $input          Whole input.
 		 * @param array $media_files    File upload data.
 		 * @param array $media_urls     URLs to fetch.
@@ -568,7 +569,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		 *  - media_ids: IDs created, by index in `$media_files`/`$media_urls`.
 		 *  - errors: Errors encountered, by index in `$media_files`/`$media_urls`.
 		 */
-		do_action( 'jetpack_dtp_fb_media', $is_dtp_fb_post, $input, $media_files, $media_urls, $media_attrs, $media_results );
+		do_action( 'jetpack_dtp_fb_media', $is_dtp_fb_post, $blog_id, $input, $media_files, $media_urls, $media_attrs, $media_results );
 
 		if ( $new ) {
 			if ( isset( $input['content'] ) && ! has_shortcode( $input['content'], 'gallery' ) && ( $has_media || $has_media_by_url ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -551,6 +551,24 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			add_filter( 'rest_api_allowed_public_metadata', array( $this, 'dtp_fb_allowed_metadata' ) );
 		}
 
+		/**
+		 * Log Media details for a Post creation request.
+		 * Temporary logging for media data.
+		 *
+		 * @see p1709028174665519-slack-CDLH4C1UZ
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool  $is_dtp_fb_post Is this for a Facebook import?
+		 * @param array $media_files    File upload data.
+		 * @param array $media_urls     URLs to fetch.
+		 * @param array $media_attrs    Attributes corresponding to each entry in `$media_files`/`$media_urls`.
+		 * @param array $media_results
+		 *  - media_ids: IDs created, by index in `$media_files`/`$media_urls`.
+		 *  - errors: Errors encountered, by index in `$media_files`/`$media_urls`.
+		 */
+		do_action( 'jetpack_dtp_fb_media', $is_dtp_fb_post, $media_files, $media_urls, $media_attrs, $media_results );
+
 		if ( $new ) {
 			if ( isset( $input['content'] ) && ! has_shortcode( $input['content'], 'gallery' ) && ( $has_media || $has_media_by_url ) ) {
 				switch ( ( $has_media + $has_media_by_url ) ) {


### PR DESCRIPTION
## Proposed changes:

This is a change that will most likely be reverted in the future. This new hook will only be useful to log data about imports.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1709028174665519-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test with this one, at least not without a patch on WordPress.com as well. See D139825-code for an example.
