### PR TITLE
Goodreads Block: Fix Styles Inherited from Legacy Widget

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-goodreads-styles
+++ b/projects/plugins/jetpack/changelog/fix-goodreads-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Goodreads Block: Fix block inheriting styles from Legacy Widget.

--- a/projects/plugins/jetpack/modules/widgets/goodreads.php
+++ b/projects/plugins/jetpack/modules/widgets/goodreads.php
@@ -128,7 +128,7 @@ class WPCOM_Widget_Goodreads extends WP_Widget {
 
 		$goodreads_url = 'https://www.goodreads.com/review/custom_widget/' . rawurlencode( $instance['user_id'] ) . '.' . rawurlencode( $instance['title'] ) . ':%20' . rawurlencode( $instance['shelf'] ) . '?cover_position=&cover_size=small&num_books=5&order=d&shelf=' . rawurlencode( $instance['shelf'] ) . '&sort=date_added&widget_bg_transparent=&widget_id=' . rawurlencode( $this->goodreads_widget_id );
 
-		echo '<div class="gr_custom_widget" id="gr_custom_widget_' . esc_attr( $this->goodreads_widget_id ) . '"></div>' . "\n";
+		echo '<div class="jetpack-goodreads-legacy-widget gr_custom_widget" id="gr_custom_widget_' . esc_attr( $this->goodreads_widget_id ) . '"></div>' . "\n";
 		echo '<script src="' . esc_url( $goodreads_url ) . '"></script>' . "\n"; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 
 		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/projects/plugins/jetpack/modules/widgets/goodreads/css/goodreads.css
+++ b/projects/plugins/jetpack/modules/widgets/goodreads/css/goodreads.css
@@ -1,4 +1,4 @@
-div[class^="gr_custom_container"] {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_container"] {
 	/* customize your Goodreads widget container here*/
 	border: 1px solid gray;
 	border-radius:10px;
@@ -7,16 +7,16 @@ div[class^="gr_custom_container"] {
 	color: #000;
 }
 
-div[class^="gr_custom_container"] a {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_container"] a {
 	color: #000;
 }
 
-h2[class^="gr_custom_header"] {
+.jetpack-goodreads-legacy-widget h2[class^="gr_custom_header"] {
 	/* customize your Goodreads header here*/
 	display: none;
 }
-div[class^="gr_custom_each_container"] {
-	/* customize each individual book container here */
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_each_container"] {
+	/* customize each in.jetpack-goodreads-legacy-widget dividual book container here */
 	width: 100%;
 	clear: both;
 	margin-bottom: 10px;
@@ -24,7 +24,7 @@ div[class^="gr_custom_each_container"] {
 	padding-bottom: 4px;
 	border-bottom: 1px solid #a7aaad;
 }
-div[class^="gr_custom_book_container"] {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_book_container"] {
 	/* customize your book covers here */
 	float: right;
 	overflow: hidden;
@@ -32,17 +32,16 @@ div[class^="gr_custom_book_container"] {
 	margin-left: 4px;
 	width: 39px;
 }
-div[class^="gr_custom_author"] {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_author"] {
 	/* customize your author names here */
 	font-size: 10px;
 }
-div[class^="gr_custom_tags"] {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_tags"] {
 	/* customize your tags here */
 	font-size: 10px;
 	color: gray;
 }
-div[class^="gr_custom_review"] {
-}
-div[class^="gr_custom_rating"] {
+
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_rating"] {
 	display: none;
 }

--- a/projects/plugins/jetpack/modules/widgets/goodreads/css/goodreads.css
+++ b/projects/plugins/jetpack/modules/widgets/goodreads/css/goodreads.css
@@ -16,7 +16,7 @@
 	display: none;
 }
 .jetpack-goodreads-legacy-widget div[class^="gr_custom_each_container"] {
-	/* customize each in.jetpack-goodreads-legacy-widget dividual book container here */
+	/* customize each individual book container here */
 	width: 100%;
 	clear: both;
 	margin-bottom: 10px;

--- a/projects/plugins/jetpack/modules/widgets/goodreads/css/rtl/goodreads-rtl.css
+++ b/projects/plugins/jetpack/modules/widgets/goodreads/css/rtl/goodreads-rtl.css
@@ -1,6 +1,6 @@
 /* This file was automatically generated on Nov 19 2013 15:54:57 */
 
-div[class^="gr_custom_container"] {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_container"] {
 	/* customize your Goodreads widget container here*/
 	border: 1px solid gray;
 	border-radius:10px;
@@ -9,15 +9,15 @@ div[class^="gr_custom_container"] {
 	color: #000;
 }
 
-div[class^="gr_custom_container"] a {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_container"] a {
 	color: #000;
 }
 
-h2[class^="gr_custom_header"] {
+.jetpack-goodreads-legacy-widget h2[class^="gr_custom_header"] {
 	/* customize your Goodreads header here*/
 	display: none;
 }
-div[class^="gr_custom_each_container"] {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_each_container"] {
 	/* customize each individual book container here */
 	width: 100%;
 	clear: both;
@@ -26,7 +26,7 @@ div[class^="gr_custom_each_container"] {
 	padding-bottom: 4px;
 	border-bottom: 1px solid #aaa;
 }
-div[class^="gr_custom_book_container"] {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_book_container"] {
 	/* customize your book covers here */
 	float: left;
 	overflow: hidden;
@@ -34,17 +34,15 @@ div[class^="gr_custom_book_container"] {
 	margin-right: 4px;
 	width: 39px;
 }
-div[class^="gr_custom_author"] {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_author"] {
 	/* customize your author names here */
 	font-size: 10px;
 }
-div[class^="gr_custom_tags"] {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_tags"] {
 	/* customize your tags here */
 	font-size: 10px;
 	color: gray;
 }
-div[class^="gr_custom_review"] {
-}
-div[class^="gr_custom_rating"] {
+.jetpack-goodreads-legacy-widget div[class^="gr_custom_rating"] {
 	display: none;
 }


### PR DESCRIPTION
Fixes #36055

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
I was going to add a transform from the Legacy Widget at the same time, but thought it might be easier to review if I split them up. This prevents styles for the Goodreads block from being inherited from the Legacy Widget. The widget forces options upon the user, hence the styling, whereas the block gives them more control. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See original issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

* Add a Legacy Widget - you'll need to remove this line to do so
https://github.com/Automattic/jetpack/blob/37300ce811d57955115df59d62ed5b35ca3b4cff/projects/plugins/jetpack/modules/widgets/goodreads.php#L50

* Save the widget, and add a Goodreads block to the same page. You'll need to enable Beta blocks to do this.
* Ensure the block is set to show ratings in the Block Settings.
* Confirm that the ratings now appear, whereas the widget styles would previously have hid them.
 
