### PR TITLE
Social: Change admin 'Write a post' button variant

### DIFF
--- a/projects/plugins/social/changelog/change-social-admin-write-post-button-variant
+++ b/projects/plugins/social/changelog/change-social-admin-write-post-button-variant
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed the admin page 'Write a post' button to primary if the site has connections

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -76,7 +76,7 @@ const Header = () => {
 								{ __( 'Connect accounts', 'jetpack-social' ) }
 							</Button>
 						) }
-						<Button href={ newPostUrl } variant="secondary">
+						<Button href={ newPostUrl } variant={ hasConnections ? 'primary' : 'secondary' }>
 							{ __( 'Write a post', 'jetpack-social' ) }
 						</Button>
 					</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/142

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed the button variant to primary if the site has connections.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
 https://github.com/Automattic/jetpack-reach/issues/142
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN site with this patch, with Social installed
* Go to the social admin page, and make sure that "Write a post" is secondary
* Add connections, then go back to the admin pagee
* The button should be the primary variant.

BEFORE | AFTER

<img src="https://github.com/Automattic/jetpack/assets/36671565/1637ba23-5f17-4b74-8e1d-a59868e51257" width="45%"></img> <img src="https://github.com/Automattic/jetpack/assets/36671565/32a9a4ca-09f9-4647-8656-5e3ee151a478" width="45%"></img>