### PR TITLE
VideoPress: display the right message when user is not connected

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-connect-standalone
+++ b/projects/packages/videopress/changelog/fix-videopress-connect-standalone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Block: display the right message when user is not connected on a site using the standalone plugin.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.4",
+	"version": "0.23.5-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.4';
+	const PACKAGE_VERSION = '0.23.5-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -396,7 +396,7 @@ export default function VideoPressEdit( {
 				<>
 					<ConnectBanner
 						isConnected={ isActive }
-						isModuleActive={ isModuleActive }
+						isModuleActive={ isModuleActive || isStandalonePluginActive }
 						isConnecting={ isRedirectingToMyJetpack }
 						onConnect={ () => {
 							setIsRedirectingToMyJetpack( true );
@@ -591,7 +591,7 @@ export default function VideoPressEdit( {
 			</InspectorControls>
 
 			<ConnectBanner
-				isModuleActive={ isModuleActive }
+				isModuleActive={ isModuleActive || isStandalonePluginActive }
 				isConnected={ isActive }
 				isConnecting={ isRedirectingToMyJetpack }
 				onConnect={ () => {


### PR DESCRIPTION
## Proposed changes:

When someone uses only the standalone plugin, we display to display the right message when an editor is not connected to WordPress.com, even though the site is connected.

| **Before | **After** |
|--------|--------|
| <img width="765" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/e4e95006-9062-43e0-a57a-8fd631526e0d"> | <img width="902" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/7d987482-ace1-4326-b1e8-37ac57e4f258"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's running only the Jetpack VideoPress plugin.
* Connect the site to your WordPress.com account and purchase a VideoPress plan.
* Back to wp-admin, go to Users > Add New and create a new "Editor" user.
* In a new browser, log in as that user.
* Go to Posts > Add New
* Add a VideoPress block
   * You should see the right invitation to connect your account (see screenshots above).
