### PR TITLE
CRM: 742 - allow floats in numeric comparisons

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-ext-784-allow_floats_in_numeric_comparisons
+++ b/projects/plugins/crm/changelog/fix-crm-ext-784-allow_floats_in_numeric_comparisons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Segments: Allow floats in all numeric segment conditions.

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.segmentedit.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.segmentedit.js
@@ -488,7 +488,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 				case 'istrue':
 				case 'isfalse':
 					html += '<input type="hidden" class="zbs-segment-edit-var-condition-value" value="1" />';
-
 					break;
 
 				case 'equal':
@@ -522,7 +521,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 							jpcrm.esc_attr( v ) +
 							'" />';
 					}
-
 					break;
 
 				case 'contains':
@@ -533,7 +531,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 						'" value="' +
 						jpcrm.esc_attr( v ) +
 						'" />';
-
 					break;
 
 				case 'larger':
@@ -546,7 +543,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 						'<input type="text" class="zbs-segment-edit-var-condition-value jpcrm-inputmask-int" value="' +
 						jpcrm.esc_attr( v ) +
 						'" />';
-
 					break;
 
 				case 'before':
@@ -555,7 +551,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 						'<input type="text" class="jpcrm-date-time zbs-segment-edit-var-condition-value" data-date-picker-format="YYYY-MM-DD HH:mm" value="' +
 						jpcrm.esc_attr( v ) +
 						'" />';
-
 					break;
 
 				case 'beforeequal':
@@ -564,7 +559,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 						'<input type="text" class="jpcrm-date zbs-segment-edit-var-condition-value" data-date-picker-format="YYYY-MM-DD" value="' +
 						jpcrm.esc_attr( v ) +
 						'" />';
-
 					break;
 
 				case 'daterange':
@@ -577,7 +571,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 						'<input type="text" class="jpcrm-date-range zbs-segment-edit-var-condition-value" data-date-picker-format="YYYY-MM-DD" value="' +
 						date_value +
 						'" />';
-
 					break;
 
 				case 'datetimerange':
@@ -590,7 +583,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 						'<input type="text" class="jpcrm-datetime-range zbs-segment-edit-var-condition-value" data-date-picker-format="YYYY-MM-DD HH:mm" value="' +
 						date_value +
 						'" />';
-
 					break;
 
 				case 'floatrange':
@@ -610,7 +602,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 						'" placeholder="' +
 						zeroBSCRMJS_segmentLang( 'eg' ) +
 						' 100.00" />';
-
 					break;
 
 				case 'intrange':
@@ -630,7 +621,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 						'" placeholder="' +
 						zeroBSCRMJS_segmentLang( 'eg' ) +
 						' 100" />';
-
 					break;
 
 				case 'tag':
@@ -653,7 +643,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 					}
 
 					html += '</select>';
-
 					break;
 
 				// transaction tags
@@ -677,7 +666,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 					}
 
 					html += '</select>';
-
 					break;
 
 				case 'extsource':
@@ -700,7 +688,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 					}
 
 					html += '</select>';
-
 					break;
 
 				case 'mailpoet_status':
@@ -725,7 +712,6 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 					}
 
 					html += '</select>';
-
 					break;
 			}
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.segmentedit.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.segmentedit.js
@@ -592,27 +592,9 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 					break;
 
 				case 'floatrange':
-					html +=
-						'<input type="text" class="zbs-float zbs-segment-edit-var-condition-value zbs-segment-pair-input jpcrm-inputmask-float' +
-						inputmask_class +
-						'" value="' +
-						jpcrm.esc_attr( v ) +
-						'" placeholder="' +
-						zeroBSCRMJS_segmentLang( 'eg' ) +
-						' 0.00" />';
-					html +=
-						'<span>' +
-						zeroBSCRMJS_segmentLang( 'to' ) +
-						'</span><input type="text" class="zbs-float zbs-segment-edit-var-condition-value-2 zbs-segment-pair-input jpcrm-inputmask-float" value="' +
-						jpcrm.esc_attr( v2 ) +
-						'" placeholder="' +
-						zeroBSCRMJS_segmentLang( 'eg' ) +
-						' 100.00" />';
-					break;
-
 				case 'intrange':
 					html +=
-						'<input type="text" class="zbs-int zbs-segment-edit-var-condition-value zbs-segment-pair-input jpcrm-inputmask-int' +
+						'<input type="text" class="zbs-float zbs-segment-edit-var-condition-value zbs-segment-pair-input jpcrm-inputmask-float' +
 						inputmask_class +
 						'" value="' +
 						jpcrm.esc_attr( v ) +
@@ -622,7 +604,7 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 					html +=
 						'<span>' +
 						zeroBSCRMJS_segmentLang( 'to' ) +
-						'</span><input type="text" class="zbs-int zbs-segment-edit-var-condition-value-2 zbs-segment-pair-input jpcrm-inputmask-int" value="' +
+						'</span><input type="text" class="zbs-float zbs-segment-edit-var-condition-value-2 zbs-segment-pair-input jpcrm-inputmask-float" value="' +
 						jpcrm.esc_attr( v2 ) +
 						'" placeholder="' +
 						zeroBSCRMJS_segmentLang( 'eg' ) +

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.segmentedit.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.segmentedit.js
@@ -537,6 +537,12 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 				case 'less':
 				case 'largerequal':
 				case 'lessequal':
+					html +=
+						'<input type="text" class="zbs-segment-edit-var-condition-value jpcrm-inputmask-float" value="' +
+						jpcrm.esc_attr( v ) +
+						'" />';
+						break;
+
 				case 'nextdays':
 				case 'previousdays':
 					html +=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: 742 - allow floats in numeric comparisons

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This addresses some issues with numeric operator issues found when exploring Automattic/jetpack-crm-extensions#742. Specifically, this PR removes some over-zealous input masks when inputting segment values.

Basically we now allow one to use floats when using a range on `numeric` custom fields as well as with these operators: `<`, `>`, `<=`, `>=`

Before it was only possible on `numeric (decimal)` custom fields when using a range. There's really no need to restrict this.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Verify one can input and use float values within the range and `<`, `>`, `<=`, and `>=` operators with `numeric` custom fields.