### PR TITLE
Boost: Add tracks

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -10,7 +10,7 @@ class Page_Cache_Setup {
 
 	/**
 	 * Runs setup steps and returns whether setup was successful or not.
-	 * @return bool
+	 * @return bool|\WP_Error
 	 */
 	public static function run_setup() {
 		$steps = array(
@@ -54,7 +54,7 @@ class Page_Cache_Setup {
 		$result   = file_put_contents( $filename, 'test' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		wp_delete_file( $filename );
 
-		if ( $result === false ) {
+		if ( $result !== false ) {
 			return new \WP_Error( 'wp-content-not-writable', 'wp-content directory is not writeable' );
 		}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -54,7 +54,7 @@ class Page_Cache_Setup {
 		$result   = file_put_contents( $filename, 'test' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		wp_delete_file( $filename );
 
-		if ( $result !== false ) {
+		if ( $result === false ) {
 			return new \WP_Error( 'wp-content-not-writable', 'wp-content directory is not writeable' );
 		}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/data-sync-actions/run-setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/data-sync-actions/run-setup.php
@@ -21,10 +21,13 @@ class Run_Setup implements Data_Sync_Action {
 	 */
 	public function handle( $_data, $_request ) {
 		$setup_result = Page_Cache_Setup::run_setup();
+
 		if ( is_wp_error( $setup_result ) ) {
 			Analytics::record_user_event( 'page_cache_setup_failed', array( 'error_code' => $setup_result->get_error_code() ) );
 			return $setup_result;
 		}
+
+		Analytics::record_user_event( 'page_cache_setup_succeeded' );
 
 		Garbage_Collection::activate();
 		Boost_Cache_Settings::get_instance()->set( array( 'enabled' => true ) );

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/data-sync-actions/run-setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/data-sync-actions/run-setup.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Data_Sync_Actions;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Data_Sync_Action;
+use Automattic\Jetpack_Boost\Lib\Analytics;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Garbage_Collection;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache_Setup;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
@@ -21,6 +22,7 @@ class Run_Setup implements Data_Sync_Action {
 	public function handle( $_data, $_request ) {
 		$setup_result = Page_Cache_Setup::run_setup();
 		if ( is_wp_error( $setup_result ) ) {
+			Analytics::record_user_event( 'page_cache_setup_failed', array( 'error_code' => $setup_result->get_error_code() ) );
 			return $setup_result;
 		}
 

--- a/projects/plugins/boost/changelog/boost-cache-tracks
+++ b/projects/plugins/boost/changelog/boost-cache-tracks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added tracking events for result of cache setup
+
+


### PR DESCRIPTION
Fixes #35891

## Proposed changes:
* Add tracks for when setup fails
* Add tracks for when setup suceeds
* There is already tracks events for module toggle.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Purposefully fail setup on any step
* Check to see if tracks events are recorded `jetpack_boost_page_cache_setup_failed`
* Make it succeed
* Check to see if tracks events are recorded `jetpack_boost_page_cache_setup_succeeded`

