### PR TITLE
Boost/Super Cache: Detect advanced-cache.php on each other and suggest workaround

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/health/lib/get-error-data.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/health/lib/get-error-data.tsx
@@ -99,6 +99,30 @@ const messages: { [ key: string ]: { title: string; message: React.ReactNode } }
 			}
 		),
 	},
+	'advanced-cache-for-super-cache': {
+		title: __( 'Cache loader file already exists', 'jetpack-boost' ),
+		message: createInterpolateElement(
+			sprintf(
+				// translators: %s refers to the path of the cache loader file.
+				__(
+					`This feature cannot be enabled because <code>%s</code> was found on your site. It was created by WP Super Cache. Please uninstall WP Super Cache to use this module.`,
+					'jetpack-boost'
+				),
+				'wp-content/advanced-cache.php'
+			),
+			{
+				code: <code className={ styles.nowrap } />,
+				link: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href={ cacheIssuesLink( 'advanced-cache-for-super-cache' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+	},
 	'unable-to-write-to-advanced-cache': {
 		title: __( 'Could not write to cache loader file', 'jetpack-boost' ),
 		message: createInterpolateElement(

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -84,6 +84,10 @@ class Page_Cache_Setup {
 		if ( file_exists( $advanced_cache_filename ) ) {
 			$content = file_get_contents( $advanced_cache_filename ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
+			if ( strpos( $content, 'WP SUPER CACHE' ) !== false ) {
+				return new \WP_Error( 'advanced-cache-for-super-cache', 'advanced-cache.php exists, but belongs to WP Super Cache.' );
+			}
+
 			if ( strpos( $content, Page_Cache::ADVANCED_CACHE_SIGNATURE ) === false ) {
 				return new \WP_Error( 'advanced-cache-incompatible', 'advanced-cache.php exists, but belongs to another plugin/system.' );
 			}

--- a/projects/plugins/boost/changelog/boost-cache-peace
+++ b/projects/plugins/boost/changelog/boost-cache-peace
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Cache: Detect WP Super Cache and customize advanced-cache.php exists message.

--- a/projects/plugins/super-cache/changelog/boost-cache-peace
+++ b/projects/plugins/super-cache/changelog/boost-cache-peace
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Setup: Detect Jetpack Boost cache and suggest troubleshooting steps

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -2290,11 +2290,15 @@ function wpsc_check_advanced_cache() {
 	global $wpsc_advanced_cache_filename;
 
 	$ret = true;
+	$boost_advanced_cache = false;
 	$other_advanced_cache = false;
 	if ( file_exists( $wpsc_advanced_cache_filename ) ) {
 		$file = file_get_contents( $wpsc_advanced_cache_filename );
 		if ( strpos( $file, "WP SUPER CACHE 0.8.9.1" ) || strpos( $file, "WP SUPER CACHE 1.2" ) ) {
 			return true;
+		} elseif ( strpos( $file, 'Boost Cache Plugin' ) ) {
+			$boost_advanced_cache = true;
+			$ret                  = false;
 		} else {
 			$other_advanced_cache = true;
 			$ret = wp_cache_create_advanced_cache();
@@ -2304,7 +2308,10 @@ function wpsc_check_advanced_cache() {
 	}
 
 	if ( false == $ret ) {
-		if ( $other_advanced_cache ) {
+		if ( $boost_advanced_cache ) {
+			echo '<div style="width: 50%" class="notice notice-error"><h2>' . esc_html__( 'You are using Page Caching on Jetpack Boost', 'wp-super-cache' ) . '</h2>';
+			echo '<p>' . esc_html__( 'It appears that Jetpack Boost Cache is currently enabled. If you wish to use WP Super Cache, please deactivate Jetpack Boost first, activate caching with WP Super Cache, and then reactivate Jetpack Boost.', 'wp-super-cache' ) . '</p>';
+		} elseif ( $other_advanced_cache ) {
 			echo '<div style="width: 50%" class="notice notice-error"><h2>' . __( 'Warning! You may not be allowed to use this plugin on your site.', 'wp-super-cache' ) . "</h2>";
 			echo '<p>' .
 				sprintf(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35497 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* While setting up Boost, detect if WP Super Cache created advanced-cache.php and customize the error message mentioning supercache.
* Vise versa on super cache.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Enable super-cache caching.
* Enable boost caching and notice the error.
> [!NOTE]  
> The error currently says Unkown Error, which is being fixed in #36015
* Deactivate Super Cache and try enabling cache on boost again. This time it should work.
* Now, reactivate Super Cache to see its side of the error.

![image](https://github.com/Automattic/jetpack/assets/3737780/00501847-2138-4cb9-b3dc-223fbb7c1265)


