### PR TITLE
Revert "jetpack-mu-wpcom: wrap wpcom URL with localized_wpcom_url"

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-site-menu-localize-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-site-menu-localize-url
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use localized_wpcom_url per PHPCS-CHANGED WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl
-
-

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -35,7 +35,7 @@ function wpcom_add_wpcom_menu_item() {
 		esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
 		esc_attr__( 'All Sites', 'jetpack-mu-wpcom' ),
 		'manage_options',
-		localized_wpcom_url( 'https://wordpress.com/sites' ),
+		'https://wordpress.com/sites',
 		null,
 		'dashicons-arrow-left-alt2',
 		0


### PR DESCRIPTION
Reverts Automattic/jetpack#35966