### PR TITLE
My Jetpack: AI product page plan/tier information and CTAs

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -53,9 +53,10 @@ export default function () {
 	const hasUnlimited = currentTier?.value === 1;
 	const isFree = currentTier?.value === 0;
 	const hasPaidTier = ! isFree && ! hasUnlimited;
-	const shouldContactUs = hasPaidTier && ! nextTier;
+	const shouldContactUs = ! hasUnlimited && hasPaidTier && ! nextTier;
 	const freeRequestsLeft = isFree && 20 - allTimeRequests >= 0 ? 20 - allTimeRequests : 0;
-	const showCurrentUsage = hasPaidTier && ! hasUnlimited && ! isFree;
+	const showCurrentUsage = hasPaidTier && ! isFree;
+	const showAllTimeUsage = hasPaidTier || hasUnlimited;
 	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
 
 	const navigateToPricingTable = useMyJetpackNavigate( '/add-jetpack-ai' );
@@ -113,7 +114,7 @@ export default function () {
 									'jetpack-my-jetpack'
 								) }
 							</div>
-							{ ! hasUnlimited && (
+							{ ! shouldContactUs && (
 								<Button
 									variant="primary"
 									onClick={ upgradeClickHandler }
@@ -123,37 +124,42 @@ export default function () {
 								</Button>
 							) }
 							{ shouldContactUs && (
-								<Button href={ contactHref } onClick={ contactClickHandler }>
+								<Button
+									variant="primary"
+									onClick={ contactClickHandler }
+									href={ contactHref }
+									className={ styles[ 'product-interstitial__hero-cta' ] }
+								>
 									{ __( 'Contact Us', 'jetpack-my-jetpack' ) }
 								</Button>
 							) }
 						</div>
 						<div className={ styles[ 'product-interstitial__hero-side' ] }>
-							{ showCurrentUsage && currentTier?.value && (
-								<>
-									<Card className={ styles[ 'stats-card' ] }>
-										<AiIcon />
-										<div>
-											<div className={ styles[ 'product-interstitial__stats-card-text' ] }>
-												{ __( 'Requests for this month', 'jetpack-my-jetpack' ) }
-											</div>
-											<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
-												{ currentTier.value - usage[ 'requests-count' ] }
-											</div>
+							{ showCurrentUsage && (
+								<Card className={ styles[ 'stats-card' ] }>
+									<AiIcon />
+									<div>
+										<div className={ styles[ 'product-interstitial__stats-card-text' ] }>
+											{ __( 'Requests for this month', 'jetpack-my-jetpack' ) }
 										</div>
-									</Card>
-									<Card className={ styles[ 'stats-card' ] }>
-										<Icon icon={ check } className={ styles[ 'stats-card-icon-check' ] } />
-										<div>
-											<div className={ styles[ 'product-interstitial__stats-card-text' ] }>
-												{ __( 'All-time requests used', 'jetpack-my-jetpack' ) }
-											</div>
-											<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
-												{ allTimeRequests }
-											</div>
+										<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
+											{ currentTier.value - usage[ 'requests-count' ] }
 										</div>
-									</Card>
-								</>
+									</div>
+								</Card>
+							) }
+							{ showAllTimeUsage && (
+								<Card className={ styles[ 'stats-card' ] }>
+									<Icon icon={ check } className={ styles[ 'stats-card-icon-check' ] } />
+									<div>
+										<div className={ styles[ 'product-interstitial__stats-card-text' ] }>
+											{ __( 'All-time requests used', 'jetpack-my-jetpack' ) }
+										</div>
+										<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
+											{ allTimeRequests }
+										</div>
+									</div>
+								</Card>
 							) }
 							{ isFree && (
 								<Card className={ styles[ 'stats-card' ] }>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -114,7 +114,7 @@ export default function () {
 									'jetpack-my-jetpack'
 								) }
 							</div>
-							{ ! shouldContactUs && (
+							{ ! shouldContactUs && ! hasUnlimited && (
 								<Button
 									variant="primary"
 									onClick={ upgradeClickHandler }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -1,20 +1,31 @@
 /**
  * External dependencies
  */
-import { AdminPage, Col, Container, JetpackLogo, AiIcon } from '@automattic/jetpack-components';
+import {
+	AdminPage,
+	Col,
+	Container,
+	JetpackLogo,
+	AiIcon,
+	getRedirectUrl,
+} from '@automattic/jetpack-components';
 import { Button, Card } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, plus, help, check } from '@wordpress/icons';
 import classnames from 'classnames';
+import debugFactory from 'debug';
 import { useCallback } from 'react';
 /**
  * Internal dependencies
  */
+import useAnalytics from '../../../hooks/use-analytics';
 import { useGoBack } from '../../../hooks/use-go-back';
+import useMyJetpackNavigate from '../../../hooks/use-my-jetpack-navigate';
 import { useProduct } from '../../../hooks/use-product';
 import GoBackLink from '../../go-back-link';
 import styles from './style.module.scss';
 
+const debug = debugFactory( 'my-jetpack:product-interstitial:jetpack-ai-product-page' );
 /**
  * Product Page for Jetpack AI
  * @returns {object} React component for the product page
@@ -22,7 +33,7 @@ import styles from './style.module.scss';
 export default function () {
 	const { onClickGoBack } = useGoBack( 'jetpack-ai' );
 	const { detail } = useProduct( 'jetpack-ai' );
-	const { description } = detail;
+	const { description, 'ai-assistant-feature': aiAssistantFeature } = detail;
 
 	const videoTitle1 = __(
 		'Generate and edit content faster with Jetpack AI Assistant',
@@ -31,9 +42,42 @@ export default function () {
 	const videoTitle2 = __( 'Build forms using prompts', 'jetpack-my-jetpack' );
 	const videoTitle3 = __( 'Get feedback on posts', 'jetpack-my-jetpack' );
 
+	debug( aiAssistantFeature );
+	const {
+		'requests-count': allTimeRequests,
+		'current-tier': currentTier,
+		'next-tier': nextTier,
+		'usage-period': usage,
+	} = aiAssistantFeature || {};
+
+	const hasUnlimited = currentTier?.value === 1;
+	const isFree = currentTier?.value === 0;
+	const hasPaidTier = ! isFree && ! hasUnlimited;
+	const shouldContactUs = hasPaidTier && ! nextTier;
+	const freeRequestsLeft = isFree && 20 - allTimeRequests >= 0 ? 20 - allTimeRequests : 0;
+	const showCurrentUsage = hasPaidTier && ! hasUnlimited && ! isFree;
+	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
+
+	const navigateToPricingTable = useMyJetpackNavigate( '/add-jetpack-ai' );
+	const { recordEvent } = useAnalytics();
+
 	const onCreateClick = useCallback( () => {
 		// console.log( 'click' );
 	}, [] );
+
+	const contactClickHandler = useCallback( () => {
+		recordEvent( 'jetpack_ai_upgrade_contact_us', { placement: 'product-page' } );
+	}, [ recordEvent ] );
+
+	const upgradeClickHandler = useCallback( () => {
+		recordEvent( 'jetpack_ai_upgrade_button', {
+			placement: 'product-page',
+			context: 'my-jetpack',
+			current_tier_slug: currentTier?.slug || '',
+			requests_count: allTimeRequests,
+		} );
+		navigateToPricingTable();
+	}, [ recordEvent, allTimeRequests, currentTier, navigateToPricingTable ] );
 
 	return (
 		<AdminPage showHeader={ false } showBackground={ true }>
@@ -69,37 +113,61 @@ export default function () {
 									'jetpack-my-jetpack'
 								) }
 							</div>
-							<Button
-								variant="primary"
-								onClick={ onCreateClick }
-								className={ styles[ 'product-interstitial__hero-cta' ] }
-							>
-								{ __( 'Get more requests', 'jetpack-my-jetpack' ) }
-							</Button>
+							{ ! hasUnlimited && (
+								<Button
+									variant="primary"
+									onClick={ upgradeClickHandler }
+									className={ styles[ 'product-interstitial__hero-cta' ] }
+								>
+									{ __( 'Get more requests', 'jetpack-my-jetpack' ) }
+								</Button>
+							) }
+							{ shouldContactUs && (
+								<Button href={ contactHref } onClick={ contactClickHandler }>
+									{ __( 'Contact Us', 'jetpack-my-jetpack' ) }
+								</Button>
+							) }
 						</div>
 						<div className={ styles[ 'product-interstitial__hero-side' ] }>
-							<Card className={ styles[ 'stats-card' ] }>
-								<AiIcon />
-								<div>
-									<div className={ styles[ 'product-interstitial__stats-card-text' ] }>
-										{ __( 'Requests for this month', 'jetpack-my-jetpack' ) }
+							{ showCurrentUsage && currentTier?.value && (
+								<>
+									<Card className={ styles[ 'stats-card' ] }>
+										<AiIcon />
+										<div>
+											<div className={ styles[ 'product-interstitial__stats-card-text' ] }>
+												{ __( 'Requests for this month', 'jetpack-my-jetpack' ) }
+											</div>
+											<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
+												{ currentTier.value - usage[ 'requests-count' ] }
+											</div>
+										</div>
+									</Card>
+									<Card className={ styles[ 'stats-card' ] }>
+										<Icon icon={ check } className={ styles[ 'stats-card-icon-check' ] } />
+										<div>
+											<div className={ styles[ 'product-interstitial__stats-card-text' ] }>
+												{ __( 'All-time requests used', 'jetpack-my-jetpack' ) }
+											</div>
+											<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
+												{ allTimeRequests }
+											</div>
+										</div>
+									</Card>
+								</>
+							) }
+							{ isFree && (
+								<Card className={ styles[ 'stats-card' ] }>
+									<Icon icon={ check } className={ styles[ 'stats-card-icon-check' ] } />
+									<div>
+										<div className={ styles[ 'product-interstitial__stats-card-text' ] }>
+											{ __( 'Free requests available', 'jetpack-my-jetpack' ) }
+										</div>
+										<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
+											{ freeRequestsLeft }
+										</div>
 									</div>
-									<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
-										{ '234' }
-									</div>
-								</div>
-							</Card>
-							<Card className={ styles[ 'stats-card' ] }>
-								<Icon icon={ check } className={ styles[ 'stats-card-icon-check' ] } />
-								<div>
-									<div className={ styles[ 'product-interstitial__stats-card-text' ] }>
-										{ __( 'All-time requests used', 'jetpack-my-jetpack' ) }
-									</div>
-									<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
-										{ '234' }
-									</div>
-								</div>
-							</Card>
+								</Card>
+							) }
 						</div>
 					</div>
 				</Col>

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-connected-flows
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-connected-flows
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack AI: add plans/tier information on product page and corresponding CTAs


### PR DESCRIPTION
The new product page for AI shows information from the current tier and usage

Fixes #36034 

## Proposed changes:
This PR addresses some of the basic scenarios to show the proper information on the product page, according to design.

hzEFw0xtiYggqdai27aYN0-fi-4677_6752

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Checkout and visit `wp-admin/admin.php?page=my-jetpack#/jetpack-ai`. Use console to simulate free, unlimited and tiered plans.

```js
// define the product object:
jetpackAi = wp.data.select( 'my-jetpack' ).getProduct( 'jetpack-ai' );

// overwrite tier conditions:
wp.data.dispatch('my-jetpack').setProduct( {
    ...jetpackAi,
    'ai-assistant-feature': {
        ...jetpackAi['ai-assistant-feature'],
        'current-tier': {
          slug: 'some',
          value: 0, // 0 = free, 1 = unlimited, 100/200/500/750/1000 tier plans
        },
        'next-tier': {}, // truthy value for upgrade CTA, null for "Contact Us"
    }
} )
```

Check with design, but the noticeable changes are:

- Free
  - CTA is "Get more requests"
  - Card shows "Free requests available"
    - Should never show less than `0` (zero)
- Unlimited
  - CTA is NOT shown
  - Card shows "All-time requests used"
- Tier plans 100/200/500/750/1000
  - CTA is "Get more requests"
    - Passing `next-tier` as `null` is how we derive the last CTA for users on the highest tier, CTA should read "Contact Us", which opens the email app
  - Card with current monthly requests
  - Card with all-time requests
