### PR TITLE
Connection: avoid deprecation warning during authorization

### DIFF
--- a/projects/packages/connection/changelog/fix-connection-php-deprecation-warning
+++ b/projects/packages/connection/changelog/fix-connection-php-deprecation-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Webhook class: avoid PHP warning with PHP 8.2

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.3.2';
+	const PACKAGE_VERSION = '2.3.3-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/webhooks/class-authorize-redirect.php
+++ b/projects/packages/connection/src/webhooks/class-authorize-redirect.php
@@ -18,6 +18,12 @@ use Jetpack_Network;
  * Authorize_Redirect Webhook handler class.
  */
 class Authorize_Redirect {
+	/**
+	 * The Connection Manager object.
+	 *
+	 * @var Manager
+	 */
+	private $connection;
 
 	/**
 	 * Constructs the object


### PR DESCRIPTION
## Proposed changes:

This should fix warnings like this one:

```
PHP Deprecated:  Creation of dynamic property Automattic\Jetpack\Connection\Webhooks\Authorize_Redirect::$connection is deprecated in /usr/local/src/jetpack-monorepo/projects/packages/connection/src/webhooks/class-authorize-redirect.php on line 28
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

I'm not too sure how to always reproduce. I ran into this when trying to connect the VideoPress plugin to my WordPress.com account.
