### PR TITLE
Boost: Don't serve expired cache files

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Garbage_Collection.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Garbage_Collection.php
@@ -13,8 +13,6 @@ class Garbage_Collection {
 	 * Register hooks.
 	 */
 	public static function setup() {
-		add_filter( 'cron_schedules', array( self::class, 'add_cron_interval' ) );
-
 		$cache = new Boost_Cache();
 		add_action( self::ACTION, array( $cache->get_storage(), 'garbage_collect' ) );
 		add_action( self::ACTION, array( Logger::class, 'delete_old_logs' ) );
@@ -27,7 +25,7 @@ class Garbage_Collection {
 		self::setup();
 
 		if ( ! wp_next_scheduled( self::ACTION ) ) {
-			wp_schedule_event( time(), self::INTERVAL_NAME, self::ACTION );
+			wp_schedule_event( time(), 'hourly', self::ACTION );
 		}
 	}
 
@@ -36,17 +34,5 @@ class Garbage_Collection {
 	 */
 	public static function deactivate() {
 		wp_clear_scheduled_hook( self::ACTION );
-	}
-
-	/**
-	 * Register a custom interval for garbage collection cron jobs.
-	 */
-	public static function add_cron_interval( $schedules ) {
-		$schedules[ self::INTERVAL_NAME ] = array(
-			'interval' => 900,
-			'display'  => __( 'Every 15 minutes', 'jetpack-boost' ),
-		);
-
-		return $schedules;
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -17,6 +17,10 @@ require_once __DIR__ . '/Request.php';
 require_once __DIR__ . '/storage/Storage.php';
 require_once __DIR__ . '/storage/File_Storage.php';
 
+if ( ! defined( 'JETPACK_BOOST_CACHE_DURATION' ) ) {
+	define( 'JETPACK_BOOST_CACHE_DURATION', 3600 );
+}
+
 class Boost_Cache {
 	/**
 	 * @var Boost_Cache_Settings - The settings for the page cache.

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/Request.php';
 require_once __DIR__ . '/storage/Storage.php';
 require_once __DIR__ . '/storage/File_Storage.php';
 
+// Define how many seconds the cache should last for each cached page.
 if ( ! defined( 'JETPACK_BOOST_CACHE_DURATION' ) ) {
 	define( 'JETPACK_BOOST_CACHE_DURATION', 3600 );
 }

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -19,7 +19,7 @@ require_once __DIR__ . '/storage/File_Storage.php';
 
 // Define how many seconds the cache should last for each cached page.
 if ( ! defined( 'JETPACK_BOOST_CACHE_DURATION' ) ) {
-	define( 'JETPACK_BOOST_CACHE_DURATION', 3600 );
+	define( 'JETPACK_BOOST_CACHE_DURATION', HOUR_IN_SECONDS );
 }
 
 class Boost_Cache {

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/storage/File_Storage.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/storage/File_Storage.php
@@ -64,14 +64,12 @@ class File_Storage implements Storage {
 	 * Garbage collect expired files.
 	 */
 	public function garbage_collect() {
-		$cache_duration = apply_filters( 'jetpack_boost_cache_duration', 3600 );
-
-		if ( $cache_duration === 0 ) {
+		if ( JETPACK_BOOST_CACHE_DURATION === 0 ) {
 			// Garbage collection is disabled.
 			return false;
 		}
 
-		$count = Filesystem_Utils::delete_expired_files( $this->root_path, $cache_duration );
+		$count = Filesystem_Utils::delete_expired_files( $this->root_path, JETPACK_BOOST_CACHE_DURATION );
 
 		Logger::debug( "Garbage collected $count files" );
 	}

--- a/projects/plugins/boost/changelog/fix-cache-serving
+++ b/projects/plugins/boost/changelog/fix-cache-serving
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cache: Stop serving expired cache files


### PR DESCRIPTION
## Proposed changes:
* Do not serve cache files that are expired; instead, delete them.
* Use `JETPACK_BOOST_CACHE_DURATION` constant instead of filter to define cache duration. the value defaults to `HOUR_IN_SECONDS`.
* Delete custom interval for garbage collection in favor of default `hourly` interval.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Define a low value for cache duration e.g. `define('JETPACK_BOOST_CACHE_DURATION', 5)`, you can add this in **wp-config.php**
* Try refreshing a cached page multiple times and notice the `<!-- cached -->` comment on the bottom of the page come and go depending on cache expiry.
* Check that the garbage collection is registered correctly.

