### PR TITLE
Untangle: update launchpad links to go to wp-admin pages on classic view

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/untangle-launchpad-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangle-launchpad-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Untangle: fix launchpad links to go to wp-admin pages on classic view

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -21,8 +21,8 @@ function wpcom_launchpad_get_task_definitions() {
 			'add_listener_callback' => function () {
 				add_action( 'load-site-editor.php', 'wpcom_launchpad_track_edit_site_task' );
 			},
-			'get_calypso_path'      => function ( $task, $default, $data ) {
-				return '/site-editor/' . $data['site_slug_encoded'];
+			'get_calypso_path'      => function () {
+				return admin_url( 'site-editor.php' );
 			},
 		),
 		// design_completed checks for task completion while design_selected always returns true.
@@ -80,7 +80,9 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'publish_post', 'wpcom_launchpad_track_publish_first_post_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
-				$base_path = '/post/' . $data['site_slug_encoded'];
+				$base_path = get_option( 'wpcom_admin_interface' ) === 'wp-admin'
+					? admin_url( 'post-new.php' )
+					: '/post/' . $data['site_slug_encoded'];
 
 				// Add a new_prompt query param for Write sites.
 				if ( 'write' === get_option( 'site_intent' ) ) {
@@ -120,6 +122,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_disabled_callback' => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'options-general.php' );
+				}
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},
 		),
@@ -151,6 +156,9 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'publish_post', 'wpcom_launchpad_track_publish_first_post_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'post-new.php' );
+				}
 				return '/post/' . $data['site_slug_encoded'];
 			},
 		),
@@ -170,6 +178,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'options-general.php' );
+				}
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},
 		),
@@ -207,6 +218,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'import.php' );
+				}
 				return '/import/' . $data['site_slug_encoded'];
 			},
 		),
@@ -228,8 +242,8 @@ function wpcom_launchpad_get_task_definitions() {
 			'add_listener_callback' => function () {
 				add_action( 'load-site-editor.php', 'wpcom_launchpad_track_edit_site_task' );
 			},
-			'get_calypso_path'      => function ( $task, $default, $data ) {
-				return '/site-editor/' . $data['site_slug_encoded'];
+			'get_calypso_path'      => function () {
+				return admin_url( 'site-editor.php' );
 			},
 		),
 		'setup_link_in_bio'               => array(
@@ -269,9 +283,12 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_calypso_path'      => function ( $task, $default, $data ) {
 				$page_on_front = get_option( 'page_on_front', false );
 				if ( $page_on_front ) {
+					if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+						return admin_url( 'post.php?post=' . $page_on_front . '&action=edit' );
+					}
 					return '/page/' . $data['site_slug_encoded'] . '/' . $page_on_front;
 				}
-				return '/site-editor/' . $data['site_slug_encoded'] . '?canvas=edit';
+				return admin_url( 'site-editor.php?canvas=edit' );
 			},
 		),
 
@@ -302,6 +319,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'options-general.php' );
+				}
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},
 		),
@@ -323,6 +343,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_site_title_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'options-general.php' );
+				}
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},
 		),
@@ -343,6 +366,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'post-new.php?post_type=page' );
+				}
 				return '/page/' . $data['site_slug_encoded'];
 			},
 		),
@@ -359,6 +385,9 @@ function wpcom_launchpad_get_task_definitions() {
 				);
 			},
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'post.php?post=' . wpcom_launchpad_get_site_about_page_id() . '&action=edit' );
+				}
 				return '/page/' . $data['site_slug_encoded'] . '/' . wpcom_launchpad_get_site_about_page_id();
 			},
 		),
@@ -370,6 +399,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_edit_page_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'edit.php?post_type=page' );
+				}
 				return '/pages/' . $data['site_slug_encoded'];
 			},
 		),
@@ -445,6 +477,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'repetition_count_callback' => 'wpcom_launchpad_get_write_3_posts_repetition_count',
 			'target_repetitions'        => 3,
 			'get_calypso_path'          => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'post-new.php' );
+				}
 				return '/post/' . $data['site_slug_encoded'];
 			},
 		),
@@ -484,6 +519,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_add_about_page_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'post-new.php?post_type=page' );
+				}
 				return '/page/' . $data['site_slug_encoded'];
 			},
 		),
@@ -524,6 +562,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'themes.php' );
+				}
 				return '/themes/' . $data['site_slug_encoded'];
 			},
 		),
@@ -533,6 +574,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					return admin_url( 'plugins.php' );
+				}
 				return '/plugins/' . $data['site_slug_encoded'];
 			},
 		),
@@ -571,8 +615,8 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_add_subscribe_block_visible',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/site-editor/' . $data['site_slug_encoded'] . '/?canvas=edit&help-center=subscribe-block';
+			'get_calypso_path'     => function () {
+				return admin_url( 'site-editor.php?canvas=edit&help-center=subscribe-block' );
 			},
 		),
 		'mobile_app_installed'            => array(
@@ -602,9 +646,12 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$page_on_front = get_option( 'page_on_front', false );
 				if ( $page_on_front ) {
+					if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+						return admin_url( 'post.php?post=' . $page_on_front . '&action=edit' );
+					}
 					return '/page/' . $data['site_slug_encoded'] . '/' . $page_on_front;
 				}
-				return '/site-editor/' . $data['site_slug_encoded'] . '?canvas=edit';
+				return admin_url( 'site-editor.php?canvas=edit' );
 			},
 		),
 		'woocommerce_setup'               => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -6,6 +6,16 @@
  */
 
 /**
+ * Returns whether the task link should point to wp-admin page
+ * instead of Calypso page.
+ *
+ * @return bool
+ */
+function wpcom_launchpad_should_use_wp_admin_link() {
+	return get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+}
+
+/**
  * Get the task definitions for the Launchpad.
  *
  * @return array
@@ -80,7 +90,7 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'publish_post', 'wpcom_launchpad_track_publish_first_post_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
-				$base_path = get_option( 'wpcom_admin_interface' ) === 'wp-admin'
+				$base_path = wpcom_launchpad_should_use_wp_admin_link()
 					? admin_url( 'post-new.php' )
 					: '/post/' . $data['site_slug_encoded'];
 
@@ -122,7 +132,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_disabled_callback' => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'options-general.php' );
 				}
 				return '/settings/general/' . $data['site_slug_encoded'];
@@ -156,7 +166,7 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'publish_post', 'wpcom_launchpad_track_publish_first_post_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'post-new.php' );
 				}
 				return '/post/' . $data['site_slug_encoded'];
@@ -178,7 +188,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'options-general.php' );
 				}
 				return '/settings/general/' . $data['site_slug_encoded'];
@@ -218,7 +228,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'import.php' );
 				}
 				return '/import/' . $data['site_slug_encoded'];
@@ -283,7 +293,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_calypso_path'      => function ( $task, $default, $data ) {
 				$page_on_front = get_option( 'page_on_front', false );
 				if ( $page_on_front ) {
-					if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 						return admin_url( 'post.php?post=' . $page_on_front . '&action=edit' );
 					}
 					return '/page/' . $data['site_slug_encoded'] . '/' . $page_on_front;
@@ -319,7 +329,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'options-general.php' );
 				}
 				return '/settings/general/' . $data['site_slug_encoded'];
@@ -343,7 +353,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_site_title_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'options-general.php' );
 				}
 				return '/settings/general/' . $data['site_slug_encoded'];
@@ -366,7 +376,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'post-new.php?post_type=page' );
 				}
 				return '/page/' . $data['site_slug_encoded'];
@@ -385,7 +395,7 @@ function wpcom_launchpad_get_task_definitions() {
 				);
 			},
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'post.php?post=' . wpcom_launchpad_get_site_about_page_id() . '&action=edit' );
 				}
 				return '/page/' . $data['site_slug_encoded'] . '/' . wpcom_launchpad_get_site_about_page_id();
@@ -399,7 +409,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_edit_page_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'edit.php?post_type=page' );
 				}
 				return '/pages/' . $data['site_slug_encoded'];
@@ -477,7 +487,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'repetition_count_callback' => 'wpcom_launchpad_get_write_3_posts_repetition_count',
 			'target_repetitions'        => 3,
 			'get_calypso_path'          => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'post-new.php' );
 				}
 				return '/post/' . $data['site_slug_encoded'];
@@ -519,7 +529,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_add_about_page_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'post-new.php?post_type=page' );
 				}
 				return '/page/' . $data['site_slug_encoded'];
@@ -562,7 +572,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'themes.php' );
 				}
 				return '/themes/' . $data['site_slug_encoded'];
@@ -574,7 +584,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'plugins.php' );
 				}
 				return '/plugins/' . $data['site_slug_encoded'];
@@ -646,7 +656,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$page_on_front = get_option( 'page_on_front', false );
 				if ( $page_on_front ) {
-					if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+					if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 						return admin_url( 'post.php?post=' . $page_on_front . '&action=edit' );
 					}
 					return '/page/' . $data['site_slug_encoded'] . '/' . $page_on_front;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of:

- https://github.com/Automattic/dotcom-forge/issues/5723

## Proposed changes:

This PR updates the links in the Launchpad card in My Home (screenshot below)

<img width="711" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/965f1f6a-254c-4c7c-93bf-a49a22c600a3">

 as follows:

(1)  Updated Site Editor link to wp-admin without any check, as it is already un-iframed for all cases.

|Task|Before|After|
|-|-|-|
|Edit site design|`/site-editor/:site`|`/wp-admin/site-editor.php`|
|Add links|`/site-editor/:site`|`/wp-admin/site-editor.php`|
|Upload your first video|`/site-editor/:site?canvas=edit`|`/wp-admin/site-editor.php?canvas=edit`|
|Add the Subscribe Block to your site|`/site-editor/:site?canvas=edit&help-center=subscribe-block`|`/wp-admin/site-editor.php?canvas=edit&help-center=subscribe-block`|
|Update your site's design|`/site-editor/:site?canvas=edit`|`/wp-admin/site-editor.php?canvas=edit`|

(2) Updated the following links to the wp-admin counterparts when the admin interface style is set to classic:

|Task|Before|After|
|-|-|-|
|Give your site a name|`/settings/general/:site`|`/wp-admin/options-general.php`|
|Write your first post|`/post/:site`|`/wp-admin/post-new.php`|
|Personalize your site|`/settings/general/:site`|`/wp-admin/options-general.php`|
|Personalize newsletter|`/settings/general/:site`|`/wp-admin/options-general.php`|
|Start writing|`/post/:site`|`/wp-admin/post-new.php`|
|Give your site a name|`/settings/general/:site`|`/wp-admin/options-general.php`|
|Add a new page|`/page/:site`|`/wp-admin/post-new.php?post_type=page`|
|Edit a page|`/pages/:site`|`/wp-admin/edit.php?post_type=page`|
|Write 3 posts|`/post/:site`|`/wp-admin/post-new.php`|
|Add your About page|`/page/:site`|`/wp-admin/post-new.php?post_type=page`|
|Choose a theme|`/themes/:site`|`/wp-admin/themes.php`|
|Install a custom plugin|`/plugins/:site`|`/wp-admin/plugins.php`|

(3) Updated the following to the wp-admin counterparts when the admin interface style is set to classic. For this one, it also depends on whether the Settings -> Reading -> "Your homepage displays" is set to latest posts (default) or a static page.

Tasks:

- Upload your first video
- Update your site's design

|Your homepage displays|Before|After|
|-|-|-|
|Latest posts / default|`/site-editor/:site?canvas=edit`|`/wp-admin/site-editor.php?canvas=edit`|
|Static page|`/page/:site/:page_id`|`/wp-admin/post.php?post=:page_id&action=edit`|

---

> [!NOTE]  
> Initially I wanted to include proxy check, but I am not sure why it won't work. So, I only touched changes that are relevant even without the nav redesign proxy gating.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare an Atomic site with the following characteristics:
   - Settings -> Hosting Configuration -> admin interface style set to Default
   - Settings -> Reading -> your homepage displays set to Default / "Your latest posts"
3. Update "WordPress.com Features" in Jetpack Beta Tester to point to the branch in this testing-only PR https://github.com/Automattic/jetpack/pull/36016.
4. Go to `wpcalypso.wordpress.com/home/:site`.
5. Go to My Home.
6. Verify that you can see ALL launchpad tasks (they are shown for ease of testing).
7. Verify the Site Editor links in the first table (1) above.
8. Change your site's admin interface style to Classic 
9. Verify the links in the second table (2) above.
10. Change your site's homepage to static page.
11. Verify the links in the third table (3) above.
12. When testing links, verify that the links actually go to the correct wp-admin page.