### PR TITLE
Sal: Add commercial reasons

### DIFF
--- a/projects/plugins/jetpack/changelog/add-commercial-reasons
+++ b/projects/plugins/jetpack/changelog/add-commercial-reasons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Sal: add is_commercial_reasons to options

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -207,6 +207,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'can_blaze',
 		'wpcom_site_setup',
 		'is_commercial',
+		'is_commercial_reasons',
 		'wpcom_admin_interface',
 	);
 
@@ -278,6 +279,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'wpcom_production_blog_id',
 		'wpcom_staging_blog_ids',
 		'is_commercial',
+		'is_commercial_reasons',
 		'wpcom_admin_interface',
 	);
 
@@ -915,6 +917,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'is_commercial':
 					$options[ $key ] = $site->is_commercial();
+					break;
+				case 'is_commercial_reasons':
+					$options[ $key ] = $site->get_is_commercial_reasons();
 					break;
 				case 'wpcom_admin_interface':
 					$options[ $key ] = $site->get_wpcom_admin_interface();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1557,18 +1557,7 @@ abstract class SAL_Site {
 	 * @return array|null
 	 */
 	public function get_is_commercial_reasons() {
-		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-			return null;
-		}
-		$es_args   = array(
-			'response_timeout' => 60,
-			'name'             => 'site-profiles',
-			'blog_id'          => $this->blog_id,
-			'size'             => 1,
-			'query'            => array( 'term' => array( 'blog_id' => $this->blog_id ) ),
-		);
-		$es_search = es_api_search_index( $es_args, 'site-profiles' );
-		return isset( $es_search['results']['hits'][0]['_source'] ) ? $es_search['results']['hits'][0]['_source'] : null;
+		return get_option( '_jetpack_site_is_commercial_reason', array() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1557,7 +1557,16 @@ abstract class SAL_Site {
 	 * @return array|null
 	 */
 	public function get_is_commercial_reasons() {
-		return get_option( '_jetpack_site_is_commercial_reason', array() );
+		$reasons = get_option( '_jetpack_site_is_commercial_reason', array() );
+
+		// Add override as reason if blog has the commercial stickers.
+		if ( empty( $reasons ) && $this->is_commercial() ) {
+			return array( 'manual-override' );
+		} elseif ( empty( $reasons ) ) {
+			return array();
+		}
+
+		return $reasons;
 	}
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1562,7 +1562,7 @@ abstract class SAL_Site {
 		// Add override as reason if blog has the commercial stickers.
 		if ( empty( $reasons ) && $this->is_commercial() ) {
 			return array( 'manual-override' );
-		} elseif ( empty( $reasons ) ) {
+		} elseif ( empty( $reasons ) || ! is_array( $reasons ) ) {
 			return array();
 		}
 

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1562,7 +1562,7 @@ abstract class SAL_Site {
 		// Add override as reason if blog has the commercial stickers.
 		if ( empty( $reasons ) && $this->is_commercial() ) {
 			return array( 'manual-override' );
-		} elseif ( empty( $reasons ) || ! is_array( $reasons ) ) {
+		} elseif ( ! is_array( $reasons ) ) {
 			return array();
 		}
 

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1552,6 +1552,26 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Returns an array of reasons why the site is considered commercial.
+	 *
+	 * @return array|null
+	 */
+	public function get_is_commercial_reasons() {
+		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+			return null;
+		}
+		$es_args   = array(
+			'response_timeout' => 60,
+			'name'             => 'site-profiles',
+			'blog_id'          => $this->blog_id,
+			'size'             => 1,
+			'query'            => array( 'term' => array( 'blog_id' => $this->blog_id ) ),
+		);
+		$es_search = es_api_search_index( $es_args, 'site-profiles' );
+		return isset( $es_search['results']['hits'][0]['_source'] ) ? $es_search['results']['hits'][0]['_source'] : null;
+	}
+
+	/**
 	 * Returns the site's interface selection e.g. calypso vs. wp-admin
 	 *
 	 * @return string


### PR DESCRIPTION
## Proposed changes:

Add `is_commercial_reasons` to site options, so that we'll be able to show users and enable self service in the future.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pejTkB-1cd-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Apply this PR change in your sandbox with the command: `bin/jetpack-downloader test jetpack add/commercial-reasons`
* Sandbox `public-api.wordpress.com`
* Open `https://developer.wordpress.com/docs/api/console/`, access the `/sites/{siteId}` wpcom v1.1
* Ensure you see `is_commercial_reasons` in the `options` object
* Please test with Jetpack self hosted, Atomic and Simple sites
* Check `/me/sites` as well