### PR TITLE
Update my jetpack product statuses to be more feature based

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -27,7 +27,7 @@ const ProductCardsSection = () => {
 		videopress: VideopressCard,
 		// Stats card is shown in the <StatsSection/> component.
 		crm: CrmCard,
-		creator: CreatorCard,
+		creator: ! window?.myJetpackInitialState?.isAtomic ? CreatorCard : null,
 		social: SocialCard,
 		ai: AiCard,
 	};

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-product-statuses-for-atomic
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-product-statuses-for-atomic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed product plan checks on My Jetpack cards

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -14,7 +14,8 @@
 		"automattic/jetpack-plugins-installer": "@dev",
 		"automattic/jetpack-redirect": "@dev",
 		"automattic/jetpack-constants": "@dev",
-		"automattic/jetpack-plans": "@dev"
+		"automattic/jetpack-plans": "@dev",
+		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.1.0",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -225,6 +225,7 @@ class Initializer {
 				'isStatsModuleActive'    => $modules->is_active( 'stats' ),
 				'isUserFromKnownHost'    => self::is_user_from_known_host(),
 				'isCommercial'           => self::is_commercial_site(),
+				'isAtomic'               => ( new Status_Host() )->is_woa_site(),
 				'welcomeBanner'          => array(
 					'hasBeenDismissed' => \Jetpack_Options::get_option( 'dismissed_welcome_banner', false ),
 				),

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Boost product
+ * AI product
  *
  * @package my-jetpack
  */
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
@@ -310,24 +311,7 @@ class Jetpack_Ai extends Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
-		$purchases_data = Wpcom_Products::get_site_current_purchases();
-		if ( is_wp_error( $purchases_data ) ) {
-			return false;
-		}
-		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
-			foreach ( $purchases_data as $purchase ) {
-				if ( str_starts_with( $purchase->product_slug, static::get_wpcom_product_slug() ) ) {
-					return true;
-				}
-				if ( str_starts_with( $purchase->product_slug, static::get_wpcom_monthly_product_slug() ) ) {
-					return true;
-				}
-				if ( str_starts_with( $purchase->product_slug, static::get_wpcom_bi_yearly_product_slug() ) ) {
-					return true;
-				}
-			}
-		}
-		return false;
+		return Current_Plan::supports( 'ai-assistant', true );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
@@ -311,7 +310,7 @@ class Jetpack_Ai extends Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
-		return Current_Plan::supports( 'ai-assistant', true );
+		return static::does_site_have_feature( 'ai-assistant' );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -7,8 +7,10 @@
 
 namespace Automattic\Jetpack\My_Jetpack;
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Plugins_Installer;
+use Jetpack_Options;
 use WP_Error;
 
 /**
@@ -152,6 +154,47 @@ abstract class Product {
 			'class'                    => static::class,
 			'post_checkout_url'        => static::get_post_checkout_url(),
 		);
+	}
+
+	/**
+	 * Collect the site's active features
+	 *
+	 * @return WP_Error|null
+	 */
+	private static function get_site_features_from_wpcom() {
+		static $features = null;
+
+		if ( $features !== null ) {
+			return $features;
+		}
+
+		$site_id  = Jetpack_Options::get_option( 'id' );
+		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/features', $site_id ), '1.1' );
+
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return new WP_Error( 'site_features_fetch_failed' );
+		}
+
+		$body           = wp_remote_retrieve_body( $response );
+		$feature_return = json_decode( $body );
+		$features       = $feature_return->active;
+
+		return $features;
+	}
+
+	/**
+	 * Check to see if the site has a feature
+	 * This will check the features provided by the site plans and products (including free ones)
+	 *
+	 * @param string $feature - the feature to check for.
+	 * @return bool
+	 */
+	public static function does_site_have_feature( $feature = null ) {
+		if ( ! $feature ) {
+			return false;
+		}
+
+		return in_array( $feature, self::get_site_features_from_wpcom(), true );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -159,7 +159,7 @@ abstract class Product {
 	/**
 	 * Collect the site's active features
 	 *
-	 * @return WP_Error|null
+	 * @return WP_Error|array
 	 */
 	private static function get_site_features_from_wpcom() {
 		static $features = null;
@@ -189,12 +189,17 @@ abstract class Product {
 	 * @param string $feature - the feature to check for.
 	 * @return bool
 	 */
-	public static function does_site_have_feature( $feature = null ) {
+	public static function does_site_have_feature( $feature ) {
 		if ( ! $feature ) {
 			return false;
 		}
 
-		return in_array( $feature, self::get_site_features_from_wpcom(), true );
+		$features = self::get_site_features_from_wpcom();
+		if ( is_wp_error( $features ) ) {
+			return false;
+		}
+
+		return in_array( $feature, $features, true );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
-use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Status\Host;
@@ -147,7 +146,7 @@ class Social extends Hybrid_Product {
 		// For atomic sites, do a feature check to see if the republicize feature is available
 		// This feature is available by default on all Jetpack sites
 		if ( ( new Host() )->is_woa_site() ) {
-			Current_Plan::supports( 'republicize', true );
+			static::does_site_have_feature( 'republicize' );
 		}
 
 		$purchases_data = Wpcom_Products::get_site_current_purchases();

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -146,7 +146,7 @@ class Social extends Hybrid_Product {
 		// For atomic sites, do a feature check to see if the republicize feature is available
 		// This feature is available by default on all Jetpack sites
 		if ( ( new Host() )->is_woa_site() ) {
-			static::does_site_have_feature( 'republicize' );
+			return static::does_site_have_feature( 'republicize' );
 		}
 
 		$purchases_data = Wpcom_Products::get_site_current_purchases();

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -7,8 +7,10 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Class responsible for handling the Social product
@@ -133,6 +135,12 @@ class Social extends Hybrid_Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
+		// For atomic sites, do a feature check to see if the republicize feature is available
+		// This feature is available by default on all Jetpack sites
+		if ( ( new Host() )->is_woa_site() ) {
+			Current_Plan::supports( 'republicize', true );
+		}
+
 		$purchases_data = Wpcom_Products::get_site_current_purchases();
 		if ( is_wp_error( $purchases_data ) ) {
 			return false;

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\My_Jetpack\Products;
 use Automattic\Jetpack\My_Jetpack\Initializer;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
+use Automattic\Jetpack\Status\Host;
 use Jetpack_Options;
 
 /**
@@ -176,6 +177,11 @@ class Stats extends Module_Product {
 	 * @return boolean
 	 */
 	public static function is_upgradable() {
+		// For now, atomic sites with stats are not in a position to upgrade
+		if ( ( new Host() )->is_woa_site() ) {
+			return false;
+		}
+
 		$purchases_data = Wpcom_Products::get_site_current_purchases();
 		if ( ! is_wp_error( $purchases_data ) && is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
 			foreach ( $purchases_data as $purchase ) {

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -165,6 +165,6 @@ class Videopress extends Hybrid_Product {
 	 */
 	public static function has_required_plan() {
 		// using second argument `true` to force fetching from wpcom
-		return Current_Plan::supports( 'videopress-1tb-storage', true );
+		return Current_Plan::supports( 'videopress', true );
 	}
 }

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
-use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
@@ -173,7 +172,6 @@ class Videopress extends Hybrid_Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
-		// using second argument `true` to force fetching from wpcom
-		return Current_Plan::supports( 'videopress', true );
+		return static::does_site_have_feature( 'videopress' );
 	}
 }

--- a/projects/plugins/backup/changelog/update-my-jetpack-product-statuses-for-atomic
+++ b/projects/plugins/backup/changelog/update-my-jetpack-product-statuses-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1122,7 +1122,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2475331cc29709ee844d2f99340199e6e3fa0f00"
+                "reference": "ea2f370e41f9bb9c9711ac528f67ddfdc8b85f8a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1135,6 +1135,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {

--- a/projects/plugins/boost/changelog/update-my-jetpack-product-statuses-for-atomic
+++ b/projects/plugins/boost/changelog/update-my-jetpack-product-statuses-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1047,7 +1047,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2475331cc29709ee844d2f99340199e6e3fa0f00"
+                "reference": "ea2f370e41f9bb9c9711ac528f67ddfdc8b85f8a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1060,6 +1060,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-product-statuses-for-atomic
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-product-statuses-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1681,7 +1681,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "2475331cc29709ee844d2f99340199e6e3fa0f00"
+				"reference": "ea2f370e41f9bb9c9711ac528f67ddfdc8b85f8a"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1694,6 +1694,7 @@
 				"automattic/jetpack-plans": "@dev",
 				"automattic/jetpack-plugins-installer": "@dev",
 				"automattic/jetpack-redirect": "@dev",
+				"automattic/jetpack-status": "@dev",
 				"php": ">=7.0"
 			},
 			"require-dev": {

--- a/projects/plugins/migration/changelog/update-my-jetpack-product-statuses-for-atomic
+++ b/projects/plugins/migration/changelog/update-my-jetpack-product-statuses-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1122,7 +1122,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2475331cc29709ee844d2f99340199e6e3fa0f00"
+                "reference": "ea2f370e41f9bb9c9711ac528f67ddfdc8b85f8a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1135,6 +1135,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {

--- a/projects/plugins/protect/changelog/update-my-jetpack-product-statuses-for-atomic
+++ b/projects/plugins/protect/changelog/update-my-jetpack-product-statuses-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1035,7 +1035,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2475331cc29709ee844d2f99340199e6e3fa0f00"
+                "reference": "ea2f370e41f9bb9c9711ac528f67ddfdc8b85f8a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1048,6 +1048,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {

--- a/projects/plugins/search/changelog/update-my-jetpack-product-statuses-for-atomic
+++ b/projects/plugins/search/changelog/update-my-jetpack-product-statuses-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2475331cc29709ee844d2f99340199e6e3fa0f00"
+                "reference": "ea2f370e41f9bb9c9711ac528f67ddfdc8b85f8a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -991,6 +991,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {

--- a/projects/plugins/social/changelog/update-my-jetpack-product-statuses-for-atomic
+++ b/projects/plugins/social/changelog/update-my-jetpack-product-statuses-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -978,7 +978,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "2475331cc29709ee844d2f99340199e6e3fa0f00"
+				"reference": "ea2f370e41f9bb9c9711ac528f67ddfdc8b85f8a"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -991,6 +991,7 @@
 				"automattic/jetpack-plans": "@dev",
 				"automattic/jetpack-plugins-installer": "@dev",
 				"automattic/jetpack-redirect": "@dev",
+				"automattic/jetpack-status": "@dev",
 				"php": ">=7.0"
 			},
 			"require-dev": {

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-product-statuses-for-atomic
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-product-statuses-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2475331cc29709ee844d2f99340199e6e3fa0f00"
+                "reference": "ea2f370e41f9bb9c9711ac528f67ddfdc8b85f8a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -991,6 +991,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {

--- a/projects/plugins/videopress/changelog/update-my-jetpack-product-statuses-for-atomic
+++ b/projects/plugins/videopress/changelog/update-my-jetpack-product-statuses-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2475331cc29709ee844d2f99340199e6e3fa0f00"
+                "reference": "ea2f370e41f9bb9c9711ac528f67ddfdc8b85f8a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -991,6 +991,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates how some My Jetpack products perform plan checks to be more compatible with WordPress.com plan types - this is done by leveraging feature checks. Specifically, we are checking for features to determine if VideoPress, Social and AI are enabled in certain contexts.
* This PR hides the "Upgrade" button for the stats My Jetpack card on Atomic
* This PR removes the Creator card from My Jetpack on Atomic

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pfsHM7-ix-p2#comment-437

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test this PR on a self-hosted Jetpack site, make sure the product active and inactive states still make sesne
* Test specifically VideoPress, AI and Social to make sure that free activation and purchases still work as expected and that the cards show as 'inactive' still when the feature/plan is absent.
* Test this on a WPCOM Atomic site with a Creator plan. You should have Backup, Protect, Social, VideoPress, Akismet, AI and Search all "Active" or "Needs Plugin" without any further action or purchase. Note that for Social and Protect to work properly, the site needs to be set to "Public" (see: p9o2xV-1r2-p2 for info on setting up a test Atomic site)
* The Atomic site should not show the Creator card
* The Atomic site should also not show an upgrade button for stats

![Screenshot 2024-02-29 at 12 09 18 PM](https://github.com/Automattic/jetpack/assets/18016357/5c8a9c38-e7a9-4773-b88e-65af90aa6ee6)