### PR TITLE
Remove the feature flag for Newsletter Categories settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -50,8 +50,6 @@ function Subscriptions( props ) {
 					<MessagesSetting { ...props } />
 				</>
 			) }
-			<NewsletterCategories />
-			<MessagesSetting { ...props } />
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -10,11 +10,6 @@ import MessagesSetting from './messages-setting';
 import NewsletterCategories from './newsletter-categories';
 import SubscriptionsSettings from './subscriptions-settings';
 
-//Check for feature flag
-const urlParams = new URLSearchParams( window.location.search );
-const isNewsletterCategoriesEnabled = urlParams.get( 'enable-newsletter-categories' ) === 'true';
-const isEmailSettingsEnabled = urlParams.get( 'enable-email-settings' ) === 'true';
-
 /**
  * Newsletter Section.
  *
@@ -55,6 +50,8 @@ function Subscriptions( props ) {
 					<MessagesSetting { ...props } />
 				</>
 			) }
+			<NewsletterCategories />
+			<MessagesSetting { ...props } />
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -45,8 +45,8 @@ function Subscriptions( props ) {
 			{ foundSubscriptions && (
 				<>
 					<SubscriptionsSettings siteRawUrl={ siteRawUrl } blogID={ blogID } />
-					{ isEmailSettingsEnabled && <EmailSettings /> }
-					{ isNewsletterCategoriesEnabled && <NewsletterCategories /> }
+					<EmailSettings />
+					<NewsletterCategories />
 					<MessagesSetting { ...props } />
 				</>
 			) }

--- a/projects/plugins/jetpack/changelog/remove-feature-flags-newsletter-settings
+++ b/projects/plugins/jetpack/changelog/remove-feature-flags-newsletter-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Removed the feature flag for newsletter categories settings.


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/88035
Fixes https://github.com/Automattic/wp-calypso/issues/88351

## Proposed changes:
Removing the feature flag for Newsletter settings in JP

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No need

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply this PR and run your JT site.
- Go to `/wp-admin/admin.php?page=jetpack#/newsletter` and check that you can see the newsletter settings.

