### PR TITLE
Revert "Admin Bar: Link Stats to Calypso"

### DIFF
--- a/projects/plugins/jetpack/changelog/revert-35435-fix-admin-bar-stats-link
+++ b/projects/plugins/jetpack/changelog/revert-35435-fix-admin-bar-stats-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Stats: link to Odyssey Stats from admin bar

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -27,7 +27,6 @@ use Automattic\Jetpack\Stats\XMLRPC_Provider as Stats_XMLRPC;
 use Automattic\Jetpack\Stats_Admin\Dashboard as Stats_Dashboard;
 use Automattic\Jetpack\Stats_Admin\Main as Stats_Main;
 use Automattic\Jetpack\Stats_Admin\Notices as Stats_Notices;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Tracking;
 
@@ -1002,11 +1001,10 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 	$img_src_2x = esc_attr( stats_get_image_chart_src( 'admin-bar-hours-scale-2x' ) );
 	$alt        = esc_attr( __( 'Stats', 'jetpack' ) );
 	$title      = esc_attr( __( 'Views over 48 hours. Click for more Jetpack Stats.', 'jetpack' ) );
-	$site_slug  = ( new Status() )->get_site_suffix();
 
 	$menu = array(
 		'id'    => 'stats',
-		'href'  => esc_url( 'https://wordpress.com/stats/day/' . $site_slug ),
+		'href'  => add_query_arg( 'page', 'stats', admin_url( 'admin.php' ) ), // no menu_page_url() blog-side.
 		'title' => "<div><img src='$img_src' srcset='$img_src 1x, $img_src_2x 2x' width='112' height='24' alt='$alt' title='$title'></div>",
 	);
 


### PR DESCRIPTION
Reverts Automattic/jetpack#35435

## Proposed changes:

Odyssey Stats is enabled for Atomic sites: https://github.com/Automattic/jetpack/pull/35528, so we are now reverting the change to redirect user to Stats within WP-Admin.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Install Jetpack Beta on an Atomic site
* Enable `revert-35435-fix/admin-bar-stats-link` from Jetpack Beta
* Open Home page on the frontend
* Click the tiny chart in the Admin bar
* Ensure you are taken to Odyssey Stats

![image](https://github.com/Automattic/jetpack/assets/1425433/1a8b55b2-446e-49bf-9b46-784652d66e68)


