### PR TITLE
Contact Form: add deprecation warnings to Contact Form module codebase

### DIFF
--- a/projects/plugins/jetpack/changelog/update-contact-form-module-depreacted-fn
+++ b/projects/plugins/jetpack/changelog/update-contact-form-module-depreacted-fn
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Contact Form: add deprecation warnings to Contact Form module codebase

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -2,6 +2,7 @@
 /**
  * Contact form elements in the admin area. Used with Classic Editor.
  *
+ * @deprecated $$next-version$$ Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -19,9 +20,12 @@ add_action( 'media_buttons', 'grunion_media_button', 999 );
 /**
  * Build contact form button.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\
  * @return void
  */
 function grunion_media_button() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->' );
+
 	global $post_ID, $temp_ID, $pagenow;// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	if ( 'press-this.php' === $pagenow ) {
@@ -44,9 +48,12 @@ add_action( 'wp_ajax_grunion_form_builder', 'grunion_display_form_view' );
 /**
  * Display edit form view.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view
  * @return void
  */
 function grunion_display_form_view() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view' );
+
 	if ( current_user_can( 'edit_posts' ) ) {
 		require_once GRUNION_PLUGIN_DIR . 'grunion-form-view.php';
 	}
@@ -58,9 +65,12 @@ add_action( 'admin_print_styles', 'grunion_admin_css' );
 /**
  * Enqueue styles.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css
  * @return void
  */
 function grunion_admin_css() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css' );
+
 	global $current_screen;
 	if (
 		$current_screen === null
@@ -82,9 +92,12 @@ add_action( 'admin_print_scripts', 'grunion_admin_js' );
 /**
  * Enqueue scripts.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js
  * @return void
  */
 function grunion_admin_js() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js' );
+
 	global $current_screen;
 	if (
 		$current_screen === null
@@ -104,8 +117,11 @@ add_action( 'admin_head', 'grunion_add_bulk_edit_option' );
  *
  * There isn't a better way to do this until
  * https://core.trac.wordpress.org/changeset/17297 is resolved
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option
  */
 function grunion_add_bulk_edit_option() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option' );
 
 	$screen = get_current_screen();
 
@@ -144,8 +160,12 @@ function grunion_add_bulk_edit_option() {
 add_action( 'admin_init', 'grunion_handle_bulk_spam' );
 /**
  * Handle a bulk spam report
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam
  */
 function grunion_handle_bulk_spam() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam' );
+
 	global $pagenow;
 
 	if ( 'edit.php' !== $pagenow
@@ -205,9 +225,12 @@ function grunion_handle_bulk_spam() {
 /**
  * Display spam message.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam
  * @return void
  */
 function grunion_message_bulk_spam() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam' );
+
 	echo '<div class="updated"><p>' . esc_html__( 'Feedback(s) marked as spam', 'jetpack' ) . '</p></div>';
 }
 
@@ -215,10 +238,13 @@ add_filter( 'bulk_actions-edit-feedback', 'grunion_admin_bulk_actions' );
 /**
  * Unset edit option when bulk editing.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions
  * @param array $actions List of actions available.
  * @return array $actions
  */
 function grunion_admin_bulk_actions( $actions ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions' );
+
 	global $current_screen;
 	if (
 		$current_screen === null
@@ -235,10 +261,13 @@ add_filter( 'views_edit-feedback', 'grunion_admin_view_tabs' );
 /**
  * Unset publish button when editing feedback.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs
  * @param array $views List of post views.
  * @return array $views
  */
 function grunion_admin_view_tabs( $views ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs' );
+
 	global $current_screen;
 	if (
 		$current_screen === null
@@ -261,10 +290,13 @@ add_filter( 'manage_feedback_posts_columns', 'grunion_post_type_columns_filter' 
 /**
  * Build Feedback admin page columns.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter
  * @param array $cols List of available columns.
  * @return array
  */
 function grunion_post_type_columns_filter( $cols ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter' );
+
 	return array(
 		'cb'                => '<input type="checkbox" />',
 		'feedback_from'     => __( 'From', 'jetpack' ),
@@ -277,19 +309,25 @@ function grunion_post_type_columns_filter( $cols ) { // phpcs:ignore VariableAna
 /**
  * Displays the value for the source column. (This function runs within the loop.)
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date
  * @return void
  */
 function grunion_manage_post_column_date() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date' );
+
 	echo esc_html( date_i18n( 'Y/m/d', get_the_time( 'U' ) ) );
 }
 
 /**
  * Displays the value for the from column.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from
  * @param  \WP_Post $post Current post.
  * @return void
  */
 function grunion_manage_post_column_from( $post ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from' );
+
 	$content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $post->ID );
 
 	if ( ! empty( $content_fields['_feedback_author'] ) ) {
@@ -317,10 +355,13 @@ function grunion_manage_post_column_from( $post ) {
 /**
  * Displays the value for the response column.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response
  * @param  \WP_Post $post Current post.
  * @return void
  */
 function grunion_manage_post_column_response( $post ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response' );
+
 	$content_fields     = array();
 	$non_printable_keys = array(
 		'email_marketing_consent',
@@ -388,10 +429,13 @@ function grunion_manage_post_column_response( $post ) {
 /**
  * Displays the value for the source column.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source
  * @param  \WP_Post $post Current post.
  * @return void
  */
 function grunion_manage_post_column_source( $post ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source' );
+
 	if ( ! isset( $post->post_parent ) ) {
 		return;
 	}
@@ -410,11 +454,14 @@ add_action( 'manage_posts_custom_column', 'grunion_manage_post_columns', 10, 2 )
 /**
  * Parse message content and display in appropriate columns.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns
  * @param array $col List of columns available on admin page.
  * @param int   $post_id The current post ID.
  * @return void
  */
 function grunion_manage_post_columns( $col, $post_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns' );
+
 	global $post;
 
 	/**
@@ -444,9 +491,12 @@ add_action( 'restrict_manage_posts', 'grunion_source_filter' );
 /**
  * Add a post filter dropdown at the top of the admin page.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter
  * @return void
  */
 function grunion_source_filter() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter' );
+
 	$screen = get_current_screen();
 
 	if ( 'edit-feedback' !== $screen->id ) {
@@ -461,11 +511,13 @@ add_action( 'pre_get_posts', 'grunion_source_filter_results' );
 /**
  * Filter feedback posts by parent_id if present.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results
  * @param WP_Query $query Current query.
- *
  * @return void
  */
 function grunion_source_filter_results( $query ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results' );
+
 	$parent_id = intval( isset( $_GET['jetpack_form_parent_id'] ) ? $_GET['jetpack_form_parent_id'] : 0 ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 	if ( ! $parent_id || $query->query_vars['post_type'] !== 'feedback' ) {
@@ -484,10 +536,13 @@ add_filter( 'post_row_actions', 'grunion_manage_post_row_actions', 10, 2 );
 /**
  * Add actions to feedback response rows in WP Admin.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions
  * @param string[] $actions Default actions.
  * @return string[]
  */
 function grunion_manage_post_row_actions( $actions ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions' );
+
 	global $post;
 
 	if ( 'feedback' !== $post->post_type ) {
@@ -543,11 +598,13 @@ function grunion_manage_post_row_actions( $actions ) {
 /**
  * Escape grunion attributes.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr
  * @param string $attr - the attribute we're escaping.
- *
  * @return string
  */
 function grunion_esc_attr( $attr ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr' );
+
 	$out = esc_attr( $attr );
 	// we also have to entity-encode square brackets so they don't interfere with the shortcode parser
 	// FIXME: do this better - just stripping out square brackets for now since they mysteriously keep reappearing
@@ -559,12 +616,14 @@ function grunion_esc_attr( $attr ) {
 /**
  * Sort grunion items.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects
  * @param array $a - the first item we're sorting.
  * @param array $b - the second item we're sorting.
- *
  * @return string
  */
 function grunion_sort_objects( $a, $b ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects' );
+
 	if ( isset( $a['order'] ) && isset( $b['order'] ) ) {
 		return $a['order'] <=> $b['order'];
 	}
@@ -574,8 +633,12 @@ function grunion_sort_objects( $a, $b ) {
 /**
  * Take an array of field types from the form builder, and construct a shortcode form.
  * returns both the shortcode form, and HTML markup representing a preview of the form
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode
  */
 function grunion_ajax_shortcode() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode' );
+
 	$field_shortcodes = array();
 	check_ajax_referer( 'grunion_shortcode' );
 
@@ -622,8 +685,12 @@ function grunion_ajax_shortcode() {
 /**
  * Takes a post_id, extracts the contact-form shortcode from that post (if there is one), parses it,
  * and constructs a json object representing its contents and attributes.
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json
  */
 function grunion_ajax_shortcode_to_json() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json' );
+
 	global $post;
 
 	check_ajax_referer( 'grunion_shortcode_to_json' );
@@ -680,8 +747,12 @@ add_action( 'wp_ajax_grunion_ajax_spam', 'grunion_ajax_spam' );
 
 /**
  * Handle marking feedback as spam.
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam
  */
 function grunion_ajax_spam() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam' );
+
 	global $wpdb;
 
 	if ( empty( $_POST['make_it'] ) ) {
@@ -855,8 +926,12 @@ function grunion_ajax_spam() {
 
 /**
  * Add the scripts that will add the "Check for Spam" button to the Feedbacks dashboard page.
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck
  */
 function grunion_enable_spam_recheck() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck' );
+
 	if ( ! defined( 'AKISMET_VERSION' ) ) {
 		return;
 	}
@@ -876,8 +951,12 @@ add_action( 'admin_enqueue_scripts', 'grunion_enable_spam_recheck' );
 
 /**
  * Add the JS and CSS necessary for the Feedback admin page to function.
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts
  */
 function grunion_add_admin_scripts() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts' );
+
 	$screen = get_current_screen();
 
 	if ( 'edit-feedback' !== $screen->id ) {
@@ -929,9 +1008,12 @@ add_action( 'admin_enqueue_scripts', 'grunion_add_admin_scripts' );
 /**
  * Adds the 'Export' button to the feedback dashboard page.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button
  * @return void
  */
 function grunion_export_button() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button' );
+
 	$current_screen = get_current_screen();
 	if ( ! in_array( $current_screen->id, array( 'edit-feedback', 'feedback_page_feedback-export' ), true ) ) {
 		return;
@@ -970,8 +1052,12 @@ function grunion_export_button() {
 
 /**
  * Add the "Check for Spam" button to the Feedbacks dashboard page.
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button
  */
 function grunion_check_for_spam_button() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button' );
+
 	// Nonce name.
 	$nonce_name = 'jetpack_check_feedback_spam_' . (string) get_current_blog_id();
 	// Get HTML for the button.
@@ -1000,8 +1086,12 @@ function grunion_check_for_spam_button() {
 
 /**
  * Recheck all approved feedbacks for spam.
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue
  */
 function grunion_recheck_queue() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue' );
+
 	$blog_id = get_current_blog_id();
 
 	if (
@@ -1080,8 +1170,12 @@ add_action( 'wp_ajax_grunion_recheck_queue', 'grunion_recheck_queue' );
 
 /**
  * Delete a number of spam feedbacks via an AJAX request.
+ * 
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks
  */
 function grunion_delete_spam_feedbacks() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks' );
+
 	if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'jetpack_delete_spam_feedbacks' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- core doesn't sanitize nonce checks either.
 		wp_send_json_error(
 			__( 'You aren’t authorized to do that.', 'jetpack' ),
@@ -1147,8 +1241,12 @@ add_action( 'wp_ajax_jetpack_delete_spam_feedbacks', 'grunion_delete_spam_feedba
 
 /**
  * Show an admin notice if the "Empty Spam" or "Check Spam" process was unable to complete, probably due to a permissions error.
+ * 
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice
  */
 function grunion_feedback_admin_notice() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice' );
+
 	if ( isset( $_GET['jetpack_empty_feedback_spam_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		echo '<div class="notice notice-error"><p>' . esc_html( __( 'An error occurred while trying to empty the Feedback spam folder.', 'jetpack' ) ) . '</p></div>';
 	} elseif ( isset( $_GET['jetpack_check_feedback_spam_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -1161,6 +1259,8 @@ add_action( 'admin_notices', 'grunion_feedback_admin_notice' );
  * Class Grunion_Admin
  *
  * Singleton for Grunion admin area support.
+ * 
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin
  */
 class Grunion_Admin {
 	/**
@@ -1180,9 +1280,12 @@ class Grunion_Admin {
 	/**
 	 * Instantiates this singleton class
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin::init
 	 * @return Grunion_Admin The Grunion Admin class instance.
 	 */
 	public static function init() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin::init' );
+
 		static $instance = false;
 
 		if ( ! $instance ) {
@@ -1194,8 +1297,12 @@ class Grunion_Admin {
 
 	/**
 	 * Grunion_Admin constructor
+	 * 
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->__construct
 	 */
 	public function __construct() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->__construct' );
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'admin_footer-edit.php', array( $this, 'print_export_modal' ) );
 
@@ -1205,8 +1312,12 @@ class Grunion_Admin {
 
 	/**
 	 * Hook handler for admin_enqueue_scripts hook
+	 * 
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts
 	 */
 	public function admin_enqueue_scripts() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts' );
+
 		$current_screen = get_current_screen();
 		if ( ! in_array( $current_screen->id, array( 'edit-feedback', 'feedback_page_feedback-export' ), true ) ) {
 			return;
@@ -1221,8 +1332,12 @@ class Grunion_Admin {
 
 	/**
 	 * Prints the modal markup with export buttons/content.
+	 * 
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal
 	 */
 	public function print_export_modal() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal' );
+
 		if ( ! current_user_can( 'export' ) ) {
 			return;
 		}
@@ -1288,9 +1403,12 @@ class Grunion_Admin {
 	 * Ajax handler for wp_ajax_grunion_export_to_gdrive.
 	 * Exports data to Google Drive, based on POST data.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive
 	 * @see Grunion_Contact_Form_Plugin::get_feedback_entries_from_post
 	 */
 	public function export_to_gdrive() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive' );
+
 		$post_data = wp_unslash( $_POST );
 		if (
 			! current_user_can( 'export' )
@@ -1354,8 +1472,12 @@ class Grunion_Admin {
 
 	/**
 	 * Return HTML markup for the CSV download button.
+	 * 
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section
 	 */
 	public function get_csv_export_section() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section' );
+
 		$button_csv_html = get_submit_button(
 			esc_html__( 'Download', 'jetpack' ),
 			'primary export-button export-csv',
@@ -1391,8 +1513,12 @@ class Grunion_Admin {
 	/**
 	 * Render/output HTML markup for the export to gdrive section.
 	 * If the user doesn't hold a Google Drive connection a button to connect will render (See grunion-admin.js).
+	 * 
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section
 	 */
 	public function get_gdrive_export_section() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section' );
+
 		$user_connected = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Connection_Manager( 'jetpack' ) )->is_user_connected( get_current_user_id() );
 		if ( ! $user_connected ) {
 			return;
@@ -1457,8 +1583,12 @@ class Grunion_Admin {
 	/**
 	 * Ajax handler. Sends a payload with connection status and html to replace
 	 * the Connect button with the Export button using get_gdrive_export_button
+	 * 
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection
 	 */
 	public function test_gdrive_connection() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection' );
+
 		$post_data = wp_unslash( $_POST );
 		$user_id   = (int) get_current_user_id();
 
@@ -1496,9 +1626,12 @@ class Grunion_Admin {
 	/**
 	 * Markup helper so we DRY, returns the button markup for the export to GDrive feature.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup
 	 * @return string The HTML button markup
 	 */
 	public function get_gdrive_export_button_markup() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup' );
+
 		return get_submit_button(
 			esc_html__( 'Export', 'jetpack' ),
 			'primary export-button export-gdrive',
@@ -1511,10 +1644,13 @@ class Grunion_Admin {
 	/**
 	 * Get a filename for export tasks
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename
 	 * @param string $source The filtered source for exported data.
 	 * @return string The filename without source nor date suffix.
 	 */
 	public function get_export_filename( $source = '' ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename' );
+
 		return $source === ''
 			? sprintf(
 				/* translators: Site title, used to craft the export filename, eg "MySite - Jetpack Form Responses" */

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -2,7 +2,7 @@
 /**
  * Contact form elements in the admin area. Used with Classic Editor.
  *
- * @deprecated jetpack-$$next-version$$ Use automattic/jetpack-forms
+ * @deprecated $$next-version$$ Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -20,7 +20,7 @@ add_action( 'media_buttons', 'grunion_media_button', 999 );
 /**
  * Build contact form button.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_media_button
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_media_button
  * @return void
  */
 function grunion_media_button() {
@@ -48,7 +48,7 @@ add_action( 'wp_ajax_grunion_form_builder', 'grunion_display_form_view' );
 /**
  * Display edit form view.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view
  * @return void
  */
 function grunion_display_form_view() {
@@ -65,7 +65,7 @@ add_action( 'admin_print_styles', 'grunion_admin_css' );
 /**
  * Enqueue styles.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css
  * @return void
  */
 function grunion_admin_css() {
@@ -92,7 +92,7 @@ add_action( 'admin_print_scripts', 'grunion_admin_js' );
 /**
  * Enqueue scripts.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js
  * @return void
  */
 function grunion_admin_js() {
@@ -118,7 +118,7 @@ add_action( 'admin_head', 'grunion_add_bulk_edit_option' );
  * There isn't a better way to do this until
  * https://core.trac.wordpress.org/changeset/17297 is resolved
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option
  */
 function grunion_add_bulk_edit_option() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option' );
@@ -161,7 +161,7 @@ add_action( 'admin_init', 'grunion_handle_bulk_spam' );
 /**
  * Handle a bulk spam report
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam
  */
 function grunion_handle_bulk_spam() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam' );
@@ -225,7 +225,7 @@ function grunion_handle_bulk_spam() {
 /**
  * Display spam message.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam
  * @return void
  */
 function grunion_message_bulk_spam() {
@@ -238,7 +238,7 @@ add_filter( 'bulk_actions-edit-feedback', 'grunion_admin_bulk_actions' );
 /**
  * Unset edit option when bulk editing.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions
  * @param array $actions List of actions available.
  * @return array $actions
  */
@@ -261,7 +261,7 @@ add_filter( 'views_edit-feedback', 'grunion_admin_view_tabs' );
 /**
  * Unset publish button when editing feedback.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs
  * @param array $views List of post views.
  * @return array $views
  */
@@ -290,7 +290,7 @@ add_filter( 'manage_feedback_posts_columns', 'grunion_post_type_columns_filter' 
 /**
  * Build Feedback admin page columns.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter
  * @param array $cols List of available columns.
  * @return array
  */
@@ -309,7 +309,7 @@ function grunion_post_type_columns_filter( $cols ) { // phpcs:ignore VariableAna
 /**
  * Displays the value for the source column. (This function runs within the loop.)
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date
  * @return void
  */
 function grunion_manage_post_column_date() {
@@ -321,7 +321,7 @@ function grunion_manage_post_column_date() {
 /**
  * Displays the value for the from column.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from
  * @param  \WP_Post $post Current post.
  * @return void
  */
@@ -355,7 +355,7 @@ function grunion_manage_post_column_from( $post ) {
 /**
  * Displays the value for the response column.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response
  * @param  \WP_Post $post Current post.
  * @return void
  */
@@ -429,7 +429,7 @@ function grunion_manage_post_column_response( $post ) {
 /**
  * Displays the value for the source column.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source
  * @param  \WP_Post $post Current post.
  * @return void
  */
@@ -454,7 +454,7 @@ add_action( 'manage_posts_custom_column', 'grunion_manage_post_columns', 10, 2 )
 /**
  * Parse message content and display in appropriate columns.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns
  * @param array $col List of columns available on admin page.
  * @param int   $post_id The current post ID.
  * @return void
@@ -491,7 +491,7 @@ add_action( 'restrict_manage_posts', 'grunion_source_filter' );
 /**
  * Add a post filter dropdown at the top of the admin page.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter
  * @return void
  */
 function grunion_source_filter() {
@@ -511,7 +511,7 @@ add_action( 'pre_get_posts', 'grunion_source_filter_results' );
 /**
  * Filter feedback posts by parent_id if present.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results
  * @param WP_Query $query Current query.
  * @return void
  */
@@ -536,7 +536,7 @@ add_filter( 'post_row_actions', 'grunion_manage_post_row_actions', 10, 2 );
 /**
  * Add actions to feedback response rows in WP Admin.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions
  * @param string[] $actions Default actions.
  * @return string[]
  */
@@ -598,7 +598,7 @@ function grunion_manage_post_row_actions( $actions ) {
 /**
  * Escape grunion attributes.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr
  * @param string $attr - the attribute we're escaping.
  * @return string
  */
@@ -616,7 +616,7 @@ function grunion_esc_attr( $attr ) {
 /**
  * Sort grunion items.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects
  * @param array $a - the first item we're sorting.
  * @param array $b - the second item we're sorting.
  * @return string
@@ -634,7 +634,7 @@ function grunion_sort_objects( $a, $b ) {
  * Take an array of field types from the form builder, and construct a shortcode form.
  * returns both the shortcode form, and HTML markup representing a preview of the form
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode
  */
 function grunion_ajax_shortcode() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode' );
@@ -686,7 +686,7 @@ function grunion_ajax_shortcode() {
  * Takes a post_id, extracts the contact-form shortcode from that post (if there is one), parses it,
  * and constructs a json object representing its contents and attributes.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json
  */
 function grunion_ajax_shortcode_to_json() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json' );
@@ -748,7 +748,7 @@ add_action( 'wp_ajax_grunion_ajax_spam', 'grunion_ajax_spam' );
 /**
  * Handle marking feedback as spam.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam
  */
 function grunion_ajax_spam() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam' );
@@ -927,7 +927,7 @@ function grunion_ajax_spam() {
 /**
  * Add the scripts that will add the "Check for Spam" button to the Feedbacks dashboard page.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck
  */
 function grunion_enable_spam_recheck() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck' );
@@ -952,7 +952,7 @@ add_action( 'admin_enqueue_scripts', 'grunion_enable_spam_recheck' );
 /**
  * Add the JS and CSS necessary for the Feedback admin page to function.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts
  */
 function grunion_add_admin_scripts() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts' );
@@ -1008,7 +1008,7 @@ add_action( 'admin_enqueue_scripts', 'grunion_add_admin_scripts' );
 /**
  * Adds the 'Export' button to the feedback dashboard page.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button
  * @return void
  */
 function grunion_export_button() {
@@ -1053,7 +1053,7 @@ function grunion_export_button() {
 /**
  * Add the "Check for Spam" button to the Feedbacks dashboard page.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button
  */
 function grunion_check_for_spam_button() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button' );
@@ -1087,7 +1087,7 @@ function grunion_check_for_spam_button() {
 /**
  * Recheck all approved feedbacks for spam.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue
  */
 function grunion_recheck_queue() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue' );
@@ -1171,7 +1171,7 @@ add_action( 'wp_ajax_grunion_recheck_queue', 'grunion_recheck_queue' );
 /**
  * Delete a number of spam feedbacks via an AJAX request.
  * 
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks
  */
 function grunion_delete_spam_feedbacks() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks' );
@@ -1242,7 +1242,7 @@ add_action( 'wp_ajax_jetpack_delete_spam_feedbacks', 'grunion_delete_spam_feedba
 /**
  * Show an admin notice if the "Empty Spam" or "Check Spam" process was unable to complete, probably due to a permissions error.
  * 
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice
  */
 function grunion_feedback_admin_notice() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice' );
@@ -1260,7 +1260,7 @@ add_action( 'admin_notices', 'grunion_feedback_admin_notice' );
  *
  * Singleton for Grunion admin area support.
  * 
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin
  */
 class Grunion_Admin {
 	/**
@@ -1280,7 +1280,7 @@ class Grunion_Admin {
 	/**
 	 * Instantiates this singleton class
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin::init
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin::init
 	 * @return Grunion_Admin The Grunion Admin class instance.
 	 */
 	public static function init() {
@@ -1298,7 +1298,7 @@ class Grunion_Admin {
 	/**
 	 * Grunion_Admin constructor
 	 * 
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->__construct
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->__construct
 	 */
 	public function __construct() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->__construct' );
@@ -1313,7 +1313,7 @@ class Grunion_Admin {
 	/**
 	 * Hook handler for admin_enqueue_scripts hook
 	 * 
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts
 	 */
 	public function admin_enqueue_scripts() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts' );
@@ -1333,7 +1333,7 @@ class Grunion_Admin {
 	/**
 	 * Prints the modal markup with export buttons/content.
 	 * 
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal
 	 */
 	public function print_export_modal() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal' );
@@ -1403,7 +1403,7 @@ class Grunion_Admin {
 	 * Ajax handler for wp_ajax_grunion_export_to_gdrive.
 	 * Exports data to Google Drive, based on POST data.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive
 	 * @see Grunion_Contact_Form_Plugin::get_feedback_entries_from_post
 	 */
 	public function export_to_gdrive() {
@@ -1473,7 +1473,7 @@ class Grunion_Admin {
 	/**
 	 * Return HTML markup for the CSV download button.
 	 * 
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section
 	 */
 	public function get_csv_export_section() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section' );
@@ -1514,7 +1514,7 @@ class Grunion_Admin {
 	 * Render/output HTML markup for the export to gdrive section.
 	 * If the user doesn't hold a Google Drive connection a button to connect will render (See grunion-admin.js).
 	 * 
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section
 	 */
 	public function get_gdrive_export_section() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section' );
@@ -1584,7 +1584,7 @@ class Grunion_Admin {
 	 * Ajax handler. Sends a payload with connection status and html to replace
 	 * the Connect button with the Export button using get_gdrive_export_button
 	 * 
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection
 	 */
 	public function test_gdrive_connection() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection' );
@@ -1626,7 +1626,7 @@ class Grunion_Admin {
 	/**
 	 * Markup helper so we DRY, returns the button markup for the export to GDrive feature.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup
 	 * @return string The HTML button markup
 	 */
 	public function get_gdrive_export_button_markup() {
@@ -1644,7 +1644,7 @@ class Grunion_Admin {
 	/**
 	 * Get a filename for export tasks
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename
 	 * @param string $source The filtered source for exported data.
 	 * @return string The filename without source nor date suffix.
 	 */

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -24,7 +24,7 @@ add_action( 'media_buttons', 'grunion_media_button', 999 );
  * @return void
  */
 function grunion_media_button() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->' );
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_media_button' );
 
 	global $post_ID, $temp_ID, $pagenow;// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -20,7 +20,7 @@ add_action( 'media_buttons', 'grunion_media_button', 999 );
 /**
  * Build contact form button.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_media_button
  * @return void
  */
 function grunion_media_button() {

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -2,7 +2,7 @@
 /**
  * Contact form elements in the admin area. Used with Classic Editor.
  *
- * @deprecated $$next-version$$ Use automattic/jetpack-forms
+ * @deprecated jetpack-$$next-version$$ Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -20,11 +20,11 @@ add_action( 'media_buttons', 'grunion_media_button', 999 );
 /**
  * Build contact form button.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\
  * @return void
  */
 function grunion_media_button() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_media_button' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_media_button' );
 
 	global $post_ID, $temp_ID, $pagenow;// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
@@ -48,11 +48,11 @@ add_action( 'wp_ajax_grunion_form_builder', 'grunion_display_form_view' );
 /**
  * Display edit form view.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view
  * @return void
  */
 function grunion_display_form_view() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view' );
 
 	if ( current_user_can( 'edit_posts' ) ) {
 		require_once GRUNION_PLUGIN_DIR . 'grunion-form-view.php';
@@ -65,11 +65,11 @@ add_action( 'admin_print_styles', 'grunion_admin_css' );
 /**
  * Enqueue styles.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css
  * @return void
  */
 function grunion_admin_css() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css' );
 
 	global $current_screen;
 	if (
@@ -92,11 +92,11 @@ add_action( 'admin_print_scripts', 'grunion_admin_js' );
 /**
  * Enqueue scripts.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js
  * @return void
  */
 function grunion_admin_js() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js' );
 
 	global $current_screen;
 	if (
@@ -118,10 +118,10 @@ add_action( 'admin_head', 'grunion_add_bulk_edit_option' );
  * There isn't a better way to do this until
  * https://core.trac.wordpress.org/changeset/17297 is resolved
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option
  */
 function grunion_add_bulk_edit_option() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option' );
 
 	$screen = get_current_screen();
 
@@ -161,10 +161,10 @@ add_action( 'admin_init', 'grunion_handle_bulk_spam' );
 /**
  * Handle a bulk spam report
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam
  */
 function grunion_handle_bulk_spam() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam' );
 
 	global $pagenow;
 
@@ -225,11 +225,11 @@ function grunion_handle_bulk_spam() {
 /**
  * Display spam message.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam
  * @return void
  */
 function grunion_message_bulk_spam() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam' );
 
 	echo '<div class="updated"><p>' . esc_html__( 'Feedback(s) marked as spam', 'jetpack' ) . '</p></div>';
 }
@@ -238,12 +238,12 @@ add_filter( 'bulk_actions-edit-feedback', 'grunion_admin_bulk_actions' );
 /**
  * Unset edit option when bulk editing.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions
  * @param array $actions List of actions available.
  * @return array $actions
  */
 function grunion_admin_bulk_actions( $actions ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions' );
 
 	global $current_screen;
 	if (
@@ -261,12 +261,12 @@ add_filter( 'views_edit-feedback', 'grunion_admin_view_tabs' );
 /**
  * Unset publish button when editing feedback.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs
  * @param array $views List of post views.
  * @return array $views
  */
 function grunion_admin_view_tabs( $views ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs' );
 
 	global $current_screen;
 	if (
@@ -290,12 +290,12 @@ add_filter( 'manage_feedback_posts_columns', 'grunion_post_type_columns_filter' 
 /**
  * Build Feedback admin page columns.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter
  * @param array $cols List of available columns.
  * @return array
  */
 function grunion_post_type_columns_filter( $cols ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter' );
 
 	return array(
 		'cb'                => '<input type="checkbox" />',
@@ -309,11 +309,11 @@ function grunion_post_type_columns_filter( $cols ) { // phpcs:ignore VariableAna
 /**
  * Displays the value for the source column. (This function runs within the loop.)
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date
  * @return void
  */
 function grunion_manage_post_column_date() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date' );
 
 	echo esc_html( date_i18n( 'Y/m/d', get_the_time( 'U' ) ) );
 }
@@ -321,12 +321,12 @@ function grunion_manage_post_column_date() {
 /**
  * Displays the value for the from column.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from
  * @param  \WP_Post $post Current post.
  * @return void
  */
 function grunion_manage_post_column_from( $post ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from' );
 
 	$content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $post->ID );
 
@@ -355,12 +355,12 @@ function grunion_manage_post_column_from( $post ) {
 /**
  * Displays the value for the response column.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response
  * @param  \WP_Post $post Current post.
  * @return void
  */
 function grunion_manage_post_column_response( $post ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response' );
 
 	$content_fields     = array();
 	$non_printable_keys = array(
@@ -429,12 +429,12 @@ function grunion_manage_post_column_response( $post ) {
 /**
  * Displays the value for the source column.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source
  * @param  \WP_Post $post Current post.
  * @return void
  */
 function grunion_manage_post_column_source( $post ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source' );
 
 	if ( ! isset( $post->post_parent ) ) {
 		return;
@@ -454,13 +454,13 @@ add_action( 'manage_posts_custom_column', 'grunion_manage_post_columns', 10, 2 )
 /**
  * Parse message content and display in appropriate columns.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns
  * @param array $col List of columns available on admin page.
  * @param int   $post_id The current post ID.
  * @return void
  */
 function grunion_manage_post_columns( $col, $post_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns' );
 
 	global $post;
 
@@ -491,11 +491,11 @@ add_action( 'restrict_manage_posts', 'grunion_source_filter' );
 /**
  * Add a post filter dropdown at the top of the admin page.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter
  * @return void
  */
 function grunion_source_filter() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter' );
 
 	$screen = get_current_screen();
 
@@ -511,12 +511,12 @@ add_action( 'pre_get_posts', 'grunion_source_filter_results' );
 /**
  * Filter feedback posts by parent_id if present.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results
  * @param WP_Query $query Current query.
  * @return void
  */
 function grunion_source_filter_results( $query ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results' );
 
 	$parent_id = intval( isset( $_GET['jetpack_form_parent_id'] ) ? $_GET['jetpack_form_parent_id'] : 0 ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
@@ -536,12 +536,12 @@ add_filter( 'post_row_actions', 'grunion_manage_post_row_actions', 10, 2 );
 /**
  * Add actions to feedback response rows in WP Admin.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions
  * @param string[] $actions Default actions.
  * @return string[]
  */
 function grunion_manage_post_row_actions( $actions ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions' );
 
 	global $post;
 
@@ -598,12 +598,12 @@ function grunion_manage_post_row_actions( $actions ) {
 /**
  * Escape grunion attributes.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr
  * @param string $attr - the attribute we're escaping.
  * @return string
  */
 function grunion_esc_attr( $attr ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr' );
 
 	$out = esc_attr( $attr );
 	// we also have to entity-encode square brackets so they don't interfere with the shortcode parser
@@ -616,13 +616,13 @@ function grunion_esc_attr( $attr ) {
 /**
  * Sort grunion items.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects
  * @param array $a - the first item we're sorting.
  * @param array $b - the second item we're sorting.
  * @return string
  */
 function grunion_sort_objects( $a, $b ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects' );
 
 	if ( isset( $a['order'] ) && isset( $b['order'] ) ) {
 		return $a['order'] <=> $b['order'];
@@ -634,10 +634,10 @@ function grunion_sort_objects( $a, $b ) {
  * Take an array of field types from the form builder, and construct a shortcode form.
  * returns both the shortcode form, and HTML markup representing a preview of the form
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode
  */
 function grunion_ajax_shortcode() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode' );
 
 	$field_shortcodes = array();
 	check_ajax_referer( 'grunion_shortcode' );
@@ -686,10 +686,10 @@ function grunion_ajax_shortcode() {
  * Takes a post_id, extracts the contact-form shortcode from that post (if there is one), parses it,
  * and constructs a json object representing its contents and attributes.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json
  */
 function grunion_ajax_shortcode_to_json() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json' );
 
 	global $post;
 
@@ -748,10 +748,10 @@ add_action( 'wp_ajax_grunion_ajax_spam', 'grunion_ajax_spam' );
 /**
  * Handle marking feedback as spam.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam
  */
 function grunion_ajax_spam() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam' );
 
 	global $wpdb;
 
@@ -927,10 +927,10 @@ function grunion_ajax_spam() {
 /**
  * Add the scripts that will add the "Check for Spam" button to the Feedbacks dashboard page.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck
  */
 function grunion_enable_spam_recheck() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck' );
 
 	if ( ! defined( 'AKISMET_VERSION' ) ) {
 		return;
@@ -952,10 +952,10 @@ add_action( 'admin_enqueue_scripts', 'grunion_enable_spam_recheck' );
 /**
  * Add the JS and CSS necessary for the Feedback admin page to function.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts
  */
 function grunion_add_admin_scripts() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts' );
 
 	$screen = get_current_screen();
 
@@ -1008,11 +1008,11 @@ add_action( 'admin_enqueue_scripts', 'grunion_add_admin_scripts' );
 /**
  * Adds the 'Export' button to the feedback dashboard page.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button
  * @return void
  */
 function grunion_export_button() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button' );
 
 	$current_screen = get_current_screen();
 	if ( ! in_array( $current_screen->id, array( 'edit-feedback', 'feedback_page_feedback-export' ), true ) ) {
@@ -1053,10 +1053,10 @@ function grunion_export_button() {
 /**
  * Add the "Check for Spam" button to the Feedbacks dashboard page.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button
  */
 function grunion_check_for_spam_button() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button' );
 
 	// Nonce name.
 	$nonce_name = 'jetpack_check_feedback_spam_' . (string) get_current_blog_id();
@@ -1087,10 +1087,10 @@ function grunion_check_for_spam_button() {
 /**
  * Recheck all approved feedbacks for spam.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue
  */
 function grunion_recheck_queue() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue' );
 
 	$blog_id = get_current_blog_id();
 
@@ -1171,10 +1171,10 @@ add_action( 'wp_ajax_grunion_recheck_queue', 'grunion_recheck_queue' );
 /**
  * Delete a number of spam feedbacks via an AJAX request.
  * 
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks
  */
 function grunion_delete_spam_feedbacks() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks' );
 
 	if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'jetpack_delete_spam_feedbacks' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- core doesn't sanitize nonce checks either.
 		wp_send_json_error(
@@ -1242,10 +1242,10 @@ add_action( 'wp_ajax_jetpack_delete_spam_feedbacks', 'grunion_delete_spam_feedba
 /**
  * Show an admin notice if the "Empty Spam" or "Check Spam" process was unable to complete, probably due to a permissions error.
  * 
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice
  */
 function grunion_feedback_admin_notice() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice' );
 
 	if ( isset( $_GET['jetpack_empty_feedback_spam_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		echo '<div class="notice notice-error"><p>' . esc_html( __( 'An error occurred while trying to empty the Feedback spam folder.', 'jetpack' ) ) . '</p></div>';
@@ -1260,7 +1260,7 @@ add_action( 'admin_notices', 'grunion_feedback_admin_notice' );
  *
  * Singleton for Grunion admin area support.
  * 
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin
  */
 class Grunion_Admin {
 	/**
@@ -1280,11 +1280,11 @@ class Grunion_Admin {
 	/**
 	 * Instantiates this singleton class
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin::init
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin::init
 	 * @return Grunion_Admin The Grunion Admin class instance.
 	 */
 	public static function init() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin::init' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin::init' );
 
 		static $instance = false;
 
@@ -1298,10 +1298,10 @@ class Grunion_Admin {
 	/**
 	 * Grunion_Admin constructor
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->__construct
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->__construct
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->__construct' );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'admin_footer-edit.php', array( $this, 'print_export_modal' ) );
@@ -1313,10 +1313,10 @@ class Grunion_Admin {
 	/**
 	 * Hook handler for admin_enqueue_scripts hook
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts
 	 */
 	public function admin_enqueue_scripts() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts' );
 
 		$current_screen = get_current_screen();
 		if ( ! in_array( $current_screen->id, array( 'edit-feedback', 'feedback_page_feedback-export' ), true ) ) {
@@ -1333,10 +1333,10 @@ class Grunion_Admin {
 	/**
 	 * Prints the modal markup with export buttons/content.
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal
 	 */
 	public function print_export_modal() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal' );
 
 		if ( ! current_user_can( 'export' ) ) {
 			return;
@@ -1403,11 +1403,11 @@ class Grunion_Admin {
 	 * Ajax handler for wp_ajax_grunion_export_to_gdrive.
 	 * Exports data to Google Drive, based on POST data.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive
 	 * @see Grunion_Contact_Form_Plugin::get_feedback_entries_from_post
 	 */
 	public function export_to_gdrive() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive' );
 
 		$post_data = wp_unslash( $_POST );
 		if (
@@ -1473,10 +1473,10 @@ class Grunion_Admin {
 	/**
 	 * Return HTML markup for the CSV download button.
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section
 	 */
 	public function get_csv_export_section() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section' );
 
 		$button_csv_html = get_submit_button(
 			esc_html__( 'Download', 'jetpack' ),
@@ -1514,10 +1514,10 @@ class Grunion_Admin {
 	 * Render/output HTML markup for the export to gdrive section.
 	 * If the user doesn't hold a Google Drive connection a button to connect will render (See grunion-admin.js).
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section
 	 */
 	public function get_gdrive_export_section() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section' );
 
 		$user_connected = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Connection_Manager( 'jetpack' ) )->is_user_connected( get_current_user_id() );
 		if ( ! $user_connected ) {
@@ -1584,10 +1584,10 @@ class Grunion_Admin {
 	 * Ajax handler. Sends a payload with connection status and html to replace
 	 * the Connect button with the Export button using get_gdrive_export_button
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection
 	 */
 	public function test_gdrive_connection() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection' );
 
 		$post_data = wp_unslash( $_POST );
 		$user_id   = (int) get_current_user_id();
@@ -1626,11 +1626,11 @@ class Grunion_Admin {
 	/**
 	 * Markup helper so we DRY, returns the button markup for the export to GDrive feature.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup
 	 * @return string The HTML button markup
 	 */
 	public function get_gdrive_export_button_markup() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup' );
 
 		return get_submit_button(
 			esc_html__( 'Export', 'jetpack' ),
@@ -1644,12 +1644,12 @@ class Grunion_Admin {
 	/**
 	 * Get a filename for export tasks
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename
 	 * @param string $source The filtered source for exported data.
 	 * @return string The filename without source nor date suffix.
 	 */
 	public function get_export_filename( $source = '' ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename' );
 
 		return $source === ''
 			? sprintf(

--- a/projects/plugins/jetpack/modules/contact-form/class-grunion-contact-form-endpoint.php
+++ b/projects/plugins/jetpack/modules/contact-form/class-grunion-contact-form-endpoint.php
@@ -2,6 +2,7 @@
 /**
  * Plugin Name: Feedback CPT Permissions over-ride
  *
+ * @deprecated $$next-version$$ Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -10,15 +11,20 @@ if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
 	/**
 	 * Class Grunion_Contact_Form_Endpoint
 	 * Used as 'rest_controller_class' parameter when 'feedback' post type is registered in modules/contact-form/grunion-contact-form.php.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint
 	 */
 	class Grunion_Contact_Form_Endpoint extends WP_REST_Posts_Controller {
 		/**
 		 * Check whether a given request has proper authorization to view feedback items.
 		 *
+		 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check
 		 * @param  WP_REST_Request $request Full details about the request.
 		 * @return WP_Error|boolean
 		 */
 		public function get_items_permissions_check( $request ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check' );
+
 			if ( ! is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
 				return new WP_Error(
 					'rest_cannot_view',
@@ -33,10 +39,13 @@ if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
 		/**
 		 * Check whether a given request has proper authorization to view feedback item.
 		 *
+		 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check
 		 * @param  WP_REST_Request $request Full details about the request.
 		 * @return WP_Error|boolean
 		 */
 		public function get_item_permissions_check( $request ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check' );
+
 			if ( ! is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
 				return new WP_Error(
 					'rest_cannot_view',

--- a/projects/plugins/jetpack/modules/contact-form/class-grunion-contact-form-endpoint.php
+++ b/projects/plugins/jetpack/modules/contact-form/class-grunion-contact-form-endpoint.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Feedback CPT Permissions over-ride
  *
- * @deprecated $$next-version$$ Use automattic/jetpack-forms
+ * @deprecated jetpack-$$next-version$$ Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -12,18 +12,18 @@ if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
 	 * Class Grunion_Contact_Form_Endpoint
 	 * Used as 'rest_controller_class' parameter when 'feedback' post type is registered in modules/contact-form/grunion-contact-form.php.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint
 	 */
 	class Grunion_Contact_Form_Endpoint extends WP_REST_Posts_Controller {
 		/**
 		 * Check whether a given request has proper authorization to view feedback items.
 		 *
-		 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check
+		 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check
 		 * @param  WP_REST_Request $request Full details about the request.
 		 * @return WP_Error|boolean
 		 */
 		public function get_items_permissions_check( $request ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-			_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check' );
+			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check' );
 
 			if ( ! is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
 				return new WP_Error(
@@ -39,12 +39,12 @@ if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
 		/**
 		 * Check whether a given request has proper authorization to view feedback item.
 		 *
-		 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check
+		 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check
 		 * @param  WP_REST_Request $request Full details about the request.
 		 * @return WP_Error|boolean
 		 */
 		public function get_item_permissions_check( $request ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-			_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check' );
+			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check' );
 
 			if ( ! is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
 				return new WP_Error(

--- a/projects/plugins/jetpack/modules/contact-form/class-grunion-contact-form-endpoint.php
+++ b/projects/plugins/jetpack/modules/contact-form/class-grunion-contact-form-endpoint.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Feedback CPT Permissions over-ride
  *
- * @deprecated jetpack-$$next-version$$ Use automattic/jetpack-forms
+ * @deprecated $$next-version$$ Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -12,13 +12,13 @@ if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
 	 * Class Grunion_Contact_Form_Endpoint
 	 * Used as 'rest_controller_class' parameter when 'feedback' post type is registered in modules/contact-form/grunion-contact-form.php.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint
 	 */
 	class Grunion_Contact_Form_Endpoint extends WP_REST_Posts_Controller {
 		/**
 		 * Check whether a given request has proper authorization to view feedback items.
 		 *
-		 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check
+		 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check
 		 * @param  WP_REST_Request $request Full details about the request.
 		 * @return WP_Error|boolean
 		 */
@@ -39,7 +39,7 @@ if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
 		/**
 		 * Check whether a given request has proper authorization to view feedback item.
 		 *
-		 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check
+		 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check
 		 * @param  WP_REST_Request $request Full details about the request.
 		 * @return WP_Error|boolean
 		 */

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -4,6 +4,7 @@
  * Add a contact form to any post, page or text widget.
  * Emails will be sent to the post's author by default, or any email address you choose.
  *
+ * @deprecated $$next-version$$ Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -24,8 +25,12 @@ add_action( 'rest_api_init', 'grunion_contact_form_require_endpoint' );
 
 /**
  * Require the Grunion endpoint.
+ *
+ * @deprecated $$next-version$$
  */
 function grunion_contact_form_require_endpoint() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$' );
+
 	require_once GRUNION_PLUGIN_DIR . 'class-grunion-contact-form-endpoint.php';
 }
 
@@ -38,9 +43,12 @@ function grunion_contact_form_require_endpoint() {
  *
  * This fixes Contact Form Blocks added to FSE _templates_ (e.g. Single or 404).
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute
  * @param string $template Template to be loaded.
  */
 function grunion_contact_form_set_block_template_attribute( $template ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute' );
+
 	global $_wp_current_template_content;
 	if ( 'template-canvas.php' === basename( $template ) ) {
 		Grunion_Contact_Form::style_on();
@@ -61,9 +69,12 @@ add_filter( 'template_include', 'grunion_contact_form_set_block_template_attribu
  * This is part of the fix for Contact Form Blocks added to FSE _template parts_ (e.g footer).
  * The global is processed in Grunion_Contact_Form::parse().
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global
  * @param string $template_part_id ID for the currently rendered template part.
  */
 function grunion_contact_form_set_block_template_part_id_global( $template_part_id ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global' );
+
 	$GLOBALS['grunion_block_template_part_id'] = $template_part_id;
 }
 add_action( 'render_block_core_template_part_post', 'grunion_contact_form_set_block_template_part_id_global' );
@@ -76,11 +87,14 @@ add_action( 'gutenberg_render_block_core_template_part_none', 'grunion_contact_f
 /**
  * Unsets the global when block is done rendering.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global
  * @param string $content Rendered block content.
  * @param array  $block   The full block, including name and attributes.
  * @return string
  */
 function grunion_contact_form_unset_block_template_part_id_global( $content, $block ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global' );
+
 	if ( isset( $block['blockName'] )
 		&& 'core/template-part' === $block['blockName']
 		&& isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
@@ -93,12 +107,15 @@ add_filter( 'render_block', 'grunion_contact_form_unset_block_template_part_id_g
 /**
  * Sets the 'widget' attribute on all instances of the contact form in the widget block.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content
  * @param string          $content  Existing widget block content.
  * @param array           $instance Array of settings for the current widget.
  * @param WP_Widget_Block $widget   Current Block widget instance.
  * @return string
  */
 function grunion_contact_form_filter_widget_block_content( $content, $instance, $widget ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content' );
+
 	Grunion_Contact_Form::style_on();
 	// Inject 'block_template' => <widget-id> into all instances of the contact form block.
 	return grunion_contact_form_apply_block_attribute(
@@ -113,11 +130,14 @@ add_filter( 'widget_block_content', 'grunion_contact_form_filter_widget_block_co
 /**
  * Adds a given attribute to all instances of the Contact Form block.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute
  * @param string $content  Existing content to process.
  * @param array  $new_attr New attributes to add.
  * @return string
  */
 function grunion_contact_form_apply_block_attribute( $content, $new_attr ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute' );
+
 	if ( false === stripos( $content, 'wp:jetpack/contact-form' ) ) {
 		return $content;
 	}
@@ -151,6 +171,8 @@ function grunion_contact_form_apply_block_attribute( $content, $new_attr ) {
 
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
  */
 class Grunion_Contact_Form_Plugin {
 
@@ -158,6 +180,7 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * The Widget ID of the widget currently being processed.  Used to build the unique contact-form ID for forms embedded in widgets.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @var string
 	 */
 	public $current_widget_id;
@@ -165,6 +188,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * If the contact form field is being used.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @var bool
 	 */
 	public static $using_contact_form_field = false;
@@ -189,8 +213,12 @@ class Grunion_Contact_Form_Plugin {
 
 	/**
 	 * Initializing function.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init
 	 */
 	public static function init() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init' );
+
 		static $instance = false;
 
 		if ( ! $instance ) {
@@ -205,8 +233,12 @@ class Grunion_Contact_Form_Plugin {
 
 	/**
 	 * Runs daily to clean up spam detection metadata after 15 days.  Keeps your DB squeaky clean.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup
 	 */
 	public function daily_akismet_meta_cleanup() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup' );
+
 		global $wpdb;
 
 		$feedback_ids = $wpdb->get_col( "SELECT p.ID FROM {$wpdb->posts} as p INNER JOIN {$wpdb->postmeta} as m on m.post_id = p.ID WHERE p.post_type = 'feedback' AND m.meta_key = '_feedback_akismet_values' AND DATE_SUB(NOW(), INTERVAL 15 DAY) > p.post_date_gmt LIMIT 10000" );
@@ -244,10 +276,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Strips HTML tags from input.  Output is NOT HTML safe.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags
 	 * @param mixed $data_with_tags - data we're stripping HTML tags from.
 	 * @return mixed
 	 */
 	public static function strip_tags( $data_with_tags ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags' );
+
 		$data_without_tags = array();
 		if ( is_array( $data_with_tags ) ) {
 			foreach ( $data_with_tags as $index => $value ) {
@@ -403,10 +438,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prevent 'contact-form-styles' script from being concatenated.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm
 	 * @param array  $do_concat - the concatenation flag.
 	 * @param string $handle - script name.
 	 */
 	public static function disable_forms_style_script_concat( $do_concat, $handle ) {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+
 		if ( 'jetpack-block-contact-form' === $handle ) {
 			$do_concat = false;
 		}
@@ -514,12 +552,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the gutenblock form.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\ontact_Form_Block::gutenblock_render_form
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string
 	 */
 	public static function gutenblock_render_form( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::gutenblock_render_form' );
+
 		// Render fallback in other contexts than frontend (i.e. feed, emails, API, etc.), unless the form is being submitted.
 		if ( ! jetpack_is_frontend() && ! isset( $_POST['contact-form-id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return sprintf(
@@ -538,12 +579,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Turn block attribute to shortcode attributes.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes
 	 * @param array  $atts - the block attributes.
 	 * @param string $type - the type.
 	 *
 	 * @return array
 	 */
 	public static function block_attributes_to_shortcode_attributes( $atts, $type ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes' );
+
 		$atts['type'] = $type;
 		if ( isset( $atts['className'] ) ) {
 			$atts['class'] = $atts['className'];
@@ -561,12 +605,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the text field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_text( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'text' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -574,12 +621,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the name field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_name( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'name' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -587,12 +637,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the email field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_email( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'email' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -600,12 +653,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the url field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_url( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'url' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -613,12 +669,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the date field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_date( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'date' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -626,12 +685,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the telephone field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_telephone( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'telephone' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -639,12 +701,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the text area field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_textarea( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'textarea' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -652,12 +717,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the checkbox field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_checkbox( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'checkbox' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -665,12 +733,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the multiple checkbox field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_checkbox_multiple( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'checkbox-multiple' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -678,12 +749,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the multiple choice field option.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_option( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'field-option' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -691,12 +765,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the radio button field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_radio( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'radio' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -704,12 +781,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the select field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_select( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'select' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
@@ -717,10 +797,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the consent field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent
 	 * @param string $atts consent attributes.
 	 * @param string $content html content.
 	 */
 	public static function gutenblock_render_field_consent( $atts, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent' );
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'consent' );
 
 		if ( ! isset( $atts['implicitConsentMessage'] ) ) {
@@ -736,8 +819,12 @@ class Grunion_Contact_Form_Plugin {
 
 	/**
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu
 	 */
 	public function admin_menu() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu' );
+
 		$slug = 'feedback';
 
 		add_menu_page(
@@ -769,9 +856,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Add to REST API post type allowed list.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type
 	 * @param array $post_types - the post types.
 	 */
 	public function allow_feedback_rest_api_type( $post_types ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type' );
+
 		$post_types[] = 'feedback';
 		return $post_types;
 	}
@@ -780,10 +870,12 @@ class Grunion_Contact_Form_Plugin {
 	 * Display the count of new feedback entries received. It's reset when user visits the Feedback screen.
 	 *
 	 * @since 4.1.0
-	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count
 	 * @param object $screen Information about the current screen.
 	 */
 	public function unread_count( $screen ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count' );
+
 		if ( isset( $screen->post_type ) && 'feedback' === $screen->post_type ) {
 			update_option( 'feedback_unread_count', 0 );
 		} else {
@@ -809,8 +901,12 @@ class Grunion_Contact_Form_Plugin {
 	 * Handles all contact-form POST submissions
 	 *
 	 * Conditionally attached to `template_redirect`
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission
 	 */
 	public function process_form_submission() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission' );
+
 		// Add a filter to replace tokens in the subject field with sanitized field values.
 		add_filter( 'contact_form_subject', array( $this, 'replace_tokens_with_input' ), 10, 2 );
 
@@ -976,8 +1072,12 @@ class Grunion_Contact_Form_Plugin {
 
 	/**
 	 * Handle the ajax request.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request
 	 */
 	public function ajax_request() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request' );
+
 		$submission_result = self::process_form_submission();
 
 		if ( ! $submission_result ) {
@@ -1008,13 +1108,15 @@ class Grunion_Contact_Form_Plugin {
 	 * Ensure the post author is always zero for contact-form feedbacks
 	 * Attached to `wp_insert_post_data`
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter
 	 * @see Grunion_Contact_Form::process_submission()
-	 *
 	 * @param array $data the data to insert.
 	 * @param array $postarr the data sent to wp_insert_post().
 	 * @return array The filtered $data to insert.
 	 */
 	public function insert_feedback_filter( $data, $postarr ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter' );
+
 		if ( $data['post_type'] === 'feedback' && $postarr['post_type'] === 'feedback' ) {
 			$data['post_author'] = 0;
 		}
@@ -1025,8 +1127,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Adds our contact-form shortcode
 	 * The "child" contact-field shortcode is enabled as needed by the contact-form shortcode handler
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode
 	 */
 	public function add_shortcode() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode' );
+
 		add_shortcode( 'contact-form', array( 'Grunion_Contact_Form', 'parse' ) );
 		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
 
@@ -1038,22 +1144,26 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Tokenize the label.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label
 	 * @param string $label - the label.
-	 *
 	 * @return string
 	 */
 	public static function tokenize_label( $label ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label' );
+
 		return '{' . trim( preg_replace( '#^\d+_#', '', $label ) ) . '}';
 	}
 
 	/**
 	 * Sanitize the value.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value
 	 * @param string $value - the value to sanitize.
-	 *
 	 * @return string
 	 */
 	public static function sanitize_value( $value ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value' );
+
 		if ( null === $value ) {
 			return '';
 		}
@@ -1064,12 +1174,14 @@ class Grunion_Contact_Form_Plugin {
 	 * Replaces tokens like {city} or {City} (case insensitive) with the value
 	 * of an input field of that name
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input
 	 * @param string $subject - the subject.
 	 * @param array  $field_values Array with field label => field value associations.
-	 *
 	 * @return string The filtered $subject with the tokens replaced.
 	 */
 	public function replace_tokens_with_input( $subject, $field_values ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input' );
+
 		// Wrap labels into tokens (inside {})
 		$wrapped_labels = array_map( array( 'Grunion_Contact_Form_Plugin', 'tokenize_label' ), array_keys( $field_values ) );
 		// Sanitize all values
@@ -1090,11 +1202,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Tracks the widget currently being processed.
 	 * Attached to `dynamic_sidebar`
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget
 	 * @see $current_widget_id - the current widget ID.
-	 *
 	 * @param array $widget The widget data.
 	 */
 	public function track_current_widget( $widget ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget' );
+
 		$this->current_widget_id = $widget['id'];
 	}
 
@@ -1103,11 +1217,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Used to tell the difference between post-embedded contact-forms and widget-embedded contact-forms
 	 * Attached to `widget_text`
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts
 	 * @param string $text The widget text.
-	 *
 	 * @return string The filtered widget text.
 	 */
 	public function widget_atts( $text ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts' );
+
 		Grunion_Contact_Form::style( true );
 
 		return preg_replace( '/\[contact-form([^a-zA-Z_-])/', '[contact-form widget="' . $this->current_widget_id . '"\\1', $text );
@@ -1117,11 +1233,13 @@ class Grunion_Contact_Form_Plugin {
 	 * For sites where text widgets are not processed for shortcodes, we add this hack to process just our shortcode
 	 * Attached to `widget_text`
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack
 	 * @param string $text The widget text.
-	 *
 	 * @return string The contact-form filtered widget text
 	 */
 	public function widget_shortcode_hack( $text ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack' );
+
 		if ( ! preg_match( '/\[contact-form([^a-zA-Z_-])/', $text ) ) {
 			return $text;
 		}
@@ -1146,11 +1264,14 @@ class Grunion_Contact_Form_Plugin {
 	 * removed from the public discussion.
 	 * Attached to `jetpack_contact_form_is_spam`
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist
 	 * @param bool  $is_spam - if the submission is spam.
 	 * @param array $form - the form data.
 	 * @return bool TRUE => spam, FALSE => not spam
 	 */
 	public function is_spam_blocklist( $is_spam, $form = array() ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist' );
+
 		if ( $is_spam ) {
 			return $is_spam;
 		}
@@ -1162,11 +1283,14 @@ class Grunion_Contact_Form_Plugin {
 	 * Check if a submission matches the comment disallowed list.
 	 * Attached to `jetpack_contact_form_in_comment_disallowed_list`.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list
 	 * @param boolean $in_disallowed_list Whether the feedback is in the disallowed list.
 	 * @param array   $form The form array.
 	 * @return bool Returns true if the form submission matches the disallowed list and false if it doesn't.
 	 */
 	public function is_in_disallowed_list( $in_disallowed_list, $form = array() ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list' );
+
 		if ( $in_disallowed_list ) {
 			return $in_disallowed_list;
 		}
@@ -1191,11 +1315,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Populate an array with all values necessary to submit a NEW contact-form feedback to Akismet.
 	 * Note that this includes the current user_ip etc, so this should only be called when accepting a new item via $_POST
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet
 	 * @param array $form - contact form feedback array.
-	 *
 	 * @return array feedback array with additional data ready for submission to Akismet.
 	 */
 	public function prepare_for_akismet( $form ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet' );
+
 		$form['comment_type']     = 'contact_form';
 		$form['user_ip']          = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
 		$form['user_agent']       = isset( $_SERVER['HTTP_USER_AGENT'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
@@ -1226,7 +1352,6 @@ class Grunion_Contact_Form_Plugin {
 		 * @module contact-form
 		 *
 		 * @since 10.2.0
-		 *
 		 * @param array $form The form values being sent to Akismet.
 		 */
 		return apply_filters( 'jetpack_contact_form_akismet_values', $form );
@@ -1237,11 +1362,14 @@ class Grunion_Contact_Form_Plugin {
 	 * If you're accepting a new item via $_POST, run it Grunion_Contact_Form_Plugin::prepare_for_akismet() first
 	 * Attached to `jetpack_contact_form_is_spam`
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet
 	 * @param bool  $is_spam - if the submission is spam.
 	 * @param array $form - the form data.
 	 * @return bool|WP_Error TRUE => spam, FALSE => not spam, WP_Error => stop processing entirely
 	 */
 	public function is_spam_akismet( $is_spam, $form = array() ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet' );
+
 		global $akismet_api_host, $akismet_api_port;
 
 		// The signature of this function changed from accepting just $form.
@@ -1283,7 +1411,6 @@ class Grunion_Contact_Form_Plugin {
 		 * @module contact-form
 		 *
 		 * @since 1.3.1
-		 *
 		 * @param WP_Error|bool $result Is the submitted feedback spam.
 		 * @param array|bool $form Submitted feedback.
 		 */
@@ -1293,12 +1420,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Submit a feedback as either spam or ham
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit
 	 * @param string $as - Either 'spam' or 'ham'.
 	 * @param array  $form - the contact-form data.
-	 *
 	 * @return bool|string
 	 */
 	public function akismet_submit( $as, $form ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit' );
+
 		global $akismet_api_host, $akismet_api_port;
 
 		if ( ! in_array( $as, array( 'ham', 'spam' ), true ) ) {
@@ -1321,10 +1450,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prints a dropdown of posts with forms.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown
 	 * @param int $selected_id Currently selected post ID.
 	 * @return void
 	 */
 	public static function form_posts_dropdown( $selected_id ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown' );
+
 		?>
 		<select name="jetpack_form_parent_id">
 			<option value="all"><?php esc_html_e( 'All sources', 'jetpack' ); ?></option>
@@ -1336,13 +1468,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Fetch post content for a post and extract just the comment.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export
 	 * @param int $post_id The post id to fetch the content for.
-	 *
 	 * @return string Trimmed post comment.
 	 *
 	 * @codeCoverageIgnore
 	 */
 	public function get_post_content_for_csv_export( $post_id ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export' );
+
 		$post_content = get_post_field( 'post_content', $post_id );
 		$content      = explode( '<!--more-->', $post_content );
 
@@ -1352,11 +1486,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get `_feedback_extra_fields` field from post meta data.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export
 	 * @param int $post_id Id of the post to fetch meta data for.
-	 *
 	 * @return mixed
 	 */
 	public function get_post_meta_for_csv_export( $post_id ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export' );
+
 		$md                     = (array) get_post_meta( $post_id, '_feedback_extra_fields', true );
 		$md['-3_response_date'] = get_the_date( 'Y-m-d H:i:s', $post_id );
 		$content_fields         = self::parse_fields_from_content( $post_id );
@@ -1394,13 +1530,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get parsed feedback post fields.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post
 	 * @param int $post_id Id of the post to fetch parsed contents for.
-	 *
 	 * @return array
 	 *
 	 * @codeCoverageIgnore - No need to be covered.
 	 */
 	public function get_parsed_field_contents_of_post( $post_id ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post' );
+
 		return self::parse_fields_from_content( $post_id );
 	}
 
@@ -1408,13 +1546,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Properly maps fields that are missing from the post meta data
 	 * to names, that are similar to those of the post meta.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names
 	 * @param array $parsed_post_content Parsed post content.
-	 *
 	 * @see parse_fields_from_content for how the input data is generated.
-	 *
 	 * @return array Mapped fields.
 	 */
 	public function map_parsed_field_contents_of_post_to_field_names( $parsed_post_content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names' );
 
 		$mapped_fields = array();
 
@@ -1443,13 +1581,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Registers the personal data exporter.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter
 	 * @since 6.1.1
-	 *
 	 * @param  array $exporters An array of personal data exporters.
-	 *
 	 * @return array $exporters An array of personal data exporters.
 	 */
 	public function register_personal_data_exporter( $exporters ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter' );
+
 		$exporters['jetpack-feedback'] = array(
 			'exporter_friendly_name' => __( 'Feedback', 'jetpack' ),
 			'callback'               => array( $this, 'personal_data_exporter' ),
@@ -1461,13 +1600,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Registers the personal data eraser.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser
 	 * @since 6.1.1
-	 *
 	 * @param  array $erasers An array of personal data erasers.
-	 *
 	 * @return array $erasers An array of personal data erasers.
 	 */
 	public function register_personal_data_eraser( $erasers ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser' );
+
 		$erasers['jetpack-feedback'] = array(
 			'eraser_friendly_name' => __( 'Feedback', 'jetpack' ),
 			'callback'             => array( $this, 'personal_data_eraser' ),
@@ -1479,14 +1619,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Exports personal data.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter
 	 * @since 6.1.1
-	 *
 	 * @param  string $email  Email address.
 	 * @param  int    $page   Page to export.
-	 *
 	 * @return array  $return Associative array with keys expected by core.
 	 */
 	public function personal_data_exporter( $email, $page = 1 ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter' );
+
 		return $this->internal_personal_data_exporter( $email, $page );
 	}
 
@@ -1496,16 +1637,17 @@ class Grunion_Contact_Form_Plugin {
 	 * Allows us to have a different signature than core expects
 	 * while protecting against future core API changes.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter
 	 * @internal
 	 * @since 6.5
-	 *
 	 * @param  string $email    Email address.
 	 * @param  int    $page     Page to export.
 	 * @param  int    $per_page Number of feedbacks to process per page. Internal use only (testing).
-	 *
 	 * @return array            Associative array with keys expected by core.
 	 */
 	public function internal_personal_data_exporter( $email, $page = 1, $per_page = 250 ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter' );
+
 		$export_data = array();
 		$post_ids    = $this->personal_data_post_ids_by_email( $email, $per_page, $page );
 
@@ -1554,14 +1696,15 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Erases personal data.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser
 	 * @since 6.1.1
-	 *
 	 * @param  string $email Email address.
 	 * @param  int    $page  Page to erase.
-	 *
 	 * @return array         Associative array with keys expected by core.
 	 */
 	public function personal_data_eraser( $email, $page = 1 ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser' );
+
 		return $this->_internal_personal_data_eraser( $email, $page );
 	}
 
@@ -1571,16 +1714,17 @@ class Grunion_Contact_Form_Plugin {
 	 * Allows us to have a different signature than core expects
 	 * while protecting against future core API changes.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser
 	 * @internal
 	 * @since 6.5
-	 *
 	 * @param  string $email    Email address.
 	 * @param  int    $page     Page to erase.
 	 * @param  int    $per_page Number of feedbacks to process per page. Internal use only (testing).
-	 *
 	 * @return array            Associative array with keys expected by core.
 	 */
 	public function _internal_personal_data_eraser( $email, $page = 1, $per_page = 250 ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- this is called in other files.
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser' );
+
 		$post_id      = null;
 		$removed      = false;
 		$retained     = false;
@@ -1648,16 +1792,17 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Queries personal data by email address.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email
 	 * @since 6.1.1
-	 *
 	 * @param  string $email        Email address.
 	 * @param  int    $per_page     Post IDs per page. Default is `250`.
 	 * @param  int    $page         Page to query. Default is `1`.
 	 * @param  int    $last_post_id Page to query. Default is `0`. If non-zero, used instead of $page.
-	 *
 	 * @return array An array of post IDs.
 	 */
 	public function personal_data_post_ids_by_email( $email, $per_page = 250, $page = 1, $last_post_id = 0 ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email' );
+
 		add_filter( 'posts_search', array( $this, 'personal_data_search_filter' ) );
 
 		$this->pde_last_post_id_erased = $last_post_id;
@@ -1690,13 +1835,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Filters searches by email address.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter
 	 * @since 6.1.1
-	 *
 	 * @param  string $search SQL where clause.
-	 *
 	 * @return array          Filtered SQL where clause.
 	 */
 	public function personal_data_search_filter( $search ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter' );
+
 		global $wpdb;
 
 		/*
@@ -1725,11 +1871,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prepares feedback post data for CSV export.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts
 	 * @param array $post_ids Post IDs to fetch the data for. These need to be Feedback posts.
-	 *
 	 * @return array
 	 */
 	public function get_export_data_for_posts( $post_ids ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts' );
 
 		$posts_data  = array();
 		$field_names = array();
@@ -1861,9 +2008,12 @@ class Grunion_Contact_Form_Plugin {
 	 * - Positive values render AFTER any form field/value column: 1, 30, 93...
 	 *   Mind using high numbering on these ones as the prefix is used on regular inputs: 1_Name, 2_Email, etc
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names
 	 * @return array
 	 */
 	public function get_well_known_column_names() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names' );
+
 		return array(
 			'-9_title'         => __( 'Title', 'jetpack' ),
 			'-6_source'        => __( 'Source', 'jetpack' ),
@@ -1875,8 +2025,12 @@ class Grunion_Contact_Form_Plugin {
 
 	/**
 	 * Extracts feedback entries based on POST data.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post
 	 */
 	public function get_feedback_entries_from_post() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post' );
+
 		if ( empty( $_POST['feedback_export_nonce_csv'] ) && empty( $_POST['feedback_export_nonce_gdrive'] ) ) {
 			return;
 		} elseif ( ! empty( $_POST['feedback_export_nonce_csv'] ) ) {
@@ -1946,8 +2100,12 @@ class Grunion_Contact_Form_Plugin {
 
 	/**
 	 * Download exported data as CSV
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv
 	 */
 	public function download_feedback_as_csv() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv' );
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- verification is done on get_feedback_entries_from_post function
 		$post_data = wp_unslash( $_POST );
 		$data      = $this->get_feedback_entries_from_post();
@@ -2023,12 +2181,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Send an event to Tracks
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event
 	 * @param string $event_name - the name of the event.
 	 * @param array  $event_props - event properties to send.
-	 *
 	 * @return null|void
 	 */
 	public function record_tracks_event( $event_name, $event_props ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event' );
+
 		/*
 		 * Event details.
 		 */
@@ -2075,13 +2235,14 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * Additionally, Excel exposes the ability to launch arbitrary commands through the DDE protocol.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv
 	 * @see https://www.contextis.com/en/blog/comma-separated-vulnerabilities
-	 *
 	 * @param string $field - the CSV field.
-	 *
 	 * @return string
 	 */
 	public function esc_csv( $field ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv' );
+
 		$active_content_triggers = array( '=', '+', '-', '@' );
 
 		if ( in_array( mb_substr( $field, 0, 1 ), $active_content_triggers, true ) ) {
@@ -2157,10 +2318,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Parse the contact form fields.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content
 	 * @param int $post_id - the post ID.
 	 * @return array Fields.
 	 */
 	public static function parse_fields_from_content( $post_id ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content' );
+
 		static $post_fields;
 
 		if ( ! is_array( $post_fields ) ) {
@@ -2270,20 +2434,26 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get the IP address.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address
 	 * @return string|null IP address.
 	 */
 	public static function get_ip_address() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address' );
+
 		return isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : null;
 	}
 
 	/**
 	 * Disable Block Editor for feedbacks.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type
 	 * @param bool   $can_edit Whether the post type can be edited or not.
 	 * @param string $post_type The post type being checked.
 	 * @return bool
 	 */
 	public function use_block_editor_for_post_type( $can_edit, $post_type ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type' );
+
 		return 'feedback' === $post_type ? false : $can_edit;
 	}
 
@@ -2294,12 +2464,15 @@ class Grunion_Contact_Form_Plugin {
 	 * - p1675781140892129-slack-C01CSBEN0QZ
 	 * - https://www.php.net/manual/en/function.print-r.php#93529
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print
 	 * @param string $print_r_output The array string to be reverted. Needs to being with 'Array'.
 	 * @param bool   $parse_html Whether to run html_entity_decode on each line.
 	 *                           As strings are stored right now, they are all escaped, so '=>' are '&gt;'.
 	 * @return array|string Array when succesfully reconstructed, string otherwise. Output will always be esc_html'd.
 	 */
 	public static function reverse_that_print( $print_r_output, $parse_html = false ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print' );
+
 		$lines = explode( "\n", trim( $print_r_output ) );
 		if ( $parse_html ) {
 			$lines = array_map( 'html_entity_decode', $lines );
@@ -2369,12 +2542,15 @@ class Grunion_Contact_Form_Plugin {
  *
  * Not very general - specific to Grunion.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+ *
  * // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
  */
 class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The name of the shortcode: [$shortcode_name /].
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var string
 	 */
 	public $shortcode_name;
@@ -2382,6 +2558,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Key => value pairs for the shortcode's attributes: [$shortcode_name key="value" ... /]
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $attributes;
@@ -2389,6 +2566,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Key => value pair for attribute defaults.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $defaults = array();
@@ -2396,6 +2574,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The inner content of otherwise: [$shortcode_name]$content[/$shortcode_name]. Null for selfclosing shortcodes.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var null|string
 	 */
 	public $content;
@@ -2403,6 +2582,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Associative array of inner "child" shortcodes equivalent to the $content: [$shortcode_name][child 1/][child 2/][/$shortcode_name]
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $fields;
@@ -2410,6 +2590,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The HTML of the parsed inner "child" shortcodes".  Null for selfclosing shortcodes.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var null|string
 	 */
 	public $body;
@@ -2417,10 +2598,13 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Constructor function.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct
 	 * @param array       $attributes An associative array of shortcode attributes.  @see shortcode_atts().
 	 * @param null|string $content Null for selfclosing shortcodes.  The inner content otherwise.
 	 */
 	public function __construct( $attributes, $content = null ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct' );
+
 		$this->attributes = $this->unesc_attr( $attributes );
 		if ( is_array( $content ) ) {
 			$string_content = '';
@@ -2439,9 +2623,12 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Processes the shortcode's inner content for "child" shortcodes.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content
 	 * @param string $content The shortcode's inner content: [shortcode]$content[/shortcode].
 	 */
 	public function parse_content( $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content' );
+
 		if ( $content === null ) {
 			$this->body = null;
 		} else {
@@ -2452,22 +2639,26 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Returns the value of the requested attribute.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute
 	 * @param string $key The attribute to retrieve.
-	 *
 	 * @return mixed
 	 */
 	public function get_attribute( $key ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute' );
+
 		return isset( $this->attributes[ $key ] ) ? $this->attributes[ $key ] : null;
 	}
 
 	/**
 	 * Escape attributes.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr
 	 * @param array $value - the value we're escaping.
-	 *
 	 * @return array
 	 */
 	public function esc_attr( $value ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr' );
+
 		if ( is_array( $value ) ) {
 			return array_map( array( $this, 'esc_attr' ), $value );
 		}
@@ -2494,11 +2685,13 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Unescape attributes.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr
 	 * @param array $value - the value we're escaping.
-	 *
 	 * @return array
 	 */
 	public function unesc_attr( $value ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr' );
+
 		if ( is_array( $value ) ) {
 			return array_map( array( $this, 'unesc_attr' ), $value );
 		}
@@ -2521,8 +2714,12 @@ class Crunion_Contact_Form_Shortcode {
 
 	/**
 	 * Generates the shortcode
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString
 	 */
 	public function __toString() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString' );
+
 		$r = "[{$this->shortcode_name} ";
 
 		foreach ( $this->attributes as $key => $value ) {
@@ -2579,12 +2776,15 @@ class Crunion_Contact_Form_Shortcode {
  * Class for the contact-form shortcode.
  * Parses shortcode to output the contact form as HTML
  * Sends email and stores the contact form response (a.k.a. "feedback")
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form
  */
 class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 	/**
 	 * The shortcode name.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var string
 	 */
 	public $shortcode_name = 'contact-form';
@@ -2593,6 +2793,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *
 	 * Stores form submission errors.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var WP_Error
 	 */
 	public $errors;
@@ -2600,6 +2801,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The SHA1 hash of the attributes that comprise the form.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var string
 	 */
 	public $hash;
@@ -2607,6 +2809,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The most recent (inclusive) contact-form shortcode processed.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var Grunion_Contact_Form
 	 */
 	public static $last;
@@ -2614,6 +2817,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Form we are currently looking at. If processed, will become $last
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var Whatever
 	 */
 	public static $current_form;
@@ -2621,6 +2825,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * All found forms, indexed by hash.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var array
 	 */
 	public static $forms = array();
@@ -2628,6 +2833,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Whether to print the grunion.css style when processing the contact-form shortcode
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var bool
 	 */
 	public static $style = false;
@@ -2635,6 +2841,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * When printing the submit button, what tags are allowed
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var array
 	 */
 	public static $allowed_html_tags_for_submit_button = array( 'br' => array() );
@@ -2642,10 +2849,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Construction function.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct
 	 * @param array  $attributes - the attributes.
 	 * @param string $content - the content.
 	 */
 	public function __construct( $attributes, $content = null ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct' );
+
 		global $post;
 
 		// Set up the default subject and recipient for this form.
@@ -2746,11 +2956,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Store shortcode content for recall later
 	 *  - used to receate shortcode when user uses do_shortcode
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode
 	 * @param string $content - the content.
 	 * @param array  $attributes - the attributes.
 	 * @param string $hash - the hash.
 	 */
 	public static function store_shortcode( $content = null, $attributes = null, $hash = null ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode' );
 
 		if ( $content && isset( $attributes['id'] ) ) {
 
@@ -2772,11 +2984,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Toggle for printing the grunion.css stylesheet
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style
 	 * @param bool $style - the CSS style.
-	 *
 	 * @return bool
 	 */
 	public static function style( $style ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::style' );
+
 		$previous_style = self::$style;
 		self::$style    = (bool) $style;
 		return $previous_style;
@@ -2785,24 +2999,28 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Turn on printing of grunion.css stylesheet
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on
 	 * @see ::style()
 	 * @internal
-	 *
 	 * @return bool
 	 */
 	public static function style_on() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on' );
+
 		return self::style( true );
 	}
 
 	/**
 	 * The contact-form shortcode processor
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse
 	 * @param array       $attributes Key => Value pairs as parsed by shortcode_parse_atts().
 	 * @param string|null $content The shortcode's inner content: [contact-form]$content[/contact-form].
-	 *
 	 * @return string HTML for the concat form.
 	 */
 	public static function parse( $attributes, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse' );
+
 		if ( Settings::is_syncing() ) {
 			return '';
 		}
@@ -3004,12 +3222,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Returns a success message to be returned if the form is sent via AJAX.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the contact form.
-	 *
 	 * @return string $message
 	 */
 	public static function success_message( $feedback_id, $form ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message' );
+
 		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
 			$message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
 		} else {
@@ -3057,12 +3277,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Returns a compiled form with labels and values in a form of  an array
 	 * of lines.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the form.
-	 *
 	 * @return array $lines
 	 */
 	public static function get_compiled_form( $feedback_id, $form ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form' );
+
 		$feedback       = get_post( $feedback_id );
 		$field_ids      = $form->get_field_ids();
 		$content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $feedback_id );
@@ -3150,12 +3372,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Returns a compiled form with labels and values formatted for the email response
 	 * in a form of an array of lines.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the form.
-	 *
 	 * @return array $lines
 	 */
 	public static function get_compiled_form_for_email( $feedback_id, $form ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email' );
+
 		$feedback       = get_post( $feedback_id );
 		$field_ids      = $form->get_field_ids();
 		$content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $feedback_id );
@@ -3265,11 +3489,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Escape and sanitize the field value.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value
 	 * @param string $value - the value we're escaping and sanitizing.
-	 *
 	 * @return string
 	 */
 	public static function escape_and_sanitize_field_value( $value ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value' );
+
 		$value = str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), $value );
 		return nl2br( wp_kses( $value, array() ) );
 	}
@@ -3277,11 +3503,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Only strip out empty string values and keep all the other values as they are.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty
 	 * @param string $single_value - the single value.
-	 *
 	 * @return bool
 	 */
 	public static function remove_empty( $single_value ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty' );
+
 		return ( $single_value !== '' );
 	}
 
@@ -3317,11 +3545,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * The contact-field shortcode processor.
 	 * We use an object method here instead of a static Grunion_Contact_Form_Field class method to parse contact-field shortcodes so that we can tie them to the contact-form object.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field
 	 * @param array       $attributes Key => Value pairs as parsed by shortcode_parse_atts().
 	 * @param string|null $content The shortcode's inner content: [contact-field]$content[/contact-field].
 	 * @return string HTML for the contact form field
 	 */
 	public static function parse_contact_field( $attributes, $content ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field' );
+
 		// Don't try to parse contact form fields if not inside a contact form
 		if ( ! Grunion_Contact_Form_Plugin::$using_contact_form_field ) {
 			$type = isset( $attributes['type'] ) ? $attributes['type'] : null;
@@ -3410,11 +3641,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Get the default label from type.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type
 	 * @param string $type - the type of label.
-	 *
 	 * @return string
 	 */
 	public static function get_default_label_from_type( $type ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type' );
+
 		$str = null;
 		switch ( $type ) {
 			case 'text':
@@ -3497,9 +3730,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *  - admin.php / grunion_manage_post_columns - add the field to the render logic.
 	 *      Otherwise it will be missing from the admin Feedback view.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids
 	 * @return array
 	 */
 	public function get_field_ids() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids' );
+
 		$field_ids = array(
 			'all'   => array(), // array of all field_ids.
 			'extra' => array(), // array of all non-allowed field IDs.
@@ -3560,8 +3796,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Process the contact form's POST submission
 	 * Stores feedback.  Sends email.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission
 	 */
 	public function process_submission() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission' );
+
 		global $post;
 
 		$plugin = Grunion_Contact_Form_Plugin::init();
@@ -4158,15 +4398,17 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Wrapper for wp_mail() that enables HTML messages with text alternatives
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail
 	 * @param string|array $to          Array or comma-separated list of email addresses to send message.
 	 * @param string       $subject     Email subject.
 	 * @param string       $message     Message contents.
 	 * @param string|array $headers     Optional. Additional headers.
 	 * @param string|array $attachments Optional. Files to attach.
-	 *
 	 * @return bool Whether the email contents were sent successfully.
 	 */
 	public static function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail' );
+
 		add_filter( 'wp_mail_content_type', __CLASS__ . '::get_mail_content_type' );
 		add_action( 'phpmailer_init', __CLASS__ . '::add_plain_text_alternative' );
 
@@ -4184,11 +4426,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * SpamAssassin doesn't like addresses in HTML messages that are missing display names (e.g., `foo@bar.org`
 	 * instead of `Foo Bar <foo@bar.org>`.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address
 	 * @param string $address - the email address.
-	 *
 	 * @return string
 	 */
 	public function add_name_to_address( $address ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address' );
+
 		// If it's just the address, without a display name
 		if ( is_email( $address ) ) {
 			$address_parts = explode( '@', $address );
@@ -4208,9 +4452,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Get the content type that should be assigned to outbound emails
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type
 	 * @return string
 	 */
 	public static function get_mail_content_type() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type' );
+
 		return 'text/html';
 	}
 
@@ -4219,13 +4466,15 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *
 	 * This helps to ensure correct parsing by clients, and also helps avoid triggering spam filtering rules
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags
 	 * @param string $title - title of the email.
 	 * @param string $body - the message body.
 	 * @param string $footer - the footer containing meta information.
-	 *
 	 * @return string
 	 */
 	public static function wrap_message_in_html_tags( $title, $body, $footer ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags' );
+
 		// Don't do anything if the message was already wrapped in HTML tags
 		// That could have be done by a plugin via filters
 		if ( str_contains( $body, '<html' ) ) {
@@ -4240,7 +4489,6 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		 * @module contact-form
 		 *
 		 * @since 12.2
-		 *
 		 * @param string the filename of the HTML template used for response emails to the form owner.
 		 */
 		require apply_filters( 'jetpack_forms_response_email_template', __DIR__ . '/grunion-response-email-template.php' );
@@ -4268,9 +4516,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * This makes the message more accessible to mail clients that aren't HTML-aware, and decreases the likelihood
 	 * that the message will be flagged as spam.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative
 	 * @param PHPMailer $phpmailer - the phpmailer.
 	 */
 	public static function add_plain_text_alternative( $phpmailer ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative' );
+
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		// Add an extra break so that the extra space above the <p> is preserved after the <p> is stripped out
@@ -4293,10 +4544,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Add deepslashes.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep
 	 * @param array $value - the value.
 	 * @return array The value, with slashes added.
 	 */
 	public function addslashes_deep( $value ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep' );
+
 		if ( is_array( $value ) ) {
 			return array_map( array( $this, 'addslashes_deep' ), $value );
 		} elseif ( is_object( $value ) ) {
@@ -4315,10 +4569,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Only allowin "wide" and "full" as "center", "left" and "right" don't
 	 * make much sense for the form.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class
 	 * @param array $attributes Block attributes.
 	 * @return string The CSS alignment class: alignfull | alignwide.
 	 */
 	public static function get_block_alignment_class( $attributes = array() ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class' );
+
 		$align_to_class_map = array(
 			'wide' => 'alignwide',
 			'full' => 'alignfull',
@@ -4335,12 +4592,15 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
  * Class for the contact-field shortcode.
  * Parses shortcode to output the contact form field as HTML.
  * Validates input.
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
  */
 class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 
 	/**
 	 * The shortcode name.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $shortcode_name = 'contact-field';
@@ -4348,6 +4608,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The parent form.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var Grunion_Contact_Form
 	 */
 	public $form;
@@ -4355,6 +4616,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Default or POSTed value.
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $value;
@@ -4362,6 +4624,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Is the input valid?
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var bool
 	 */
 	public $error = false;
@@ -4369,6 +4632,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $block_styles = '';
@@ -4376,6 +4640,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $field_styles = '';
@@ -4383,6 +4648,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field option
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $option_styles = '';
@@ -4390,6 +4656,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $label_styles = '';
@@ -4397,11 +4664,14 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Constructor function.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct
 	 * @param array                $attributes An associative array of shortcode attributes.  @see shortcode_atts().
 	 * @param null|string          $content Null for selfclosing shortcodes.  The inner content otherwise.
 	 * @param Grunion_Contact_Form $form The parent form.
 	 */
 	public function __construct( $attributes, $content = null, $form = null ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct' );
+
 		$attributes = shortcode_atts(
 			array(
 				'label'                  => null,
@@ -4496,9 +4766,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * This field's input is invalid.  Flag as invalid and add an error to the parent form
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error
 	 * @param string $message The error message to display on the form.
 	 */
 	public function add_error( $message ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error' );
+
 		$this->is_error = true;
 
 		if ( ! is_wp_error( $this->form->errors ) ) {
@@ -4511,18 +4784,24 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Is the field input invalid?
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error
 	 * @see $error
-	 *
 	 * @return bool
 	 */
 	public function is_error() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error' );
+
 		return $this->error;
 	}
 
 	/**
 	 * Validates the form input
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate
 	 */
 	public function validate() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate' );
+
 		// If it's not required, there's nothing to validate
 		if ( ! $this->get_attribute( 'required' ) ) {
 			return;
@@ -4578,13 +4857,15 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Check the default value for options field
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value
 	 * @param string $value - the value we're checking.
 	 * @param int    $index - the index.
 	 * @param string $options - default field option.
-	 *
 	 * @return string
 	 */
 	public function get_option_value( $value, $index, $options ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value' );
+
 		if ( empty( $value[ $index ] ) ) {
 			return $options;
 		}
@@ -4594,9 +4875,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Outputs the HTML for this form field
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render
 	 * @return string HTML
 	 */
 	public function render() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render' );
+
 		global $current_user, $user_identity;
 
 		$field_id            = $this->get_attribute( 'id' );
@@ -4728,16 +5012,18 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the label.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label
 	 * @param string $type - the field type.
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
 	 * @param array  $extra_attrs Array of key/value pairs to append as attributes to the element.
-	 *
 	 * @return string HTML
 	 */
 	public function render_label( $type, $id, $label, $required, $required_field_text, $extra_attrs = array() ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label' );
+
 		$form_style = $this->get_form_style();
 
 		if ( ! empty( $form_style ) && $form_style !== 'default' ) {
@@ -4769,6 +5055,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the input field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field
 	 * @param string $type - the field type.
 	 * @param int    $id - the ID.
 	 * @param string $value - the value of the field.
@@ -4776,10 +5063,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @param string $placeholder - the field placeholder content.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param array  $extra_attrs Array of key/value pairs to append as attributes to the element.
-	 *
 	 * @return string HTML
 	 */
 	public function render_input_field( $type, $id, $value, $class, $placeholder, $required, $extra_attrs = array() ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field' );
+
 		$extra_attrs_string = '';
 
 		if ( ! empty( $this->field_styles ) ) {
@@ -4805,6 +5093,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -4812,10 +5101,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
 	 * @param string $placeholder - the field placeholder content.
-	 *
 	 * @return string HTML
 	 */
 	public function render_email_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field' );
+
 		$field  = $this->render_label( 'email', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'email', $id, $value, $class, $placeholder, $required );
 		return $field;
@@ -4824,6 +5114,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the telephone field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -4831,10 +5122,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
 	 * @param string $placeholder - the field placeholder content.
-	 *
 	 * @return string HTML
 	 */
 	public function render_telephone_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field' );
+
 		$field  = $this->render_label( 'telephone', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'tel', $id, $value, $class, $placeholder, $required );
 		return $field;
@@ -4843,6 +5135,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the URL field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -4850,10 +5143,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
 	 * @param string $placeholder - the field placeholder content.
-	 *
 	 * @return string HTML
 	 */
 	public function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field' );
+
 		$custom_validation_message = __( 'Please enter a valid URL - https://www.example.com', 'jetpack' );
 		$validation_attrs          = array(
 			'title'              => $custom_validation_message,
@@ -4871,6 +5165,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the text area field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -4878,10 +5173,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
 	 * @param string $placeholder - the field placeholder content.
-	 *
 	 * @return string HTML
 	 */
 	public function render_textarea_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field' );
+
 		$field  = $this->render_label( 'textarea', 'contact-form-comment-' . $id, $label, $required, $required_field_text );
 		$field .= "<textarea
 		                style='" . $this->field_styles . "'
@@ -4899,16 +5195,18 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the radio field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
 	 * @param string $class - the field class.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
-	 *
 	 * @return string HTML
 	 */
 	public function render_radio_field( $id, $label, $value, $class, $required, $required_field_text ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field' );
+
 		$field  = $this->render_label( '', $id, $label, $required, $required_field_text );
 		$field .= '<div class="grunion-radio-options">';
 
@@ -4936,16 +5234,18 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the checkbox field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
 	 * @param string $class - the field class.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
-	 *
 	 * @return string HTML
 	 */
 	public function render_checkbox_field( $id, $label, $value, $class, $required, $required_field_text ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field' );
+
 		$field  = "<label class='grunion-field-label checkbox" . ( $this->is_error() ? ' form-error' : '' ) . "' style='" . $this->label_styles . "'>";
 		$field .= "\t\t<input type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
 		$field .= "\t\t" . esc_html( $label ) . ( $required ? '<span>' . $required_field_text . '</span>' : '' );
@@ -4980,16 +5280,18 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the multiple checkbox field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
 	 * @param string $class - the field class.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
-	 *
 	 * @return string HTML
 	 */
 	public function render_checkbox_multiple_field( $id, $label, $value, $class, $required, $required_field_text ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field' );
+
 		$field  = $this->render_label( '', $id, $label, $required, $required_field_text );
 		$field .= '<div class="grunion-checkbox-multiple-options">';
 
@@ -5011,16 +5313,18 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the select field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
 	 * @param string $class - the field class.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
-	 *
 	 * @return string HTML
 	 */
 	public function render_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field' );
+
 		$field  = $this->render_label( 'select', $id, $label, $required, $required_field_text );
 		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . ">\n";
 
@@ -5063,6 +5367,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5070,10 +5375,10 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
 	 * @param string $placeholder - the field placeholder content.
-	 *
 	 * @return string HTML
 	 */
 	public function render_date_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field' );
 
 		$field  = $this->render_label( 'date', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required );
@@ -5108,6 +5413,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the default field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5116,10 +5422,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @param string $required_field_text - the text in the required text field.
 	 * @param string $placeholder - the field placeholder content.
 	 * @param string $type - the type.
-	 *
 	 * @return string HTML
 	 */
 	public function render_default_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder, $type ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field' );
+
 		$field  = $this->render_label( $type, $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required );
 		return $field;
@@ -5128,14 +5435,16 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the outlined label.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
-	 *
 	 * @return string HTML
 	 */
 	public function render_outline_label( $id, $label, $required, $required_field_text ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label' );
+
 		return '
 			<div class="notched-label">
 				<div class="notched-label__leading"></div>
@@ -5156,14 +5465,16 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the animated label.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
-	 *
 	 * @return string HTML
 	 */
 	public function render_animated_label( $id, $label, $required, $required_field_text ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label' );
+
 		return '
 			<label
 				for="' . esc_attr( $id ) . '"
@@ -5178,14 +5489,16 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the below label.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
-	 *
 	 * @return string HTML
 	 */
 	public function render_below_label( $id, $label, $required, $required_field_text ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label' );
+
 		return '
 			<label
 				for="' . esc_attr( $id ) . '"
@@ -5199,6 +5512,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field
 	 * @param string $type - the type.
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
@@ -5207,10 +5521,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @param string $placeholder - the field placeholder content.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text for a field marked as required.
-	 *
 	 * @return string HTML
 	 */
 	public function render_field( $type, $id, $label, $value, $class, $placeholder, $required, $required_field_text ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field' );
+
 		$class .= ' grunion-field';
 
 		if ( $type === 'select' ) {
@@ -5363,8 +5678,12 @@ add_action( 'grunion_scheduled_delete', 'grunion_delete_old_spam' );
 
 /**
  * Deletes old spam feedbacks to keep the posts table size under control
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam'
  */
 function grunion_delete_old_spam() {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );
+
 	global $wpdb;
 
 	$grunion_delete_limit = 100;
@@ -5414,11 +5733,13 @@ function grunion_delete_old_spam() {
 /**
  * Send an event to Tracks on form submission.
  *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent
  * @param int $post_id - the post_id for the CPT that is created.
- *
  * @return null|void
  */
 function jetpack_tracks_record_grunion_pre_message_sent( $post_id ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent' );
+
 	$post = get_post( $post_id );
 	if ( $post ) {
 		$extra = gmdate( 'Y-W', strtotime( $post->post_date_gmt ) );

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -4,7 +4,7 @@
  * Add a contact form to any post, page or text widget.
  * Emails will be sent to the post's author by default, or any email address you choose.
  *
- * @deprecated jetpack-$$next-version$$ Use automattic/jetpack-forms
+ * @deprecated $$next-version$$ Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -26,7 +26,7 @@ add_action( 'rest_api_init', 'grunion_contact_form_require_endpoint' );
 /**
  * Require the Grunion endpoint.
  *
- * @deprecated jetpack-$$next-version$$
+ * @deprecated $$next-version$$
  */
 function grunion_contact_form_require_endpoint() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
@@ -43,7 +43,7 @@ function grunion_contact_form_require_endpoint() {
  *
  * This fixes Contact Form Blocks added to FSE _templates_ (e.g. Single or 404).
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute
  * @param string $template Template to be loaded.
  */
 function grunion_contact_form_set_block_template_attribute( $template ) {
@@ -69,7 +69,7 @@ add_filter( 'template_include', 'grunion_contact_form_set_block_template_attribu
  * This is part of the fix for Contact Form Blocks added to FSE _template parts_ (e.g footer).
  * The global is processed in Grunion_Contact_Form::parse().
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global
  * @param string $template_part_id ID for the currently rendered template part.
  */
 function grunion_contact_form_set_block_template_part_id_global( $template_part_id ) {
@@ -87,7 +87,7 @@ add_action( 'gutenberg_render_block_core_template_part_none', 'grunion_contact_f
 /**
  * Unsets the global when block is done rendering.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global
  * @param string $content Rendered block content.
  * @param array  $block   The full block, including name and attributes.
  * @return string
@@ -107,7 +107,7 @@ add_filter( 'render_block', 'grunion_contact_form_unset_block_template_part_id_g
 /**
  * Sets the 'widget' attribute on all instances of the contact form in the widget block.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content
  * @param string          $content  Existing widget block content.
  * @param array           $instance Array of settings for the current widget.
  * @param WP_Widget_Block $widget   Current Block widget instance.
@@ -130,7 +130,7 @@ add_filter( 'widget_block_content', 'grunion_contact_form_filter_widget_block_co
 /**
  * Adds a given attribute to all instances of the Contact Form block.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute
  * @param string $content  Existing content to process.
  * @param array  $new_attr New attributes to add.
  * @return string
@@ -172,7 +172,7 @@ function grunion_contact_form_apply_block_attribute( $content, $new_attr ) {
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
  */
 class Grunion_Contact_Form_Plugin {
 
@@ -180,7 +180,7 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * The Widget ID of the widget currently being processed.  Used to build the unique contact-form ID for forms embedded in widgets.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @var string
 	 */
 	public $current_widget_id;
@@ -188,7 +188,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * If the contact form field is being used.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @var bool
 	 */
 	public static $using_contact_form_field = false;
@@ -214,7 +214,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Initializing function.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init
 	 */
 	public static function init() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init' );
@@ -234,7 +234,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Runs daily to clean up spam detection metadata after 15 days.  Keeps your DB squeaky clean.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup
 	 */
 	public function daily_akismet_meta_cleanup() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup' );
@@ -276,7 +276,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Strips HTML tags from input.  Output is NOT HTML safe.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags
 	 * @param mixed $data_with_tags - data we're stripping HTML tags from.
 	 * @return mixed
 	 */
@@ -438,7 +438,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prevent 'contact-form-styles' script from being concatenated.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm
 	 * @param array  $do_concat - the concatenation flag.
 	 * @param string $handle - script name.
 	 */
@@ -552,7 +552,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the gutenblock form.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\ontact_Form_Block::gutenblock_render_form
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\ontact_Form_Block::gutenblock_render_form
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -579,7 +579,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Turn block attribute to shortcode attributes.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes
 	 * @param array  $atts - the block attributes.
 	 * @param string $type - the type.
 	 *
@@ -605,7 +605,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the text field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -621,7 +621,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the name field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -637,7 +637,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the email field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -653,7 +653,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the url field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -669,7 +669,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the date field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -685,7 +685,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the telephone field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -701,7 +701,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the text area field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -717,7 +717,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the checkbox field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -733,7 +733,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the multiple checkbox field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -749,7 +749,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the multiple choice field option.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -765,7 +765,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the radio button field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -781,7 +781,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the select field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
@@ -797,7 +797,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the consent field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent
 	 * @param string $atts consent attributes.
 	 * @param string $content html content.
 	 */
@@ -820,7 +820,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu
 	 */
 	public function admin_menu() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu' );
@@ -856,7 +856,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Add to REST API post type allowed list.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type
 	 * @param array $post_types - the post types.
 	 */
 	public function allow_feedback_rest_api_type( $post_types ) {
@@ -870,7 +870,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Display the count of new feedback entries received. It's reset when user visits the Feedback screen.
 	 *
 	 * @since 4.1.0
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count
 	 * @param object $screen Information about the current screen.
 	 */
 	public function unread_count( $screen ) {
@@ -902,7 +902,7 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * Conditionally attached to `template_redirect`
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission
 	 */
 	public function process_form_submission() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission' );
@@ -1073,7 +1073,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Handle the ajax request.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request
 	 */
 	public function ajax_request() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request' );
@@ -1108,7 +1108,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Ensure the post author is always zero for contact-form feedbacks
 	 * Attached to `wp_insert_post_data`
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter
 	 * @see Grunion_Contact_Form::process_submission()
 	 * @param array $data the data to insert.
 	 * @param array $postarr the data sent to wp_insert_post().
@@ -1128,7 +1128,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Adds our contact-form shortcode
 	 * The "child" contact-field shortcode is enabled as needed by the contact-form shortcode handler
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode
 	 */
 	public function add_shortcode() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode' );
@@ -1144,7 +1144,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Tokenize the label.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label
 	 * @param string $label - the label.
 	 * @return string
 	 */
@@ -1157,7 +1157,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Sanitize the value.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value
 	 * @param string $value - the value to sanitize.
 	 * @return string
 	 */
@@ -1174,7 +1174,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Replaces tokens like {city} or {City} (case insensitive) with the value
 	 * of an input field of that name
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input
 	 * @param string $subject - the subject.
 	 * @param array  $field_values Array with field label => field value associations.
 	 * @return string The filtered $subject with the tokens replaced.
@@ -1202,7 +1202,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Tracks the widget currently being processed.
 	 * Attached to `dynamic_sidebar`
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget
 	 * @see $current_widget_id - the current widget ID.
 	 * @param array $widget The widget data.
 	 */
@@ -1217,7 +1217,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Used to tell the difference between post-embedded contact-forms and widget-embedded contact-forms
 	 * Attached to `widget_text`
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts
 	 * @param string $text The widget text.
 	 * @return string The filtered widget text.
 	 */
@@ -1233,7 +1233,7 @@ class Grunion_Contact_Form_Plugin {
 	 * For sites where text widgets are not processed for shortcodes, we add this hack to process just our shortcode
 	 * Attached to `widget_text`
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack
 	 * @param string $text The widget text.
 	 * @return string The contact-form filtered widget text
 	 */
@@ -1264,7 +1264,7 @@ class Grunion_Contact_Form_Plugin {
 	 * removed from the public discussion.
 	 * Attached to `jetpack_contact_form_is_spam`
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist
 	 * @param bool  $is_spam - if the submission is spam.
 	 * @param array $form - the form data.
 	 * @return bool TRUE => spam, FALSE => not spam
@@ -1283,7 +1283,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Check if a submission matches the comment disallowed list.
 	 * Attached to `jetpack_contact_form_in_comment_disallowed_list`.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list
 	 * @param boolean $in_disallowed_list Whether the feedback is in the disallowed list.
 	 * @param array   $form The form array.
 	 * @return bool Returns true if the form submission matches the disallowed list and false if it doesn't.
@@ -1315,7 +1315,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Populate an array with all values necessary to submit a NEW contact-form feedback to Akismet.
 	 * Note that this includes the current user_ip etc, so this should only be called when accepting a new item via $_POST
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet
 	 * @param array $form - contact form feedback array.
 	 * @return array feedback array with additional data ready for submission to Akismet.
 	 */
@@ -1362,7 +1362,7 @@ class Grunion_Contact_Form_Plugin {
 	 * If you're accepting a new item via $_POST, run it Grunion_Contact_Form_Plugin::prepare_for_akismet() first
 	 * Attached to `jetpack_contact_form_is_spam`
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet
 	 * @param bool  $is_spam - if the submission is spam.
 	 * @param array $form - the form data.
 	 * @return bool|WP_Error TRUE => spam, FALSE => not spam, WP_Error => stop processing entirely
@@ -1420,7 +1420,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Submit a feedback as either spam or ham
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit
 	 * @param string $as - Either 'spam' or 'ham'.
 	 * @param array  $form - the contact-form data.
 	 * @return bool|string
@@ -1450,7 +1450,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prints a dropdown of posts with forms.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown
 	 * @param int $selected_id Currently selected post ID.
 	 * @return void
 	 */
@@ -1468,7 +1468,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Fetch post content for a post and extract just the comment.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export
 	 * @param int $post_id The post id to fetch the content for.
 	 * @return string Trimmed post comment.
 	 *
@@ -1486,7 +1486,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get `_feedback_extra_fields` field from post meta data.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export
 	 * @param int $post_id Id of the post to fetch meta data for.
 	 * @return mixed
 	 */
@@ -1530,7 +1530,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get parsed feedback post fields.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post
 	 * @param int $post_id Id of the post to fetch parsed contents for.
 	 * @return array
 	 *
@@ -1546,7 +1546,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Properly maps fields that are missing from the post meta data
 	 * to names, that are similar to those of the post meta.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names
 	 * @param array $parsed_post_content Parsed post content.
 	 * @see parse_fields_from_content for how the input data is generated.
 	 * @return array Mapped fields.
@@ -1581,7 +1581,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Registers the personal data exporter.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter
 	 * @since 6.1.1
 	 * @param  array $exporters An array of personal data exporters.
 	 * @return array $exporters An array of personal data exporters.
@@ -1600,7 +1600,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Registers the personal data eraser.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser
 	 * @since 6.1.1
 	 * @param  array $erasers An array of personal data erasers.
 	 * @return array $erasers An array of personal data erasers.
@@ -1619,7 +1619,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Exports personal data.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter
 	 * @since 6.1.1
 	 * @param  string $email  Email address.
 	 * @param  int    $page   Page to export.
@@ -1637,7 +1637,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Allows us to have a different signature than core expects
 	 * while protecting against future core API changes.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter
 	 * @internal
 	 * @since 6.5
 	 * @param  string $email    Email address.
@@ -1696,7 +1696,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Erases personal data.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser
 	 * @since 6.1.1
 	 * @param  string $email Email address.
 	 * @param  int    $page  Page to erase.
@@ -1714,7 +1714,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Allows us to have a different signature than core expects
 	 * while protecting against future core API changes.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser
 	 * @internal
 	 * @since 6.5
 	 * @param  string $email    Email address.
@@ -1792,7 +1792,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Queries personal data by email address.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email
 	 * @since 6.1.1
 	 * @param  string $email        Email address.
 	 * @param  int    $per_page     Post IDs per page. Default is `250`.
@@ -1835,7 +1835,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Filters searches by email address.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter
 	 * @since 6.1.1
 	 * @param  string $search SQL where clause.
 	 * @return array          Filtered SQL where clause.
@@ -1871,7 +1871,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prepares feedback post data for CSV export.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts
 	 * @param array $post_ids Post IDs to fetch the data for. These need to be Feedback posts.
 	 * @return array
 	 */
@@ -2008,7 +2008,7 @@ class Grunion_Contact_Form_Plugin {
 	 * - Positive values render AFTER any form field/value column: 1, 30, 93...
 	 *   Mind using high numbering on these ones as the prefix is used on regular inputs: 1_Name, 2_Email, etc
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names
 	 * @return array
 	 */
 	public function get_well_known_column_names() {
@@ -2026,7 +2026,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Extracts feedback entries based on POST data.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post
 	 */
 	public function get_feedback_entries_from_post() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post' );
@@ -2101,7 +2101,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Download exported data as CSV
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv
 	 */
 	public function download_feedback_as_csv() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv' );
@@ -2181,7 +2181,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Send an event to Tracks
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event
 	 * @param string $event_name - the name of the event.
 	 * @param array  $event_props - event properties to send.
 	 * @return null|void
@@ -2235,7 +2235,7 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * Additionally, Excel exposes the ability to launch arbitrary commands through the DDE protocol.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv
 	 * @see https://www.contextis.com/en/blog/comma-separated-vulnerabilities
 	 * @param string $field - the CSV field.
 	 * @return string
@@ -2318,7 +2318,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Parse the contact form fields.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content
 	 * @param int $post_id - the post ID.
 	 * @return array Fields.
 	 */
@@ -2434,7 +2434,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get the IP address.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address
 	 * @return string|null IP address.
 	 */
 	public static function get_ip_address() {
@@ -2446,7 +2446,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Disable Block Editor for feedbacks.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type
 	 * @param bool   $can_edit Whether the post type can be edited or not.
 	 * @param string $post_type The post type being checked.
 	 * @return bool
@@ -2464,7 +2464,7 @@ class Grunion_Contact_Form_Plugin {
 	 * - p1675781140892129-slack-C01CSBEN0QZ
 	 * - https://www.php.net/manual/en/function.print-r.php#93529
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print
 	 * @param string $print_r_output The array string to be reverted. Needs to being with 'Array'.
 	 * @param bool   $parse_html Whether to run html_entity_decode on each line.
 	 *                           As strings are stored right now, they are all escaped, so '=>' are '&gt;'.
@@ -2542,7 +2542,7 @@ class Grunion_Contact_Form_Plugin {
  *
  * Not very general - specific to Grunion.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
  *
  * // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
  */
@@ -2550,7 +2550,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The name of the shortcode: [$shortcode_name /].
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var string
 	 */
 	public $shortcode_name;
@@ -2558,7 +2558,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Key => value pairs for the shortcode's attributes: [$shortcode_name key="value" ... /]
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $attributes;
@@ -2566,7 +2566,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Key => value pair for attribute defaults.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $defaults = array();
@@ -2574,7 +2574,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The inner content of otherwise: [$shortcode_name]$content[/$shortcode_name]. Null for selfclosing shortcodes.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var null|string
 	 */
 	public $content;
@@ -2582,7 +2582,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Associative array of inner "child" shortcodes equivalent to the $content: [$shortcode_name][child 1/][child 2/][/$shortcode_name]
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $fields;
@@ -2590,7 +2590,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The HTML of the parsed inner "child" shortcodes".  Null for selfclosing shortcodes.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var null|string
 	 */
 	public $body;
@@ -2598,7 +2598,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Constructor function.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct
 	 * @param array       $attributes An associative array of shortcode attributes.  @see shortcode_atts().
 	 * @param null|string $content Null for selfclosing shortcodes.  The inner content otherwise.
 	 */
@@ -2623,7 +2623,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Processes the shortcode's inner content for "child" shortcodes.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content
 	 * @param string $content The shortcode's inner content: [shortcode]$content[/shortcode].
 	 */
 	public function parse_content( $content ) {
@@ -2639,7 +2639,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Returns the value of the requested attribute.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute
 	 * @param string $key The attribute to retrieve.
 	 * @return mixed
 	 */
@@ -2652,7 +2652,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Escape attributes.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr
 	 * @param array $value - the value we're escaping.
 	 * @return array
 	 */
@@ -2685,7 +2685,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Unescape attributes.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr
 	 * @param array $value - the value we're escaping.
 	 * @return array
 	 */
@@ -2715,7 +2715,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Generates the shortcode
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString
 	 */
 	public function __toString() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString' );
@@ -2777,14 +2777,14 @@ class Crunion_Contact_Form_Shortcode {
  * Parses shortcode to output the contact form as HTML
  * Sends email and stores the contact form response (a.k.a. "feedback")
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form
  */
 class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 	/**
 	 * The shortcode name.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var string
 	 */
 	public $shortcode_name = 'contact-form';
@@ -2793,7 +2793,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *
 	 * Stores form submission errors.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var WP_Error
 	 */
 	public $errors;
@@ -2801,7 +2801,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The SHA1 hash of the attributes that comprise the form.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var string
 	 */
 	public $hash;
@@ -2809,7 +2809,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The most recent (inclusive) contact-form shortcode processed.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var Grunion_Contact_Form
 	 */
 	public static $last;
@@ -2817,7 +2817,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Form we are currently looking at. If processed, will become $last
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var Whatever
 	 */
 	public static $current_form;
@@ -2825,7 +2825,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * All found forms, indexed by hash.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var array
 	 */
 	public static $forms = array();
@@ -2833,7 +2833,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Whether to print the grunion.css style when processing the contact-form shortcode
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var bool
 	 */
 	public static $style = false;
@@ -2841,7 +2841,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * When printing the submit button, what tags are allowed
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var array
 	 */
 	public static $allowed_html_tags_for_submit_button = array( 'br' => array() );
@@ -2849,7 +2849,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Construction function.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct
 	 * @param array  $attributes - the attributes.
 	 * @param string $content - the content.
 	 */
@@ -2956,7 +2956,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Store shortcode content for recall later
 	 *  - used to receate shortcode when user uses do_shortcode
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode
 	 * @param string $content - the content.
 	 * @param array  $attributes - the attributes.
 	 * @param string $hash - the hash.
@@ -2984,7 +2984,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Toggle for printing the grunion.css stylesheet
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style
 	 * @param bool $style - the CSS style.
 	 * @return bool
 	 */
@@ -2999,7 +2999,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Turn on printing of grunion.css stylesheet
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on
 	 * @see ::style()
 	 * @internal
 	 * @return bool
@@ -3013,7 +3013,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The contact-form shortcode processor
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse
 	 * @param array       $attributes Key => Value pairs as parsed by shortcode_parse_atts().
 	 * @param string|null $content The shortcode's inner content: [contact-form]$content[/contact-form].
 	 * @return string HTML for the concat form.
@@ -3222,7 +3222,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Returns a success message to be returned if the form is sent via AJAX.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the contact form.
 	 * @return string $message
@@ -3277,7 +3277,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Returns a compiled form with labels and values in a form of  an array
 	 * of lines.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the form.
 	 * @return array $lines
@@ -3372,7 +3372,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Returns a compiled form with labels and values formatted for the email response
 	 * in a form of an array of lines.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the form.
 	 * @return array $lines
@@ -3489,7 +3489,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Escape and sanitize the field value.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value
 	 * @param string $value - the value we're escaping and sanitizing.
 	 * @return string
 	 */
@@ -3503,7 +3503,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Only strip out empty string values and keep all the other values as they are.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty
 	 * @param string $single_value - the single value.
 	 * @return bool
 	 */
@@ -3545,7 +3545,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * The contact-field shortcode processor.
 	 * We use an object method here instead of a static Grunion_Contact_Form_Field class method to parse contact-field shortcodes so that we can tie them to the contact-form object.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field
 	 * @param array       $attributes Key => Value pairs as parsed by shortcode_parse_atts().
 	 * @param string|null $content The shortcode's inner content: [contact-field]$content[/contact-field].
 	 * @return string HTML for the contact form field
@@ -3641,7 +3641,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Get the default label from type.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type
 	 * @param string $type - the type of label.
 	 * @return string
 	 */
@@ -3730,7 +3730,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *  - admin.php / grunion_manage_post_columns - add the field to the render logic.
 	 *      Otherwise it will be missing from the admin Feedback view.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids
 	 * @return array
 	 */
 	public function get_field_ids() {
@@ -3797,7 +3797,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Process the contact form's POST submission
 	 * Stores feedback.  Sends email.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission
 	 */
 	public function process_submission() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission' );
@@ -4398,7 +4398,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Wrapper for wp_mail() that enables HTML messages with text alternatives
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail
 	 * @param string|array $to          Array or comma-separated list of email addresses to send message.
 	 * @param string       $subject     Email subject.
 	 * @param string       $message     Message contents.
@@ -4426,7 +4426,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * SpamAssassin doesn't like addresses in HTML messages that are missing display names (e.g., `foo@bar.org`
 	 * instead of `Foo Bar <foo@bar.org>`.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address
 	 * @param string $address - the email address.
 	 * @return string
 	 */
@@ -4452,7 +4452,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Get the content type that should be assigned to outbound emails
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type
 	 * @return string
 	 */
 	public static function get_mail_content_type() {
@@ -4466,7 +4466,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *
 	 * This helps to ensure correct parsing by clients, and also helps avoid triggering spam filtering rules
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags
 	 * @param string $title - title of the email.
 	 * @param string $body - the message body.
 	 * @param string $footer - the footer containing meta information.
@@ -4516,7 +4516,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * This makes the message more accessible to mail clients that aren't HTML-aware, and decreases the likelihood
 	 * that the message will be flagged as spam.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative
 	 * @param PHPMailer $phpmailer - the phpmailer.
 	 */
 	public static function add_plain_text_alternative( $phpmailer ) {
@@ -4544,7 +4544,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Add deepslashes.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep
 	 * @param array $value - the value.
 	 * @return array The value, with slashes added.
 	 */
@@ -4569,7 +4569,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Only allowin "wide" and "full" as "center", "left" and "right" don't
 	 * make much sense for the form.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class
 	 * @param array $attributes Block attributes.
 	 * @return string The CSS alignment class: alignfull | alignwide.
 	 */
@@ -4593,14 +4593,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
  * Parses shortcode to output the contact form field as HTML.
  * Validates input.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
  */
 class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 
 	/**
 	 * The shortcode name.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $shortcode_name = 'contact-field';
@@ -4608,7 +4608,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The parent form.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var Grunion_Contact_Form
 	 */
 	public $form;
@@ -4616,7 +4616,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Default or POSTed value.
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $value;
@@ -4624,7 +4624,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Is the input valid?
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var bool
 	 */
 	public $error = false;
@@ -4632,7 +4632,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $block_styles = '';
@@ -4640,7 +4640,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $field_styles = '';
@@ -4648,7 +4648,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field option
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $option_styles = '';
@@ -4656,7 +4656,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
-	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $label_styles = '';
@@ -4664,7 +4664,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Constructor function.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct
 	 * @param array                $attributes An associative array of shortcode attributes.  @see shortcode_atts().
 	 * @param null|string          $content Null for selfclosing shortcodes.  The inner content otherwise.
 	 * @param Grunion_Contact_Form $form The parent form.
@@ -4766,7 +4766,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * This field's input is invalid.  Flag as invalid and add an error to the parent form
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error
 	 * @param string $message The error message to display on the form.
 	 */
 	public function add_error( $message ) {
@@ -4784,7 +4784,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Is the field input invalid?
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error
 	 * @see $error
 	 * @return bool
 	 */
@@ -4797,7 +4797,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Validates the form input
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate
 	 */
 	public function validate() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate' );
@@ -4857,7 +4857,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Check the default value for options field
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value
 	 * @param string $value - the value we're checking.
 	 * @param int    $index - the index.
 	 * @param string $options - default field option.
@@ -4875,7 +4875,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Outputs the HTML for this form field
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render
 	 * @return string HTML
 	 */
 	public function render() {
@@ -5012,7 +5012,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the label.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label
 	 * @param string $type - the field type.
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
@@ -5055,7 +5055,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the input field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field
 	 * @param string $type - the field type.
 	 * @param int    $id - the ID.
 	 * @param string $value - the value of the field.
@@ -5093,7 +5093,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5114,7 +5114,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the telephone field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5135,7 +5135,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the URL field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5165,7 +5165,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the text area field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5195,7 +5195,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the radio field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5234,7 +5234,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the checkbox field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5280,7 +5280,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the multiple checkbox field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5313,7 +5313,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the select field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5367,7 +5367,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5413,7 +5413,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the default field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5435,7 +5435,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the outlined label.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
@@ -5465,7 +5465,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the animated label.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
@@ -5489,7 +5489,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the below label.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
@@ -5512,7 +5512,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field
 	 * @param string $type - the type.
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
@@ -5679,7 +5679,7 @@ add_action( 'grunion_scheduled_delete', 'grunion_delete_old_spam' );
 /**
  * Deletes old spam feedbacks to keep the posts table size under control
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam'
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam'
  */
 function grunion_delete_old_spam() {
 	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );
@@ -5733,7 +5733,7 @@ function grunion_delete_old_spam() {
 /**
  * Send an event to Tracks on form submission.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent
  * @param int $post_id - the post_id for the CPT that is created.
  * @return null|void
  */

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -4,7 +4,7 @@
  * Add a contact form to any post, page or text widget.
  * Emails will be sent to the post's author by default, or any email address you choose.
  *
- * @deprecated $$next-version$$ Use automattic/jetpack-forms
+ * @deprecated jetpack-$$next-version$$ Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -26,10 +26,10 @@ add_action( 'rest_api_init', 'grunion_contact_form_require_endpoint' );
 /**
  * Require the Grunion endpoint.
  *
- * @deprecated $$next-version$$
+ * @deprecated jetpack-$$next-version$$
  */
 function grunion_contact_form_require_endpoint() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
 
 	require_once GRUNION_PLUGIN_DIR . 'class-grunion-contact-form-endpoint.php';
 }
@@ -43,11 +43,11 @@ function grunion_contact_form_require_endpoint() {
  *
  * This fixes Contact Form Blocks added to FSE _templates_ (e.g. Single or 404).
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute
  * @param string $template Template to be loaded.
  */
 function grunion_contact_form_set_block_template_attribute( $template ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute' );
 
 	global $_wp_current_template_content;
 	if ( 'template-canvas.php' === basename( $template ) ) {
@@ -69,11 +69,11 @@ add_filter( 'template_include', 'grunion_contact_form_set_block_template_attribu
  * This is part of the fix for Contact Form Blocks added to FSE _template parts_ (e.g footer).
  * The global is processed in Grunion_Contact_Form::parse().
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global
  * @param string $template_part_id ID for the currently rendered template part.
  */
 function grunion_contact_form_set_block_template_part_id_global( $template_part_id ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global' );
 
 	$GLOBALS['grunion_block_template_part_id'] = $template_part_id;
 }
@@ -87,13 +87,13 @@ add_action( 'gutenberg_render_block_core_template_part_none', 'grunion_contact_f
 /**
  * Unsets the global when block is done rendering.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global
  * @param string $content Rendered block content.
  * @param array  $block   The full block, including name and attributes.
  * @return string
  */
 function grunion_contact_form_unset_block_template_part_id_global( $content, $block ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global' );
 
 	if ( isset( $block['blockName'] )
 		&& 'core/template-part' === $block['blockName']
@@ -107,14 +107,14 @@ add_filter( 'render_block', 'grunion_contact_form_unset_block_template_part_id_g
 /**
  * Sets the 'widget' attribute on all instances of the contact form in the widget block.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content
  * @param string          $content  Existing widget block content.
  * @param array           $instance Array of settings for the current widget.
  * @param WP_Widget_Block $widget   Current Block widget instance.
  * @return string
  */
 function grunion_contact_form_filter_widget_block_content( $content, $instance, $widget ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content' );
 
 	Grunion_Contact_Form::style_on();
 	// Inject 'block_template' => <widget-id> into all instances of the contact form block.
@@ -130,13 +130,13 @@ add_filter( 'widget_block_content', 'grunion_contact_form_filter_widget_block_co
 /**
  * Adds a given attribute to all instances of the Contact Form block.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute
  * @param string $content  Existing content to process.
  * @param array  $new_attr New attributes to add.
  * @return string
  */
 function grunion_contact_form_apply_block_attribute( $content, $new_attr ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute' );
 
 	if ( false === stripos( $content, 'wp:jetpack/contact-form' ) ) {
 		return $content;
@@ -172,7 +172,7 @@ function grunion_contact_form_apply_block_attribute( $content, $new_attr ) {
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
  */
 class Grunion_Contact_Form_Plugin {
 
@@ -180,7 +180,7 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * The Widget ID of the widget currently being processed.  Used to build the unique contact-form ID for forms embedded in widgets.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @var string
 	 */
 	public $current_widget_id;
@@ -188,7 +188,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * If the contact form field is being used.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @var bool
 	 */
 	public static $using_contact_form_field = false;
@@ -214,10 +214,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Initializing function.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init
 	 */
 	public static function init() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init' );
 
 		static $instance = false;
 
@@ -234,10 +234,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Runs daily to clean up spam detection metadata after 15 days.  Keeps your DB squeaky clean.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup
 	 */
 	public function daily_akismet_meta_cleanup() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup' );
 
 		global $wpdb;
 
@@ -276,12 +276,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Strips HTML tags from input.  Output is NOT HTML safe.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags
 	 * @param mixed $data_with_tags - data we're stripping HTML tags from.
 	 * @return mixed
 	 */
 	public static function strip_tags( $data_with_tags ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags' );
 
 		$data_without_tags = array();
 		if ( is_array( $data_with_tags ) ) {
@@ -438,12 +438,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prevent 'contact-form-styles' script from being concatenated.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm
 	 * @param array  $do_concat - the concatenation flag.
 	 * @param string $handle - script name.
 	 */
 	public static function disable_forms_style_script_concat( $do_concat, $handle ) {
-		_deprecated_function( __METHOD__, '$$next-version$$' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$' );
 
 		if ( 'jetpack-block-contact-form' === $handle ) {
 			$do_concat = false;
@@ -552,14 +552,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the gutenblock form.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\ontact_Form_Block::gutenblock_render_form
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\ontact_Form_Block::gutenblock_render_form
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string
 	 */
 	public static function gutenblock_render_form( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::gutenblock_render_form' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::gutenblock_render_form' );
 
 		// Render fallback in other contexts than frontend (i.e. feed, emails, API, etc.), unless the form is being submitted.
 		if ( ! jetpack_is_frontend() && ! isset( $_POST['contact-form-id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
@@ -579,14 +579,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Turn block attribute to shortcode attributes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes
 	 * @param array  $atts - the block attributes.
 	 * @param string $type - the type.
 	 *
 	 * @return array
 	 */
 	public static function block_attributes_to_shortcode_attributes( $atts, $type ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes' );
 
 		$atts['type'] = $type;
 		if ( isset( $atts['className'] ) ) {
@@ -605,14 +605,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the text field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_text( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'text' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -621,14 +621,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the name field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_name( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'name' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -637,14 +637,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the email field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_email( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'email' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -653,14 +653,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the url field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_url( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'url' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -669,14 +669,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the date field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_date( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'date' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -685,14 +685,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the telephone field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_telephone( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'telephone' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -701,14 +701,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the text area field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_textarea( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'textarea' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -717,14 +717,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the checkbox field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_checkbox( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'checkbox' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -733,14 +733,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the multiple checkbox field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_checkbox_multiple( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'checkbox-multiple' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -749,14 +749,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the multiple choice field option.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_option( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'field-option' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -765,14 +765,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the radio button field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_radio( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'radio' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -781,14 +781,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the select field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_select( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'select' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -797,12 +797,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the consent field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent
 	 * @param string $atts consent attributes.
 	 * @param string $content html content.
 	 */
 	public static function gutenblock_render_field_consent( $atts, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'consent' );
 
@@ -820,10 +820,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu
 	 */
 	public function admin_menu() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu' );
 
 		$slug = 'feedback';
 
@@ -856,11 +856,11 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Add to REST API post type allowed list.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type
 	 * @param array $post_types - the post types.
 	 */
 	public function allow_feedback_rest_api_type( $post_types ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type' );
 
 		$post_types[] = 'feedback';
 		return $post_types;
@@ -870,11 +870,11 @@ class Grunion_Contact_Form_Plugin {
 	 * Display the count of new feedback entries received. It's reset when user visits the Feedback screen.
 	 *
 	 * @since 4.1.0
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count
 	 * @param object $screen Information about the current screen.
 	 */
 	public function unread_count( $screen ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count' );
 
 		if ( isset( $screen->post_type ) && 'feedback' === $screen->post_type ) {
 			update_option( 'feedback_unread_count', 0 );
@@ -902,10 +902,10 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * Conditionally attached to `template_redirect`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission
 	 */
 	public function process_form_submission() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission' );
 
 		// Add a filter to replace tokens in the subject field with sanitized field values.
 		add_filter( 'contact_form_subject', array( $this, 'replace_tokens_with_input' ), 10, 2 );
@@ -1073,10 +1073,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Handle the ajax request.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request
 	 */
 	public function ajax_request() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request' );
 
 		$submission_result = self::process_form_submission();
 
@@ -1108,14 +1108,14 @@ class Grunion_Contact_Form_Plugin {
 	 * Ensure the post author is always zero for contact-form feedbacks
 	 * Attached to `wp_insert_post_data`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter
 	 * @see Grunion_Contact_Form::process_submission()
 	 * @param array $data the data to insert.
 	 * @param array $postarr the data sent to wp_insert_post().
 	 * @return array The filtered $data to insert.
 	 */
 	public function insert_feedback_filter( $data, $postarr ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter' );
 
 		if ( $data['post_type'] === 'feedback' && $postarr['post_type'] === 'feedback' ) {
 			$data['post_author'] = 0;
@@ -1128,10 +1128,10 @@ class Grunion_Contact_Form_Plugin {
 	 * Adds our contact-form shortcode
 	 * The "child" contact-field shortcode is enabled as needed by the contact-form shortcode handler
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode
 	 */
 	public function add_shortcode() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode' );
 
 		add_shortcode( 'contact-form', array( 'Grunion_Contact_Form', 'parse' ) );
 		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
@@ -1144,12 +1144,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Tokenize the label.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label
 	 * @param string $label - the label.
 	 * @return string
 	 */
 	public static function tokenize_label( $label ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label' );
 
 		return '{' . trim( preg_replace( '#^\d+_#', '', $label ) ) . '}';
 	}
@@ -1157,12 +1157,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Sanitize the value.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value
 	 * @param string $value - the value to sanitize.
 	 * @return string
 	 */
 	public static function sanitize_value( $value ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value' );
 
 		if ( null === $value ) {
 			return '';
@@ -1174,13 +1174,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Replaces tokens like {city} or {City} (case insensitive) with the value
 	 * of an input field of that name
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input
 	 * @param string $subject - the subject.
 	 * @param array  $field_values Array with field label => field value associations.
 	 * @return string The filtered $subject with the tokens replaced.
 	 */
 	public function replace_tokens_with_input( $subject, $field_values ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input' );
 
 		// Wrap labels into tokens (inside {})
 		$wrapped_labels = array_map( array( 'Grunion_Contact_Form_Plugin', 'tokenize_label' ), array_keys( $field_values ) );
@@ -1202,12 +1202,12 @@ class Grunion_Contact_Form_Plugin {
 	 * Tracks the widget currently being processed.
 	 * Attached to `dynamic_sidebar`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget
 	 * @see $current_widget_id - the current widget ID.
 	 * @param array $widget The widget data.
 	 */
 	public function track_current_widget( $widget ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget' );
 
 		$this->current_widget_id = $widget['id'];
 	}
@@ -1217,12 +1217,12 @@ class Grunion_Contact_Form_Plugin {
 	 * Used to tell the difference between post-embedded contact-forms and widget-embedded contact-forms
 	 * Attached to `widget_text`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts
 	 * @param string $text The widget text.
 	 * @return string The filtered widget text.
 	 */
 	public function widget_atts( $text ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts' );
 
 		Grunion_Contact_Form::style( true );
 
@@ -1233,12 +1233,12 @@ class Grunion_Contact_Form_Plugin {
 	 * For sites where text widgets are not processed for shortcodes, we add this hack to process just our shortcode
 	 * Attached to `widget_text`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack
 	 * @param string $text The widget text.
 	 * @return string The contact-form filtered widget text
 	 */
 	public function widget_shortcode_hack( $text ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack' );
 
 		if ( ! preg_match( '/\[contact-form([^a-zA-Z_-])/', $text ) ) {
 			return $text;
@@ -1264,13 +1264,13 @@ class Grunion_Contact_Form_Plugin {
 	 * removed from the public discussion.
 	 * Attached to `jetpack_contact_form_is_spam`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist
 	 * @param bool  $is_spam - if the submission is spam.
 	 * @param array $form - the form data.
 	 * @return bool TRUE => spam, FALSE => not spam
 	 */
 	public function is_spam_blocklist( $is_spam, $form = array() ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist' );
 
 		if ( $is_spam ) {
 			return $is_spam;
@@ -1283,13 +1283,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Check if a submission matches the comment disallowed list.
 	 * Attached to `jetpack_contact_form_in_comment_disallowed_list`.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list
 	 * @param boolean $in_disallowed_list Whether the feedback is in the disallowed list.
 	 * @param array   $form The form array.
 	 * @return bool Returns true if the form submission matches the disallowed list and false if it doesn't.
 	 */
 	public function is_in_disallowed_list( $in_disallowed_list, $form = array() ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list' );
 
 		if ( $in_disallowed_list ) {
 			return $in_disallowed_list;
@@ -1315,12 +1315,12 @@ class Grunion_Contact_Form_Plugin {
 	 * Populate an array with all values necessary to submit a NEW contact-form feedback to Akismet.
 	 * Note that this includes the current user_ip etc, so this should only be called when accepting a new item via $_POST
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet
 	 * @param array $form - contact form feedback array.
 	 * @return array feedback array with additional data ready for submission to Akismet.
 	 */
 	public function prepare_for_akismet( $form ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet' );
 
 		$form['comment_type']     = 'contact_form';
 		$form['user_ip']          = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
@@ -1362,13 +1362,13 @@ class Grunion_Contact_Form_Plugin {
 	 * If you're accepting a new item via $_POST, run it Grunion_Contact_Form_Plugin::prepare_for_akismet() first
 	 * Attached to `jetpack_contact_form_is_spam`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet
 	 * @param bool  $is_spam - if the submission is spam.
 	 * @param array $form - the form data.
 	 * @return bool|WP_Error TRUE => spam, FALSE => not spam, WP_Error => stop processing entirely
 	 */
 	public function is_spam_akismet( $is_spam, $form = array() ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet' );
 
 		global $akismet_api_host, $akismet_api_port;
 
@@ -1420,13 +1420,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Submit a feedback as either spam or ham
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit
 	 * @param string $as - Either 'spam' or 'ham'.
 	 * @param array  $form - the contact-form data.
 	 * @return bool|string
 	 */
 	public function akismet_submit( $as, $form ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit' );
 
 		global $akismet_api_host, $akismet_api_port;
 
@@ -1450,12 +1450,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prints a dropdown of posts with forms.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown
 	 * @param int $selected_id Currently selected post ID.
 	 * @return void
 	 */
 	public static function form_posts_dropdown( $selected_id ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown' );
 
 		?>
 		<select name="jetpack_form_parent_id">
@@ -1468,14 +1468,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Fetch post content for a post and extract just the comment.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export
 	 * @param int $post_id The post id to fetch the content for.
 	 * @return string Trimmed post comment.
 	 *
 	 * @codeCoverageIgnore
 	 */
 	public function get_post_content_for_csv_export( $post_id ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export' );
 
 		$post_content = get_post_field( 'post_content', $post_id );
 		$content      = explode( '<!--more-->', $post_content );
@@ -1486,12 +1486,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get `_feedback_extra_fields` field from post meta data.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export
 	 * @param int $post_id Id of the post to fetch meta data for.
 	 * @return mixed
 	 */
 	public function get_post_meta_for_csv_export( $post_id ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export' );
 
 		$md                     = (array) get_post_meta( $post_id, '_feedback_extra_fields', true );
 		$md['-3_response_date'] = get_the_date( 'Y-m-d H:i:s', $post_id );
@@ -1530,14 +1530,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get parsed feedback post fields.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post
 	 * @param int $post_id Id of the post to fetch parsed contents for.
 	 * @return array
 	 *
 	 * @codeCoverageIgnore - No need to be covered.
 	 */
 	public function get_parsed_field_contents_of_post( $post_id ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post' );
 
 		return self::parse_fields_from_content( $post_id );
 	}
@@ -1546,13 +1546,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Properly maps fields that are missing from the post meta data
 	 * to names, that are similar to those of the post meta.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names
 	 * @param array $parsed_post_content Parsed post content.
 	 * @see parse_fields_from_content for how the input data is generated.
 	 * @return array Mapped fields.
 	 */
 	public function map_parsed_field_contents_of_post_to_field_names( $parsed_post_content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names' );
 
 		$mapped_fields = array();
 
@@ -1581,13 +1581,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Registers the personal data exporter.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter
 	 * @since 6.1.1
 	 * @param  array $exporters An array of personal data exporters.
 	 * @return array $exporters An array of personal data exporters.
 	 */
 	public function register_personal_data_exporter( $exporters ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter' );
 
 		$exporters['jetpack-feedback'] = array(
 			'exporter_friendly_name' => __( 'Feedback', 'jetpack' ),
@@ -1600,13 +1600,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Registers the personal data eraser.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser
 	 * @since 6.1.1
 	 * @param  array $erasers An array of personal data erasers.
 	 * @return array $erasers An array of personal data erasers.
 	 */
 	public function register_personal_data_eraser( $erasers ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser' );
 
 		$erasers['jetpack-feedback'] = array(
 			'eraser_friendly_name' => __( 'Feedback', 'jetpack' ),
@@ -1619,14 +1619,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Exports personal data.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter
 	 * @since 6.1.1
 	 * @param  string $email  Email address.
 	 * @param  int    $page   Page to export.
 	 * @return array  $return Associative array with keys expected by core.
 	 */
 	public function personal_data_exporter( $email, $page = 1 ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter' );
 
 		return $this->internal_personal_data_exporter( $email, $page );
 	}
@@ -1637,7 +1637,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Allows us to have a different signature than core expects
 	 * while protecting against future core API changes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter
 	 * @internal
 	 * @since 6.5
 	 * @param  string $email    Email address.
@@ -1646,7 +1646,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array            Associative array with keys expected by core.
 	 */
 	public function internal_personal_data_exporter( $email, $page = 1, $per_page = 250 ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter' );
 
 		$export_data = array();
 		$post_ids    = $this->personal_data_post_ids_by_email( $email, $per_page, $page );
@@ -1696,14 +1696,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Erases personal data.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser
 	 * @since 6.1.1
 	 * @param  string $email Email address.
 	 * @param  int    $page  Page to erase.
 	 * @return array         Associative array with keys expected by core.
 	 */
 	public function personal_data_eraser( $email, $page = 1 ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser' );
 
 		return $this->_internal_personal_data_eraser( $email, $page );
 	}
@@ -1714,7 +1714,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Allows us to have a different signature than core expects
 	 * while protecting against future core API changes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser
 	 * @internal
 	 * @since 6.5
 	 * @param  string $email    Email address.
@@ -1723,7 +1723,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array            Associative array with keys expected by core.
 	 */
 	public function _internal_personal_data_eraser( $email, $page = 1, $per_page = 250 ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- this is called in other files.
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser' );
 
 		$post_id      = null;
 		$removed      = false;
@@ -1792,7 +1792,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Queries personal data by email address.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email
 	 * @since 6.1.1
 	 * @param  string $email        Email address.
 	 * @param  int    $per_page     Post IDs per page. Default is `250`.
@@ -1801,7 +1801,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array An array of post IDs.
 	 */
 	public function personal_data_post_ids_by_email( $email, $per_page = 250, $page = 1, $last_post_id = 0 ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email' );
 
 		add_filter( 'posts_search', array( $this, 'personal_data_search_filter' ) );
 
@@ -1835,13 +1835,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Filters searches by email address.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter
 	 * @since 6.1.1
 	 * @param  string $search SQL where clause.
 	 * @return array          Filtered SQL where clause.
 	 */
 	public function personal_data_search_filter( $search ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter' );
 
 		global $wpdb;
 
@@ -1871,12 +1871,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prepares feedback post data for CSV export.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts
 	 * @param array $post_ids Post IDs to fetch the data for. These need to be Feedback posts.
 	 * @return array
 	 */
 	public function get_export_data_for_posts( $post_ids ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts' );
 
 		$posts_data  = array();
 		$field_names = array();
@@ -2008,11 +2008,11 @@ class Grunion_Contact_Form_Plugin {
 	 * - Positive values render AFTER any form field/value column: 1, 30, 93...
 	 *   Mind using high numbering on these ones as the prefix is used on regular inputs: 1_Name, 2_Email, etc
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names
 	 * @return array
 	 */
 	public function get_well_known_column_names() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names' );
 
 		return array(
 			'-9_title'         => __( 'Title', 'jetpack' ),
@@ -2026,10 +2026,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Extracts feedback entries based on POST data.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post
 	 */
 	public function get_feedback_entries_from_post() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post' );
 
 		if ( empty( $_POST['feedback_export_nonce_csv'] ) && empty( $_POST['feedback_export_nonce_gdrive'] ) ) {
 			return;
@@ -2101,10 +2101,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Download exported data as CSV
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv
 	 */
 	public function download_feedback_as_csv() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv' );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- verification is done on get_feedback_entries_from_post function
 		$post_data = wp_unslash( $_POST );
@@ -2181,13 +2181,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Send an event to Tracks
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event
 	 * @param string $event_name - the name of the event.
 	 * @param array  $event_props - event properties to send.
 	 * @return null|void
 	 */
 	public function record_tracks_event( $event_name, $event_props ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event' );
 
 		/*
 		 * Event details.
@@ -2235,13 +2235,13 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * Additionally, Excel exposes the ability to launch arbitrary commands through the DDE protocol.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv
 	 * @see https://www.contextis.com/en/blog/comma-separated-vulnerabilities
 	 * @param string $field - the CSV field.
 	 * @return string
 	 */
 	public function esc_csv( $field ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv' );
 
 		$active_content_triggers = array( '=', '+', '-', '@' );
 
@@ -2318,12 +2318,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Parse the contact form fields.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content
 	 * @param int $post_id - the post ID.
 	 * @return array Fields.
 	 */
 	public static function parse_fields_from_content( $post_id ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content' );
 
 		static $post_fields;
 
@@ -2434,11 +2434,11 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get the IP address.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address
 	 * @return string|null IP address.
 	 */
 	public static function get_ip_address() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address' );
 
 		return isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : null;
 	}
@@ -2446,13 +2446,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Disable Block Editor for feedbacks.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type
 	 * @param bool   $can_edit Whether the post type can be edited or not.
 	 * @param string $post_type The post type being checked.
 	 * @return bool
 	 */
 	public function use_block_editor_for_post_type( $can_edit, $post_type ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type' );
 
 		return 'feedback' === $post_type ? false : $can_edit;
 	}
@@ -2464,14 +2464,14 @@ class Grunion_Contact_Form_Plugin {
 	 * - p1675781140892129-slack-C01CSBEN0QZ
 	 * - https://www.php.net/manual/en/function.print-r.php#93529
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print
 	 * @param string $print_r_output The array string to be reverted. Needs to being with 'Array'.
 	 * @param bool   $parse_html Whether to run html_entity_decode on each line.
 	 *                           As strings are stored right now, they are all escaped, so '=>' are '&gt;'.
 	 * @return array|string Array when succesfully reconstructed, string otherwise. Output will always be esc_html'd.
 	 */
 	public static function reverse_that_print( $print_r_output, $parse_html = false ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print' );
 
 		$lines = explode( "\n", trim( $print_r_output ) );
 		if ( $parse_html ) {
@@ -2542,7 +2542,7 @@ class Grunion_Contact_Form_Plugin {
  *
  * Not very general - specific to Grunion.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
  *
  * // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
  */
@@ -2550,7 +2550,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The name of the shortcode: [$shortcode_name /].
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var string
 	 */
 	public $shortcode_name;
@@ -2558,7 +2558,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Key => value pairs for the shortcode's attributes: [$shortcode_name key="value" ... /]
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $attributes;
@@ -2566,7 +2566,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Key => value pair for attribute defaults.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $defaults = array();
@@ -2574,7 +2574,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The inner content of otherwise: [$shortcode_name]$content[/$shortcode_name]. Null for selfclosing shortcodes.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var null|string
 	 */
 	public $content;
@@ -2582,7 +2582,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Associative array of inner "child" shortcodes equivalent to the $content: [$shortcode_name][child 1/][child 2/][/$shortcode_name]
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $fields;
@@ -2590,7 +2590,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The HTML of the parsed inner "child" shortcodes".  Null for selfclosing shortcodes.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var null|string
 	 */
 	public $body;
@@ -2598,12 +2598,12 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Constructor function.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct
 	 * @param array       $attributes An associative array of shortcode attributes.  @see shortcode_atts().
 	 * @param null|string $content Null for selfclosing shortcodes.  The inner content otherwise.
 	 */
 	public function __construct( $attributes, $content = null ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct' );
 
 		$this->attributes = $this->unesc_attr( $attributes );
 		if ( is_array( $content ) ) {
@@ -2623,11 +2623,11 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Processes the shortcode's inner content for "child" shortcodes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content
 	 * @param string $content The shortcode's inner content: [shortcode]$content[/shortcode].
 	 */
 	public function parse_content( $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content' );
 
 		if ( $content === null ) {
 			$this->body = null;
@@ -2639,12 +2639,12 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Returns the value of the requested attribute.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute
 	 * @param string $key The attribute to retrieve.
 	 * @return mixed
 	 */
 	public function get_attribute( $key ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute' );
 
 		return isset( $this->attributes[ $key ] ) ? $this->attributes[ $key ] : null;
 	}
@@ -2652,12 +2652,12 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Escape attributes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr
 	 * @param array $value - the value we're escaping.
 	 * @return array
 	 */
 	public function esc_attr( $value ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr' );
 
 		if ( is_array( $value ) ) {
 			return array_map( array( $this, 'esc_attr' ), $value );
@@ -2685,12 +2685,12 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Unescape attributes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr
 	 * @param array $value - the value we're escaping.
 	 * @return array
 	 */
 	public function unesc_attr( $value ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr' );
 
 		if ( is_array( $value ) ) {
 			return array_map( array( $this, 'unesc_attr' ), $value );
@@ -2715,10 +2715,10 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Generates the shortcode
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString
 	 */
 	public function __toString() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString' );
 
 		$r = "[{$this->shortcode_name} ";
 
@@ -2777,14 +2777,14 @@ class Crunion_Contact_Form_Shortcode {
  * Parses shortcode to output the contact form as HTML
  * Sends email and stores the contact form response (a.k.a. "feedback")
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form
  */
 class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 	/**
 	 * The shortcode name.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var string
 	 */
 	public $shortcode_name = 'contact-form';
@@ -2793,7 +2793,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *
 	 * Stores form submission errors.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var WP_Error
 	 */
 	public $errors;
@@ -2801,7 +2801,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The SHA1 hash of the attributes that comprise the form.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var string
 	 */
 	public $hash;
@@ -2809,7 +2809,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The most recent (inclusive) contact-form shortcode processed.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var Grunion_Contact_Form
 	 */
 	public static $last;
@@ -2817,7 +2817,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Form we are currently looking at. If processed, will become $last
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var Whatever
 	 */
 	public static $current_form;
@@ -2825,7 +2825,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * All found forms, indexed by hash.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var array
 	 */
 	public static $forms = array();
@@ -2833,7 +2833,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Whether to print the grunion.css style when processing the contact-form shortcode
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var bool
 	 */
 	public static $style = false;
@@ -2841,7 +2841,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * When printing the submit button, what tags are allowed
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var array
 	 */
 	public static $allowed_html_tags_for_submit_button = array( 'br' => array() );
@@ -2849,12 +2849,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Construction function.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct
 	 * @param array  $attributes - the attributes.
 	 * @param string $content - the content.
 	 */
 	public function __construct( $attributes, $content = null ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct' );
 
 		global $post;
 
@@ -2956,13 +2956,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Store shortcode content for recall later
 	 *  - used to receate shortcode when user uses do_shortcode
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode
 	 * @param string $content - the content.
 	 * @param array  $attributes - the attributes.
 	 * @param string $hash - the hash.
 	 */
 	public static function store_shortcode( $content = null, $attributes = null, $hash = null ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode' );
 
 		if ( $content && isset( $attributes['id'] ) ) {
 
@@ -2984,12 +2984,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Toggle for printing the grunion.css stylesheet
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style
 	 * @param bool $style - the CSS style.
 	 * @return bool
 	 */
 	public static function style( $style ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::style' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::style' );
 
 		$previous_style = self::$style;
 		self::$style    = (bool) $style;
@@ -2999,13 +2999,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Turn on printing of grunion.css stylesheet
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on
 	 * @see ::style()
 	 * @internal
 	 * @return bool
 	 */
 	public static function style_on() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on' );
 
 		return self::style( true );
 	}
@@ -3013,13 +3013,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The contact-form shortcode processor
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse
 	 * @param array       $attributes Key => Value pairs as parsed by shortcode_parse_atts().
 	 * @param string|null $content The shortcode's inner content: [contact-form]$content[/contact-form].
 	 * @return string HTML for the concat form.
 	 */
 	public static function parse( $attributes, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse' );
 
 		if ( Settings::is_syncing() ) {
 			return '';
@@ -3222,13 +3222,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Returns a success message to be returned if the form is sent via AJAX.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the contact form.
 	 * @return string $message
 	 */
 	public static function success_message( $feedback_id, $form ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message' );
 
 		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
 			$message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
@@ -3277,13 +3277,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Returns a compiled form with labels and values in a form of  an array
 	 * of lines.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the form.
 	 * @return array $lines
 	 */
 	public static function get_compiled_form( $feedback_id, $form ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form' );
 
 		$feedback       = get_post( $feedback_id );
 		$field_ids      = $form->get_field_ids();
@@ -3372,13 +3372,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Returns a compiled form with labels and values formatted for the email response
 	 * in a form of an array of lines.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the form.
 	 * @return array $lines
 	 */
 	public static function get_compiled_form_for_email( $feedback_id, $form ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email' );
 
 		$feedback       = get_post( $feedback_id );
 		$field_ids      = $form->get_field_ids();
@@ -3489,12 +3489,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Escape and sanitize the field value.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value
 	 * @param string $value - the value we're escaping and sanitizing.
 	 * @return string
 	 */
 	public static function escape_and_sanitize_field_value( $value ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value' );
 
 		$value = str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), $value );
 		return nl2br( wp_kses( $value, array() ) );
@@ -3503,12 +3503,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Only strip out empty string values and keep all the other values as they are.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty
 	 * @param string $single_value - the single value.
 	 * @return bool
 	 */
 	public static function remove_empty( $single_value ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty' );
 
 		return ( $single_value !== '' );
 	}
@@ -3545,13 +3545,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * The contact-field shortcode processor.
 	 * We use an object method here instead of a static Grunion_Contact_Form_Field class method to parse contact-field shortcodes so that we can tie them to the contact-form object.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field
 	 * @param array       $attributes Key => Value pairs as parsed by shortcode_parse_atts().
 	 * @param string|null $content The shortcode's inner content: [contact-field]$content[/contact-field].
 	 * @return string HTML for the contact form field
 	 */
 	public static function parse_contact_field( $attributes, $content ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field' );
 
 		// Don't try to parse contact form fields if not inside a contact form
 		if ( ! Grunion_Contact_Form_Plugin::$using_contact_form_field ) {
@@ -3641,12 +3641,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Get the default label from type.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type
 	 * @param string $type - the type of label.
 	 * @return string
 	 */
 	public static function get_default_label_from_type( $type ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type' );
 
 		$str = null;
 		switch ( $type ) {
@@ -3730,11 +3730,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *  - admin.php / grunion_manage_post_columns - add the field to the render logic.
 	 *      Otherwise it will be missing from the admin Feedback view.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids
 	 * @return array
 	 */
 	public function get_field_ids() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids' );
 
 		$field_ids = array(
 			'all'   => array(), // array of all field_ids.
@@ -3797,10 +3797,10 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Process the contact form's POST submission
 	 * Stores feedback.  Sends email.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission
 	 */
 	public function process_submission() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission' );
 
 		global $post;
 
@@ -4398,7 +4398,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Wrapper for wp_mail() that enables HTML messages with text alternatives
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail
 	 * @param string|array $to          Array or comma-separated list of email addresses to send message.
 	 * @param string       $subject     Email subject.
 	 * @param string       $message     Message contents.
@@ -4407,7 +4407,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * @return bool Whether the email contents were sent successfully.
 	 */
 	public static function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail' );
 
 		add_filter( 'wp_mail_content_type', __CLASS__ . '::get_mail_content_type' );
 		add_action( 'phpmailer_init', __CLASS__ . '::add_plain_text_alternative' );
@@ -4426,12 +4426,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * SpamAssassin doesn't like addresses in HTML messages that are missing display names (e.g., `foo@bar.org`
 	 * instead of `Foo Bar <foo@bar.org>`.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address
 	 * @param string $address - the email address.
 	 * @return string
 	 */
 	public function add_name_to_address( $address ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address' );
 
 		// If it's just the address, without a display name
 		if ( is_email( $address ) ) {
@@ -4452,11 +4452,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Get the content type that should be assigned to outbound emails
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type
 	 * @return string
 	 */
 	public static function get_mail_content_type() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type' );
 
 		return 'text/html';
 	}
@@ -4466,14 +4466,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *
 	 * This helps to ensure correct parsing by clients, and also helps avoid triggering spam filtering rules
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags
 	 * @param string $title - title of the email.
 	 * @param string $body - the message body.
 	 * @param string $footer - the footer containing meta information.
 	 * @return string
 	 */
 	public static function wrap_message_in_html_tags( $title, $body, $footer ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags' );
 
 		// Don't do anything if the message was already wrapped in HTML tags
 		// That could have be done by a plugin via filters
@@ -4516,11 +4516,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * This makes the message more accessible to mail clients that aren't HTML-aware, and decreases the likelihood
 	 * that the message will be flagged as spam.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative
 	 * @param PHPMailer $phpmailer - the phpmailer.
 	 */
 	public static function add_plain_text_alternative( $phpmailer ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative' );
 
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
@@ -4544,12 +4544,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Add deepslashes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep
 	 * @param array $value - the value.
 	 * @return array The value, with slashes added.
 	 */
 	public function addslashes_deep( $value ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep' );
 
 		if ( is_array( $value ) ) {
 			return array_map( array( $this, 'addslashes_deep' ), $value );
@@ -4569,12 +4569,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Only allowin "wide" and "full" as "center", "left" and "right" don't
 	 * make much sense for the form.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class
 	 * @param array $attributes Block attributes.
 	 * @return string The CSS alignment class: alignfull | alignwide.
 	 */
 	public static function get_block_alignment_class( $attributes = array() ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class' );
 
 		$align_to_class_map = array(
 			'wide' => 'alignwide',
@@ -4593,14 +4593,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
  * Parses shortcode to output the contact form field as HTML.
  * Validates input.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
  */
 class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 
 	/**
 	 * The shortcode name.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $shortcode_name = 'contact-field';
@@ -4608,7 +4608,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The parent form.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var Grunion_Contact_Form
 	 */
 	public $form;
@@ -4616,7 +4616,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Default or POSTed value.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $value;
@@ -4624,7 +4624,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Is the input valid?
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var bool
 	 */
 	public $error = false;
@@ -4632,7 +4632,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $block_styles = '';
@@ -4640,7 +4640,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $field_styles = '';
@@ -4648,7 +4648,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field option
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $option_styles = '';
@@ -4656,7 +4656,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated jetpack-$$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $label_styles = '';
@@ -4664,13 +4664,13 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Constructor function.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct
 	 * @param array                $attributes An associative array of shortcode attributes.  @see shortcode_atts().
 	 * @param null|string          $content Null for selfclosing shortcodes.  The inner content otherwise.
 	 * @param Grunion_Contact_Form $form The parent form.
 	 */
 	public function __construct( $attributes, $content = null, $form = null ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct' );
 
 		$attributes = shortcode_atts(
 			array(
@@ -4766,11 +4766,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * This field's input is invalid.  Flag as invalid and add an error to the parent form
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error
 	 * @param string $message The error message to display on the form.
 	 */
 	public function add_error( $message ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error' );
 
 		$this->is_error = true;
 
@@ -4784,12 +4784,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Is the field input invalid?
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error
 	 * @see $error
 	 * @return bool
 	 */
 	public function is_error() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error' );
 
 		return $this->error;
 	}
@@ -4797,10 +4797,10 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Validates the form input
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate
 	 */
 	public function validate() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate' );
 
 		// If it's not required, there's nothing to validate
 		if ( ! $this->get_attribute( 'required' ) ) {
@@ -4857,14 +4857,14 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Check the default value for options field
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value
 	 * @param string $value - the value we're checking.
 	 * @param int    $index - the index.
 	 * @param string $options - default field option.
 	 * @return string
 	 */
 	public function get_option_value( $value, $index, $options ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value' );
 
 		if ( empty( $value[ $index ] ) ) {
 			return $options;
@@ -4875,11 +4875,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Outputs the HTML for this form field
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render
 	 * @return string HTML
 	 */
 	public function render() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render' );
 
 		global $current_user, $user_identity;
 
@@ -5012,7 +5012,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the label.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label
 	 * @param string $type - the field type.
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
@@ -5022,7 +5022,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_label( $type, $id, $label, $required, $required_field_text, $extra_attrs = array() ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label' );
 
 		$form_style = $this->get_form_style();
 
@@ -5055,7 +5055,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the input field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field
 	 * @param string $type - the field type.
 	 * @param int    $id - the ID.
 	 * @param string $value - the value of the field.
@@ -5066,7 +5066,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_input_field( $type, $id, $value, $class, $placeholder, $required, $extra_attrs = array() ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field' );
 
 		$extra_attrs_string = '';
 
@@ -5093,7 +5093,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5104,7 +5104,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_email_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field' );
 
 		$field  = $this->render_label( 'email', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'email', $id, $value, $class, $placeholder, $required );
@@ -5114,7 +5114,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the telephone field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5125,7 +5125,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_telephone_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field' );
 
 		$field  = $this->render_label( 'telephone', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'tel', $id, $value, $class, $placeholder, $required );
@@ -5135,7 +5135,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the URL field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5146,7 +5146,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field' );
 
 		$custom_validation_message = __( 'Please enter a valid URL - https://www.example.com', 'jetpack' );
 		$validation_attrs          = array(
@@ -5165,7 +5165,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the text area field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5176,7 +5176,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_textarea_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field' );
 
 		$field  = $this->render_label( 'textarea', 'contact-form-comment-' . $id, $label, $required, $required_field_text );
 		$field .= "<textarea
@@ -5195,7 +5195,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the radio field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5205,7 +5205,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_radio_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field' );
 
 		$field  = $this->render_label( '', $id, $label, $required, $required_field_text );
 		$field .= '<div class="grunion-radio-options">';
@@ -5234,7 +5234,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the checkbox field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5244,7 +5244,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_checkbox_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field' );
 
 		$field  = "<label class='grunion-field-label checkbox" . ( $this->is_error() ? ' form-error' : '' ) . "' style='" . $this->label_styles . "'>";
 		$field .= "\t\t<input type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
@@ -5280,7 +5280,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the multiple checkbox field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5290,7 +5290,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_checkbox_multiple_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field' );
 
 		$field  = $this->render_label( '', $id, $label, $required, $required_field_text );
 		$field .= '<div class="grunion-checkbox-multiple-options">';
@@ -5313,7 +5313,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the select field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5323,7 +5323,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field' );
 
 		$field  = $this->render_label( 'select', $id, $label, $required, $required_field_text );
 		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . ">\n";
@@ -5367,7 +5367,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5378,7 +5378,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_date_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field' );
 
 		$field  = $this->render_label( 'date', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required );
@@ -5413,7 +5413,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the default field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5425,7 +5425,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_default_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder, $type ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field' );
 
 		$field  = $this->render_label( $type, $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required );
@@ -5435,7 +5435,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the outlined label.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
@@ -5443,7 +5443,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_outline_label( $id, $label, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label' );
 
 		return '
 			<div class="notched-label">
@@ -5465,7 +5465,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the animated label.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
@@ -5473,7 +5473,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_animated_label( $id, $label, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label' );
 
 		return '
 			<label
@@ -5489,7 +5489,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the below label.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
@@ -5497,7 +5497,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_below_label( $id, $label, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label' );
 
 		return '
 			<label
@@ -5512,7 +5512,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field
 	 * @param string $type - the type.
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
@@ -5524,7 +5524,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_field( $type, $id, $label, $value, $class, $placeholder, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field' );
 
 		$class .= ' grunion-field';
 
@@ -5679,10 +5679,10 @@ add_action( 'grunion_scheduled_delete', 'grunion_delete_old_spam' );
 /**
  * Deletes old spam feedbacks to keep the posts table size under control
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam'
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam'
  */
 function grunion_delete_old_spam() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );
 
 	global $wpdb;
 
@@ -5733,12 +5733,12 @@ function grunion_delete_old_spam() {
 /**
  * Send an event to Tracks on form submission.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent
  * @param int $post_id - the post_id for the CPT that is created.
  * @return null|void
  */
 function jetpack_tracks_record_grunion_pre_message_sent( $post_id ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent' );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent' );
 
 	$post = get_post( $post_id );
 	if ( $post ) {

--- a/projects/plugins/jetpack/modules/contact-form/grunion-editor-view.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-editor-view.php
@@ -11,15 +11,20 @@ use Automattic\Jetpack\Assets;
 
 /**
  * Grunion editor view class.
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View
  */
 class Grunion_Editor_View {
 
 	/**
 	 * Add hooks according to screen.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks
 	 * @param WP_Screen $screen Data about current screen.
 	 */
 	public static function add_hooks( $screen ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
+
 		if ( isset( $screen->base ) && 'post' === $screen->base ) {
 			add_action( 'admin_notices', array( __CLASS__, 'handle_editor_view_js' ) );
 			add_action( 'admin_head', array( __CLASS__, 'admin_head' ) );
@@ -28,16 +33,24 @@ class Grunion_Editor_View {
 
 	/**
 	 * Admin header.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head
 	 */
 	public static function admin_head() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head' );
+
 		remove_action( 'media_buttons', 'grunion_media_button', 999 );
 		add_action( 'media_buttons', array( __CLASS__, 'grunion_media_button' ), 999 );
 	}
 
 	/**
 	 * Render the grunion media button.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button
 	 */
 	public static function grunion_media_button() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button' );
+
 		$title = __( 'Add Contact Form', 'jetpack' );
 		?>
 
@@ -52,11 +65,13 @@ class Grunion_Editor_View {
 	/**
 	 * Get external plugins.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins
 	 * @param array $plugin_array - the plugin array.
-	 *
 	 * @return array
 	 */
 	public static function mce_external_plugins( $plugin_array ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins' );
+
 		$plugin_array['grunion_form'] = Assets::get_file_url_for_environment(
 			'_inc/build/contact-form/js/tinymce-plugin-form-button.min.js',
 			'modules/contact-form/js/tinymce-plugin-form-button.js'
@@ -67,11 +82,13 @@ class Grunion_Editor_View {
 	/**
 	 * MCE buttons.
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons
 	 * @param array $buttons - the buttons.
-	 *
 	 * @return array
 	 */
 	public static function mce_buttons( $buttons ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons' );
+
 		$size     = count( $buttons );
 		$buttons1 = array_slice( $buttons, 0, $size - 1 );
 		$buttons2 = array_slice( $buttons, $size - 1 );
@@ -84,8 +101,12 @@ class Grunion_Editor_View {
 
 	/**
 	 * WordPress Shortcode Editor View JS Code
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js
 	 */
 	public static function handle_editor_view_js() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js' );
+
 		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'editor_view_js_templates' ), 1 );
 		add_filter( 'mce_external_plugins', array( __CLASS__, 'mce_external_plugins' ) );
 		add_filter( 'mce_buttons', array( __CLASS__, 'mce_buttons' ) );
@@ -129,8 +150,11 @@ class Grunion_Editor_View {
 
 	/**
 	 * JS Templates.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates
 	 */
 	public static function editor_view_js_templates() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates' );
 		?>
 <script type="text/html" id="tmpl-grunion-contact-form">
 	<form class="card jetpack-contact-form-shortcode-preview" action='#' method='post' class='contact-form commentsblock' onsubmit="return false;">

--- a/projects/plugins/jetpack/modules/contact-form/grunion-editor-view.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-editor-view.php
@@ -12,14 +12,14 @@ use Automattic\Jetpack\Assets;
 /**
  * Grunion editor view class.
  *
- * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View
  */
 class Grunion_Editor_View {
 
 	/**
 	 * Add hooks according to screen.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks
 	 * @param WP_Screen $screen Data about current screen.
 	 */
 	public static function add_hooks( $screen ) {
@@ -34,7 +34,7 @@ class Grunion_Editor_View {
 	/**
 	 * Admin header.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head
 	 */
 	public static function admin_head() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head' );
@@ -46,7 +46,7 @@ class Grunion_Editor_View {
 	/**
 	 * Render the grunion media button.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button
 	 */
 	public static function grunion_media_button() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button' );
@@ -65,7 +65,7 @@ class Grunion_Editor_View {
 	/**
 	 * Get external plugins.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins
 	 * @param array $plugin_array - the plugin array.
 	 * @return array
 	 */
@@ -82,7 +82,7 @@ class Grunion_Editor_View {
 	/**
 	 * MCE buttons.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons
 	 * @param array $buttons - the buttons.
 	 * @return array
 	 */
@@ -102,7 +102,7 @@ class Grunion_Editor_View {
 	/**
 	 * WordPress Shortcode Editor View JS Code
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js
 	 */
 	public static function handle_editor_view_js() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js' );
@@ -151,7 +151,7 @@ class Grunion_Editor_View {
 	/**
 	 * JS Templates.
 	 *
-	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates
 	 */
 	public static function editor_view_js_templates() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates' );

--- a/projects/plugins/jetpack/modules/contact-form/grunion-editor-view.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-editor-view.php
@@ -12,18 +12,18 @@ use Automattic\Jetpack\Assets;
 /**
  * Grunion editor view class.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View
+ * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View
  */
 class Grunion_Editor_View {
 
 	/**
 	 * Add hooks according to screen.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks
 	 * @param WP_Screen $screen Data about current screen.
 	 */
 	public static function add_hooks( $screen ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
 
 		if ( isset( $screen->base ) && 'post' === $screen->base ) {
 			add_action( 'admin_notices', array( __CLASS__, 'handle_editor_view_js' ) );
@@ -34,10 +34,10 @@ class Grunion_Editor_View {
 	/**
 	 * Admin header.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head
 	 */
 	public static function admin_head() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head' );
 
 		remove_action( 'media_buttons', 'grunion_media_button', 999 );
 		add_action( 'media_buttons', array( __CLASS__, 'grunion_media_button' ), 999 );
@@ -46,10 +46,10 @@ class Grunion_Editor_View {
 	/**
 	 * Render the grunion media button.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button
 	 */
 	public static function grunion_media_button() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button' );
 
 		$title = __( 'Add Contact Form', 'jetpack' );
 		?>
@@ -65,12 +65,12 @@ class Grunion_Editor_View {
 	/**
 	 * Get external plugins.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins
 	 * @param array $plugin_array - the plugin array.
 	 * @return array
 	 */
 	public static function mce_external_plugins( $plugin_array ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins' );
 
 		$plugin_array['grunion_form'] = Assets::get_file_url_for_environment(
 			'_inc/build/contact-form/js/tinymce-plugin-form-button.min.js',
@@ -82,12 +82,12 @@ class Grunion_Editor_View {
 	/**
 	 * MCE buttons.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons
 	 * @param array $buttons - the buttons.
 	 * @return array
 	 */
 	public static function mce_buttons( $buttons ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons' );
 
 		$size     = count( $buttons );
 		$buttons1 = array_slice( $buttons, 0, $size - 1 );
@@ -102,10 +102,10 @@ class Grunion_Editor_View {
 	/**
 	 * WordPress Shortcode Editor View JS Code
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js
 	 */
 	public static function handle_editor_view_js() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js' );
 
 		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'editor_view_js_templates' ), 1 );
 		add_filter( 'mce_external_plugins', array( __CLASS__, 'mce_external_plugins' ) );
@@ -151,10 +151,10 @@ class Grunion_Editor_View {
 	/**
 	 * JS Templates.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates
+	 * @deprecated jetpack-$$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates
 	 */
 	public static function editor_view_js_templates() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates' );
 		?>
 <script type="text/html" id="tmpl-grunion-contact-form">
 	<form class="card jetpack-contact-form-shortcode-preview" action='#' method='post' class='contact-form commentsblock' onsubmit="return false;">

--- a/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -1,18 +1,22 @@
 <?php
+
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field;
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
+use Automattic\Jetpack\Forms\ContactForm\Util;
+
 /**
- * Unit Tests for Grunion_Contact_Form.
+ * Unit Tests for Contact_Form.
  *
  * @package automattic/jetpack
  */
 
-require_once JETPACK__PLUGIN_DIR . 'modules/contact-form/grunion-contact-form.php';
-
 /**
- * Test class for Grunion_Contact_Form
+ * Test class for Contact_Form
  *
- * @covers Grunion_Contact_Form
+ * @covers Contact_Form
  */
-class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
+class WP_Test_Contact_Form extends WP_UnitTestCase {
 
 	private $post;
 	private $plugin;
@@ -70,7 +74,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->post = $post;
 
 		// Initialize plugin.
-		$this->plugin = Grunion_Contact_Form_Plugin::init();
+		$this->plugin = Contact_Form_Plugin::init();
 		// Call to add tokenization hook.
 		$this->plugin->process_form_submission();
 	}
@@ -105,7 +109,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @author tonykova
 	 */
 	public function test_process_submission_will_store_a_feedback_correctly_with_default_form() {
-		$form   = new Grunion_Contact_Form( array() );
+		$form   = new Contact_Form( array() );
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
@@ -140,7 +144,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		// Initialize a form with name, dropdown and radiobutton (first, second
 		// and third option), text field.
-		$form   = new Grunion_Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
+		$form   = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
@@ -173,7 +177,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @author tonykova
 	 */
 	public function test_process_submission_will_store_subject_when_specified() {
-		$form   = new Grunion_Contact_Form( array( 'subject' => 'I\'m sorry, but the party\'s over' ) ); // Default form.
+		$form   = new Contact_Form( array( 'subject' => 'I\'m sorry, but the party\'s over' ) ); // Default form.
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
@@ -202,7 +206,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			)
 		);
 
-		$form = new Grunion_Contact_Form( array( 'subject' => 'Hello {name} from {state}!' ), "[contact-field label='Name' type='name' required='1'/][contact-field label='State' type='text'/]" );
+		$form = new Contact_Form( array( 'subject' => 'Hello {name} from {state}!' ), "[contact-field label='Name' type='name' required='1'/][contact-field label='State' type='text'/]" );
 
 		$result = $form->process_submission();
 
@@ -232,7 +236,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			)
 		);
 
-		$form   = new Grunion_Contact_Form( array( 'subject' => 'Hello {name} from {state}!' ), "[contact-field label='Name' type='name' required='1'/][contact-field label='State' type='radio' options='Kansas,California'/]" );
+		$form   = new Contact_Form( array( 'subject' => 'Hello {name} from {state}!' ), "[contact-field label='Name' type='name' required='1'/][contact-field label='State' type='radio' options='Kansas,California'/]" );
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
@@ -261,7 +265,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			)
 		);
 
-		$form   = new Grunion_Contact_Form( array( 'subject' => 'Hello {name} from {state}!' ), "[contact-field label='Name' type='name' required='1'/][contact-field label='State' type='select' options='Kansas,California'/]" );
+		$form   = new Contact_Form( array( 'subject' => 'Hello {name} from {state}!' ), "[contact-field label='Name' type='name' required='1'/][contact-field label='State' type='select' options='Kansas,California'/]" );
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
@@ -294,7 +298,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		// Initialize a form with name, dropdown and radiobutton (first, second
 		// and third option), text field.
-		$form   = new Grunion_Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
+		$form   = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
@@ -330,7 +334,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		// Initialize a form with name, dropdown and radiobutton (first, second
 		// and third option), text field.
-		$form   = new Grunion_Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
+		$form   = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
@@ -371,7 +375,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		// Initialize a form with name, dropdown and radiobutton (first, second
 		// and third option), text field.
-		$form   = new Grunion_Contact_Form(
+		$form   = new Contact_Form(
 			array(
 				'to'      => 'john <john@example.com>',
 				'subject' => 'Hello there!',
@@ -416,7 +420,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		// Initialize a form with name, dropdown and radiobutton (first, second
 		// and third option), text field.
-		$form = new Grunion_Contact_Form(
+		$form = new Contact_Form(
 			array(
 				'to'      => 'john@example.com, jane@example.com',
 				'subject' => 'Hello there!',
@@ -454,7 +458,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		// Initialize a form with name, dropdown and radiobutton (first, second
 		// and third option), text field.
-		$form = new Grunion_Contact_Form(
+		$form = new Contact_Form(
 			array(
 				'to'      => 'john@example.com, jane@example.com',
 				'subject' => 'Hello there!',
@@ -484,7 +488,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	public function test_process_submission_fails_if_spam_marked_with_WP_Error() {
 		add_filter( 'jetpack_contact_form_is_spam', array( $this, 'pre_test_process_submission_fails_if_spam_marked_with_WP_Error' ), 11 ); // Run after akismet filter.
 
-		$form   = new Grunion_Contact_Form( array() );
+		$form   = new Contact_Form( array() );
 		$result = $form->process_submission();
 
 		$this->assertInstanceOf( 'WP_Error', $result, 'When $is_spam contains a WP_Error, the result of process_submission should be a WP_Error' );
@@ -508,7 +512,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		add_filter( 'wp_mail', array( $this, 'pre_test_process_submission_wont_send_spam_if_marked_as_spam_with_true' ) );
 
-		$form   = new Grunion_Contact_Form( array( 'to' => 'john@example.com' ) );
+		$form   = new Contact_Form( array( 'to' => 'john@example.com' ) );
 		$result = $form->process_submission();
 		$this->assertNotNull( $result );
 	}
@@ -532,7 +536,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		add_filter( 'wp_mail', array( $this, 'pre_test_process_submission_labels_message_as_spam_in_subject_if_marked_as_spam_with_true_and_sending_spam' ) );
 
-		$form   = new Grunion_Contact_Form( array( 'to' => 'john@example.com' ) );
+		$form   = new Contact_Form( array( 'to' => 'john@example.com' ) );
 		$result = $form->process_submission();
 		$this->assertNotNull( $result );
 	}
@@ -562,7 +566,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			)
 		);
 
-		grunion_delete_old_spam();
+		Util::grunion_delete_old_spam();
 		$this->assertNull( get_post( $post_id ), 'An old spam feedback should be deleted' );
 	}
 
@@ -580,7 +584,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			)
 		);
 
-		grunion_delete_old_spam();
+		Util::grunion_delete_old_spam();
 		$this->assertEquals( $post_id, get_post( $post_id )->ID, 'A new spam feedback should be left intact when deleting old spam' );
 	}
 
@@ -588,10 +592,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * Tests that token is left intact when there is not matching field.
 	 *
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form_Plugin
+	 * @covers Contact_Form_Plugin
 	 */
 	public function test_token_left_intact_when_no_matching_field() {
-		$plugin       = Grunion_Contact_Form_Plugin::init();
+		$plugin       = Contact_Form_Plugin::init();
 		$subject      = 'Hello {name}!';
 		$field_values = array(
 			'City' => 'Chicago',
@@ -604,10 +608,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * Tests that token is replaced with an empty string when there is not value in field.
 	 *
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form_Plugin
+	 * @covers Contact_Form_Plugin
 	 */
 	public function test_replaced_with_empty_string_when_no_value_in_field() {
-		$plugin       = Grunion_Contact_Form_Plugin::init();
+		$plugin       = Contact_Form_Plugin::init();
 		$subject      = 'Hello {name}!';
 		$field_values = array(
 			'Name' => null,
@@ -620,10 +624,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * Tests that token in curly brackets is replaced with the value when the name has whitespace.
 	 *
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form_Plugin
+	 * @covers Contact_Form_Plugin
 	 */
 	public function test_token_can_replace_entire_subject_with_token_field_whose_name_has_whitespace() {
-		$plugin       = Grunion_Contact_Form_Plugin::init();
+		$plugin       = Contact_Form_Plugin::init();
 		$subject      = '{subject token}';
 		$field_values = array(
 			'Subject Token' => 'Chicago',
@@ -636,10 +640,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * Tests that token with curly brackets is replaced with value.
 	 *
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form_Plugin
+	 * @covers Contact_Form_Plugin
 	 */
 	public function test_token_with_curly_brackets_can_be_replaced() {
-		$plugin       = Grunion_Contact_Form_Plugin::init();
+		$plugin       = Contact_Form_Plugin::init();
 		$subject      = '{subject {token}}';
 		$field_values = array(
 			'Subject {Token}' => 'Chicago',
@@ -654,7 +658,12 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @author tonykova
 	 */
 	public function test_parse_contact_field_keeps_string_unchanged_when_no_escaping_necesssary() {
-		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
+		add_shortcode(
+			'contact-field',
+			function ( $attributes, $content ) {
+				return Contact_Form::parse_contact_field( $attributes, $content );
+			}
+		);
 
 		// @phpcs:ignore Squiz.Strings.DoubleQuoteUsage.NotRequired
 		$shortcode = "[contact-field label=\"Name\" type=\"name\" required=\"1\"/][contact-field label=\"Email\" type=\"email\" required=\"1\"/][contact-field label=\"asdasd\" type=\"text\"/][contact-field id=\"1\" required derp herp asd lkj]adsasd[/contact-field]";
@@ -667,7 +676,12 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * Tests that the default label is added when no label is present.
 	 */
 	public function test_make_sure_that_we_add_default_label_when_non_is_present() {
-		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
+		add_shortcode(
+			'contact-field',
+			function ( $attributes, $content ) {
+				return Contact_Form::parse_contact_field( $attributes, $content );
+			}
+		);
 		$shortcode = "[contact-field type='name' required='1' /]";
 		$html      = do_shortcode( $shortcode );
 		// @phpcs:ignore Squiz.Strings.DoubleQuoteUsage.NotRequired
@@ -678,7 +692,12 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * Tests the empty options are removed from form fields.
 	 */
 	public function test_make_sure_that_we_remove_empty_options_from_form_field() {
-		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
+		add_shortcode(
+			'contact-field',
+			function ( $attributes, $content ) {
+				return Contact_Form::parse_contact_field( $attributes, $content );
+			}
+		);
 		$shortcode = "[contact-field type='select' required='1' options='fun,,run' label='fun times' values='go,,have some fun'/]";
 		$html      = do_shortcode( $shortcode );
 		// @phpcs:ignore Squiz.Strings.DoubleQuoteUsage.NotRequired
@@ -688,10 +707,15 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Tests shortcode with commas and brackets.
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_array_values_with_commas_and_brackets() {
-		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
+		add_shortcode(
+			'contact-field',
+			function ( $attributes, $content ) {
+				return Contact_Form::parse_contact_field( $attributes, $content );
+			}
+		);
 		$shortcode = "[contact-field type='radio' options='\"foo\",bar&#044; baz,&#091;b&#092;rackets&#093;' label='fun &#093;&#091; times'/]";
 		$html      = do_shortcode( $shortcode );
 		$this->assertEquals( '[contact-field type="radio" options="&quot;foo&quot;,bar&#044; baz,&#091;b&#092;rackets&#093;" label="fun &#093;&#091; times"/]', $html );
@@ -700,7 +724,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Tests Gutenblock input with commas and brackets.
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_array_values_with_commas_and_brackets_from_gutenblock() {
 		$attr = array(
@@ -708,14 +732,14 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'options' => array( '"foo"', 'bar, baz', '[b\\rackets]' ),
 			'label'   => 'fun ][ times',
 		);
-		$html = Grunion_Contact_Form_Plugin::gutenblock_render_field_radio( $attr, '' );
+		$html = Contact_Form_Plugin::gutenblock_render_field_radio( $attr, '' );
 		$this->assertEquals( '[contact-field type="radio" options="&quot;foo&quot;,bar&#044; baz,&#091;b&#092;rackets&#093;" label="fun &#093;&#091; times"/]', $html );
 	}
 
 	/**
 	 * Test for text field_renders
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_make_sure_text_field_renders_as_expected() {
 		$attributes = array(
@@ -734,7 +758,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test for email field_renders
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_make_sure_email_field_renders_as_expected() {
 		$attributes = array(
@@ -753,7 +777,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test for url field_renders
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_make_sure_url_field_renders_as_expected() {
 		$attributes = array(
@@ -772,7 +796,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test for telephone field_renders
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_make_sure_telephone_field_renders_as_expected() {
 		$attributes = array(
@@ -791,7 +815,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test for date field_renders
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_make_sure_date_field_renders_as_expected() {
 		$attributes = array(
@@ -801,6 +825,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'default'     => 'foo',
 			'placeholder' => 'PLACEHOLDTHIS!',
 			'id'          => 'funID',
+			'format'      => '(YYYY-MM-DD)',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'text' ) );
@@ -810,7 +835,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test for textarea field_renders
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_make_sure_textarea_field_renders_as_expected() {
 		$attributes = array(
@@ -829,7 +854,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test for checkbox field_renders
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_make_sure_checkbox_field_renders_as_expected() {
 		$attributes = array(
@@ -848,7 +873,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Multiple fields
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_make_sure_checkbox_multiple_field_renders_as_expected() {
 		$attributes = array(
@@ -868,7 +893,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test for radio field_renders
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_make_sure_radio_field_renders_as_expected() {
 		$attributes = array(
@@ -888,7 +913,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test for select field_renders
 	 *
-	 * @covers Grunion_Contact_Form_Field
+	 * @covers Contact_Form_Field
 	 */
 	public function test_make_sure_select_field_renders_as_expected() {
 		$attributes = array(
@@ -906,15 +931,15 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Renders a Grunion_Contact_Form_Field.
+	 * Renders a Contact_Form_Field.
 	 *
 	 * @param array $attributes An associative array of shortcode attributes.
 	 *
 	 * @return string The field html string.
 	 */
 	public function render_field( $attributes ) {
-		$form  = new Grunion_Contact_Form( array() );
-		$field = new Grunion_Contact_Form_Field( $attributes, '', $form );
+		$form  = new Contact_Form( array() );
+		$field = new Contact_Form_Field( $attributes, '', $form );
 		return $field->render();
 	}
 
@@ -976,6 +1001,43 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests whether the class attribute in the wrapper div matches the field's class attribute value.
+	 *
+	 * @param DOMElement $wrapper_div The wrapper div.
+	 * @param array      $attributes An associative array containing the field's attributes.
+	 */
+	public function assertFieldClasses( $wrapper_div, $attributes ) {
+		if ( 'date' === $attributes['type'] ) {
+			$attributes['class'] = 'jp-contact-form-date';
+		}
+
+		$css_class = "grunion-field-{$attributes['type']}-wrap {$attributes['class']}-wrap grunion-field-wrap";
+
+		$this->assertEquals(
+			$wrapper_div->getAttribute( 'class' ),
+			$css_class,
+			'div class attribute doesn\'t match'
+		);
+	}
+
+	/**
+	 * Tests whether the label in the wrapper div matches the field's label.
+	 *
+	 * @param DOMElement $wrapper_div The wrapper div.
+	 * @param array      $attributes An associative array containing the field's attributes.
+	 * @param string     $tag_name The tag used to label the field. Could be `legend` for checkboxes
+	 *                                                       and radio buttons.
+	 */
+	public function assertFieldLabel( $wrapper_div, $attributes, $tag_name = 'label' ) {
+		$type     = $attributes['type'];
+		$label    = $this->getFirstElement( $wrapper_div, $tag_name );
+		$expected = 'date' === $type ? $attributes['label'] . ' ' . $attributes['format'] : $attributes['label'];
+
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$this->assertEquals( $expected, trim( $label->nodeValue ), 'Label is not what we expect it to be...' );
+	}
+
+	/**
 	 * Tests whether a field is valid.
 	 *
 	 * @param string $html The html string.
@@ -984,7 +1046,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	public function assertValidField( $html, $attributes ) {
 
 		$wrapper_div = $this->getCommonDiv( $html );
-		$this->assertCommonValidHtml( $wrapper_div, $attributes );
+		$this->assertFieldClasses( $wrapper_div, $attributes );
+		$this->assertFieldLabel( $wrapper_div, $attributes );
 
 		// Get label.
 		$label = $this->getFirstElement( $wrapper_div, 'label' );
@@ -1047,10 +1110,11 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	public function assertValidCheckboxField( $html, $attributes ) {
 
 		$wrapper_div = $this->getCommonDiv( $html );
-		$this->assertCommonValidHtml( $wrapper_div, $attributes );
+		$this->assertFieldClasses( $wrapper_div, $attributes );
+		$this->assertFieldLabel( $wrapper_div, $attributes );
 
-		$label = $this->getFirstElement( $wrapper_div, 'label' );
-		$input = $this->getFirstElement( $label, 'input' );
+		$label = $wrapper_div->getElementsByTagName( 'label' )->item( 0 );
+		$input = $wrapper_div->getElementsByTagName( 'input' )->item( 0 );
 
 		$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label ' . $attributes['type'], 'label class doesn\'t match' );
 
@@ -1073,13 +1137,13 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	public function assertValidFieldMultiField( $html, $attributes ) {
 
 		$wrapper_div = $this->getCommonDiv( $html );
-		$this->assertCommonValidHtml( $wrapper_div, $attributes );
-
-		// Get label.
-		$label = $this->getFirstElement( $wrapper_div, 'label' );
+		$this->assertFieldClasses( $wrapper_div, $attributes );
 
 		// Inputs.
 		if ( 'select' === $attributes['type'] ) {
+			$label = $this->getFirstElement( $wrapper_div, 'label' );
+
+			$this->assertFieldLabel( $wrapper_div, $attributes );
 			$this->assertEquals( 'grunion-field-label select', $label->getAttribute( 'class' ), 'label class doesn\'t match' );
 
 			$select = $this->getFirstElement( $wrapper_div, 'select' );
@@ -1095,7 +1159,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				'label for does not equal input name!'
 			);
 
-			$this->assertEquals( $select->getAttribute( 'class' ), 'select ' . $attributes['class'] . ' grunion-field contact-form-dropdown', ' select class does not match expected' );
+			$this->assertEquals( $select->getAttribute( 'class' ), 'select ' . $attributes['class'] . ' grunion-field', ' select class does not match expected' );
 
 			// Options.
 			$options = $select->getElementsByTagName( 'option' );
@@ -1114,18 +1178,22 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				$this->assertEquals( $option->nodeValue, $attributes['options'][ $i ], 'Input does not match the option' );
 			}
 		} else {
+			$label = $this->getFirstElement( $wrapper_div, 'legend' );
+
+			$this->assertFieldLabel( $wrapper_div, $attributes, 'legend' );
 			$this->assertEquals( 'grunion-field-label', $label->getAttribute( 'class' ), 'label class doesn\'t match' );
 			// Radio and Checkboxes.
 			$labels = $wrapper_div->getElementsByTagName( 'label' );
-			$n      = $labels->length - 1;
+			$n      = $labels->length;
 			$this->assertCount( $n, $attributes['options'], 'Number of inputs doesn\'t match number of options' );
 			$this->assertCount( $n, $attributes['values'], 'Number of inputs doesn\'t match number of values' );
 			for ( $i = 0; $i < $n; $i++ ) {
-				$item_label = $labels->item( $i + 1 );
+				$item_label = $labels->item( $i );
 				//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$this->assertEquals( $item_label->nodeValue, ' ' . $attributes['options'][ $i ] ); // extra space added for a padding.
+				$this->assertEquals( $item_label->nodeValue, $attributes['options'][ $i ] );
 
-				$input = $this->getFirstElement( $item_label, 'input' );
+				//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$input = $item_label->parentNode->getElementsByTagName( 'input' )->item( 0 );
 				$this->assertEquals( $input->getAttribute( 'type' ), $attributes['input_type'], 'Type doesn\'t match' );
 				if ( 'radio' === $attributes['input_type'] ) {
 					$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );
@@ -1149,7 +1217,12 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @author tonykova
 	 */
 	public function test_parse_contact_field_escapes_things_inside_a_value_and_attribute_and_the_content() {
-		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
+		add_shortcode(
+			'contact-field',
+			function ( $attributes, $content ) {
+				return Contact_Form::parse_contact_field( $attributes, $content );
+			}
+		);
 
 		$shortcode = "[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type=''email'' req'uired='1'/][contact-field label='asdasd' type='text'/][contact-field id='1' required 'derp' herp asd lkj]adsasd[/contact-field]";
 		$html      = do_shortcode( $shortcode );
@@ -1164,22 +1237,23 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test get_export_data_for_posts with fully vaid data input.
 	 *
-	 * @covers Grunion_Contact_Form_Plugin
+	 * @covers Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_fully_valid_data() {
 		/**
-		 * Grunion_Contact_Form_Plugin mock object.
+		 * Contact_Form_Plugin mock object.
 		 *
-		 * @var Grunion_Contact_Form_Plugin $mock
+		 * @var Contact_Form_Plugin $mock
 		 */
-		$mock = $this->getMockBuilder( 'Grunion_Contact_Form_Plugin' )
+		$mock = $this->getMockBuilder( Contact_Form_Plugin::class )
 			->setMethods(
 				array(
 					'get_post_meta_for_csv_export',
 					'get_parsed_field_contents_of_post',
 					'get_post_content_for_csv_export',
 					'map_parsed_field_contents_of_post_to_field_names',
+					'has_json_data',
 				)
 			)
 			->disableOriginalConstructor()
@@ -1188,6 +1262,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$get_post_meta_for_csv_export_map = array(
 			array(
 				15,
+				false,
 				array(
 					'key1' => 'value1',
 					'key2' => 'value2',
@@ -1198,6 +1273,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			),
 			array(
 				16,
+				false,
 				array(
 					'key3' => 'value3',
 					'key4' => 'value4',
@@ -1223,6 +1299,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'_feedback_subject'      => 'subj1',
 					'_feedback_main_comment' => 'This is my test 15',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj1',
 					'4_Comment'    => 'This is my test 15',
@@ -1233,6 +1310,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'_feedback_subject'      => 'subj2',
 					'_feedback_main_comment' => 'This is my test 16',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj2',
 					'4_Comment'    => 'This is my test 16',
@@ -1256,6 +1334,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			->method( 'map_parsed_field_contents_of_post_to_field_names' )
 			->willReturnMap( $mapped_fields_contents_map );
 
+		$mock->expects( $this->exactly( 2 ) )
+			->method( 'has_json_data' )
+			->willReturn( false );
+
 		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
 
 		$expected_result = array(
@@ -1275,16 +1357,16 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test get_export_data_for_posts with single invalid entry for post meta
 	 *
-	 * @covers Grunion_Contact_Form_Plugin
+	 * @covers Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_invalid_single_entry_meta() {
 		/**
-		 * Grunion_Contact_Form_Plugin mock object.
+		 * Contact_Form_Plugin mock object.
 		 *
-		 * @var Grunion_Contact_Form_Plugin $mock
+		 * @var Contact_Form_Plugin $mock
 		 * */
-		$mock = $this->getMockBuilder( 'Grunion_Contact_Form_Plugin' )
+		$mock = $this->getMockBuilder( Contact_Form_Plugin::class )
 			->setMethods(
 				array(
 					'get_post_meta_for_csv_export',
@@ -1297,9 +1379,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			->getMock();
 
 		$get_post_meta_for_csv_export_map = array(
-			array( 15, null ),
+			array( 15, false, null ),
 			array(
 				16,
+				false,
 				array(
 					'key3' => 'value3',
 					'key4' => 'value4',
@@ -1325,6 +1408,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'_feedback_subject'      => 'subj1',
 					'_feedback_main_comment' => 'This is my test 15',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj1',
 					'Comment'      => 'This is my test 15',
@@ -1335,6 +1419,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'_feedback_subject'      => 'subj2',
 					'_feedback_main_comment' => 'This is my test 16',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj2',
 					'Comment'      => 'This is my test 16',
@@ -1377,16 +1462,16 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test get_export_data_for_posts with invalid all entries for post meta
 	 *
-	 * @covers Grunion_Contact_Form_Plugin
+	 * @covers Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_invalid_all_entries_meta() {
 		/**
-		 * Grunion_Contact_Form_Plugin mock object.
+		 * Contact_Form_Plugin mock object.
 		 *
-		 * @var Grunion_Contact_Form_Plugin $mock
+		 * @var Contact_Form_Plugin $mock
 		 */
-		$mock = $this->getMockBuilder( 'Grunion_Contact_Form_Plugin' )
+		$mock = $this->getMockBuilder( Contact_Form_Plugin::class )
 			->setMethods(
 				array(
 					'get_post_meta_for_csv_export',
@@ -1399,8 +1484,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			->getMock();
 
 		$get_post_meta_for_csv_export_map = array(
-			array( 15, null ),
-			array( 16, null ),
+			array( 15, false, null ),
+			array( 16, false, null ),
 		);
 
 		$get_parsed_field_contents_of_post_map = array(
@@ -1419,6 +1504,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'_feedback_subject'      => 'subj1',
 					'_feedback_main_comment' => 'This is my test 15',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj1',
 					'Comment'      => 'This is my test 15',
@@ -1429,6 +1515,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'_feedback_subject'      => 'subj2',
 					'_feedback_main_comment' => 'This is my test 16',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj2',
 					'Comment'      => 'This is my test 16',
@@ -1465,16 +1552,16 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test get_export_data_for_posts with single invalid entry for parsed fields.
 	 *
-	 * @covers Grunion_Contact_Form_Plugin
+	 * @covers Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_single_invalid_entry_for_parse_fields() {
 		/**
-		 * Grunion_Contact_Form_Plugin mock object.
+		 * Contact_Form_Plugin mock object.
 		 *
-		 * @var Grunion_Contact_Form_Plugin $mock
+		 * @var Contact_Form_Plugin $mock
 		 * */
-		$mock = $this->getMockBuilder( 'Grunion_Contact_Form_Plugin' )
+		$mock = $this->getMockBuilder( Contact_Form_Plugin::class )
 			->setMethods(
 				array(
 					'get_post_meta_for_csv_export',
@@ -1489,6 +1576,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$get_post_meta_for_csv_export_map = array(
 			array(
 				15,
+				false,
 				array(
 					'key1' => 'value1',
 					'key2' => 'value2',
@@ -1499,6 +1587,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			),
 			array(
 				16,
+				false,
 				array(
 					'key3' => 'value3',
 					'key4' => 'value4',
@@ -1524,6 +1613,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'_feedback_subject'      => 'subj1',
 					'_feedback_main_comment' => 'This is my test 15',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj1',
 					'Comment'      => 'This is my test 15',
@@ -1534,6 +1624,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'_feedback_subject'      => 'subj2',
 					'_feedback_main_comment' => 'This is my test 16',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj2',
 					'Comment'      => 'This is my test 16',
@@ -1574,16 +1665,16 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test get_export_data_for_posts with all entries for parsed fields invalid.
 	 *
-	 * @covers Grunion_Contact_Form_Plugin
+	 * @covers Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_all_entries_for_parse_fields_invalid() {
 		/**
-		 * Grunion_Contact_Form_Plugin mock object.
+		 * Contact_Form_Plugin mock object.
 		 *
-		 * @var Grunion_Contact_Form_Plugin $mock
+		 * @var Contact_Form_Plugin $mock
 		 */
-		$mock = $this->getMockBuilder( 'Grunion_Contact_Form_Plugin' )
+		$mock = $this->getMockBuilder( Contact_Form_Plugin::class )
 			->setMethods(
 				array(
 					'get_post_meta_for_csv_export',
@@ -1617,7 +1708,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test map_parsed_field_contents_of_post_to_field_names
 	 *
-	 * @covers Grunion_Contact_Form_Plugin
+	 * @covers Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_map_parsed_field_contents_of_post_to_field_names() {
@@ -1632,7 +1723,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'another_field'          => 'thunderstruck',
 		);
 
-		$plugin = Grunion_Contact_Form_Plugin::init();
+		$plugin = Contact_Form_Plugin::init();
 
 		$result = $plugin->map_parsed_field_contents_of_post_to_field_names( $input_data );
 
@@ -1646,7 +1737,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests the functionality of 'Grunion_Contact_Form_Plugin::personal_data_exporter'.
+	 * Tests the functionality of 'Contact_Form_Plugin::personal_data_exporter'.
 	 *
 	 * @author jaswrks
 	 */
@@ -1662,7 +1753,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		);
 
 		for ( $i = 1; $i <= 2; $i++ ) {
-			$form = new Grunion_Contact_Form(
+			$form = new Contact_Form(
 				array(
 					'to'      => '"john" <john@example.com>',
 					'subject' => 'Hello world! [ ' . wp_rand() . ' ]',
@@ -1696,7 +1787,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests the functionality of 'Grunion_Contact_Form_Plugin::personal_data_eraser'.
+	 * Tests the functionality of 'Contact_Form_Plugin::personal_data_eraser'.
 	 *
 	 * @author jaswrks
 	 */
@@ -1709,7 +1800,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		);
 
 		for ( $i = 1; $i <= 2; $i++ ) {
-			$form = new Grunion_Contact_Form(
+			$form = new Contact_Form(
 				array(
 					'to'      => '"john" <john@example.com>',
 					'subject' => 'Hello world! [ ' . wp_rand() . ' ]',
@@ -1735,7 +1826,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests the functionality of 'Grunion_Contact_Form_Plugin::personal_data_eraser' with pagination.
+	 * Tests the functionality of 'Contact_Form_Plugin::personal_data_eraser' with pagination.
 	 */
 	public function test_personal_data_eraser_pagination() {
 		$this->add_field_values(
@@ -1746,7 +1837,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		);
 
 		for ( $i = 1; $i <= 3; $i++ ) {
-			$form = new Grunion_Contact_Form(
+			$form = new Contact_Form(
 				array(
 					'to'      => '"jane" <jane_doe@example.com>',
 					'subject' => 'Hello world! [ ' . wp_rand() . ' ]',
@@ -1769,7 +1860,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			)
 		);
 
-		$form = new Grunion_Contact_Form(
+		$form = new Contact_Form(
 			array(
 				'to'      => '"jane" <jane@example.com>',
 				'subject' => 'Hello world! [ ' . wp_rand() . ' ]',
@@ -1853,7 +1944,7 @@ EOT;
 EOT;
 		$this->assertEquals(
 			$expected,
-			grunion_contact_form_apply_block_attribute( $original, array( 'foo' => 'bar' ) )
+			Util::grunion_contact_form_apply_block_attribute( $original, array( 'foo' => 'bar' ) )
 		);
 		// Contact form block without attributes.
 		$original = <<<EOT
@@ -1916,7 +2007,7 @@ EOT;
 EOT;
 		$this->assertEquals(
 			$expected,
-			grunion_contact_form_apply_block_attribute( $original, array( 'foo' => 'bar' ) )
+			Util::grunion_contact_form_apply_block_attribute( $original, array( 'foo' => 'bar' ) )
 		);
 		// Contact form block with attributes.
 		$original = <<<EOT
@@ -1979,7 +2070,7 @@ EOT;
 EOT;
 		$this->assertEquals(
 			$expected,
-			grunion_contact_form_apply_block_attribute( $original, array( 'foo' => 'bar' ) )
+			Util::grunion_contact_form_apply_block_attribute( $original, array( 'foo' => 'bar' ) )
 		);
 	}
 } // end class

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -3,12 +3,11 @@
  * Testing CRUD on Meta
  */
 
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Posts;
 use Automattic\Jetpack\Sync\Settings;
-
-require_once JETPACK__PLUGIN_DIR . 'modules/contact-form/grunion-contact-form.php';
 
 class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	protected $post_id;
@@ -267,7 +266,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		// This event can trigger a deletion of many _feedbacakismet_values terms.
 		add_post_meta( $post_id, '_feedback_akismet_values', '1' );
 
-		$grunion = Grunion_Contact_Form_Plugin::init();
+		$grunion = Contact_Form_Plugin::init();
 		$grunion->daily_akismet_meta_cleanup();
 
 		$this->sender->do_sync();

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Modules;
@@ -902,11 +903,9 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	public function test_remove_contact_form_shortcode_from_filtered_content() {
 		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
-		require_once JETPACK__PLUGIN_DIR . 'modules/contact-form/grunion-contact-form.php';
-
 		$this->post->post_content = '<p>This post has a contact form:[contact-form][contact-field label=\'Name\' type=\'name\' required=\'1\'/][/contact-form]</p>';
 
-		Grunion_Contact_Form_Plugin::init();
+		Contact_Form_Plugin::init();
 
 		wp_update_post( $this->post );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35654

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add deprecation warnings to the global functions, classes, public methods, and properties in the Contact Form module codebase. The code has been brought over to the Forms package.

This PR also updates some Jetpack plugin tests to reference the Forms package instead of the Contact Form module. Indeed, the deprecation warnings added to the module made many tests fail.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-Aj-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There's not much to test here.

- Spin up a test site with this branch
- Make sure you have access to the server logs
- Use the Contact Form module instead of the Forms package by ensuring the condition at this line is falsy: https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/modules/contact-form.php#L33
- Verify you see the deprecation warnings in the logs