### PR TITLE
[Boost] Disable caching by default

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -19,6 +19,7 @@ class Page_Cache_Setup {
 			'create_settings_file',
 			'create_advanced_cache',
 			'add_wp_cache_define',
+			'enable_caching',
 		);
 
 		foreach ( $steps as $step ) {
@@ -33,6 +34,16 @@ class Page_Cache_Setup {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Enable caching step of setup.
+	 *
+	 * @return Boost_Cache_Error|true - True on success, error otherwise.
+	 */
+	private static function enable_caching() {
+		$settings = Boost_Cache_Settings::get_instance();
+		return $settings->set( array( 'enabled' => true ) );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Settings.php
@@ -19,9 +19,9 @@ class Boost_Cache_Settings {
 	 * An uninitialized config holds these settings.
 	 */
 	private $default_settings = array(
-		'enabled'    => false,
-		'exceptions' => array(),
-		'logging'    => false,
+		'enabled'         => false,
+		`bypass_patterns' => [],
+		'logging'         => false,
 	);
 
 	private function __construct() {

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Settings.php
@@ -20,7 +20,7 @@ class Boost_Cache_Settings {
 	 */
 	private $default_settings = array(
 		'enabled'         => false,
-		`bypass_patterns' => [],
+		'bypass_patterns' => array(),
 		'logging'         => false,
 	);
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Settings.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Settings.php
@@ -19,7 +19,7 @@ class Boost_Cache_Settings {
 	 * An uninitialized config holds these settings.
 	 */
 	private $default_settings = array(
-		'enabled'    => true,
+		'enabled'    => false,
 		'exceptions' => array(),
 		'logging'    => false,
 	);

--- a/projects/plugins/boost/changelog/boost-disabled-caching-by-default
+++ b/projects/plugins/boost/changelog/boost-disabled-caching-by-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Changed default setting for unreleased feature
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

By default, we had caching enabled in the settings file. That means that, if the settings file is scrambled, unreadable or unwritable then the cache would consider itself always "on".

As we do not remove WP_CACHE or advanced-cache.php until plugin uninstallation, that means there are possible fail-states where the cache can be jammed on until Boost is uninstalled.

This corrects that by making the default setting "off", which is then set to "on" after all other setup steps have been successfully completed.

## Proposed changes:
* enabled=false by default in boost cache settings file.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Make sure you can still turn caching on and off again.

