### PR TITLE
Boost: Fix cache translations

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -55,7 +55,7 @@ class Page_Cache_Setup {
 		wp_delete_file( $filename );
 
 		if ( $result === false ) {
-			return new \WP_Error( 'wp-content-not-writable', 'wp-content directory is not writeable' );
+			return new \WP_Error( 'wp-content-not-writable' );
 		}
 
 		return true;
@@ -68,7 +68,7 @@ class Page_Cache_Setup {
 		global $wp_rewrite;
 
 		if ( ! $wp_rewrite || ! $wp_rewrite->using_permalinks() ) {
-			return new \WP_Error( 'not-using-permalinks', 'This site does not appear to use permalinks' );
+			return new \WP_Error( 'not-using-permalinks' );
 		}
 	}
 
@@ -96,11 +96,11 @@ class Page_Cache_Setup {
 			$content = file_get_contents( $advanced_cache_filename ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
 			if ( strpos( $content, 'WP SUPER CACHE' ) !== false ) {
-				return new \WP_Error( 'advanced-cache-for-super-cache', 'advanced-cache.php exists, but belongs to WP Super Cache.' );
+				return new \WP_Error( 'advanced-cache-for-super-cache' );
 			}
 
 			if ( strpos( $content, Page_Cache::ADVANCED_CACHE_SIGNATURE ) === false ) {
-				return new \WP_Error( 'advanced-cache-incompatible', 'advanced-cache.php exists, but belongs to another plugin/system.' );
+				return new \WP_Error( 'advanced-cache-incompatible' );
 			}
 
 			if ( strpos( $content, Page_Cache::ADVANCED_CACHE_VERSION ) !== false ) {
@@ -112,7 +112,7 @@ class Page_Cache_Setup {
 		$plugin_dir_name      = untrailingslashit( str_replace( JETPACK_BOOST_PLUGIN_FILENAME, '', JETPACK_BOOST_PLUGIN_BASE ) );
 		$boost_cache_filename = WP_CONTENT_DIR . '/plugins/' . $plugin_dir_name . '/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php';
 		if ( ! file_exists( $boost_cache_filename ) ) {
-			return new \WP_Error( 'boost-cache-file-not-found', 'Boost_Cache.php not found' );
+			return new \WP_Error( 'boost-cache-file-not-found' );
 		}
 		$contents = '<?php
 // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE . ' - ' . Page_Cache::ADVANCED_CACHE_VERSION . '
@@ -127,7 +127,7 @@ $boost_cache->serve();
 
 		$write_advanced_cache = Filesystem_Utils::write_to_file( $advanced_cache_filename, $contents );
 		if ( $write_advanced_cache instanceof Boost_Cache_Error ) {
-			return new \WP_Error( 'unable-to-write-to-advanced-cache', $write_advanced_cache->get_error_message() );
+			return new \WP_Error( 'unable-to-write-to-advanced-cache', $write_advanced_cache->get_error_code() );
 		}
 
 		if ( function_exists( 'opcache_invalidate' ) ) {
@@ -151,7 +151,7 @@ $boost_cache->serve();
 			 * in wp-config.php.
 			 */
 			if ( defined( 'WP_CACHE' ) && ! WP_CACHE ) {
-				return new \WP_Error( 'wp-cache-defined-not-true', 'WP_CACHE is defined but not true' );
+				return new \WP_Error( 'wp-cache-defined-not-true' );
 			}
 
 			return true; // WP_CACHE already added.
@@ -165,7 +165,7 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 
 		$result = file_put_contents( ABSPATH . 'wp-config.php', $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		if ( $result === false ) {
-			return new \WP_Error( 'wp-config-not-writable', 'Could not write to wp-config.php' );
+			return new \WP_Error( 'wp-config-not-writable' );
 		}
 
 		if ( function_exists( 'opcache_invalidate' ) ) {

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
@@ -19,17 +19,17 @@ class Filesystem_Utils {
 		$path = realpath( $path );
 		if ( ! $path ) {
 			// translators: %s is the directory that does not exist.
-			return new Boost_Cache_Error( 'directory-missing', sprintf( __( 'Directory does not exist: %s', 'jetpack-boost' ), $path ) ); // realpath returns false if a file does not exist.
+			return new Boost_Cache_Error( 'directory-missing', 'Directory does not exist: ' . $path ); // realpath returns false if a file does not exist.
 		}
 
 		// make sure that $dir is a directory inside WP_CONTENT . '/boost-cache/';
 		if ( self::is_boost_cache_directory( $path ) === false ) {
 			// translators: %s is the directory that is invalid.
-			return new Boost_Cache_Error( 'invalid-directory', sprintf( __( 'Invalid directory %s', 'jetpack-boost' ), $path ) );
+			return new Boost_Cache_Error( 'invalid-directory', 'Invalid directory %s' . $path );
 		}
 
 		if ( ! is_dir( $path ) ) {
-			return new Boost_Cache_Error( 'not-a-directory', __( 'Not a directory', 'jetpack-boost' ) );
+			return new Boost_Cache_Error( 'not-a-directory', 'Not a directory' );
 		}
 
 		switch ( $type ) {

--- a/projects/plugins/boost/changelog/fix-cache-translations
+++ b/projects/plugins/boost/changelog/fix-cache-translations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updates related to translatable strings
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35855

I ended up removing translations instead of adding them. I found that we don't have any messages displayed to users that aren't translated. But, there were some `__()` calls on pre-wordpress files. The code-path wouldn't fail. But, I still decided to remove the translation calls as those errors were not being displayed to user.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove localization from pre-wordpress files
* Remove error strings that aren't used

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure cache related strings still have messages shown where required


