### PR TITLE
CRM: 3433 - Additional HPOS tweaks

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3433-hpos-tweaks
+++ b/projects/plugins/crm/changelog/fix-crm-3433-hpos-tweaks
@@ -3,3 +3,4 @@ Type: fixed
 
 WooSync: No longer shows today as renewal date if subscription has no renewal date set.
 WooSync: Modernize code.
+Segments: Fix output if segment has an error.

--- a/projects/plugins/crm/changelog/fix-crm-3433-hpos-tweaks
+++ b/projects/plugins/crm/changelog/fix-crm-3433-hpos-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+WooSync: No longer shows today as renewal date if subscription has no renewal date set.
+WooSync: Modernize code.

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -2799,15 +2799,15 @@ function zeroBSCRMJS_listView_segment_added( dataLine ) {
  * @param dataLine
  */
 function zeroBSCRMJS_listView_segment_name( dataLine ) {
-	var name_str = dataLine.name;
+	var name_str = jpcrm.esc_html(dataLine.name);
 
 	// if any errors, attach an exclaimation mark
 	if ( typeof dataLine.error !== 'undefined' ) {
-		name_str += ' <i class="red exclamation triangle icon" title="' + dataLine.error + '"></i>';
+		name_str += ' <i class="red exclamation triangle icon" title="' + jpcrm.esc_attr(dataLine.error) + '"></i>';
 	}
 
 	var td =
-		'<td><a href="' + zeroBSCRMJS_listView_editURL( dataLine.id ) + '">' + jpcrm.esc_html(name_str) + '</a></td>';
+		'<td><a href="' + zeroBSCRMJS_listView_editURL( dataLine.id ) + '">' + name_str + '</a></td>';
 
 	return td;
 }

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync.php
@@ -131,17 +131,25 @@ class Woo_Sync_Background_Sync {
 	/**
 	 * Initialise Hooks
 	 */
-	private function init_hooks( ) {
+	private function init_hooks() {
 
 		// cron
 		add_action( 'jpcrm_woosync_sync', array( $this, 'cron_job' ) );
 
-		// Syncing based on WooCommerce hooks:
+		// add our cron task to the core crm cron monitor list
+		add_filter( 'jpcrm_cron_to_monitor', array( $this, 'add_cron_monitor' ) );
+
+		global $zbs;
+
+		// Abort if Woo isn't active.
+		if ( ! $zbs->woocommerce_is_active() ) {
+			return;
+		}
 
 		// Order changes:
-		add_action( 'woocommerce_order_status_changed',    array( $this, 'add_update_from_woo_order' ), 1, 1 );
+		add_action( 'woocommerce_order_status_changed', array( $this, 'add_update_from_woo_order' ), 1, 1 );
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'add_update_from_woo_order' ), 100, 1 );
-		add_action( 'woocommerce_deposits_create_order',   array( $this, 'add_update_from_woo_order' ), 100, 1 );
+		add_action( 'woocommerce_deposits_create_order', array( $this, 'add_update_from_woo_order' ), 100, 1 );
 		if ( jpcrm_woosync_is_hpos_enabled() ) {
 			// These hooks are available as of Woo 7.1.0 and are required for HPOS.
 			add_action( 'woocommerce_before_trash_order', array( $this, 'woocommerce_order_trashed' ), 10, 1 );
@@ -152,13 +160,8 @@ class Woo_Sync_Background_Sync {
 		}
 
 		// Catch WooCommerce customer address changes and update contact:
-		add_action( 'woocommerce_customer_save_address',   array( $this, 'update_contact_address_from_wp_user' ), 10, 3 );
-
-		// add our cron task to the core crm cron monitor list
-		add_filter( 'jpcrm_cron_to_monitor',               array( $this, 'add_cron_monitor' ) );
-
+		add_action( 'woocommerce_customer_save_address', array( $this, 'update_contact_address_from_wp_user' ), 10, 3 );
 	}
-
 
 	/**
 	 * Setup cron schedule

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -143,20 +143,28 @@ class Woo_Sync_Woo_Admin_Integration {
 	 * Add CRM meta boxes to Woo pages
 	 */
 	public function add_meta_boxes() {
-		if ( jpcrm_woosync_is_hpos_enabled() ) {
-			$screen = wc_get_page_screen_id( 'shop-order' );
-		} else {
-			$screen = array( 'shop_order', 'shop_subscription' );
+
+		// Gather Woo screens where we'll want to add metaboxes.
+		$screens_to_use = array();
+		$woo_screens    = array( 'shop_order', 'shop_subscription' );
+		foreach ( $woo_screens as $woo_screen ) {
+			$potential_screen = wc_get_page_screen_id( $woo_screen );
+			if ( ! empty( $potential_screen ) ) {
+				$screens_to_use[] = $potential_screen;
+			}
 		}
 
-		add_meta_box(
-			'zbs_crm_contact',
-			__( 'CRM Contact', 'zero-bs-crm' ),
-			array( $this, 'render_woo_order_page_contact_box' ),
-			$screen,
-			'side',
-			'core'
-		);
+		// Currently if Woo is active we should at least have the orders page, but that could change.
+		if ( ! empty( $screens_to_use ) ) {
+			add_meta_box(
+				'zbs_crm_contact',
+				__( 'CRM Contact', 'zero-bs-crm' ),
+				array( $this, 'render_woo_order_page_contact_box' ),
+				$screens_to_use,
+				'side',
+				'core'
+			);
+		}
 	}
 
 	/**

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -51,6 +51,12 @@ class Woo_Sync_Woo_Admin_Integration {
 	 * Initialise Hooks
 	 */
 	private function init_hooks() {
+		global $zbs;
+
+		// Abort if Woo isn't active.
+		if ( ! $zbs->woocommerce_is_active() ) {
+			return;
+		}
 
 		// Hook into Woo orders listview.
 		if ( jpcrm_woosync_is_hpos_enabled() ) {

--- a/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
@@ -358,6 +358,7 @@ class Woo_Sync_Contact_Tabs {
 	 * @param int $object_id Contact ID.
 	 */
 	private function get_contact_subscriptions( $object_id = -1 ) {
+		$all_sub_statuses = array_keys( wcs_get_subscription_statuses() );
 
 		$subscription_ids = array();
 
@@ -368,6 +369,7 @@ class Woo_Sync_Contact_Tabs {
 			if ( $user_id > 0 ) {
 				$args = array(
 					'customer_id' => $user_id,
+					'status'      => $all_sub_statuses,
 					'type'        => 'shop_subscription',
 					'return'      => 'ids',
 				);
@@ -386,6 +388,7 @@ class Woo_Sync_Contact_Tabs {
 
 					$args = array(
 						'billing_email' => $email,
+						'status'        => $all_sub_statuses,
 						'type'          => 'shop_subscription',
 						'return'        => 'ids',
 					);

--- a/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
@@ -374,7 +374,7 @@ class Woo_Sync_Contact_Tabs {
 					'return'      => 'ids',
 				);
 
-				$subscription_ids_by_user = wc_get_orders( $args );
+				$subscription_ids = wc_get_orders( $args );
 			}
 
 			// 2 - find subs for all emails (inc aliases)
@@ -394,11 +394,12 @@ class Woo_Sync_Contact_Tabs {
 					);
 
 					$subscription_ids_by_email = wc_get_orders( $args );
+					$subscription_ids          = array_merge( $subscription_ids, $subscription_ids_by_email );
 				}
 			}
 
 			// 3 - remove any duplicate IDs between array_1 and array_2
-			$subscription_ids = array_unique( array_merge( $subscription_ids_by_user, $subscription_ids_by_email ), SORT_REGULAR );
+			$subscription_ids = array_unique( $subscription_ids, SORT_REGULAR );
 		}
 
 		return $subscription_ids;

--- a/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
@@ -374,34 +374,24 @@ class Woo_Sync_Contact_Tabs {
 				$subscription_user_ids = \WCS_Customer_Store::instance()->get_users_subscription_ids( $user_id );
 			}
 
-			// 2 - find subs for all emails (inc aliases) #3.0.12+ of core
-			if ( function_exists( 'zeroBS_customerEmails' ) ) {
+			// 2 - find subs for all emails (inc aliases)
+			$emails = zeroBS_customerEmails( $object_id );
+			if ( is_array( $emails ) ) {
 
-				// multi, inc aliases
-				$emails = zeroBS_customerEmails( $object_id );
-				if ( is_array( $emails ) ) {
+				foreach ( $emails as $email ) {
 
-					foreach ( $emails as $email ) {
+					$subscription_ids = $this->get_subscriptions_by_email( $email );
 
-						$subscription_ids = $this->get_subscriptions_by_email( $email );
+					// add any to the stack
+					if ( is_array( $subscription_ids ) ) {
 
-						// add any to the stack
-						if ( is_array( $subscription_ids ) ) {
+						foreach ( $subscription_ids as $id ) {
 
-							foreach ( $subscription_ids as $id ) {
+							$subscription_email_ids[] = $id;
 
-								$subscription_email_ids[] = $id;
-
-							}
 						}
 					}
 				}
-			} else {
-
-				// subscription IDs for the main EMAIL  (array_2)
-				$contact_email          = zeroBS_customerEmail( $object_id );
-				$subscription_email_ids = $this->get_subscriptions_by_email( $contact_email );
-
 			}
 
 			// 3 - remove any duplicate IDs between array_1 and array_2

--- a/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
@@ -210,8 +210,8 @@ class Woo_Sync_Contact_Tabs {
 			$price        = $order->get_formatted_order_total();
 			$name         = '';
 			$sub_link     = admin_url( "post.php?post={$order_id}&action=edit" );
-			$created      = zeroBSCRM_date_i18n( zeroBSCRM_getDateFormat(), strtotime( $date_created ), true, false );
-			$next         = zeroBSCRM_date_i18n( zeroBSCRM_getDateFormat(), strtotime( $date_renew ), true, false );
+			$created      = jpcrm_uts_to_date_str( strtotime( $date_created ) );
+			$next         = jpcrm_uts_to_date_str( strtotime( $date_renew ) );
 
 			$html .= '<tr>';
 			$html .= '<td><a href="' . esc_url( $sub_link ) . '">' . $name . __( ' Subscription #', 'zero-bs-crm' ) . $order_id . '</a></td>';
@@ -262,12 +262,12 @@ class Woo_Sync_Contact_Tabs {
 		foreach ( $memberships as $membership ) {
 
 			// populate fields
-			$member_id      = $membership->id;
-			$status         = $this->display_membership_status( $membership->get_status() );
-			$name           = $membership->plan->name;
-			$date_expires   = $membership->get_end_date( 'Y-m-d H:i:s' );
-			$date_created   = $membership->get_start_date();
-			$created        = zeroBSCRM_date_i18n( zeroBSCRM_getDateFormat(), strtotime( $date_created ), true, false );
+			$member_id    = $membership->id;
+			$status       = $this->display_membership_status( $membership->get_status() );
+			$name         = $membership->plan->name;
+			$date_expires = $membership->get_end_date( 'Y-m-d H:i:s' );
+			$date_created = $membership->get_start_date();
+			$created      = jpcrm_uts_to_date_str( strtotime( $date_created ) );
 
 			if ( empty( $date_expires ) ) {
 
@@ -275,7 +275,7 @@ class Woo_Sync_Contact_Tabs {
 
 			} else {
 
-				$expires = zeroBSCRM_date_i18n( zeroBSCRM_getDateFormat(), strtotime( $date_expires ), true, false );
+				$expires = jpcrm_uts_to_date_str( strtotime( $date_expires ) );
 
 			}
 

--- a/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
@@ -415,58 +415,57 @@ class Woo_Sync_Contact_Tabs {
 		return $return;
 	}
 
-    /**
-     * Turns out that wcs_get_users_subscriptions runs from userIDs and we need a variant from email
-     */
-    private function get_subscriptions_by_id_array( $subscription_ids ){
+	/**
+	 * Turns out that wcs_get_users_subscriptions runs from userIDs and we need a variant from email
+	 *
+	 * @param array $subscription_ids Subscription IDs.
+	 */
+	private function get_subscriptions_by_id_array( $subscription_ids ) {
 
-        $subscriptions = array();
-        foreach ( $subscription_ids as $subscription_id ) {
-            $subscription = wcs_get_subscription( $subscription_id );
+		$subscriptions = array();
+		foreach ( $subscription_ids as $subscription_id ) {
+			$subscription = wcs_get_subscription( $subscription_id );
 
-            if ( $subscription ) {
-                $subscriptions[ $subscription_id ] = $subscription;
-            }
-        }
+			if ( $subscription ) {
+				$subscriptions[ $subscription_id ] = $subscription;
+			}
+		}
 
-        return $subscriptions;
+		return $subscriptions;
+	}
 
-    }
+	/**
+	 * Get subs by email
+	 *
+	 * @param string $email Customer email.
+	 */
+	private function get_subscriptions_by_email( $email = '' ) {
 
+		if ( empty( $email ) ) {
+			return array();
+		}
 
-    /**
-     * Get subs by email
-     */
-    private function get_subscriptions_by_email($email = ''){
-        
-        if ( empty( $email ) ) {
+		$query = new \WP_Query();
 
-            return array();
-
-        }
-
-        $query = new \WP_Query();
-
-        return $query->query( array(
-
-            'post_type'           => 'shop_subscription',
-            'posts_per_page'      => -1,
-            'post_status'         => 'any',
-            'orderby'             => array(
-                'date' => 'DESC',
-                'ID'   => 'DESC',
-            ),
-            'fields'              => 'ids',
-            'no_found_rows'       => true,
-            'ignore_sticky_posts' => true,
-            'meta_query'          => array(
-                array(
-                    'key'   => '_billing_email',
-                    'value' => $email,
-                ),
-            ),
-
-        ));        
-
-    }
+		return $query->query(
+			array(
+				'post_type'           => 'shop_subscription',
+				'posts_per_page'      => -1,
+				'post_status'         => 'any',
+				'orderby'             => array(
+					'date' => 'DESC',
+					'ID'   => 'DESC',
+				),
+				'fields'              => 'ids',
+				'no_found_rows'       => true,
+				'ignore_sticky_posts' => true,
+				'meta_query'          => array(
+					array(
+						'key'   => '_billing_email',
+						'value' => $email,
+					),
+				),
+			)
+		);
+	}
 }

--- a/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/jpcrm-woo-sync-contact-tabs.php
@@ -181,13 +181,12 @@ class Woo_Sync_Contact_Tabs {
 	 */
 	private function generate_subscriptions_tab_html( $object_id = -1 ) {
 
-		$contact_has_subscriptions = false;
+		$subscriptions = array();
 		if ( zeroBSCRM_getClientPortalUserID( $object_id ) > 0 ) {
 			// Retrieve any subs against the main email or aliases.
-			$subscriptions             = $this->get_contact_subscriptions( $object_id );
-			$contact_has_subscriptions = ( 'success' === $subscriptions['message'] && count( $subscriptions['data'] ) > 0 );
+			$subscriptions = $this->get_contact_subscriptions( $object_id );
 		}
-		if ( ! $contact_has_subscriptions ) {
+		if ( count( $subscriptions ) === 0 ) {
 			return '<div class="ui message info blue"><i class="ui icon info circle"></i>' . __( 'This contact does not have any WooCommerce Subscriptions yet.', 'zero-bs-crm' ) . '</div>';
 		}
 
@@ -203,7 +202,7 @@ class Woo_Sync_Contact_Tabs {
 		$html .= '</tr></thead>';
 		$html .= '<tbody>';
 
-		foreach ( $subscriptions['data'] as $order_id ) {
+		foreach ( $subscriptions as $order_id ) {
 			$order        = wc_get_order( $order_id );
 			$status       = $order->get_status();
 			$date_created = $order->get_date_created();
@@ -360,7 +359,7 @@ class Woo_Sync_Contact_Tabs {
 	 */
 	private function get_contact_subscriptions( $object_id = -1 ) {
 
-		$return = array();
+		$subscription_ids = array();
 
 		if ( $object_id > 0 ) {
 
@@ -397,14 +396,8 @@ class Woo_Sync_Contact_Tabs {
 
 			// 3 - remove any duplicate IDs between array_1 and array_2
 			$subscription_ids = array_unique( array_merge( $subscription_ids_by_user, $subscription_ids_by_email ), SORT_REGULAR );
-
-			// 4 - get the subscriptions from the combined IDs
-			$return = array(
-				'data'    => $subscription_ids,
-				'message' => count( $subscription_ids ) > 0 ? 'success' : 'notfound',
-			);
 		}
 
-		return $return;
+		return $subscription_ids;
 	}
 }

--- a/projects/plugins/crm/modules/woo-sync/jpcrm-woo-sync-init.php
+++ b/projects/plugins/crm/modules/woo-sync/jpcrm-woo-sync-init.php
@@ -237,7 +237,7 @@ add_filter( 'jpcrm_system_assistant_jobs', 'jpcrm_add_woo_jobs_to_system_assista
  * @return bool Defaults to false.
  */
 function jpcrm_woosync_is_hpos_enabled() {
-	if ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) ) {
+	if ( class_exists( '\Automattic\WooCommerce\Utilities\OrderUtil' ) ) {
 		return \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
 	}
 	return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3433 - Additional HPOS tweaks
Resolves Automattic/zero-bs-crm#3434 - Fix segment error output

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This does a bit of cleanup around the HPOS changes made in #35797:

* Prevents some PHP fatals caused by our hooks logic.
* Ensures the contact metabox shows on subscription screens.
* Updates the code that gets subscription data for the contact profile tab.
* Uses proper date functions for subscription/membership dates.

Note that the changelog doesn't reflect most of the above, as it's either behind-the-scenes changes or unreleased regressions.

Also, I solved a small segment listview issue here (meant to be on a different branch + PR, but pushed it onto this one, so leaving it).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Test on JPCRM + Woo (non-HPOS) as well as JPCRM + Woo (HPOS) to ensure no regressions. HPOS is enabled on all new empty Woo sites; one can disable it per these instructions:

https://woo.com/document/high-performance-order-storage/#section-7

1. Enable WooSync.
2. Disable WooCommerce.
3. Enable WooCommerce.

In `trunk`, this will cause a PHP fatal whether or not an HPOS site.

In the `fix/crm/3433-hpos-tweaks` branch, it'll work as expected.

4. Create a Woo subscription assigned to an existing contact.
5. Ensure the contact metabox shows on the right side of the subscription screen (in `trunk` it won't on an HPOS site).
6. Ensure the subscription shows up on the contact profile. If the WP user exists, it'll show on both `trunk` and this branch. If the WP user doesn't exist, it'll only show on HPOS sites with this branch (as it matches by email).

---
Segment issue:
1. Create a segment using an Advanced Segments condition.
2. Disable the Advanced Segments extension.
3. Visit the Segments listview: `/wp-admin/admin.php?page=manage-segments`

In `trunk`, the error message is improperly escaped:
![image](https://github.com/Automattic/jetpack/assets/32492176/4583994f-3828-4142-9ac8-cde77020dc66)

In the `fix/crm/3433-hpos-tweaks` branch, it is properly escaped:
![image](https://github.com/Automattic/jetpack/assets/32492176/b975e3cc-b672-4c28-8bf4-122b643139a9)
