### PR TITLE
Social: Fix og:title having a word break for the Social Note CPT

### DIFF
--- a/projects/plugins/social/changelog/fix-og-title-word-break
+++ b/projects/plugins/social/changelog/fix-og-title-word-break
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed og:title having word-breaks.

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -238,6 +238,26 @@ class Meta_Tags {
 	}
 
 	/**
+	 * To set a custom OG:title for social notes.
+	 */
+	public function get_og_title_for_social_notes() {
+		$text   = wp_strip_all_tags( get_the_excerpt() );
+		$length = 55;
+		if ( strlen( $text ) <= $length ) {
+			return $text;
+		}
+
+		$trimmed_text   = substr( $text, 0, $length );
+		$last_space_pos = strrpos( $trimmed_text, ' ' );
+
+		if ( $last_space_pos !== false ) {
+			$trimmed_text = substr( $trimmed_text, 0, $last_space_pos );
+		}
+
+		return $trimmed_text . '...';
+	}
+
+	/**
 	 * Render meta tags in head.
 	 *
 	 * @param WP_Post|null $post The post to render the tags for.
@@ -256,7 +276,7 @@ class Meta_Tags {
 
 		if ( empty( $data->post_title ) ) {
 			if ( $data->post_type === Note::JETPACK_SOCIAL_NOTE_CPT ) {
-				$tags['og:title'] = substr( get_the_excerpt(), 0, 50 );
+				$tags['og:title'] = $this->get_og_title_for_social_notes();
 			} else {
 				$tags['og:title'] = __( '(no title)', 'jetpack-social' );
 			}

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -254,7 +254,7 @@ class Meta_Tags {
 			$trimmed_text = substr( $trimmed_text, 0, $last_space_pos );
 		}
 
-		return $trimmed_text . '...';
+		return $trimmed_text . "\u{2026}";
 	}
 
 	/**

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -277,7 +277,7 @@ class Meta_Tags {
 	 * @param array $tags The array of OG tags so far.
 	 */
 	public function get_note_title( $tags ) {
-		if ( empty( trim( $tags['og:title'] ) ) ) {
+		if ( ! isset( $tags['og:title'] ) || empty( trim( $tags['og:title'] ) ) ) {
 			$tags['og:title'] = $this->get_og_title_for_social_notes();
 		}
 		return $tags;

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -241,17 +241,30 @@ class Meta_Tags {
 	 * To set a custom OG:title for social notes.
 	 */
 	public function get_og_title_for_social_notes() {
-		$text   = wp_strip_all_tags( get_the_excerpt() );
+		$text = wp_strip_all_tags( get_the_excerpt() );
+
 		$length = 55;
 		if ( strlen( $text ) <= $length ) {
 			return $text;
 		}
 
-		$trimmed_text   = substr( $text, 0, $length );
-		$last_space_pos = strrpos( $trimmed_text, ' ' );
+		$words   = str_word_count( $text, 2 );
+		$indices = array_keys( $words );
 
-		if ( $last_space_pos !== false ) {
-			$trimmed_text = substr( $trimmed_text, 0, $last_space_pos );
+		$trimmed_text = '';
+		// There is only one word that is longer than 55 characters.
+		if ( count( $indices ) === 1 ) {
+			$trimmed_text = substr( $text, 0, $length );
+		} else {
+			$substring_index = 0;
+			foreach ( $indices as $current_index ) {
+				$current_length  = $current_index + strlen( $words[ $current_index ] );
+				$substring_index = $current_index;
+				if ( $current_length > $length ) {
+					break;
+				}
+			}
+			$trimmed_text = substr( $text, 0, $substring_index - 1 );
 		}
 
 		return $trimmed_text . "\u{2026}";

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -241,9 +241,10 @@ class Meta_Tags {
 	 * To set a custom OG:title for social notes.
 	 */
 	public function get_og_title_for_social_notes() {
-		$text = wp_strip_all_tags( get_the_excerpt() );
+		$text     = wp_strip_all_tags( get_the_excerpt() );
+		$length   = 55;
+		$ellipsis = "\u{2026}";
 
-		$length = 55;
 		if ( strlen( $text ) <= $length ) {
 			return $text;
 		}
@@ -251,23 +252,35 @@ class Meta_Tags {
 		$words   = str_word_count( $text, 2 );
 		$indices = array_keys( $words );
 
-		$trimmed_text = '';
-		// There is only one word that is longer than 55 characters.
-		if ( count( $indices ) === 1 ) {
-			$trimmed_text = substr( $text, 0, $length );
-		} else {
-			$substring_index = 0;
-			foreach ( $indices as $current_index ) {
-				$current_length  = $current_index + strlen( $words[ $current_index ] );
-				$substring_index = $current_index;
-				if ( $current_length > $length ) {
-					break;
-				}
-			}
-			$trimmed_text = substr( $text, 0, $substring_index - 1 );
+		// There is only one word, or the first word plus initial non-word characters, is longer than 55 characters.
+		if ( count( $indices ) === 1 || $indices[0] + strlen( $words[ $indices[0] ] ) > $length ) {
+			return substr( $text, 0, $length ) . $ellipsis;
 		}
 
-		return $trimmed_text . "\u{2026}";
+		$substring_index = 0;
+		foreach ( $indices as $current_index ) {
+			$current_length = $current_index + strlen( $words[ $current_index ] );
+			if ( $current_length > $length ) {
+				$substring_index = $current_index - 1;
+				break;
+			}
+			$substring_index = $current_length;
+		}
+		return substr( $text, 0, $substring_index ) . $ellipsis;
+	}
+
+	/**
+	 * Filters the OG tags when we are displaying a Social Note,
+	 * and adjusts the title. This allows us to adjust the title
+	 * when Jetpack is active as well as social.
+	 *
+	 * @param array $tags The array of OG tags so far.
+	 */
+	public function get_note_title( $tags ) {
+		if ( empty( trim( $tags['og:title'] ) ) ) {
+			$tags['og:title'] = $this->get_og_title_for_social_notes();
+		}
+		return $tags;
 	}
 
 	/**
@@ -276,29 +289,24 @@ class Meta_Tags {
 	 * @param WP_Post|null $post The post to render the tags for.
 	 */
 	public function render_tags( $post = null ) {
-		if ( ! $this->should_render_meta_tags() ) {
-			return;
-		}
-
 		$data = get_post( $post );
 		if ( empty( $data ) ) {
 			return;
 		}
 
-		$tags = array();
-
-		if ( empty( $data->post_title ) ) {
-			if ( $data->post_type === Note::JETPACK_SOCIAL_NOTE_CPT ) {
-				$tags['og:title'] = $this->get_og_title_for_social_notes();
-			} else {
-				$tags['og:title'] = __( '(no title)', 'jetpack-social' );
-			}
-		} else {
-			/** This filter is documented in core/src/wp-includes/post-template.php */
-			$tags['og:title'] = wp_kses( apply_filters( 'the_title', $data->post_title, $data->ID ), array() );
+		if ( $data->post_type === Note::JETPACK_SOCIAL_NOTE_CPT ) {
+			add_filter( 'jetpack_open_graph_tags', array( $this, 'get_note_title' ) );
 		}
 
-		$tags['og:url'] = get_permalink( $data->ID );
+		if ( ! $this->should_render_meta_tags() ) {
+			return;
+		}
+
+		$tags = array();
+
+		/** This filter is documented in core/src/wp-includes/post-template.php */
+		$tags['og:title'] = wp_kses( apply_filters( 'the_title', $data->post_title, $data->ID ), array() );
+		$tags['og:url']   = get_permalink( $data->ID );
 		if ( ! post_password_required( $data ) ) {
 			$excerpt = '';
 
@@ -331,6 +339,9 @@ class Meta_Tags {
 
 		// Add SIG image if enabled.
 		$tags = apply_filters( 'jetpack_open_graph_tags', $tags );
+		if ( empty( trim( $tags['og:title'] ) ) ) {
+				$tags['og:title'] = __( '(no title)', 'jetpack-social' );
+		}
 
 		if ( ! empty( $tags['og:image'] ) && $this->should_render_twitter_cards_tags() ) {
 			$tags = array_merge(

--- a/projects/plugins/social/tests/php/test-class-meta-tags.php
+++ b/projects/plugins/social/tests/php/test-class-meta-tags.php
@@ -250,4 +250,93 @@ class Meta_Tags_Test extends BaseTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test the logic to create a title for Social Notes from the content.
+	 *
+	 * @dataProvider get_note_title_data_provider
+	 *
+	 * @param string $content Post content.
+	 * @param string $note_title The expected note title.
+	 */
+	public function test_get_social_note_title( $content, $note_title ) {
+		global $post;
+
+		wp_update_post(
+			array(
+				'ID'           => self::$post,
+				'post_type'    => Automattic\Jetpack\Social\Note::JETPACK_SOCIAL_NOTE_CPT,
+				'post_title'   => '',
+				'post_content' => $content,
+			)
+		);
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post = get_post( self::$post );
+		setup_postdata( $post );
+
+		$this->assertEquals( $note_title, $this->meta_tags->get_og_title_for_social_notes() );
+	}
+
+	/**
+	 * Provides the test cases for the note titles.
+	 *
+	 * @return array An array of test case tuples. Input and expected title.
+	 */
+	public function get_note_title_data_provider() {
+		$ellipsis = "\u{2026}";
+		return array(
+			'standard_content'                   => array(
+				'This is a test of the title logic to see at what point it will cut it off',
+				'This is a test of the title logic to see at what point' . $ellipsis,
+			),
+			'55_chars'                           => array(
+				'This is a test of the title logic where it is 55 charss',
+				'This is a test of the title logic where it is 55 charss',
+			),
+			'56_chars'                           => array(
+				'This is a test of the title logic where it is 56 charsss',
+				'This is a test of the title logic where it is 56' . $ellipsis,
+			),
+			'long_word_55'                       => array(
+				'Thisisatestofthetitlelogicwhereitis55wordbutthatsoktooo',
+				'Thisisatestofthetitlelogicwhereitis55wordbutthatsoktooo',
+			),
+			'long_word_56'                       => array(
+				'Thisisatestofthetitlelogicwhereitisfiftysixcharacterslon',
+				'Thisisatestofthetitlelogicwhereitisfiftysixcharacterslo' . $ellipsis,
+			),
+			'leading_non_word_55_whitespace'     => array(
+				'@#$#$@%#$%@#$%@#$%                    Thisisatestofthe',
+				'@#$#$@%#$%@#$%@#$% Thisisatestofthe',
+			),
+			'leading_non_word_56_whitespace'     => array(
+				'@#$#$@%#$%@#$%@#$%                    Thisisatestoftheuo',
+				'@#$#$@%#$%@#$%@#$% Thisisatestoftheuo',
+			),
+			'leading_55_non_word_multiple_space' => array(
+				'@#$#$@%#$%@#$%@#$%                    Thisisatestofthoentuh aoestuhaoeusth',
+				'@#$#$@%#$%@#$%@#$% Thisisatestofthoentuh aoestuhaoeusth',
+			),
+			'leading_56_non_word_multiple_space' => array(
+				'@#$#$@%#$%@#$%@#$%                    Thisisatestofthoentuh aoestuhaoeusthu',
+				'@#$#$@%#$%@#$%@#$% Thisisatestofthoentuh' . $ellipsis,
+			),
+			'leading_non_word_55_multiple'       => array(
+				'@#$#$@%#$%@#$%@#$%#$%#$%#$^#$^%#$%#$%#$%#$%#$%%This isa',
+				'@#$#$@%#$%@#$%@#$%#$%#$%#$^#$^%#$%#$%#$%#$%#$%%This isa',
+			),
+			'leading_non_word_56_multiple'       => array(
+				'@#$#$@%#$%@#$%@#$%#$%#$%#$^#$^%#$%#$%#$%#$%#$%%This isat',
+				'@#$#$@%#$%@#$%@#$%#$%#$%#$^#$^%#$%#$%#$%#$%#$%%This' . $ellipsis,
+			),
+			'leading_non_word_55'                => array(
+				'@#$#$@%#$%@#$%@#$%#$%#$%#$^#$^%#$%#$%#$%#$%#$%%Thisisat',
+				'@#$#$@%#$%@#$%@#$%#$%#$%#$^#$^%#$%#$%#$%#$%#$%%Thisisat',
+			),
+			'leading_non_word_56'                => array(
+				'@#$#$@%#$%@#$%@#$%#$%#$%#$^#$^%#$%#$%#$%#$%#$%%Thisisate',
+				'@#$#$@%#$%@#$%@#$%#$%#$%#$^#$^%#$%#$%#$%#$%#$%%Thisisat' . $ellipsis,
+			),
+		);
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Have written a custom function to truncate og:title without wordbreaks. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1709207341096019/1709200160.433839-slack-C02JJ910CNL

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. --> 
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a Social Note on trunk with content longer than 55 characters. Go the published note and inspect its og:title. It will have a word break, i.e a word is broken randomly. 
For eg, it will be set to something like `Lorem ipsum dolor sit amet, consectetur adipisci` when the whole word is `adipiscing`
* Switch to this branch and look at the og:title and ensure that we don't break words. 
It will be something like `Lorem ipsum dolor sit amet, consectetur` and we won't break mid-word.