### PR TITLE
Goodreads Block: Add Transform from Legacy Widget

### DIFF
--- a/projects/plugins/jetpack/changelog/update-goodreads-widget
+++ b/projects/plugins/jetpack/changelog/update-goodreads-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Goodreads Block: Add transform from Legacy Widget.

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/edit.js
@@ -30,6 +30,12 @@ const GoodreadsEdit = props => {
 				setErrorNotice();
 			}
 
+			// Applies when transforming from Legacy Widget,
+			// in which case goodreadsId is already known.
+			if ( attributes.goodreadsId ) {
+				setRequestLink();
+			}
+
 			if ( goodreadsUserId && ! isError ) {
 				setAttributes( { goodreadsId: goodreadsUserId } );
 				setRequestLink();

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/editor.js
@@ -1,3 +1,4 @@
+import { createBlock } from '@wordpress/blocks';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
 import edit from './edit';
@@ -6,4 +7,28 @@ import save from './save';
 registerJetpackBlockFromMetadata( metadata, {
 	edit,
 	save,
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/legacy-widget' ],
+				isMatch: ( { idBase, instance } ) => {
+					if ( ! instance?.raw ) {
+						return false;
+					}
+
+					return idBase === 'wpcom-goodreads';
+				},
+				transform: ( { instance } ) => {
+					return createBlock( 'jetpack/goodreads', {
+						customTitle: instance.raw.title,
+						goodreadsId: parseInt( instance.raw.user_id ),
+						shelfOption: instance.raw.shelf,
+						showRating: false,
+						widgetId: Math.floor( Math.random() * 9999999 ),
+					} );
+				},
+			},
+		],
+	},
 } );

--- a/projects/plugins/jetpack/modules/widgets/goodreads.php
+++ b/projects/plugins/jetpack/modules/widgets/goodreads.php
@@ -35,6 +35,7 @@ class WPCOM_Widget_Goodreads extends WP_Widget {
 				'classname'                   => 'widget_goodreads',
 				'description'                 => __( 'Display your books from Goodreads', 'jetpack' ),
 				'customize_selective_refresh' => true,
+				'show_instance_in_rest'       => true,
 			)
 		);
 		// For user input sanitization and display.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enables users to easily transform the Legacy Widget into a block, which has more options. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add a Legacy Widget - you'll need to remove this line to do so
https://github.com/Automattic/jetpack/blob/37300ce811d57955115df59d62ed5b35ca3b4cff/projects/plugins/jetpack/modules/widgets/goodreads.php#L50

You'll need to add a user ID and click out of the widget to save it - you could use 1176283 for this.

Then confirm that the transform to the block works by clicking the Calendar icon and selecting "Goodreads".

<img width="697" alt="Screenshot 2024-02-29 at 09 04 20" src="https://github.com/Automattic/jetpack/assets/43215253/7ed33952-ff0e-4278-a66e-fe0556f22909">

