### PR TITLE
Jetpack Sync: Ensure Woo HPOS order date fields are properly encoded

### DIFF
--- a/projects/packages/sync/changelog/fix-jp-sync-woo-order-dates
+++ b/projects/packages/sync/changelog/fix-jp-sync-woo-order-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Ensure Woo HPOS order date fields are properly encoded

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.8.0';
+	const PACKAGE_VERSION = '2.8.1-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -254,6 +254,18 @@ class WooCommerce_HPOS_Orders extends Module {
 				}
 			}
 
+			/**
+			 * We need to convert the WC_DateTime objects to stdClass objects to ensure they are properly encoded.
+			 *
+			 * @see Automattic\Jetpack\Sync\Functions::json_wrap as the return value of get_object_vars can vary depending on PHP version.
+			 */
+			if ( in_array( $key, array( 'date_created', 'date_modified', 'date_paid', 'date_completed' ), true ) ) {
+				if ( is_a( $order_data[ $key ], 'WC_DateTime' ) ) {
+					$filtered_order_data[ $key ] = (object) (array) $order_data[ $key ];
+					continue;
+				}
+			}
+
 			if ( isset( $order_data[ $key ] ) ) {
 				$filtered_order_data[ $key ] = $order_data[ $key ];
 				continue;


### PR DESCRIPTION
When syncing Woo HPOS orders, datetime fields are instances of `WC_DateTime`, which depending on the PHP version, may result in empty objects upon encoding.
The reason is the usage of `get_object_vars` [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-functions.php#L606) which will [return different results depending on the PHP version](https://onlinephp.io/?s=FctBCoMwFEXReSB7eAXBCAUXYEsndQfOgzWPWsH8EL-Ku9dOL-c-XmlM1tQ12qjMOGTNGCQQIzPvYJzkuFlTBMUTkTvevbL7zXQoo-wlqsYaa7Y--7DOyeFL9fKZOKi_4uLwX6uLnQ%2C%2C&v=8.1.27%2C8.0.30%2C7.4.33%2C7.2.34%2C5.6.40).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders: Adds a check for instances of `WC_DateTime` in `filter_order_data` and casts them to `stdObject`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
peaMlT-rA-p2#comment-1026
pf5801-Eq-p2


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
- Setup a JN site on **PHP 8.2** (trunk) with **WooCommerce** installed and activated. Make sure to also install the **Jetpack Beta** plugin
- Add an order 
- Check the corresponding order in the Cache site and confirm that `date_created_gmt` and `date_updated_gmt` are empty
- Mark the order as completed
- Check the corresponding order data in the Cache site and confirm that `date_paid_gmt` and `date_completed_gmt` are empty
- Switch to this branch and repeat the above
- Check the corresponding order in the Cache site and confirm that `date_created_gmt` and `date_updated_gmt` are populated
- Check the corresponding order data in the Cache site and confirm that `date_paid_gmt` and `date_completed_gmt` are populated