### PR TITLE
Show all launchpad tasks for testing

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-monetize-jpcloud-launchpad-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-monetize-jpcloud-launchpad-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update Monetize Launchpad links to Jetpack Cloud

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -404,12 +404,8 @@ class Launchpad_Task_Lists {
 	 * @param Task $task_definition A task definition.
 	 * @return boolean True if task is visible, false if not.
 	 */
-	protected function is_visible( $task_definition ) {
-		if ( empty( $task_definition ) ) {
-			return false;
-		}
-
-		return $this->load_value_from_callback( $task_definition, 'is_visible_callback', true );
+	protected function is_visible( $task_definition ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return true;
 	}
 
 	/**
@@ -601,8 +597,8 @@ class Launchpad_Task_Lists {
 	 * @param array $task Task definition.
 	 * @return boolean
 	 */
-	public function is_task_disabled( $task ) {
-		return $this->load_value_from_callback( $task, 'is_disabled_callback', false );
+	public function is_task_disabled( $task ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return false;
 	}
 
 	/**
@@ -611,15 +607,8 @@ class Launchpad_Task_Lists {
 	 * @param Task $task Task definition.
 	 * @return boolean
 	 */
-	public function is_task_complete( $task ) {
-		// First we calculate the value from our statuses option. This will get passed to the callback, if it exists.
-		// Othewise there is the temptation for the callback to fall back to the option, which would cause infinite recursion
-		// as it continues to calculate the callback which falls back to the option: ∞.
-		$statuses    = get_option( 'launchpad_checklist_tasks_statuses', array() );
-		$key         = $this->get_task_key( $task );
-		$is_complete = isset( $statuses[ $key ] ) ? $statuses[ $key ] : false;
-
-		return (bool) $this->load_value_from_callback( $task, 'is_complete_callback', $is_complete );
+	public function is_task_complete( $task ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return false;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -577,6 +577,9 @@ function wpcom_launchpad_get_task_definitions() {
 						'earn-launchpad'
 					);
 				}
+				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
+					return 'https://cloud.jetpack.com/monetize/payments/' . $data['site_slug_encoded'];
+				}
 				return '/earn/payments/' . $data['site_slug_encoded'];
 			},
 		),
@@ -587,6 +590,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_has_paid_membership_plans',
 			'is_visible_callback'  => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
+					return 'https://cloud.jetpack.com/monetize/payments/' . $data['site_slug_encoded'] . '#add-new-payment-plan';
+				}
 				return '/earn/payments/' . $data['site_slug_encoded'] . '#add-new-payment-plan';
 			},
 		),

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -287,8 +287,25 @@ function wpcom_launchpad_get_task_list_definitions() {
 
 	$extended_task_list_definitions = apply_filters( 'wpcom_launchpad_extended_task_list_definitions', array() );
 
+	$all_task_list_definitions = array(
+		'all' => array(
+			'get_title' => function () {
+				return __( 'All steps for your site', 'jetpack-mu-wpcom' );
+			},
+			'task_ids'  => array_unique(
+				array_merge(
+					...array_map(
+						function ( $task_list ) {
+							return $task_list['task_ids']; },
+						array_values( $core_task_list_definitions )
+					)
+				)
+			),
+		),
+	);
+
 	// As for tasks, we can decide what overrides we allow later.
-	return array_merge( $extended_task_list_definitions, $core_task_list_definitions );
+	return array_merge( $extended_task_list_definitions, $core_task_list_definitions, $all_task_list_definitions );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -148,7 +148,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	 *               and `checklist`.
 	 */
 	public function get_data( $request ) {
-		$checklist_slug = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );
+		$checklist_slug = 'all';
 
 		$launchpad_context = isset( $request['launchpad_context'] )
 			? $request['launchpad_context']


### PR DESCRIPTION
DO NOT MERGE. This is only for testing https://github.com/Automattic/jetpack/pull/36014 & https://github.com/Automattic/jetpack/pull/36495 & https://github.com/Automattic/jetpack/pull/36573.

This helps show all launchpad tasks in My Home:

<img width="708" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/6595e809-3a9e-406a-81f2-fd65276d7e9e">
