### PR TITLE
Command Palette: Defer load script

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-commad-palette-defer-script
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-commad-palette-defer-script
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+The Command Palette loads the script with a `defer` strategy now to improve the performance.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-command-palette/wpcom-command-palette.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-command-palette/wpcom-command-palette.php
@@ -38,7 +38,10 @@ function wpcom_load_command_palette() {
 		'//widgets.wp.com/command-palette/build.min.js',
 		array(),
 		$version,
-		true
+		array(
+			'strategy'  => 'defer',
+			'in_footer' => true,
+		)
 	);
 	$site_id    = Jetpack_Options::get_option( 'id' );
 	$is_p2_site = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( $site_id );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87326

## Proposed changes:

The Command Palette loads the script with a `defer` strategy now to improve the performance.

<img width="1090" alt="Screenshot 2024-02-29 at 16 03 31" src="https://github.com/Automattic/jetpack/assets/1233880/6259faac-bfcb-47c9-b012-d094f88fa934">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com site
- Load WP Admin and check the HTML source code
- Search the command palette script
- Make sure it has been loaded with a `defer` strategy

