### PR TITLE
My Jetpack: Fix Jetpack AI responsive styles

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
@@ -3,6 +3,7 @@
  */
 import { AdminPage, Col, Container, JetpackLogo } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
+import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import debugFactory from 'debug';
 /**
@@ -48,7 +49,7 @@ export default function JetpackAiInterstitial() {
 	const highlightLastFeature = nextTier?.value !== 1;
 
 	return tiers && tiers.length ? (
-		<AdminPage showHeader={ false } showBackground={ false }>
+		<AdminPage showHeader={ false } showBackground={ true }>
 			<Container
 				fluid
 				horizontalSpacing={ 3 }
@@ -67,7 +68,7 @@ export default function JetpackAiInterstitial() {
 					>
 						<JetpackLogo />
 						<div className={ styles[ 'product-interstitial__product-header-name' ] }>
-							AI Assistant
+							{ __( 'AI Assistant', 'jetpack-my-jetpack' ) }
 						</div>
 					</div>
 				</Col>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -118,7 +118,6 @@ export default function () {
 										width="280"
 										height="157"
 										src="https://videopress.com/embed/GdXmtVtW?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F02%2Fimage-37.png%3Fw%3D560"
-										frameborder="0"
 										allowFullScreen
 										allow="clipboard-write"
 										title={ videoTitle1 }
@@ -150,7 +149,6 @@ export default function () {
 										width="280"
 										height="157"
 										src="https://videopress.com/embed/GdXmtVtW?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F02%2Fimage-38.png%3Fw%3D560"
-										frameborder="0"
 										allowFullScreen
 										allow="clipboard-write"
 										title={ videoTitle2 }
@@ -182,7 +180,6 @@ export default function () {
 										width="280"
 										height="157"
 										src="https://videopress.com/embed/GdXmtVtW?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F02%2Fimage-39.png%3Fw%3D560"
-										frameborder="0"
 										allowFullScreen
 										allow="clipboard-write"
 										title={ videoTitle3 }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
@@ -220,6 +220,7 @@
 		flex-direction: column;
 		gap: var(--spacing-base);
 		flex: 1;
+		min-width: 280px;
 
 		.product-interstitial__usage-videos-heading {
 			font-size: 20px;

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
@@ -40,18 +40,22 @@
 	max-width: 1128px;
 	margin: 0 auto;
 	flex-wrap: wrap;
+	gap: calc( var( --spacing-base ) * 6 );
 
-	@media only screen and (max-width: 960px) {
+	@media only screen and (max-width: 1366px) {
 		padding-left: calc( var( --spacing-base ) * 3 );
 		padding-right: calc( var( --spacing-base ) * 3 );
 	}
 
 	.product-interstitial__hero-content {
-		margin-right: 1.5rem;
 		flex: 1;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
+
+		@media screen and ( min-width: 960px ) {
+			max-width: 70%;
+		}
 
 		.product-interstitial__hero-heading {
 			font-size: 36px;
@@ -76,12 +80,14 @@
 
 	.product-interstitial__hero-side {
 		display: flex;
-		flex: 1;
 		gap: calc(var(--spacing-base)* 3);
 		align-items: center;
 		flex-wrap: wrap;
 		justify-content: flex-end;
-		margin: calc( var( --spacing-base ) * 6 ) 0;
+
+		@media only screen and (max-width: 430px) {
+			flex: 1;
+		}
 	}
 
 	// stolen from stats-section
@@ -152,7 +158,7 @@
 		max-width: 744px;
 		margin: 0 auto;
 
-		@media only screen and (max-width: 960px) {
+		@media only screen and (max-width: 1366px) {
 			padding-left: calc( var( --spacing-base ) * 3 );
 			padding-right: calc( var( --spacing-base ) * 3 );
 		}
@@ -161,6 +167,11 @@
 	.product-interstitial__section-wrapper-wide {
 		max-width: 1128px;
 		margin: 0 auto;
+
+		@media only screen and (max-width: 960px) {
+			padding-left: calc( var( --spacing-base ) * 3 );
+			padding-right: calc( var( --spacing-base ) * 3 );
+		}
 	}
 
 	.product-interstitial__section-heading {

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-responsive-styles
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-responsive-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack AI: address responsive issues on the styles


### PR DESCRIPTION
Some styles don't look neat on all widths

## Proposed changes:
This PR addresses some issues with horizontal paddings and flex gaps when switching from desktop to mobile views

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Do a visual check on the new styles, particularly on mid sized screens, where the paddings would be too narrow and look weird on the hero section. Could be useful to test on local env, so `watch`ing my-jetpack and contrasting from `add/my-jetpack-ai-detail-table` branch.

**Before:**
<img width="892" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/cfb9b1e0-6838-40e7-a85e-29656c1944e4">

**After:**
<img width="903" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/24c00d7d-6931-4176-9220-0c141036ee4c">
