### PR TITLE
Boost: don't add a trailing slash to request uri when it ends in a filename

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Utils.php
@@ -74,7 +74,7 @@ class Boost_Cache_Utils {
 		$request_uri = parse_url( $request_uri, PHP_URL_PATH ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 		if ( empty( $request_uri ) ) {
 			$request_uri = '/';
-		} elseif ( substr( $request_uri, -1 ) !== '/' ) {
+		} elseif ( substr( $request_uri, -1 ) !== '/' && ! is_file( ABSPATH . $request_uri ) ) {
 			$request_uri .= '/';
 		}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
@@ -99,10 +99,7 @@ class Logger {
 	public function log( $message ) {
 		$request     = Request::current();
 		$request_uri = htmlspecialchars( $request->get_uri(), ENT_QUOTES, 'UTF-8' );
-		if ( ! empty( $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$request_uri .= '?' . htmlspecialchars( http_build_query( $_GET ), ENT_QUOTES, 'UTF-8' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		}
-		$line = gmdate( 'H:i:s' ) . " {$this->pid}\t{$request_uri}\t\t{$message}" . PHP_EOL;
+		$line        = gmdate( 'H:i:s' ) . " {$this->pid}\t{$request_uri}\t\t{$message}" . PHP_EOL;
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		error_log( $line, 3, $this->get_log_file() );
 	}

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
@@ -99,7 +99,10 @@ class Logger {
 	public function log( $message ) {
 		$request     = Request::current();
 		$request_uri = htmlspecialchars( $request->get_uri(), ENT_QUOTES, 'UTF-8' );
-		$line        = gmdate( 'H:i:s' ) . " {$this->pid}\t{$request_uri}\t\t{$message}" . PHP_EOL;
+		if ( ! empty( $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$request_uri .= '?' . htmlspecialchars( http_build_query( $_GET ), ENT_QUOTES, 'UTF-8' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+		$line = gmdate( 'H:i:s' ) . " {$this->pid}\t{$request_uri}\t\t{$message}" . PHP_EOL;
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		error_log( $line, 3, $this->get_log_file() );
 	}

--- a/projects/plugins/boost/changelog/update-logger-get-parameters
+++ b/projects/plugins/boost/changelog/update-logger-get-parameters
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Boost: add the $_GET parameters to the data logged

--- a/projects/plugins/boost/changelog/update-logger-get-parameters
+++ b/projects/plugins/boost/changelog/update-logger-get-parameters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Boost: add the $_GET parameters to the data logged


### PR DESCRIPTION
The normalize_request_uri function adds a trailing slash even if the uri includes a filename. It shouldn't do that for filenames.

## Proposed changes:
* In the normalize_request_uri function I added a check if the request_uri was a file before adding a "/" at the end.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-2vF-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR
* Enable logging
* navigate around your blog.
* There shouldn't be any visible changes.