### PR TITLE
Jetpack Boost: Refactor error handling and restore message formatting

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/health/health.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/health/health.tsx
@@ -1,9 +1,10 @@
 import { Button, Notice } from '@automattic/jetpack-components';
 import getErrorData from './lib/get-error-data';
 import { __ } from '@wordpress/i18n';
+import { type PageCacheError } from '$lib/stores/page-cache';
 
 type HealthProps = {
-	error: string;
+	error: PageCacheError;
 	setupCache: () => void;
 };
 

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -23,7 +23,7 @@ const PageCache = ( { setup, error }: Props ) => {
 				errorMessage={ __( 'An error occurred while setting up cache.', 'jetpack-boost' ) }
 				successMessage={ __( 'Cache setup complete.', 'jetpack-boost' ) }
 			/>
-			{ error ? <Health setupCache={ () => setup.mutate() } error={ error.message } /> : <Meta /> }
+			{ error ? <Health setupCache={ () => setup.mutate() } error={ error } /> : <Meta /> }
 		</>
 	);
 };

--- a/projects/plugins/boost/changelog/fix-boost-error-notice-message
+++ b/projects/plugins/boost/changelog/fix-boost-error-notice-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cache: Restore error message formatting


### PR DESCRIPTION
## Proposed changes:
- Refactor error handling in PageCache component to use PageCacheError type
- Restore error message formatting with enhanced details
- Add type hinting for error objects within health.tsx and get-error-data.tsx files

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Trigger different error states in the PageCache component
- Verify that the error messages are displayed correctly with detailed formatting
- Ensure that no console errors are shown regarding type mismatches for error objects



