### PR TITLE
WP Super Cache: The wp_super_cache_clear_post_cache filter must stop all edits

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-no-clear-homepage
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-no-clear-homepage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache - fix the wp_super_cache_clear_post_cache so the homepage cache isn't deleted too.

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -3132,6 +3132,11 @@ function wpsc_post_transition( $new_status, $old_status, $post ) {
 		return;
 	}
 
+	// Allow plugins to reject cache clears for specific posts.
+	if ( ! apply_filters( 'wp_super_cache_clear_post_cache', true, $post ) ) {
+		return;
+	}
+
 	if ( ( $old_status === 'private' || $old_status === 'publish' ) && $new_status !== 'publish' ) { // post unpublished
 		if ( ! function_exists( 'get_sample_permalink' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/post.php';
@@ -3237,6 +3242,11 @@ function wp_cache_post_change( $post_id ) {
 	$post  = get_post( $post_id );
 	$ptype = is_object( $post ) ? get_post_type_object( $post->post_type ) : null;
 	if ( empty( $ptype ) || ! $ptype->public ) {
+		return $post_id;
+	}
+
+	// Allow plugins to reject cache clears for specific posts.
+	if ( ! apply_filters( 'wp_super_cache_clear_post_cache', true, $post ) ) {
 		return $post_id;
 	}
 


### PR DESCRIPTION
The wp_super_cache_clear_post_cache filter allows a site owner to stop the plugin clearing the cache for a particular post, but it wasn't being used everywhere it should be. The cache for the post was being deleted, and the cache for the home page was too.

Fixes #28668

## Proposed changes:
* Add this filter check to wp_cache_post_change and wpsc_post_transition.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR.
* Load the homepage and the post you will edit so there are cache files for them. Check wp-content/cache/supercache/.... for the cache files.
* Create an mu-plugin with this code in it: 
```
add_filter( 'wp_super_cache_clear_post_cache', function ( $clear, $post ) {
        if ( $post->ID === 15 ) {
                error_log( "post 15 detected!" );
                return false;
        }

        return $clear;
}, 10, 2 );
```
* Change 15 to the post_id of your test post.
* Edit and save the post.
* Check your cache folder to see if the cache files are deleted or not.
* Check your error_log for the "detected" message.