### PR TITLE
[Boost] Fix E2E tests

### DIFF
--- a/projects/js-packages/react-data-sync-client/changelog/boost-fix-e2e-tests
+++ b/projects/js-packages/react-data-sync-client/changelog/boost-fix-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Internal fix: e2e tests
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Over the past week, Jetpack's E2E tests were broken due to some dependency in Jetpack Backups. While we kept on working on other things, our E2E tests broke but we couldn't tell. This fixes them.

The problem: DataSync action mutationKeys have to be the same as the querykey of the data sync store they are mutating, because that allows the action result to update the original sync store.

The caused the critical CSS status to fail to update when it should, to trigger a regenerate.

## Proposed changes:
* Revert DataSync mutationKeys to the queryKey.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
no

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Make sure E2E tests pass :)