### PR TITLE
Jetpack 13.2: move blocks from beta to production: blog-stats, top-posts, goodreads

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jp-13.2-prod-blocks
+++ b/projects/plugins/jetpack/changelog/update-jp-13.2-prod-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Move blocks from beta to production: blog-stats, top-posts, goodreads

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -61,18 +61,18 @@
 		"ai-assistant-usage-panel",
 		"sharing-button",
 		"sharing-buttons",
-		"ai-content-lens"
+		"ai-content-lens",
+		"blog-stats",
+		"top-posts",
+		"goodreads"
 	],
 	"beta": [
 		"google-docs-embed",
 		"launchpad-save-modal",
 		"recipe",
-		"goodreads",
 		"v6-video-frame-poster",
 		"videopress/video-chapters",
 		"voice-to-content",
-		"blog-stats",
-		"top-posts",
 		"ai-assistant-backend-prompts",
 		"ai-logo-generator"
 	],


### PR DESCRIPTION
Fixes #35436
Fixes #32937

## Proposed changes:

Move blocks from beta to production: blog-stats, top-posts, goodreads

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

These blocks are being tested internally for Jetpack 13.2: p8oabR-1t3-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread. 