### PR TITLE
Scheduled Updates: Add a way to retrieve all events scheduled for a s…

### DIFF
--- a/projects/packages/scheduled-updates/changelog/try-get-all-events
+++ b/projects/packages/scheduled-updates/changelog/try-get-all-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added a Cron API function to retrieve all events scheduled for a specified hook.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -23,6 +23,8 @@ class Scheduled_Updates {
 	 * Initialize the class.
 	 */
 	public static function init() {
+		require_once __DIR__ . '/pluggable.php';
+
 		/*
 		 * We want to load the REST API endpoints in all environments.
 		 * On WP.com they're needed for registering the routes with public-api and pass-through to self-hosted sites.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -23,8 +23,6 @@ class Scheduled_Updates {
 	 * Initialize the class.
 	 */
 	public static function init() {
-		require_once __DIR__ . '/pluggable.php';
-
 		/*
 		 * We want to load the REST API endpoints in all environments.
 		 * On WP.com they're needed for registering the routes with public-api and pass-through to self-hosted sites.

--- a/projects/packages/scheduled-updates/src/pluggable.php
+++ b/projects/packages/scheduled-updates/src/pluggable.php
@@ -14,8 +14,8 @@ if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
 	 * This should really be in Core, and until it is, we'll define it here in a forward-compatible way.
 	 *
 	 * @param string $hook Action hook of the event.
-	 * @return object[]|false {
-	 *     Array of event objects. False if no events exist for the hook.
+	 * @return object[]|array {
+	 *     Array of event objects. Empty array if no events exist for the hook.
 	 *
 	 *     @type string       $hook      Action hook to execute when the event is run.
 	 *     @type int          $timestamp Unix timestamp (UTC) for when to next run the event.
@@ -45,7 +45,7 @@ if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
 
 		$crons = _get_cron_array();
 		if ( empty( $crons ) ) {
-			return false;
+			return array();
 		}
 
 		$events = array();
@@ -66,10 +66,6 @@ if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
 
 				$events[ $key ] = $event;
 			}
-		}
-
-		if ( empty( $events ) ) {
-			return false;
 		}
 
 		return $events;

--- a/projects/packages/scheduled-updates/src/pluggable.php
+++ b/projects/packages/scheduled-updates/src/pluggable.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Functions.
+ *
+ * @package automattic/scheduled-updates
+ */
+
+if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
+	/**
+	 * Retrieves scheduled events.
+	 *
+	 * Retrieves all the events that have been scheduled for the hook provided.
+	 *
+	 * This should really be in Core, and until it is, we'll define it here in a forward-compatible way.
+	 *
+	 * @param string $hook Action hook of the event.
+	 * @return object[]|false {
+	 *     Array of event objects. False if no events exist for the hook.
+	 *
+	 *     @type string       $hook      Action hook to execute when the event is run.
+	 *     @type int          $timestamp Unix timestamp (UTC) for when to next run the event.
+	 *     @type string|false $schedule  How often the event should subsequently recur.
+	 *     @type array        $args      Array containing each separate argument to pass to the hook's callback function.
+	 *     @type int          $interval  Optional. The interval time in seconds for the schedule. Only present for recurring events.
+	 * }
+	 */
+	function wp_get_scheduled_events( $hook ) {
+		/**
+		 * Filter to override retrieving scheduled events.
+		 *
+		 * Returning a non-null value will short-circuit the normal process,
+		 * returning the filtered value instead.
+		 *
+		 * Return false if the event does not exist, otherwise an event object
+		 * should be returned.
+		 *
+		 * @param null|false|object $pre  Value to return instead. Default null to continue retrieving the event.
+		 * @param string            $hook Action hook of the event.
+		 */
+		$pre = apply_filters( 'pre_get_scheduled_events', null, $hook );
+
+		if ( null !== $pre ) {
+			return $pre;
+		}
+
+		$crons = _get_cron_array();
+		if ( empty( $crons ) ) {
+			return false;
+		}
+
+		$events = array();
+		foreach ( $crons as $timestamp => $cron ) {
+			if ( isset( $cron[ $hook ] ) ) {
+				$scheduled_event = array_pop( $cron[ $hook ] );
+
+				$event = (object) array(
+					'hook'      => $hook,
+					'timestamp' => $timestamp,
+					'schedule'  => $scheduled_event['schedule'],
+					'args'      => $scheduled_event['args'],
+				);
+				if ( isset( $scheduled_event['interval'] ) ) {
+					$event->interval = $scheduled_event['interval'];
+				}
+
+				$events[] = $event;
+			}
+		}
+
+		if ( empty( $events ) ) {
+			return false;
+		}
+
+		return $events;
+	}
+}

--- a/projects/packages/scheduled-updates/src/pluggable.php
+++ b/projects/packages/scheduled-updates/src/pluggable.php
@@ -51,6 +51,7 @@ if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
 		$events = array();
 		foreach ( $crons as $timestamp => $cron ) {
 			if ( isset( $cron[ $hook ] ) ) {
+				$key             = key( $cron[ $hook ] );
 				$scheduled_event = array_pop( $cron[ $hook ] );
 
 				$event = (object) array(
@@ -63,7 +64,7 @@ if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
 					$event->interval = $scheduled_event['interval'];
 				}
 
-				$events[] = $event;
+				$events[ $key ] = $event;
 			}
 		}
 

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -7,10 +7,20 @@
  * @package automattic/scheduled-updates
  */
 
+// Load dependencies.
+require_once dirname( __DIR__ ) . '/pluggable.php';
+
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Update_Schedules
  */
 class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
+	/**
+	 * The pattern for a plugin basename.
+	 *
+	 * @var string
+	 */
+	const PATTERN = '[^.\/]+(?:\/[^.\/]+)?';
+
 	/**
 	 * The namespace of this controller's route.
 	 *
@@ -113,20 +123,11 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	/**
 	 * Returns a list of update schedules.
 	 *
-	 * Checks the jetpack_update_schedules option for saved schedule ids and retries scheduled events with the `jetpack_scheduled_update` hook.
-	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$schedules = get_option( 'jetpack_update_schedules', array() );
-		$events    = array();
-
-		foreach ( $schedules as $schedule_args ) {
-			$events[] = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args );
-		}
-
-		return rest_ensure_response( $events );
+		return rest_ensure_response( wp_get_scheduled_events( 'jetpack_scheduled_update' ) );
 	}
 
 	/**
@@ -144,19 +145,18 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 		}
 
-		$schedules = get_option( 'jetpack_update_schedules', array() );
-		if ( count( $schedules ) >= 2 ) {
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+		if ( count( $events ) >= 2 ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create more than two schedules at this time.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 		}
 
-		foreach ( $schedules as $schedule_args ) {
-			$event = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args );
-
+		foreach ( $events as $event ) {
 			if ( $request['schedule']['timestamp'] === $event->timestamp ) {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same time as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 
-			if ( $this->generate_schedule_id( $schedule_args ) === $this->generate_schedule_id( $request['plugins'] ) ) {
+			usort( $request['plugins'], 'strnatcasecmp' );
+			if ( $event->args === $request['plugins'] ) {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same plugins as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 		}
@@ -177,15 +177,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	public function create_item( $request ) {
 		$schedule = $request['schedule'];
 		$plugins  = $request['plugins'];
+		usort( $plugins, 'strnatcasecmp' );
 
 		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], 'jetpack_scheduled_update', $plugins, true );
 		if ( is_wp_error( $event ) ) {
 			return $event;
 		}
-
-		$schedules   = get_option( 'jetpack_update_schedules', array() );
-		$schedules[] = $plugins;
-		update_option( 'jetpack_update_schedules', $schedules );
 
 		return rest_ensure_response( $this->generate_schedule_id( $plugins ) );
 	}
@@ -211,21 +208,13 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error The scheduled event or a WP_Error if the schedule could not be found.
 	 */
 	public function get_item( $request ) {
-		$schedules = get_option( 'jetpack_update_schedules', array() );
-		$event     = array();
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
 
-		foreach ( $schedules as $schedule_args ) {
-			if ( $this->generate_schedule_id( $schedule_args ) === $request['schedule_id'] ) {
-				$event = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args );
-				break;
-			}
-		}
-
-		if ( empty( $event ) ) {
+		if ( empty( $events[ $request['schedule_id'] ] ) ) {
 			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
 		}
 
-		return rest_ensure_response( $event );
+		return rest_ensure_response( $events[ $request['schedule_id'] ] );
 	}
 
 	/**
@@ -243,11 +232,11 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 		}
 
-		$schedules = get_option( 'jetpack_update_schedules', array() );
-		foreach ( $schedules as $schedule_args ) {
-			$event = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args );
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+		foreach ( $events as $key => $event ) {
 
-			if ( $this->generate_schedule_id( $schedule_args ) === $request['schedule_id'] ) {
+			// We'll update this schedule, so none of the checks apply.
+			if ( $key === $request['schedule_id'] ) {
 				continue;
 			}
 
@@ -255,7 +244,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same time as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 
-			if ( $this->generate_schedule_id( $schedule_args ) === $this->generate_schedule_id( $request['plugins'] ) ) {
+			usort( $request['plugins'], 'strnatcasecmp' );
+			if ( $event->args === $request['plugins'] ) {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same plugins as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 		}
@@ -274,27 +264,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error The updated event or a WP_Error if the schedule could not be found.
 	 */
 	public function update_item( $request ) {
-		$schedules = get_option( 'jetpack_update_schedules', array() );
-		$event     = array();
-
-		foreach ( $schedules as $key => $schedule_args ) {
-			if ( $this->generate_schedule_id( $schedule_args ) === $request['schedule_id'] ) {
-				$event  = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args );
-				$result = wp_unschedule_event( $event->timestamp, 'jetpack_scheduled_update', $schedule_args, true );
-				if ( is_wp_error( $result ) ) {
-					return $result;
-				}
-
-				// Remove the old schedule.
-				unset( $schedules[ $key ] );
-				update_option( 'jetpack_update_schedules', $schedules );
-
-				break;
-			}
-		}
-
-		if ( empty( $event ) ) {
-			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
+		$deleted = $this->delete_item( $request );
+		if ( is_wp_error( $deleted ) ) {
+			return $deleted;
 		}
 
 		return $this->create_item( $request );
@@ -321,30 +293,44 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
-		$schedules = get_option( 'jetpack_update_schedules', array() );
-		$event     = array();
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
 
-		foreach ( $schedules as $key => $schedule_args ) {
-			if ( $this->generate_schedule_id( $schedule_args ) === $request['schedule_id'] ) {
-				$event  = wp_get_scheduled_event( 'jetpack_scheduled_update', $schedule_args );
-				$result = wp_unschedule_event( $event->timestamp, 'jetpack_scheduled_update', $schedule_args, true );
-				if ( is_wp_error( $result ) ) {
-					return $result;
-				}
-
-				// Remove the old schedule.
-				unset( $schedules[ $key ] );
-				break;
-			}
-		}
-
-		if ( empty( $event ) ) {
+		if ( ! isset( $events[ $request['schedule_id'] ] ) ) {
 			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
 		}
 
-		update_option( 'jetpack_update_schedules', $schedules );
+		$event = $events[ $request['schedule_id'] ];
+
+		$result = wp_unschedule_event( $event->timestamp, 'jetpack_scheduled_update', $event->args, true );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 
 		return rest_ensure_response( true );
+	}
+
+	/**
+	 * Checks that the "plugin" parameter is a valid path.
+	 *
+	 * @param string $file The plugin file parameter.
+	 * @return bool
+	 */
+	public function validate_plugin_param( $file ) {
+		if ( ! is_string( $file ) || ! preg_match( '/' . self::PATTERN . '/u', $file ) ) {
+			return false;
+		}
+
+		return 0 === validate_file( plugin_basename( $file ) );
+	}
+
+	/**
+	 * Sanitizes the "plugin" parameter to be a proper plugin file with ".php" appended.
+	 *
+	 * @param string $file The plugin file parameter.
+	 * @return string
+	 */
+	public function sanitize_plugin_param( $file ) {
+		return plugin_basename( sanitize_text_field( $file . '.php' ) );
 	}
 
 	/**
@@ -404,6 +390,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				'description' => 'List of plugin slugs to update.',
 				'type'        => 'array',
 				'required'    => false,
+				'items'       => array(
+					'type'              => 'string',
+					'pattern'           => self::PATTERN,
+					'validate_callback' => array( $this, 'validate_plugin_param' ),
+					'sanitize_callback' => array( $this, 'sanitize_plugin_param' ),
+				),
 			),
 			'themes'   => array(
 				'description' => 'List of theme slugs to update.',

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -103,7 +103,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		);
 		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_update', array( 'hello-dolly/hello-dolly.php' ) );
 		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
-		update_option( 'jetpack_update_schedules', array( array( 'hello-dolly/hello-dolly.php' ), $plugins ) );
 
 		// Successful request.
 		$result = rest_do_request( $request );
@@ -111,14 +110,14 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertEquals(
 			array(
-				(object) array(
+				$this->generate_schedule_id( array( 'hello-dolly/hello-dolly.php' ) ) => (object) array(
 					'hook'      => 'jetpack_scheduled_update',
 					'args'      => array( 'hello-dolly/hello-dolly.php' ),
 					'timestamp' => strtotime( 'next Tuesday 9:00' ),
 					'schedule'  => 'daily',
 					'interval'  => DAY_IN_SECONDS,
 				),
-				(object) array(
+				$this->generate_schedule_id( $plugins ) => (object) array(
 					'hook'      => 'jetpack_scheduled_update',
 					'args'      => $plugins,
 					'timestamp' => strtotime( 'next Monday 8:00' ),
@@ -140,8 +139,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$request->set_body_params(
 			array(
 				'plugins'  => array(
-					'gutenberg/gutenberg.php',
 					'custom-plugin/custom-plugin.php',
+					'gutenberg/gutenberg.php',
 				),
 				'schedule' => array(
 					'timestamp' => strtotime( 'next Monday 8:00' ),
@@ -175,8 +174,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$request->set_body_params(
 			array(
 				'plugins'  => array(
-					'gutenberg/gutenberg.php',
 					'custom-plugin/custom-plugin.php',
+					'gutenberg/gutenberg.php',
 				),
 				'schedule' => array(
 					'timestamp' => strtotime( 'next Monday 8:00' ),
@@ -331,8 +330,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	 */
 	public function test_update_item() {
 		$plugins     = array(
-			'gutenberg/gutenberg.php',
 			'custom-plugin/custom-plugin.php',
+			'gutenberg/gutenberg.php',
 		);
 		$schedule_id = $this->generate_schedule_id( $plugins );
 
@@ -431,7 +430,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertTrue( $result->get_data() );
 
-		$this->assertEmpty( get_option( 'jetpack_update_schedules' ) );
 		$this->assertFalse( wp_get_scheduled_event( 'jetpack_scheduled_update', $plugins ) );
 	}
 

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -60,15 +60,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
-	 * Tear down.
-	 */
-	public function tear_down() {
-		delete_option( 'jetpack_update_schedules' );
-
-		parent::tear_down();
-	}
-
-	/**
 	 * Test get_items.
 	 *
 	 * @covers ::get_items
@@ -197,21 +188,17 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	 */
 	public function test_creating_schedules_for_same_time() {
 		$plugins = array(
-			'gutenberg/gutenberg.php',
 			'custom-plugin/custom-plugin.php',
+			'gutenberg/gutenberg.php',
 		);
 
 		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
-		update_option( 'jetpack_update_schedules', array( $plugins ) );
 
 		// Can't create a schedule for the same time again.
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(
 			array(
-				'plugins'  => array(
-					'gutenberg/gutenberg.php',
-					'custom-plugin/custom-plugin.php',
-				),
+				'plugins'  => $plugins,
 				'schedule' => array(
 					'timestamp' => strtotime( 'next Monday 8:00' ),
 					'interval'  => 'weekly',
@@ -240,7 +227,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		// Create two schedules.
 		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
 		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_update', $plugins );
-		update_option( 'jetpack_update_schedules', array( $plugins, $plugins ) );
 
 		// Number 3.
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
@@ -275,7 +261,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$schedule_id = $this->generate_schedule_id( $plugins );
 
 		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
-		update_option( 'jetpack_update_schedules', array( $plugins ) );
 
 		// Unauthenticated request.
 		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules/' . $schedule_id );
@@ -336,7 +321,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$schedule_id = $this->generate_schedule_id( $plugins );
 
 		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
-		update_option( 'jetpack_update_schedules', array( $plugins ) );
 
 		// Unauthenticated request.
 		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $schedule_id );
@@ -406,7 +390,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$schedule_id = $this->generate_schedule_id( $plugins );
 
 		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
-		update_option( 'jetpack_update_schedules', array( $plugins ) );
 
 		// Unauthenticated request.
 		wp_set_current_user( 0 );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduces a Cron API function to get all events scheduled for a given hook.
* Switches API endpoint to using only events data for permission checks and endpoint responses.
* Orders plugin lists alphabetically to generate consistent md5 hashes.
* Introduces plugin slug validation & sanitization callbacks.
* Updates unit tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Output of the `get_items` endpoint:
```php
array (
	'38806d9af7f8b51483f1508140d2c3f4' => (object) array(
		'hook' => 'jetpack_scheduled_update',
		'timestamp' => 1709310981,
		'schedule' => 'daily',
		'args' => array (
			0 => 'wp-last-login/wp-last-login.php',
			1 => 'page-optimize/page-optimize.php',
		),
		'interval' => 86400,
	),
	'657ad8d2b43546aa1674da4587420cb3' => (object) array(
		'hook' => 'jetpack_scheduled_update',
		'timestamp' => 1709649213,
		'schedule' => 'weekly',
		'args' => array (
			0 => 'rest-api-console/rest-api-console.php',
		),
		'interval' => 604800,
	),
)

```

