### PR TITLE
Boost: `X-Jetpack-Boost-Cache` header

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -94,15 +94,21 @@ class Boost_Cache {
 
 		$cached = $this->storage->read( $this->request->get_uri(), $this->request->get_parameters() );
 		if ( is_string( $cached ) ) {
-			header( 'X-Jetpack-Boost-Cache: hit' );
+			$this->send_header( 'X-Jetpack-Boost-Cache: hit' );
 			Logger::debug( 'Serving cached page' );
 			echo $cached; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			die();
 		}
 
-		header( 'X-Jetpack-Boost-Cache: miss' );
+		$this->send_header( 'X-Jetpack-Boost-Cache: miss' );
 
 		return false;
+	}
+
+	private function send_header( $header ) {
+		if ( ! headers_sent() ) {
+			header( $header );
+		}
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -96,7 +96,7 @@ class Boost_Cache {
 		if ( is_string( $cached ) ) {
 			header( 'X-Jetpack-Boost-Cache: hit' );
 			Logger::debug( 'Serving cached page' );
-			echo $cached . '<!-- cached -->'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $cached; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			die();
 		}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -94,10 +94,13 @@ class Boost_Cache {
 
 		$cached = $this->storage->read( $this->request->get_uri(), $this->request->get_parameters() );
 		if ( is_string( $cached ) ) {
+			header( 'X-Jetpack-Boost-Cache: hit' );
 			Logger::debug( 'Serving cached page' );
 			echo $cached . '<!-- cached -->'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			die();
 		}
+
+		header( 'X-Jetpack-Boost-Cache: miss' );
 
 		return false;
 	}

--- a/projects/plugins/boost/changelog/boost-cache-cache-hit-miss-header
+++ b/projects/plugins/boost/changelog/boost-cache-cache-hit-miss-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Cache: Added header indicating cache hit or miss


### PR DESCRIPTION
Fixes #35938
## Proposed changes:
* Added a `X-Jetpack-Boost-Cache` header that would indicate if the page cache was a hit or miss. This is useful for:
  * The Boost Debugger chrome extension to detect if caching is attempted. (not yet implemented).
  * Giving clues to what is caching the page if a developer is trying to debug it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Enable caching
* Visit a page for the first time in incognito.
* See the `X-Jetpack-Boost-Cache` HTTP header and the value should be `miss`.
* Reload the page.
* The value should now be `hit` since the page is supposed to be cached.