### PR TITLE
Boost: Update cache logging

### DIFF
--- a/projects/plugins/boost/changelog/update-cache-logging
+++ b/projects/plugins/boost/changelog/update-cache-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Cache: Save log lines as json for better presentation


### PR DESCRIPTION
## Proposed changes:
* Save cache debug logs as json lines.
* Format the debug log lines on the fly before returning.
* Skip any non-json valid lines or lines that seem to have missing keys.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1709096448284769-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Enable logging
* Browse the logs
* It should now output like this:

```
[2024-02-28 05:25:19] [294] /sample-page/
                            Serving cached page
[2024-02-28 05:25:19] [287] /sample-page/
                            Serving cached page
[2024-02-28 05:25:19] [282] /sample-page/
                            Serving cached page
[2024-02-28 05:25:19] [294] /sample-page/
                            Serving cached page
[2024-02-28 05:25:19] [287] /sample-page/
                            Serving cached page
[2024-02-28 05:25:31] [287] /sample-page/
                            Serving cached page
[2024-02-28 05:25:31] [294] /sample-page/
                            Serving cached page
[2024-02-28 05:25:31] [294] /sample-page/
                            Serving cached page
[2024-02-28 05:25:32] [294] /sample-page/
                            Serving cached page
[2024-02-28 05:25:32] [294] /sample-page/
                            Serving cached page
[2024-02-28 05:25:32] [294] /sample-page/
                            Serving cached page
[2024-02-28 05:25:40] [296] /sample-page/?foo=bar
                            Cache file created
[2024-02-28 05:25:46] [296] /sample-page/?foo=bar
                            Serving cached page
[2024-02-28 05:28:26] [294] /wp-json/jetpack-boost-ds/cache-debug-log
                            Fatal error detected, caching disabled
[2024-02-28 05:33:50] [287] /sample-page/?foo=bar
                            Serving cached page
[2024-02-28 05:33:50] [294] /sample-page/?foo=bar
                            Serving cached page
[2024-02-28 05:33:50] [296] /sample-page/?foo=bar
                            Serving cached page
[2024-02-28 05:33:51] [287] /sample-page/?foo=bar
                            Serving cached page
[2024-02-28 05:33:51] [294] /sample-page/?foo=bar
                            Serving cached page
[2024-02-28 05:33:51] [296] /sample-page/?foo=bar
                            Serving cached page
[2024-02-28 05:34:02] [294] /sample-page/
                            Serving cached page
[2024-02-28 05:34:03] [287] /sample-page/sample-sample-page/
                            Serving cached page
[2024-02-28 05:34:04] [296] /sample-page/
                            Serving cached page
[2024-02-28 05:37:22] [287] /wp-json/jetpack-boost-ds/cache-debug-log
                            Fatal error detected, caching disabled
[2024-02-28 05:43:29] [294] /sample-page/
                            Serving cached page
```