### PR TITLE
Hide the Customizer menu for block themes

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -98,6 +98,8 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	/**
 	 * Hides the Customizer menu items when the block theme is active by removing the dotcom-specific actions.
 	 * They are not needed for block themes.
+	 *
+	 * @see https://github.com/Automattic/jetpack/pull/36017
 	 */
 	private function hide_customizer_menu_on_block_theme() {
 		if ( wp_is_block_theme() ) {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -88,10 +88,35 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		// All globals need to be declared for menu items to properly register.
 		global $admin_page_hooks, $menu, $menu_order, $submenu, $_wp_menu_nopriv, $_wp_submenu_nopriv; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
+		$this->hide_customizer_menu_on_block_theme();
 		require_once ABSPATH . 'wp-admin/includes/admin.php';
 		require_once ABSPATH . 'wp-admin/menu.php';
 
 		return rest_ensure_response( $this->prepare_menu_for_response( $menu ) );
+	}
+
+	/**
+	 * Hides the Customizer menu items when the block theme is active by removing the dotcom-specific actions.
+	 * They are not needed for block themes.
+	 */
+	private function hide_customizer_menu_on_block_theme() {
+		if ( wp_is_block_theme() ) {
+			remove_action( 'customize_register', 'add_logotool_button', 20 );
+			remove_action( 'customize_register', 'footercredits_register', 99 );
+			remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );
+
+			if ( class_exists( '\Jetpack_Fonts' ) ) {
+				$jetpack_fonts_instance = \Jetpack_Fonts::get_instance();
+				remove_action( 'customize_register', array( $jetpack_fonts_instance, 'register_controls' ) );
+				remove_action( 'customize_register', array( $jetpack_fonts_instance, 'maybe_prepopulate_option' ), 0 );
+			}
+
+			remove_action( 'customize_register', array( 'Jetpack_Fonts_Typekit', 'maybe_override_for_advanced_mode' ), 20 );
+
+			remove_action( 'customize_register', 'Automattic\Jetpack\Dashboard_Customizations\register_css_nudge_control' );
+
+			remove_action( 'customize_register', array( 'Jetpack_Custom_CSS_Enhancements', 'customize_register' ) );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-hide-customizer-menu
+++ b/projects/plugins/jetpack/changelog/update-hide-customizer-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Hides the Customizer menu items for block themes

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -39,11 +39,42 @@ function should_customize_nav( $admin_menu_class ) {
 }
 
 /**
+ * Hides the Customizer menu items when the block theme is active by removing the dotcom-specific actions.
+ * They are not needed for block themes.
+ */
+function hide_customizer_menu_on_block_theme() {
+	add_action(
+		'init',
+		function () {
+			if ( wp_is_block_theme() ) {
+				remove_action( 'customize_register', 'add_logotool_button', 20 );
+				remove_action( 'customize_register', 'footercredits_register', 99 );
+				remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );
+
+				if ( class_exists( '\Jetpack_Fonts' ) ) {
+					$jetpack_fonts_instance = \Jetpack_Fonts::get_instance();
+					remove_action( 'customize_register', array( $jetpack_fonts_instance, 'register_controls' ) );
+					remove_action( 'customize_register', array( $jetpack_fonts_instance, 'maybe_prepopulate_option' ), 0 );
+				}
+
+				remove_action( 'customize_register', array( 'Jetpack_Fonts_Typekit', 'maybe_override_for_advanced_mode' ), 20 );
+
+				remove_action( 'customize_register', 'Automattic\Jetpack\Dashboard_Customizations\register_css_nudge_control' );
+
+				remove_action( 'customize_register', array( 'Jetpack_Custom_CSS_Enhancements', 'customize_register' ) );
+			}
+		}
+	);
+}
+
+/**
  * Gets the name of the class that customizes the admin menu.
  *
  * @return string Class name.
  */
 function get_admin_menu_class() {
+	hide_customizer_menu_on_block_theme();
+
 	// WordPress.com Atomic sites.
 	if ( ( new Host() )->is_woa_site() ) {
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -41,6 +41,8 @@ function should_customize_nav( $admin_menu_class ) {
 /**
  * Hides the Customizer menu items when the block theme is active by removing the dotcom-specific actions.
  * They are not needed for block themes.
+ *
+ * @see https://github.com/Automattic/jetpack/pull/36017
  */
 function hide_customizer_menu_on_block_theme() {
 	add_action(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes https://github.com/Automattic/dotcom-forge/issues/5778
Related to: 
- https://github.com/Automattic/wp-calypso/pull/87973
- pfsHM7-fU-p2#comment-393
- https://github.com/Automattic/jetpack/pull/27238
- https://github.com/Automattic/wp-calypso/issues/60732
- https://github.com/Automattic/jetpack/pull/23670

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR aims to hide the Customizer menu when a block theme is active.

<img width="456" alt="Screenshot 2024-02-29 at 10 41 35" src="https://github.com/Automattic/jetpack/assets/5287479/fb29853c-a59d-4136-8f19-5a01c7ff3eee">

- The approach is to remove all actions added on WordPress.com, as discussed in p58i-f7m-p2#comment-59243. The rationale for this approach is detailed in the same post (p58i-f7m-p2), noting that the majority of these actions are features designed for classic themes and are not necessary when a block theme is in use. 
- There is one thing that should be utilized even in block themes, so I have submitted a PR: https://github.com/Automattic/wp-calypso/pull/87973. We need to update the doc afterward: https://wordpress.com/support/footer-credits/.
- Note that the Customizer menu is shown if a **3rd party plugin** depends on Customizer (this PR only removes actions from the dotcom side). This is the [core behavior](https://github.com/wordpress/wordpress-develop/blob/64b699e8e31fbff60c1a4cf51a70cbdcbb794d7b/src/wp-admin/menu.php#L219) and a reasonable decision as seen in https://github.com/Automattic/wp-calypso/issues/60732, for example.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new site
* Patch this change: https://github.com/Automattic/jetpack/pull/36017#issuecomment-1968478186
* Go to any Calypso page
* Ensure the Customizer menu is hidden
* Go to any wp-admin page
* Ensure the Customizer menu is hidden
* Switch to a Classic theme (e.g., Twenty Eleven)
* Ensure the Customizer menu is shown