### PR TITLE
Scheduled Updates: Load API endpoints on WP.com so it works with public-api passthrough

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-schedules-endpoint-on-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-schedules-endpoint-on-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Scheduled Updates: Load API endpoints on WP.com so it works with public-api passthrough.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.14.1",
+	"version": "5.14.2-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -29,28 +29,21 @@ class Jetpack_Mu_Wpcom {
 		// Shared code for src/features.
 		require_once self::PKG_DIR . 'src/common/index.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 
-		// Coming Soon feature.
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_coming_soon' ) );
-
+		// Load features that don't need any special loading considerations.
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_features' ) );
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
+
+		/*
+		 * Please double-check whether you really need to load your feature separately.
+		 * Chances are you can just add it to the `load_features` method.
+		 */
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_launchpad' ), 0 );
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_coming_soon' ) );
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_block_theme_previews' ) );
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_site_editor_dashboard_link' ) );
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_import_customizations' ) );
-
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_marketplace_products_updater' ) );
-
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_first_posts_stream_helpers' ) );
 
 		// This feature runs only on simple sites.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_comments' ) );
-		}
-
-		// Features that only run on WoA sites.
-		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-			add_action( 'plugins_loaded', array( __CLASS__, 'load_atomic_only_features' ) );
 		}
 
 		// Unified navigation fix for changes in WordPress 6.2.
@@ -61,6 +54,7 @@ class Jetpack_Mu_Wpcom {
 
 		// Load the Newsletter category settings.
 		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_newsletter_categories_settings' ), 999 );
+
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
 		 *
@@ -73,18 +67,27 @@ class Jetpack_Mu_Wpcom {
 	 * Load features that don't need any special loading considerations.
 	 */
 	public static function load_features() {
+
+		// Please keep the features in alphabetical order.
 		require_once __DIR__ . '/features/100-year-plan/enhanced-ownership.php';
 		require_once __DIR__ . '/features/100-year-plan/locked-mode.php';
-
-		require_once __DIR__ . '/features/error-reporting/error-reporting.php';
-
-		require_once __DIR__ . '/features/media/heif-support.php';
-
 		require_once __DIR__ . '/features/block-patterns/block-patterns.php';
-
+		require_once __DIR__ . '/features/blog-privacy/blog-privacy.php';
+		require_once __DIR__ . '/features/error-reporting/error-reporting.php';
+		require_once __DIR__ . '/features/first-posts-stream/first-posts-stream-helpers.php';
+		require_once __DIR__ . '/features/import-customizations/import-customizations.php';
+		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
+		require_once __DIR__ . '/features/media/heif-support.php';
+		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';
 		require_once __DIR__ . '/features/wpcom-site-menu/wpcom-site-menu.php';
 
-		require_once __DIR__ . '/features/blog-privacy/blog-privacy.php';
+		// Initializers, if needed.
+		\Marketplace_Products_Updater::init();
+
+		// Gets autoloaded from the Scheduled_Updates package.
+		if ( class_exists( 'Automattic\Jetpack\Scheduled_Updates' ) ) {
+			Scheduled_Updates::init();
+		}
 	}
 
 	/**
@@ -199,39 +202,12 @@ class Jetpack_Mu_Wpcom {
 	}
 
 	/**
-	 * Change the Site Editor's dashboard link.
-	 */
-	public static function load_site_editor_dashboard_link() {
-		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';
-	}
-
-	/**
 	 * Unbinds focusout event handler on #wp-admin-bar-menu-toggle introduced in WordPress 6.2.
 	 *
 	 * The focusout event handler is preventing the unified navigation from being closed on mobile.
 	 */
 	public static function unbind_focusout_on_wp_admin_bar_menu_toggle() {
 		wp_add_inline_script( 'common', '(function($){ $(document).on("wp-responsive-activate", function(){ $(".is-nav-unification #wp-admin-bar-menu-toggle, .is-nav-unification #adminmenumain").off("focusout"); } ); }(jQuery) );' );
-	}
-
-	/**
-	 * Load WPCOM Marketplace products updates provider.
-	 *
-	 * @return void
-	 */
-	public static function load_marketplace_products_updater() {
-		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
-
-		\Marketplace_Products_Updater::init();
-	}
-
-	/**
-	 * Load First Posts stream helpers.
-	 *
-	 * @return void
-	 */
-	public static function load_first_posts_stream_helpers() {
-		require_once __DIR__ . '/features/first-posts-stream/first-posts-stream-helpers.php';
 	}
 
 	/**
@@ -249,7 +225,7 @@ class Jetpack_Mu_Wpcom {
 
 		// This covers both P2 and P2020 themes.
 		$is_p2     = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( $blog_id );
-		$is_forums = str_contains( get_stylesheet(), 'a8c/supportforums' ); // Not in /forums
+		$is_forums = str_contains( get_stylesheet(), 'a8c/supportforums' ); // Not in /forums.
 
 		// Don't load any comment experience in the Reader, GlotPress, wp-admin, or P2.
 		return ( 1 === $blog_id || TRANSLATE_BLOG_ID === $blog_id || is_admin() || $is_p2 || $is_forums );
@@ -275,21 +251,5 @@ class Jetpack_Mu_Wpcom {
 			require_once __DIR__ . '/features/verbum-comments/class-verbum-comments.php';
 			new \Automattic\Jetpack\Verbum_Comments();
 		}
-	}
-
-	/**
-	 * Load features that only run on WoA sites.
-	 */
-	public static function load_atomic_only_features() {
-		if ( class_exists( 'Automattic\Jetpack\Scheduled_Updates' ) ) {
-			Scheduled_Updates::init();
-		}
-	}
-
-	/**
-	 * Load import.php customizations.
-	 */
-	public static function load_import_customizations() {
-		require_once __DIR__ . '/features/import-customizations/import-customizations.php';
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.14.1';
+	const PACKAGE_VERSION = '5.14.2-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/scheduled-updates/changelog/update-schedules-endpoint-on-wpcom
+++ b/projects/packages/scheduled-updates/changelog/update-schedules-endpoint-on-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Scheduled Updates: Load API endpoints on WP.com so it works with public-api passthrough.

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -9,7 +9,8 @@
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.1.0",
 		"automattic/jetpack-changelogger": "@dev",
-		"automattic/wordbless": "@dev"
+		"automattic/wordbless": "@dev",
+		"automattic/jetpack-plans": "^0.4.0@dev"
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -10,7 +10,7 @@
 		"yoast/phpunit-polyfills": "1.1.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/wordbless": "@dev",
-		"automattic/jetpack-plans": "^0.4.0@dev"
+		"automattic/jetpack-plans": "@dev"
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -23,11 +23,21 @@ class Scheduled_Updates {
 	 * Initialize the class.
 	 */
 	public static function init() {
+		/*
+		 * We want to load the REST API endpoints in all environments.
+		 * On WP.com they're needed for registering the routes with public-api and pass-through to self-hosted sites.
+		 */
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_rest_api_endpoints' ), 20 );
+
+		// Never load on Simple sites.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return;
+		}
+
 		if ( ! ( method_exists( 'Automattic\Jetpack\Current_Plan', 'supports' ) && Current_Plan::supports( 'scheduled-updates' ) ) ) {
 			return;
 		}
 
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_rest_api_endpoints' ), 20 );
 		add_action( 'jetpack_scheduled_update', array( __CLASS__, 'run_scheduled_update' ) );
 		add_filter( 'auto_update_plugin', array( __CLASS__, 'allowlist_scheduled_plugins' ), 10, 2 );
 		add_filter( 'plugin_auto_update_setting_html', array( __CLASS__, 'show_scheduled_updates' ), 10, 2 );

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -100,7 +100,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * Permission check for retrieving schedules.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return bool
+	 * @return bool|WP_Error
 	 */
 	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -140,7 +140,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 		}
 
-		if ( ! ( method_exists( 'Automattic\Jetpack\Current_Plan', 'supports' ) && Automattic\Jetpack\Current_Plan::supports( 'scheduled-updates', true ) ) ) {
+		if ( ! ( method_exists( 'Automattic\Jetpack\Current_Plan', 'supports' ) && Automattic\Jetpack\Current_Plan::supports( 'scheduled-updates' ) ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 		}
 
@@ -235,7 +235,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 		}
 
-		if ( ! ( method_exists( 'Automattic\Jetpack\Current_Plan', 'supports' ) && Automattic\Jetpack\Current_Plan::supports( 'scheduled-updates', true ) ) ) {
+		if ( ! ( method_exists( 'Automattic\Jetpack\Current_Plan', 'supports' ) && Automattic\Jetpack\Current_Plan::supports( 'scheduled-updates' ) ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 		}
 

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -103,6 +103,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return bool
 	 */
 	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+		}
+
 		return current_user_can( 'update_plugins' );
 	}
 
@@ -132,10 +136,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function create_item_permissions_check( $request ) {
-		// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+		}
+
 		if ( ! ( method_exists( 'Automattic\Jetpack\Current_Plan', 'supports' ) && Automattic\Jetpack\Current_Plan::supports( 'scheduled-updates', true ) ) ) {
-			// phpcs:ignore
-			// return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 		}
 
 		$schedules = get_option( 'jetpack_update_schedules', array() );
@@ -188,9 +194,13 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * Permission check for retrieving a specific schedule.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return bool
+	 * @return bool|WP_Error
 	 */
 	public function get_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+		}
+
 		return current_user_can( 'update_plugins' );
 	}
 
@@ -221,10 +231,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function update_item_permissions_check( $request ) {
-		// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+		}
+
 		if ( ! ( method_exists( 'Automattic\Jetpack\Current_Plan', 'supports' ) && Automattic\Jetpack\Current_Plan::supports( 'scheduled-updates', true ) ) ) {
-			// phpcs:ignore
-			// return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 		}
 
 		$schedules = get_option( 'jetpack_update_schedules', array() );
@@ -291,9 +303,13 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * Permission check for deleting a specific schedule.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return bool
+	 * @return bool|WP_Error
 	 */
 	public function delete_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+		}
+
 		return current_user_can( 'update_plugins' );
 	}
 

--- a/projects/packages/scheduled-updates/tests/lib/functions-wordpress.php
+++ b/projects/packages/scheduled-updates/tests/lib/functions-wordpress.php
@@ -23,3 +23,34 @@ if ( ! function_exists( 'wpcom_rest_api_v2_load_plugin' ) ) {
 		}
 	}
 }
+
+if ( ! function_exists( 'wpcom_site_has_feature' ) ) {
+	/**
+	 * A drop-in for a WordPress.com function.
+	 *
+	 * @param string $feature The name of the feature to check.
+	 * @return bool
+	 */
+	function wpcom_site_has_feature( $feature ) {
+		/**
+		 * Filters whether a site has a feature. Only used for testing purposes.
+		 *
+		 * @param bool   $has_feature Whether the site has the feature.
+		 * @param string $feature     The name of the feature to check.
+		 */
+		return apply_filters( 'wpcom_site_has_feature_test', true, $feature );
+	}
+}
+
+if ( ! function_exists( 'wpcom_feature_exists' ) ) {
+	/**
+	 * A drop-in for a WordPress.com function.
+	 *
+	 * @param string $feature The name of the feature to check.
+	 * @return bool
+	 */
+	function wpcom_feature_exists( $feature ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// All features exist in the test environment.
+		return true;
+	}
+}

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-schedules-endpoint-on-wpcom
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-schedules-endpoint-on-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dev dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_25"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_0_26_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -198,13 +198,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "18ab06e2a6efbcee909885e814271e5feadf1d97"
+                "reference": "9be90d23b55e43e40816ff79dbd2d65b1c392fc8"
             },
             "require": {
                 "php": ">=7.0"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-plans": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.1.0"
             },

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.0.25
+ * Version: 2.0.26-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.0.25",
+	"version": "2.0.26-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Loads `update-schedule` API endpoint in all environments.
* Moves loading logic in jetpack-mu-wpcom since it doesn't need special considerations anymore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this diff to a test site using Jetpack Beta.
* Apply D139852-code to your sandbox and sandbox `public-api`.
* Go to https://developer.wordpress.com/docs/api/console/ and make a GET request to WPCOM V2 `/sites/YOUR_TEST_SITE/update-schedule`