### PR TITLE
Voice to Content: move transcription logic to it's own hook to simplify block code

### DIFF
--- a/projects/plugins/jetpack/changelog/update-voice-to-content-transcription-hook-refactoring
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-transcription-hook-refactoring
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Voice to Content: move transcription to a dedicated hook so the block code becomes more simple

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -8,7 +8,7 @@ import {
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { Button, Modal, Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
 /**
@@ -20,6 +20,8 @@ import useTranscriptionCreator from './hooks/use-transcription-creator';
 import useTranscriptionInserter from './hooks/use-transcription-inserter';
 
 export default function VoiceToContentEdit( { clientId } ) {
+	const [ audio, setAudio ] = useState< Blob >( null );
+
 	const dispatch: {
 		removeBlock: ( id: number ) => void;
 	} = useDispatch( 'core/block-editor' );
@@ -61,13 +63,23 @@ export default function VoiceToContentEdit( { clientId } ) {
 	} );
 
 	const onAudioHandler = useCallback(
-		( audio: Blob ) => {
-			if ( audio ) {
-				createTranscription( audio, TRANSCRIPTION_POST_PROCESSING_ACTION_SIMPLE_DRAFT );
+		( audioFile: Blob ) => {
+			if ( audioFile ) {
+				setAudio( audioFile );
 			}
 		},
-		[ createTranscription ]
+		[ setAudio ]
 	);
+
+	/**
+	 * When the audio changes, create the transcription. In the future,
+	 * we can trigger this action (and others) from a button in the UI.
+	 */
+	useEffect( () => {
+		if ( audio ) {
+			createTranscription( audio, TRANSCRIPTION_POST_PROCESSING_ACTION_SIMPLE_DRAFT );
+		}
+	}, [ audio, createTranscription ] );
 
 	// Destructure controls
 	const {

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-creator/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-creator/index.ts
@@ -61,12 +61,15 @@ export default function useTranscriptionCreator( {
 			},
 		} );
 
-	const onTranscriptionReady = ( content: string ) => {
-		transcription.current = content;
-		if ( postProcessingAction.current ) {
-			processTranscription( postProcessingAction.current, content );
-		}
-	};
+	const onTranscriptionReady = useCallback(
+		( content: string ) => {
+			transcription.current = content;
+			if ( postProcessingAction.current ) {
+				processTranscription( postProcessingAction.current, content );
+			}
+		},
+		[ processTranscription ]
+	);
 
 	const { transcribeAudio, cancelTranscription, isTranscribingAudio }: UseAudioTranscriptionReturn =
 		useAudioTranscription( {

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-creator/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-creator/index.ts
@@ -12,6 +12,8 @@ import debugFactory from 'debug';
 
 const debug = debugFactory( 'voice-to-content:use-transcription-creator' );
 
+const VOICE_TO_CONTENT_FEATURE = 'voice-to-content';
+
 /**
  * The props for the transcription creator hook.
  */
@@ -41,7 +43,6 @@ export default function useTranscriptionCreator( {
 	onUpdate,
 	onError,
 }: UseTranscriptionCreatorProps ): UseTranscriptionCreatorReturn {
-	const VOICE_TO_CONTENT_FEATURE = 'voice-to-content';
 	const transcription = useRef< string >( null );
 	const postProcessingAction = useRef< PostProcessingAction >( null );
 

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-creator/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/hooks/use-transcription-creator/index.ts
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import {
+	useAudioTranscription,
+	UseAudioTranscriptionReturn,
+	useTranscriptionPostProcessing,
+	PostProcessingAction,
+} from '@automattic/jetpack-ai-client';
+import { useCallback, useRef } from '@wordpress/element';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'voice-to-content:use-transcription-creator' );
+
+/**
+ * The props for the transcription creator hook.
+ */
+export type UseTranscriptionCreatorProps = {
+	onReady: ( content: string ) => void;
+	onUpdate: ( content: string ) => void;
+	onError: ( error: string ) => void;
+};
+
+/**
+ * The return value for the transcription creator hook.
+ */
+export type UseTranscriptionCreatorReturn = {
+	isCreatingTranscription: boolean;
+	createTranscription: ( audio: Blob, action: PostProcessingAction ) => void;
+	cancelTranscription: () => void;
+};
+
+/**
+ * Hook to handle the creation of a transcription.
+ *
+ * @param {UseTranscriptionCreatorProps} props - Callbacks to handle the transcription when it's ready, updated or fails.
+ * @returns {UseTranscriptionCreatorReturn} - Object with functions to handle transcription creation.
+ */
+export default function useTranscriptionCreator( {
+	onReady,
+	onUpdate,
+	onError,
+}: UseTranscriptionCreatorProps ): UseTranscriptionCreatorReturn {
+	const VOICE_TO_CONTENT_FEATURE = 'voice-to-content';
+	const transcription = useRef< string >( null );
+	const postProcessingAction = useRef< PostProcessingAction >( null );
+
+	const { processTranscription, cancelTranscriptionProcessing, isProcessingTranscription } =
+		useTranscriptionPostProcessing( {
+			feature: VOICE_TO_CONTENT_FEATURE,
+			onReady: onReady,
+			onUpdate: onUpdate,
+			onError: error => {
+				// In case of post-processing error, use the raw transcription instead for a partial result
+				if ( transcription.current ) {
+					return onReady( transcription.current );
+				}
+
+				// No action over the transcription, just log the error
+				debug( 'Transcription post-processing error: ', error );
+			},
+		} );
+
+	const onTranscriptionReady = ( content: string ) => {
+		transcription.current = content;
+		if ( postProcessingAction.current ) {
+			processTranscription( postProcessingAction.current, content );
+		}
+	};
+
+	const { transcribeAudio, cancelTranscription, isTranscribingAudio }: UseAudioTranscriptionReturn =
+		useAudioTranscription( {
+			feature: VOICE_TO_CONTENT_FEATURE,
+			onReady: onTranscriptionReady,
+			onError: onError,
+		} );
+
+	const handleCreateTranscription = useCallback(
+		( audio: Blob, action: PostProcessingAction ) => {
+			if ( audio && action ) {
+				postProcessingAction.current = action;
+				return transcribeAudio( audio );
+			}
+		},
+		[ transcribeAudio ]
+	);
+
+	const handleCancelTranscription = useCallback( () => {
+		cancelTranscription();
+		cancelTranscriptionProcessing();
+	}, [ cancelTranscription, cancelTranscriptionProcessing ] );
+
+	return {
+		isCreatingTranscription: isTranscribingAudio || isProcessingTranscription,
+		createTranscription: handleCreateTranscription,
+		cancelTranscription: handleCancelTranscription,
+	};
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #35547.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create `useTranscriptionCreator` hook to abstract the details of the transcription requesting
* Change the block code to use the new hook
* Change the block code to set the audio to a local state, and react to a change of it as a trigger for the transcription; in the future, we can use UI buttons to trigger the transcription actions

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open the browser console to inspect for errors and debug messages
* Insert a Voice to Content block
* Use the block to record voice and transcribe it
* Use the block to upload an audio and transcribe it
* You should expect no regressions

