### PR TITLE
revert: ensure `playsInline` attribute conforms when falling back to core Video block

### DIFF
--- a/projects/plugins/jetpack/changelog/rnmobile-revert-playsinline-setting-change-in-core-video
+++ b/projects/plugins/jetpack/changelog/rnmobile-revert-playsinline-setting-change-in-core-video
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+RNMobile: Revert change to the way playsInline attribute is saved, prevent regression on web.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/save.js
@@ -42,14 +42,7 @@ const VideoPressSave = CoreVideoSave => props => {
 		 * @see https://github.com/WordPress/gutenberg/blob/c5f9bd88125282a0c35f887cc8d835f065893112/packages/editor/src/hooks/generated-class-name.js#L42
 		 * @see https://github.com/Automattic/wp-calypso/pull/30546#issuecomment-463637946
 		 */
-		// Rename `playsinline` to `playsInline` to conform the block schema of core Video block.
-		const { playsinline: videoPressPlayinline, ...restAttributes } = props.attributes;
-		const coreVideoAttributes = { ...restAttributes, playsInline: playsinline };
-
-		return CoreVideoSave( {
-			...props,
-			attributes: coreVideoAttributes,
-		} );
+		return CoreVideoSave( props );
 	}
 
 	const url = getVideoPressUrl( guid, {


### PR DESCRIPTION
Fixes a regression that prevents the "plays inline" setting working for Atomic sites with VideoPress enabled on the web.

## Proposed changes:

* The changes in https://github.com/Automattic/jetpack/pull/35981 have been reverted to prevent a regression on the web.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/pull/35981#issuecomment-1969386975

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

* On the web, navigate to an Atomic site with VideoPress enabled.
* Navigate to the site's post editor.
* Add a Video block and upload to it. 
* Toggle the block's "plays inline" setting to on.
* Save the change and exit the post.
* Return to the post and confirm the setting remains toggled on.