### PR TITLE
Host utilities: bail early when dns_get_record is not defined.

### DIFF
--- a/projects/packages/status/changelog/update-host-dns-get-record-undefined
+++ b/projects/packages/status/changelog/update-host-dns-get-record-undefined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid issues when the dns_get_record function is not defined

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -142,9 +142,13 @@ class Host {
 	 * @return string
 	 */
 	public function get_nameserver_dns_records( $domain ) {
-		$dns_records = dns_get_record( $domain, DNS_NS ); // Fetches the DNS records of type NS (Name Server)
 		$nameservers = array();
 
+		if ( ! function_exists( 'dns_get_record' ) ) {
+			return $nameservers;
+		}
+
+		$dns_records = dns_get_record( $domain, DNS_NS ); // Fetches the DNS records of type NS (Name Server)
 		foreach ( $dns_records as $record ) {
 			if ( isset( $record['target'] ) ) {
 				$nameservers[] = $record['target']; // Adds the nameserver to the array

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -139,16 +139,15 @@ class Host {
 	 * Returns an array of nameservers for the current site.
 	 *
 	 * @param string $domain The domain of the site to check.
-	 * @return string
+	 * @return array
 	 */
 	public function get_nameserver_dns_records( $domain ) {
-		$nameservers = array();
-
 		if ( ! function_exists( 'dns_get_record' ) ) {
-			return $nameservers;
+			return array();
 		}
 
 		$dns_records = dns_get_record( $domain, DNS_NS ); // Fetches the DNS records of type NS (Name Server)
+		$nameservers = array();
 		foreach ( $dns_records as $record ) {
 			if ( isset( $record['target'] ) ) {
 				$nameservers[] = $record['target']; // Adds the nameserver to the array


### PR DESCRIPTION
## Proposed changes:

This should avoid errors in environments where `dns_get_record()` is not available, like on WordPress Playground at the moment:
https://github.com/WordPress/wordpress-playground/issues/1042

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1HpG7-rqu-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* I do not quite know how to test this. Once it is merged, we will be able to test it with WordPress Playground.
