### PR TITLE
Stats: link to Odyssey Stats from Jetpack Dashboard

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -96,16 +96,15 @@ class DashStatsBottom extends Component {
 					<div className="jp-at-a-glance__stats-ctas">
 						{
 							// Only show link for non-atomic Jetpack sites.
-							! this.props.isWoASite &&
-								createInterpolateElement( __( '<button>View detailed stats</button>', 'jetpack' ), {
-									button: (
-										<Button
-											href={ this.props.siteAdminUrl + 'admin.php?page=stats' }
-											onClick={ this.trackViewDetailedStats }
-											primary
-										/>
-									),
-								} )
+							createInterpolateElement( __( '<button>View detailed stats</button>', 'jetpack' ), {
+								button: (
+									<Button
+										href={ this.props.siteAdminUrl + 'admin.php?page=stats' }
+										onClick={ this.trackViewDetailedStats }
+										primary
+									/>
+								),
+							} )
 						}
 						{ ! this.props.isLinked && this.props.userCanConnectAccount && (
 							<ConnectButton

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -43,17 +43,14 @@ export class DashStats extends Component {
 	}
 
 	shouldLinkToWpcomStats() {
-		return ! this.props.isOdysseyStatsEnabled || this.props.isAtomicSite;
+		return ! this.props.isOdysseyStatsEnabled;
 	}
 
 	barClick = bar => {
 		if ( bar.data.link ) {
 			analytics.tracks.recordJetpackClick( 'stats_bar' );
 			// Open the link in the same tab if the user has Odyssey enabled or is on at Atomic site.
-			window.open(
-				bar.data.link,
-				this.props.isOdysseyStatsEnabled || this.props.isAtomicSite ? '_self' : '_blank'
-			);
+			window.open( bar.data.link, this.props.isOdysseyStatsEnabled ? '_self' : '_blank' );
 		}
 	};
 

--- a/projects/plugins/jetpack/changelog/update-link-to-odyssey-stats-from-jetpack-dashboard
+++ b/projects/plugins/jetpack/changelog/update-link-to-odyssey-stats-from-jetpack-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Dashboard: link to Odyssey Stats for Atomic sites


### PR DESCRIPTION
## Proposed changes:

Odyssey Stats is enabled for Atomic sites: https://github.com/Automattic/jetpack/pull/35528

- Link to Odyssey Stats for Atomic sites
- Show 'View detailed stats' button for Atomic sites

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:


* Install Jetpack Beta on an Atomic site
* Enable Jetpack bleeding edge from Jetpack Beta
* Open `/wp-admin/admin.php?page=jetpack#/dashboard`
* Ensure the bars and button link to Odyssey Stats (Jetpack Stats in WP-Admin)


![image](https://github.com/Automattic/jetpack/assets/1425433/0f5e1ea1-d941-4544-bc25-0d5db829e94a)


