### PR TITLE
Voice to Content: refactor processing and error state handling, and ensure proper error handling

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-state-handling
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-state-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: change loading and error state handling on media recording hook.

--- a/projects/js-packages/ai-client/src/hooks/use-audio-transcription/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-audio-transcription/index.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useCallback, useState, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 /**
  * Internal dependencies
@@ -28,6 +29,63 @@ export type UseAudioTranscriptionProps = {
 	feature: string;
 	onReady?: ( transcription: string ) => void;
 	onError?: ( error: string ) => void;
+};
+
+/**
+ * The error response from the audio transcription service.
+ */
+type AudioTranscriptionErrorResponse = {
+	/**
+	 * The error message.
+	 */
+	message: string;
+
+	/**
+	 * The error code.
+	 */
+	code: string;
+};
+
+/**
+ * Map error response to a string.
+ * @param {Error | string | AudioTranscriptionErrorResponse} error - The error response from the audio transcription service.
+ * @returns {string} the translated error message
+ */
+const mapErrorResponse = ( error: Error | string | AudioTranscriptionErrorResponse ): string => {
+	if ( typeof error === 'string' ) {
+		return error;
+	}
+
+	if ( 'code' in error ) {
+		switch ( error.code ) {
+			case 'error_quota_exceeded':
+				return __(
+					'You exceeded your current quota, please check your plan details.',
+					'jetpack-ai-client'
+				);
+			case 'jetpack_ai_missing_audio_param':
+				return __( 'The audio_file is required to perform a transcription.', 'jetpack-ai-client' );
+			case 'jetpack_ai_service_unavailable':
+				return __( 'The Jetpack AI service is temporarily unavailable.', 'jetpack-ai-client' );
+			case 'file_size_not_supported':
+				return __( 'The provided audio file is too big.', 'jetpack-ai-client' );
+			case 'file_type_not_supported':
+				return __( 'The provided audio file type is not supported.', 'jetpack-ai-client' );
+			case 'jetpack_ai_error':
+				return __(
+					'There was an error processing the transcription request.',
+					'jetpack-ai-client'
+				);
+			default:
+				return error.message;
+		}
+	}
+
+	if ( 'message' in error ) {
+		return error.message;
+	}
+
+	return __( 'There was an error processing the transcription request.', 'jetpack-ai-client' );
 };
 
 /**
@@ -74,7 +132,7 @@ export default function useAudioTranscription( {
 				.catch( error => {
 					if ( ! controller.signal.aborted ) {
 						setTranscriptionError( error.message );
-						onError?.( error.message );
+						onError?.( mapErrorResponse( error ) );
 					}
 				} )
 				.finally( () => setIsTranscribingAudio( false ) );

--- a/projects/js-packages/ai-client/src/hooks/use-media-recording/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-media-recording/index.ts
@@ -5,7 +5,7 @@ import { useRef, useState, useEffect, useCallback } from '@wordpress/element';
 /*
  * Types
  */
-export type RecordingState = 'inactive' | 'recording' | 'paused' | 'processing' | 'error';
+export type RecordingState = 'inactive' | 'recording' | 'paused' | 'error';
 type UseMediaRecordingProps = {
 	onDone?: ( blob: Blob ) => void;
 };
@@ -40,11 +40,6 @@ type UseMediaRecordingReturn = {
 	 * The error handler
 	 */
 	onError: ( err: string | Error ) => void;
-
-	/**
-	 * The processing handler
-	 */
-	onProcessing: () => void;
 
 	controls: {
 		/**
@@ -90,7 +85,7 @@ export default function useMediaRecording( {
 	// Reference to the media recorder instance
 	const mediaRecordRef = useRef( null );
 
-	// Recording state: `inactive`, `recording`, `paused`, `processing`, `error`
+	// Recording state: `inactive`, `recording`, `paused`, `error`
 	const [ state, setState ] = useState< RecordingState >( 'inactive' );
 
 	// reference to the paused state to be used in the `onDataAvailable` event listener,
@@ -239,11 +234,6 @@ export default function useMediaRecording( {
 		setState( 'error' );
 	}, [] );
 
-	// manually set the state to `processing` for the file upload case
-	const onProcessing = useCallback( () => {
-		setState( 'processing' );
-	}, [] );
-
 	/**
 	 * `start` event listener for the media recorder instance.
 	 */
@@ -258,7 +248,6 @@ export default function useMediaRecording( {
 	 * @returns {void}
 	 */
 	function onStopListener(): void {
-		setState( 'processing' );
 		const lastBlob = getBlob();
 		onDone?.( lastBlob );
 
@@ -326,7 +315,6 @@ export default function useMediaRecording( {
 		duration,
 		analyser: analyser.current,
 		onError,
-		onProcessing,
 
 		controls: {
 			start,

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -88,6 +88,11 @@ export type { RecordingState } from './hooks/use-media-recording/index.js';
  */
 export type CancelablePromise< T = void > = Promise< T > & { canceled?: boolean };
 
+/*
+ * Transcription types
+ */
+export type TranscriptionState = RecordingState | 'processing' | 'error';
+
 // Connection initial state
 // @todo: it should be provided by the connection package
 interface JPConnectionInitialState {

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-state-handling
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-state-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Voice to Content: change the way the processing and error states are handled, and ensure proper error handling.

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -6,7 +6,6 @@ import { Button, FormFileUpload } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function ActionButtons( {
-	isCreatingTranscription,
 	state,
 	onUpload,
 	onCancel,
@@ -17,7 +16,7 @@ export default function ActionButtons( {
 } ) {
 	return (
 		<div className="jetpack-ai-voice-to-content__action-buttons">
-			{ ! isCreatingTranscription && [ 'inactive', 'error' ].includes( state ) && (
+			{ [ 'inactive', 'error' ].includes( state ) && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					icon={ micIcon }
@@ -27,7 +26,7 @@ export default function ActionButtons( {
 					{ __( 'Begin recording', 'jetpack' ) }
 				</Button>
 			) }
-			{ ! isCreatingTranscription && [ 'recording' ].includes( state ) && (
+			{ [ 'recording' ].includes( state ) && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					icon={ playerPauseIcon }
@@ -37,7 +36,7 @@ export default function ActionButtons( {
 					{ __( 'Pause recording', 'jetpack' ) }
 				</Button>
 			) }
-			{ ! isCreatingTranscription && [ 'paused' ].includes( state ) && (
+			{ [ 'paused' ].includes( state ) && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					icon={ micIcon }
@@ -47,7 +46,7 @@ export default function ActionButtons( {
 					{ __( 'Resume recording', 'jetpack' ) }
 				</Button>
 			) }
-			{ ! isCreatingTranscription && [ 'inactive', 'error' ].includes( state ) && (
+			{ [ 'inactive', 'error' ].includes( state ) && (
 				<FormFileUpload
 					accept="audio/*"
 					onChange={ onUpload }
@@ -57,7 +56,7 @@ export default function ActionButtons( {
 					{ __( 'Upload audio', 'jetpack' ) }
 				</FormFileUpload>
 			) }
-			{ ! isCreatingTranscription && [ 'recording', 'paused' ].includes( state ) && (
+			{ [ 'recording', 'paused' ].includes( state ) && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					variant="primary"
@@ -66,16 +65,7 @@ export default function ActionButtons( {
 					{ __( 'Done', 'jetpack' ) }
 				</Button>
 			) }
-			{ ! isCreatingTranscription && [ 'recording', 'paused' ].includes( state ) && (
-				<Button
-					className="jetpack-ai-voice-to-content__button"
-					variant="secondary"
-					onClick={ onCancel }
-				>
-					{ __( 'Cancel', 'jetpack' ) }
-				</Button>
-			) }
-			{ isCreatingTranscription && (
+			{ [ 'recording', 'paused', 'processing' ].includes( state ) && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					variant="secondary"

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/action-buttons.tsx
@@ -6,6 +6,7 @@ import { Button, FormFileUpload } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function ActionButtons( {
+	isCreatingTranscription,
 	state,
 	onUpload,
 	onCancel,
@@ -16,7 +17,7 @@ export default function ActionButtons( {
 } ) {
 	return (
 		<div className="jetpack-ai-voice-to-content__action-buttons">
-			{ [ 'inactive', 'error' ].includes( state ) && (
+			{ ! isCreatingTranscription && [ 'inactive', 'error' ].includes( state ) && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					icon={ micIcon }
@@ -26,7 +27,7 @@ export default function ActionButtons( {
 					{ __( 'Begin recording', 'jetpack' ) }
 				</Button>
 			) }
-			{ [ 'recording' ].includes( state ) && (
+			{ ! isCreatingTranscription && [ 'recording' ].includes( state ) && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					icon={ playerPauseIcon }
@@ -36,7 +37,7 @@ export default function ActionButtons( {
 					{ __( 'Pause recording', 'jetpack' ) }
 				</Button>
 			) }
-			{ [ 'paused' ].includes( state ) && (
+			{ ! isCreatingTranscription && [ 'paused' ].includes( state ) && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					icon={ micIcon }
@@ -46,7 +47,7 @@ export default function ActionButtons( {
 					{ __( 'Resume recording', 'jetpack' ) }
 				</Button>
 			) }
-			{ [ 'inactive', 'error' ].includes( state ) && (
+			{ ! isCreatingTranscription && [ 'inactive', 'error' ].includes( state ) && (
 				<FormFileUpload
 					accept="audio/*"
 					onChange={ onUpload }
@@ -56,7 +57,7 @@ export default function ActionButtons( {
 					{ __( 'Upload audio', 'jetpack' ) }
 				</FormFileUpload>
 			) }
-			{ [ 'recording', 'paused' ].includes( state ) && (
+			{ ! isCreatingTranscription && [ 'recording', 'paused' ].includes( state ) && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					variant="primary"
@@ -65,7 +66,16 @@ export default function ActionButtons( {
 					{ __( 'Done', 'jetpack' ) }
 				</Button>
 			) }
-			{ [ 'recording', 'paused', 'processing' ].includes( state ) && (
+			{ ! isCreatingTranscription && [ 'recording', 'paused' ].includes( state ) && (
+				<Button
+					className="jetpack-ai-voice-to-content__button"
+					variant="secondary"
+					onClick={ onCancel }
+				>
+					{ __( 'Cancel', 'jetpack' ) }
+				</Button>
+			) }
+			{ isCreatingTranscription && (
 				<Button
 					className="jetpack-ai-voice-to-content__button"
 					variant="secondary"

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/audio-status-panel.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/audio-status-panel.tsx
@@ -13,16 +13,26 @@ import Oscilloscope from './oscilloscope';
 import type { RecordingState } from '@automattic/jetpack-ai-client';
 
 export default function AudioStatusPanel( {
+	isCreatingTranscription = false,
 	state,
 	error = null,
 	analyser,
 	duration = 0,
 }: {
+	isCreatingTranscription: boolean;
 	state: RecordingState;
 	error: string;
 	analyser: AnalyserNode;
 	duration: number;
 } ) {
+	if ( isCreatingTranscription ) {
+		return (
+			<div className="jetpack-ai-voice-to-content__information">
+				{ __( 'Uploading and transcribing audio…', 'jetpack' ) }
+			</div>
+		);
+	}
+
 	if ( state === 'inactive' ) {
 		return (
 			<div className="jetpack-ai-voice-to-content__information">
@@ -57,14 +67,6 @@ export default function AudioStatusPanel( {
 				<span className="jetpack-ai-voice-to-content__information">
 					{ __( 'Paused', 'jetpack' ) }
 				</span>
-			</div>
-		);
-	}
-
-	if ( state === 'processing' ) {
-		return (
-			<div className="jetpack-ai-voice-to-content__information">
-				{ __( 'Uploading and transcribing audio…', 'jetpack' ) }
 			</div>
 		);
 	}

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/audio-status-panel.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/components/audio-status-panel.tsx
@@ -10,29 +10,19 @@ import Oscilloscope from './oscilloscope';
 /**
  * Types
  */
-import type { RecordingState } from '@automattic/jetpack-ai-client';
+import type { TranscriptionState } from '@automattic/jetpack-ai-client';
 
 export default function AudioStatusPanel( {
-	isCreatingTranscription = false,
 	state,
 	error = null,
 	analyser,
 	duration = 0,
 }: {
-	isCreatingTranscription: boolean;
-	state: RecordingState;
+	state: TranscriptionState;
 	error: string;
 	analyser: AnalyserNode;
 	duration: number;
 } ) {
-	if ( isCreatingTranscription ) {
-		return (
-			<div className="jetpack-ai-voice-to-content__information">
-				{ __( 'Uploading and transcribing audio…', 'jetpack' ) }
-			</div>
-		);
-	}
-
 	if ( state === 'inactive' ) {
 		return (
 			<div className="jetpack-ai-voice-to-content__information">
@@ -67,6 +57,14 @@ export default function AudioStatusPanel( {
 				<span className="jetpack-ai-voice-to-content__information">
 					{ __( 'Paused', 'jetpack' ) }
 				</span>
+			</div>
+		);
+	}
+
+	if ( state === 'processing' ) {
+		return (
+			<div className="jetpack-ai-voice-to-content__information">
+				{ __( 'Uploading and transcribing audio…', 'jetpack' ) }
 			</div>
 		);
 	}

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -165,16 +165,14 @@ export default function VoiceToContentEdit( { clientId } ) {
 						</span>
 						<div className="jetpack-ai-voice-to-content__contextual-row">
 							<AudioStatusPanel
-								isCreatingTranscription={ isCreatingTranscription }
-								state={ state }
+								state={ isCreatingTranscription ? 'processing' : state }
 								error={ error }
 								duration={ duration }
 								analyser={ analyser }
 							/>
 						</div>
 						<ActionButtons
-							isCreatingTranscription={ isCreatingTranscription }
-							state={ state }
+							state={ isCreatingTranscription ? 'processing' : state }
 							onUpload={ onUploadHandler }
 							onCancel={ onCancelHandler }
 							onRecord={ onRecordHandler }

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -148,6 +148,8 @@ export default function VoiceToContentEdit( { clientId } ) {
 	// To avoid a wrong TS warning
 	const iconProps = { className: 'icon' };
 
+	const transcriptionState = isCreatingTranscription ? 'processing' : state;
+
 	return (
 		<Modal
 			onRequestClose={ handleClose }
@@ -165,14 +167,14 @@ export default function VoiceToContentEdit( { clientId } ) {
 						</span>
 						<div className="jetpack-ai-voice-to-content__contextual-row">
 							<AudioStatusPanel
-								state={ isCreatingTranscription ? 'processing' : state }
+								state={ transcriptionState }
 								error={ error }
 								duration={ duration }
 								analyser={ analyser }
 							/>
 						</div>
 						<ActionButtons
-							state={ isCreatingTranscription ? 'processing' : state }
+							state={ transcriptionState }
 							onUpload={ onUploadHandler }
 							onCancel={ onCancelHandler }
 							onRecord={ onRecordHandler }

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -42,30 +42,31 @@ export default function VoiceToContentEdit( { clientId } ) {
 
 	const { upsertTranscription } = useTranscriptionInserter();
 
-	const { processTranscription, cancelTranscriptionProcessing } = useTranscriptionPostProcessing( {
-		feature: 'voice-to-content',
-		onReady: postProcessingResult => {
-			// Insert the content into the editor
-			upsertTranscription( postProcessingResult );
-			handleClose();
-		},
-		onError: error => {
-			// Use the transcription instead for a partial result
-			if ( transcription ) {
-				dispatch.insertBlock( createBlock( 'core/paragraph', { content: transcription } ) );
-			}
-			// eslint-disable-next-line no-console
-			console.log( 'Post-processing error: ', error );
-			handleClose();
-		},
-		onUpdate: currentPostProcessingResult => {
-			/*
-			 * We can upsert partial results because the hook takes care of replacing
-			 * the previous result with the new one.
-			 */
-			upsertTranscription( currentPostProcessingResult );
-		},
-	} );
+	const { processTranscription, cancelTranscriptionProcessing, isProcessingTranscription } =
+		useTranscriptionPostProcessing( {
+			feature: 'voice-to-content',
+			onReady: postProcessingResult => {
+				// Insert the content into the editor
+				upsertTranscription( postProcessingResult );
+				handleClose();
+			},
+			onError: error => {
+				// Use the transcription instead for a partial result
+				if ( transcription ) {
+					dispatch.insertBlock( createBlock( 'core/paragraph', { content: transcription } ) );
+				}
+				// eslint-disable-next-line no-console
+				console.log( 'Post-processing error: ', error );
+				handleClose();
+			},
+			onUpdate: currentPostProcessingResult => {
+				/*
+				 * We can upsert partial results because the hook takes care of replacing
+				 * the previous result with the new one.
+				 */
+				upsertTranscription( currentPostProcessingResult );
+			},
+		} );
 
 	const onTranscriptionReady = ( content: string ) => {
 		// eslint-disable-next-line no-console
@@ -78,14 +79,16 @@ export default function VoiceToContentEdit( { clientId } ) {
 		onError( error );
 	};
 
-	const { transcribeAudio, cancelTranscription }: UseAudioTranscriptionReturn =
+	const { transcribeAudio, cancelTranscription, isTranscribingAudio }: UseAudioTranscriptionReturn =
 		useAudioTranscription( {
 			feature: 'voice-to-content',
 			onReady: onTranscriptionReady,
 			onError: onTranscriptionError,
 		} );
 
-	const { state, controls, error, onError, onProcessing, duration, analyser } = useMediaRecording( {
+	const isCreatingTranscription = isTranscribingAudio || isProcessingTranscription;
+
+	const { state, controls, error, onError, duration, analyser } = useMediaRecording( {
 		onDone: lastBlob => {
 			// When recording is done, set the audio to be transcribed
 			onAudioHandler( lastBlob );
@@ -95,11 +98,10 @@ export default function VoiceToContentEdit( { clientId } ) {
 	const onAudioHandler = useCallback(
 		( audio: Blob ) => {
 			if ( audio ) {
-				onProcessing();
 				transcribeAudio( audio );
 			}
 		},
-		[ transcribeAudio, onProcessing ]
+		[ transcribeAudio ]
 	);
 
 	// Destructure controls
@@ -163,6 +165,7 @@ export default function VoiceToContentEdit( { clientId } ) {
 						</span>
 						<div className="jetpack-ai-voice-to-content__contextual-row">
 							<AudioStatusPanel
+								isCreatingTranscription={ isCreatingTranscription }
 								state={ state }
 								error={ error }
 								duration={ duration }
@@ -170,6 +173,7 @@ export default function VoiceToContentEdit( { clientId } ) {
 							/>
 						</div>
 						<ActionButtons
+							isCreatingTranscription={ isCreatingTranscription }
 							state={ state }
 							onUpload={ onUploadHandler }
 							onCancel={ onCancelHandler }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32770. Part of #35547.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the processing state out of the useMediaRecording hook since it's more related to transcription than recording
* Add translated error messages to transcription hook based on the error code provided by backend (D139979-code is updating some codes there to align with the UI codes)
* I planned to move the error state out of the useMediaRecording hook as well, but it got a bit complicated for now, so we can revisit it on the next PR, when more pieces are in place

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* To test the processing state, go to the block editor, insert a Voice to Content block, then pick a file (or record something) for transcription
* As soon as you pick the file (or finish recording something), the UI should change to show the `Uploading and transcribing audio…` message
* To test the error states, let's simulate the errors on backend and try to use the block while simulating it
* To make it work, sandbox the `public-api` domain and point your testing env to use it (if it's a JN site, make sure you check the box to "Enable Sandbox Access")
* On your sandbox, modify the `jetpack-ai-transcription.php` file to add the following snippet as the first line of the `run_transcription` function:

```
return new \WP_Error( 'random_code', 'Random string', array( 'status' => 400 ) );
```

* The first parameter is the error code, we need to change it to each of the following ones to make sure the proper message will show on the Voice to Content block UI:
   * error_quota_exceeded
   * jetpack_ai_missing_audio_param
   * jetpack_ai_service_unavailable
   * file_size_not_supported
   * file_type_not_supported
   * jetpack_ai_error
* For each code, change it, go to the Voice to Content block, pick a small file for upload and wait until you see the error message
* Any other error code will fallback to the error message provided as the second parameter, so test using the snippet as-is and expect it to show "Random string" on the block UI