### PR TITLE
Subscription Site: Prevent the Subscribe block from rendering when the Paywall block is visible

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-post-end-hide-restricted
+++ b/projects/plugins/jetpack/changelog/update-subscribe-post-end-hide-restricted
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscription Site: Do not render Subscribe Block after the post with restricted access

--- a/projects/plugins/jetpack/changelog/update-subscribe-post-end-hide-restricted
+++ b/projects/plugins/jetpack/changelog/update-subscribe-post-end-hide-restricted
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Subscription Site: Do not render Subscribe Block after the post with restricted access
+Subscription Site: Prevent the Subscribe block from rendering when the Paywall block is visible

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -8,7 +8,6 @@
 
 namespace Automattic\Jetpack\Extensions\Subscriptions;
 
-use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
 use Jetpack_Memberships;
 
 /**
@@ -60,19 +59,16 @@ class Jetpack_Subscription_Site {
 	}
 
 	/**
-	 * Returns true if post is accessible by everyone
+	 * Returns true if current user can view the post.
 	 *
 	 * @return bool
 	 */
-	protected function is_post_accessible_by_everyone() {
-		if (
-			! class_exists( 'Jetpack_Memberships' ) ||
-			! class_exists( 'Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service' )
-		) {
+	protected function user_can_view_post() {
+		if ( ! class_exists( 'Jetpack_Memberships' ) ) {
 			return true;
 		}
 
-		return Jetpack_Memberships::get_post_access_level() === Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY;
+		return Jetpack_Memberships::user_can_view_post();
 	}
 
 	/**
@@ -95,7 +91,7 @@ class Jetpack_Subscription_Site {
 						is_singular() &&
 						in_the_loop() &&
 						is_main_query() &&
-						$this->is_post_accessible_by_everyone()
+						$this->user_can_view_post()
 					) {
 						return $content . '
 	<!-- wp:group {"className":"wp-block-jetpack-subscriptions__subscribe_post_end","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
@@ -125,7 +121,7 @@ class Jetpack_Subscription_Site {
 				if (
 					$anchor_block === 'core/post-content' &&
 					$relative_position === 'after' &&
-					$this->is_post_accessible_by_everyone()
+					$this->user_can_view_post()
 				) {
 					$hooked_blocks[] = 'jetpack/subscriptions';
 				}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -65,7 +65,10 @@ class Jetpack_Subscription_Site {
 	 * @return bool
 	 */
 	protected function is_post_accessible_by_everyone() {
-		if ( ! class_exists( 'Jetpack_Memberships' ) || ! class_exists( 'Abstract_Token_Subscription_Service' ) ) {
+		if (
+			! class_exists( 'Jetpack_Memberships' ) ||
+			! class_exists( 'Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service' )
+		) {
 			return true;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -65,7 +65,7 @@ class Jetpack_Subscription_Site {
 	 * @return bool
 	 */
 	protected function is_post_accessible_by_everyone() {
-		if ( ! class_exists( 'Jetpack_Memberships' ) ) {
+		if ( ! class_exists( 'Jetpack_Memberships' ) || ! class_exists( 'Abstract_Token_Subscription_Service' ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/36021

## Proposed changes:

Prevents the Subscribe block from rendering when the Paywall block is visible.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites

- enable the Subscription Site feature by adding the following line to your `0-sandbox.php` file:
```php
add_filter( 'jetpack_subscription_site_enabled', '__return_true' );
```
- enable the Jetpack Newsletter Module
- go to Jetpack Newsletter Settings and enable automatic insertion of the Subscribe block at the end of each post

### Testing scenarios
- open a post with **Access: Everyone** and make sure the Subscribe block is visible
- open a post with **Access: Anyone subscribed** when **not** subscribed and make sure the Subscribe block is **not** visible
- open a post with **Access: Anyone subscribed** when subscribed and make sure the Subscribe block is visible
