### PR TITLE
Add wp-cron.php to Jetpack Monitor

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-cron
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-cron
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Scheduled Updates: add wp-cron.php to Jetpack Monitor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5702

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `wp-cron.php` to Jetpack Monitor after the creation of a new scheduled update

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jetpack Beta
* In `/wp-admin/admin.php?page=jetpack-beta` select for `WordPress.com Features` `add/scheduled-updates-cron`
* Install https://wordpress.org/plugins/rest-api-console
* Install one plugin

From https://developer.wordpress.com/docs/api/console/ `/wpcom/v2/sites/__BLOG__/jetpack-monitor-settings`. It should output something similar to:
```
{
  "success": true,
  "settings": {
    "monitor_active": false,
    "email_notifications": true,
    "sms_notifications": false,
    "wp_note_notifications": true,
    "urls": [],
    "contacts": {
      "emails": [],
      "sms_numbers": []
    }
  }
}
```

In your blog REST API console call `/wp-admin/tools.php?page=rest_api_console`
```
POST /wpcom/v2/update-schedules
{
    "plugins": [
        "w.org/plugins/__YOUR_PLUGIN__"
    ],
    "schedule": {
        "timestamp": 2709157674,
        "interval": "weekly"
    }
}
```

Now you should see `__BLOG__/wp-cron.php` in the `urls` field of `/wpcom/v2/sites/__BLOG__/jetpack-monitor-settings` with 5 seconds. And that endpoint will be pinged every 5 minutes.