### PR TITLE
WP Super Cache: check for the advanced-cache.php created by Boost Cache

### DIFF
--- a/projects/plugins/super-cache/changelog/update-super-cache-advanced-cache-warning
+++ b/projects/plugins/super-cache/changelog/update-super-cache-advanced-cache-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WP Super Cache: check for Boost Cache when creating advanced-cache.php

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -2310,8 +2310,8 @@ function wpsc_check_advanced_cache() {
 			// translators: %s is the filename of the advanced-cache.php file
 			echo '<p>' . sprintf( esc_html__( 'The file %s was created by the Jetpack Boost plugin.', 'wp-super-cache' ), esc_html( $wpsc_advanced_cache_filename ) ) . '</p>';
 			echo '<p>' . esc_html__( 'You can use Jetpack Boost and WP Super Cache at the same time but only if the Cache Site Pages module in Boost is disabled. To use WP Super Cache for caching:', 'wp-super-cache' ) . '</p>';
-			// translators: %s is a link to the plugins page
-			echo '<ol><li>' . sprintf( esc_html__( 'Deactivate Jetpack Boost on the <a href="%s">Plugins</a> page.', 'wp-super-cache' ), esc_url( admin_url( 'plugins.php' ) ) ) . '</li>';
+			// translators: %s is a html link to the plugins page
+			echo '<ol><li>' . sprintf( esc_html__( 'Deactivate Jetpack Boost on the %s page.', 'wp-super-cache' ), '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">' . esc_html__( 'Plugins', 'wp-super-cache' ) . '</a>' ) . '</li>';
 			echo '<li>' . esc_html__( 'Reload this page to configure WP Super Cache.', 'wp-super-cache' ) . '</li>';
 			echo '<li>' . esc_html__( 'Activate the Jetpack Boost plugin again.', 'wp-super-cache' ) . '</li>';
 			echo '</ol>';

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -2289,28 +2289,32 @@ function wp_cache_create_advanced_cache() {
 function wpsc_check_advanced_cache() {
 	global $wpsc_advanced_cache_filename;
 
-	$ret = true;
-	$boost_advanced_cache = false;
+	$ret                  = false;
 	$other_advanced_cache = false;
 	if ( file_exists( $wpsc_advanced_cache_filename ) ) {
 		$file = file_get_contents( $wpsc_advanced_cache_filename );
 		if ( strpos( $file, "WP SUPER CACHE 0.8.9.1" ) || strpos( $file, "WP SUPER CACHE 1.2" ) ) {
 			return true;
-		} elseif ( strpos( $file, 'Boost Cache Plugin' ) ) {
-			$boost_advanced_cache = true;
-			$ret                  = false;
+		} elseif ( strpos( $file, 'Boost Cache Plugin' ) !== false ) {
+			$other_advanced_cache = 'BOOST';
 		} else {
 			$other_advanced_cache = true;
-			$ret = wp_cache_create_advanced_cache();
 		}
 	} else {
 		$ret = wp_cache_create_advanced_cache();
 	}
 
 	if ( false == $ret ) {
-		if ( $boost_advanced_cache ) {
-			echo '<div style="width: 50%" class="notice notice-error"><h2>' . esc_html__( 'You are using Page Caching on Jetpack Boost', 'wp-super-cache' ) . '</h2>';
-			echo '<p>' . esc_html__( 'It appears that Jetpack Boost Cache is currently enabled. If you wish to use WP Super Cache, please deactivate Jetpack Boost first, activate caching with WP Super Cache, and then reactivate Jetpack Boost.', 'wp-super-cache' ) . '</p>';
+		if ( $other_advanced_cache === 'BOOST' ) {
+			echo '<div style="width: 50%" class="notice notice-error"><h2>' . esc_html__( 'Warning! Jetpack Boost Cache Detected', 'wp-super-cache' ) . '</h2>';
+			// translators: %s is the filename of the advanced-cache.php file
+			echo '<p>' . sprintf( esc_html__( 'The file %s was created by the Jetpack Boost plugin.', 'wp-super-cache' ), esc_html( $wpsc_advanced_cache_filename ) ) . '</p>';
+			echo '<p>' . esc_html__( 'You can use Jetpack Boost and WP Super Cache at the same time but only if the Cache Site Pages module in Boost is disabled. To use WP Super Cache for caching:', 'wp-super-cache' ) . '</p>';
+			// translators: %s is a link to the plugins page
+			echo '<ol><li>' . sprintf( esc_html__( 'Deactivate Jetpack Boost on the <a href="%s">Plugins</a> page.', 'wp-super-cache' ), esc_url( admin_url( 'plugins.php' ) ) ) . '</li>';
+			echo '<li>' . esc_html__( 'Reload this page to configure WP Super Cache.', 'wp-super-cache' ) . '</li>';
+			echo '<li>' . esc_html__( 'Activate the Jetpack Boost plugin again.', 'wp-super-cache' ) . '</li>';
+			echo '</ol>';
 		} elseif ( $other_advanced_cache ) {
 			echo '<div style="width: 50%" class="notice notice-error"><h2>' . __( 'Warning! You may not be allowed to use this plugin on your site.', 'wp-super-cache' ) . "</h2>";
 			echo '<p>' .


### PR DESCRIPTION
When installing WP Super Cache it must create a file called wp-content/advanced-cache.php but another caching plugin may have already created that file. This PR checks if it was created by Jetpack Boost and informs the site owner how to disable the plugin temporarily so WP Super Cache can create the same file.


## Proposed changes:
* Check for "Jetpack Boost" text in advanced-cache.php and if found display a different message to the user.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Install Jetpack Boost and enable the Cache module
* Install this branch of Super Cache and activate it.
* Go to the plugin settings page and you will see a warning. It should mention Jetpack Boost and how to disable it temporarily.
* Disable Jetpack Boost
* Reload the WP Super Cache settings page
* Enable Jetpack Boost again.

The warning screen looks like this:
![Screenshot 2024-02-28 at 15 08 04](https://github.com/Automattic/jetpack/assets/5656673/da654609-df89-4f0c-b423-241185f9cee1)