### PR TITLE
[Boost] Fix missing permalink.

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
@@ -31,12 +31,18 @@ class WP_Core_Provider extends Provider {
 
 		$front_page = get_option( 'page_on_front' );
 		if ( ! empty( $front_page ) ) {
-			$urls['front_page'] = (array) get_permalink( $front_page );
+			$permalink = get_permalink( $front_page );
+			if ( ! empty( $permalink ) ) {
+				$urls['front_page'] = array( $permalink );
+			}
 		}
 
 		$posts_page = get_option( 'page_for_posts' );
 		if ( ! empty( $posts_page ) ) {
-			$urls['posts_page'] = (array) get_permalink( $posts_page );
+			$permalink = get_permalink( $front_page );
+			if ( ! empty( $permalink ) ) {
+				$urls['posts_page'] = array( $permalink );
+			}
 		} else {
 			$urls['posts_page'] = (array) home_url( '/' );
 		}

--- a/projects/plugins/boost/changelog/boost-fix-missing-permalink
+++ b/projects/plugins/boost/changelog/boost-fix-missing-permalink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: Prevent errors when page_for_posts misconfigured.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1709042869876659/1707398907.914029-slack-C016BBAFHHS

User saw an "Invalid URL" error while trying to generate Critical CSS because their `page_for_posts` option contained an invalid value. This PR fixes the problem by checking the permalink returned for the `page_for_posts` is actually valid before using it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent adding empty/broken permalinks to Critical CSS generation set.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Set your site to use an invalid (but truthy) value for `page_for_posts`. e.g.: 
```
update wp_options set option_value=10000000 where option_name='page_for_posts';
```
* Generate Critical CSS
* Ensure you do not see an Invalid URL error.