### PR TITLE
[Super Cache] exit the cache system if request uri is not set

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-request_uri_null
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-request_uri_null
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: bail if the request uri isn't set. It means the plugin isn't configured yet.

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -390,6 +390,11 @@ function wp_cache_postload() {
 	global $cache_enabled, $wp_super_cache_late_init;
 	global $wp_cache_request_uri;
 
+	if ( empty( $wp_cache_request_uri ) ) {
+		wp_cache_debug( 'wp_cache_postload: no request uri configured. Not running.' );
+		return false;
+	}
+
 	// have to sanitize here because formatting.php is loaded after wp_cache_request_uri is set
 	$wp_cache_request_uri = esc_url_raw( wp_unslash( $wp_cache_request_uri ) );
 


### PR DESCRIPTION
If another cache plugin has already been set up on a website, then this plugin exits with a warning but wp-cache.php is still loaded which loads wp-cache-phse2.php.

The file wp-cache-phse2.php contains a function called wp_cache_postload() that wp-setting.php looks for and loads as part of the ordinary caching system. However, if wp-content/advanced-cache.php belongs to another plugin it won't have loaded wp-cache-phase1.php, which is where $wp_cache_request_uri is set.

The end result is the warning about advanced-cache.php and a warning about passing null to ltrim() in esc_url().

## Proposed changes:
* Check that $wp_cache_request_uri is not empty before using it. Exit if it is.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Install and set up a different caching plugin. (whistles..)
* Activate WP Super Cache and you'll see the advanced-cache.php error and a warning about ltrim not accepting null parameters.
* Apply PR and reload the WP Super Cache settings page.
* You'll see the  advanced-cache.php error message, but no ltrim warning.