### PR TITLE
Stats: Fix posts endpoint on atomic

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-fix-posts-endpoint-on-atomic
+++ b/projects/packages/stats-admin/changelog/fix-fix-posts-endpoint-on-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: fix posts endpoint for Atomic sites

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.16.1",
+	"version": "0.16.2-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.16.1';
+	const VERSION = '0.16.2-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -575,7 +575,7 @@ class REST_Controller {
 		$params   = array_merge( array( 'force' => 'wpcom' ), $req->get_params() );
 		$response = wp_remote_get(
 			sprintf(
-				'%s/rest/v1.2/sites/%d/posts?%s',
+				'%s/rest/v1.1/sites/%d/posts?%s',
 				Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 				Jetpack_Options::get_option( 'id' ),
 				$req->get_param( 'resource_id' ),


### PR DESCRIPTION
### Proposed changes:

Change v1.2 to v1.1, otherwise posts endpoint wouldn't work.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Create an Atomic dev blog following instructions at p9o2xV-1r2-p2
* Install Jetpack and Jetpack Beta plugin
* Choose branch `fix/fix-posts-endpoint-on-atomic` in Jetpack Beta
* Open `/wp-admin/admin.php?page=stats#!/stats/insights/:site`
* Ensure latest posts is showing up

<img width="769" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/0b6711f7-a272-4c20-88d3-2bffca0f18d6">
