### PR TITLE
Contact Form: make constrained inputs full-width on mobile

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-mobile-input
+++ b/projects/packages/forms/changelog/fix-contact-form-mobile-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: make constrained inputs full-width on mobile

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.6",
+	"version": "0.30.7-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -75,6 +75,13 @@
 				max-width: 75%;
 			}
 
+			@media (max-width: #{ ($break-mobile) }) {
+				&[class*=jetpack-field__width-] {
+					flex-basis: 100%;
+					max-width: none;
+				}
+			}
+
 			&[data-type='jetpack/field-checkbox'],
 			&[data-type='jetpack/field-consent'] {
 				align-self: center;

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.6';
+	const PACKAGE_VERSION = '0.30.7-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -264,6 +264,13 @@
 	max-width: 75%;
 }
 
+@media only screen and ( max-width: 480px ) {
+	.wp-block-jetpack-contact-form .grunion-field-wrap {
+		flex-basis: 100%;
+		max-width: none;
+	}
+}
+
 .grunion-field-consent-wrap {
 	align-self: center;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35881

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the Contact Form, constrained inputs (at 25, 50, or 75%) don't provide a good typing experience on mobile. This PR ensures they're displayed full-width for screen up to 480px wide.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Make sure to build the `forms` package if you're running the branch locally
- Create a new post
- Add a Contact Form
- Set the Name and Email fields to 50%
- Open the preview
- Resize the window to have a viewport narrower than 480px
- Notice all fields take the full available space in both the editor and preview

|Before|After|
|-|-|
|<img width="403" alt="Screenshot 2024-02-27 at 3 30 08 PM" src="https://github.com/Automattic/jetpack/assets/1620183/602e61b4-2c66-4256-be23-82211da0d564">|<img width="409" alt="Screenshot 2024-02-27 at 3 30 01 PM" src="https://github.com/Automattic/jetpack/assets/1620183/ff4838a3-754e-47c1-9324-0eb5047588e1">|

- For wider viewports, check the two fields are on the same row
<img width="408" alt="Screenshot 2024-02-27 at 3 30 17 PM" src="https://github.com/Automattic/jetpack/assets/1620183/8b1ccc8b-6cae-4d3b-a7b3-fade555eaba1">


