### PR TITLE
My Jetpack: add links on product page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -62,6 +62,7 @@ export default function () {
 	const showCurrentUsage = hasPaidTier && ! isFree;
 	const showAllTimeUsage = hasPaidTier || hasUnlimited;
 	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
+	const newPostURL = 'post-new.php?use_ai_block=1&_wpnonce=' + window?.jetpackAi?.nonce;
 
 	const showRenewalNotice = isOverLimit && hasPaidTier;
 	const showUpgradeNotice = isOverLimit && isFree;
@@ -93,10 +94,6 @@ export default function () {
 
 	const navigateToPricingTable = useMyJetpackNavigate( '/add-jetpack-ai' );
 	const { recordEvent } = useAnalytics();
-
-	const onCreateClick = useCallback( () => {
-		// console.log( 'click' );
-	}, [] );
 
 	const contactClickHandler = useCallback( () => {
 		recordEvent( 'jetpack_ai_upgrade_contact_us', { placement: 'product-page' } );
@@ -267,7 +264,7 @@ export default function () {
 									<Button
 										className={ styles[ 'product-interstitial__usage-videos-link' ] }
 										icon={ plus }
-										onClick={ onCreateClick }
+										href={ newPostURL }
 									>
 										{ __( 'Create new post', 'jetpack-my-jetpack' ) }
 									</Button>
@@ -298,7 +295,8 @@ export default function () {
 									<Button
 										className={ styles[ 'product-interstitial__usage-videos-link' ] }
 										icon={ help }
-										onClick={ onCreateClick }
+										target="_blank"
+										href="https://jetpack.com/support/jetpack-blocks/contact-form/#forms-with-ai"
 									>
 										{ __( 'Learn about forms', 'jetpack-my-jetpack' ) }
 									</Button>
@@ -329,7 +327,8 @@ export default function () {
 									<Button
 										className={ styles[ 'product-interstitial__usage-videos-link' ] }
 										icon={ help }
-										onClick={ onCreateClick }
+										target="_blank"
+										href="https://jetpack.com/support/jetpack-blocks/jetpack-ai-assistant-block/"
 									>
 										{ __( 'Learn more', 'jetpack-my-jetpack' ) }
 									</Button>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -59,13 +59,18 @@ export default function () {
 	const hasPaidTier = ! isFree && ! hasUnlimited;
 	const shouldContactUs = ! hasUnlimited && hasPaidTier && ! nextTier;
 	const freeRequestsLeft = isFree && 20 - allTimeRequests >= 0 ? 20 - allTimeRequests : 0;
-	const showCurrentUsage = hasPaidTier && ! isFree;
+	const showCurrentUsage = hasPaidTier && ! isFree && usage;
 	const showAllTimeUsage = hasPaidTier || hasUnlimited;
 	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
 	const newPostURL = 'post-new.php?use_ai_block=1&_wpnonce=' + window?.jetpackAi?.nonce;
 
 	const showRenewalNotice = isOverLimit && hasPaidTier;
 	const showUpgradeNotice = isOverLimit && isFree;
+
+	const currentTierValue = currentTier?.value || 0;
+	const currentUsage = usage?.[ 'requests-count' ] || 0;
+	const tierRequestsLeft =
+		currentTierValue - currentUsage >= 0 ? currentTierValue - currentUsage : 0;
 
 	const renewalNoticeTitle = __(
 		"You've reached your request limit for this month",
@@ -178,9 +183,7 @@ export default function () {
 											{ __( 'Requests for this month', 'jetpack-my-jetpack' ) }
 										</div>
 										<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
-											{ currentTier.value - usage[ 'requests-count' ] >= 0
-												? currentTier.value - usage[ 'requests-count' ]
-												: 0 }
+											{ tierRequestsLeft }
 										</div>
 									</div>
 								</Card>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -47,7 +47,7 @@ export default function () {
 
 	debug( aiAssistantFeature );
 	const {
-		'requests-count': allTimeRequests,
+		'requests-count': allTimeRequests = 0,
 		'current-tier': currentTier,
 		'next-tier': nextTier,
 		'usage-period': usage,
@@ -57,7 +57,7 @@ export default function () {
 	const hasUnlimited = currentTier?.value === 1;
 	const isFree = currentTier?.value === 0;
 	const hasPaidTier = ! isFree && ! hasUnlimited;
-	const shouldContactUs = ! hasUnlimited && hasPaidTier && ! nextTier;
+	const shouldContactUs = ! hasUnlimited && hasPaidTier && ! nextTier && currentTier;
 	const freeRequestsLeft = isFree && 20 - allTimeRequests >= 0 ? 20 - allTimeRequests : 0;
 	const showCurrentUsage = hasPaidTier && ! isFree && usage;
 	const showAllTimeUsage = hasPaidTier || hasUnlimited;
@@ -84,7 +84,7 @@ export default function () {
 			'Wait for %d days to reset your limit, or upgrade now to a higher tier for additional requests and keep your work moving forward.',
 			'jetpack-my-jetpack'
 		),
-		Math.floor( ( new Date( usage[ 'next-start' ] ) - new Date() ) / ( 1000 * 60 * 60 * 24 ) )
+		Math.floor( ( new Date( usage?.[ 'next-start' ] ) - new Date() ) / ( 1000 * 60 * 60 * 24 ) )
 	);
 	const upgradeNoticeBody = __(
 		'Reach for More with Jetpack AI! Upgrade now for additional requests and keep your momentum going.',

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-create-post-with-block
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-create-post-with-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack AI: add support and create post links on product page

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -36,6 +36,7 @@ class Products {
 			'protect'    => Products\Protect::class,
 			'videopress' => Products\Videopress::class,
 			'stats'      => Products\Stats::class,
+			'ai'         => Products\Jetpack_Ai::class,
 		);
 
 		/**
@@ -179,6 +180,7 @@ class Products {
 			'protect',
 			'crm',
 			'search',
+			'ai',
 		);
 
 		// Add plugin action links for the core Jetpack plugin.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -552,7 +552,6 @@ class Jetpack_Ai extends Product {
 	 * @return string
 	 */
 	public static function add_ai_block( $content, $post ) {
-		wplog( 'executing filter: content' );
 		if ( isset( $_GET['use_ai_block'] ) && isset( $_GET['_wpnonce'] )
 			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'ai-assistant-content-nonce' )
 			&& current_user_can( 'edit_post', $post->ID )

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\My_Jetpack\Initializer;
 use Automattic\Jetpack\My_Jetpack\Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
@@ -502,5 +503,63 @@ class Jetpack_Ai extends Product {
 	 */
 	private static function is_site_connected() {
 		return ( new Connection_Manager() )->is_connected();
+	}
+
+	/**
+	 * Get the URL where the user manages the product
+	 *
+	 * NOTE: this method is the only thing that resembles an initialization for the product.
+	 *
+	 * @return void
+	 */
+	public static function extend_plugin_action_links() {
+		add_action( 'admin_enqueue_scripts', array( static::class, 'admin_enqueue_scripts' ) );
+		add_filter( 'default_content', array( static::class, 'add_ai_block' ), 10, 2 );
+	}
+
+	/**
+	 * Enqueue the AI Assistant script
+	 *
+	 * The script is just a global variable used for the nonce, needed for the create post link.
+	 *
+	 * @return void
+	 */
+	public static function admin_enqueue_scripts() {
+		wp_register_script(
+			'my_jetpack_ai_app',
+			false,
+			array(),
+			Initializer::PACKAGE_VERSION,
+			array( 'in_footer' => true )
+		);
+		wp_localize_script(
+			'my_jetpack_ai_app',
+			'jetpackAi',
+			array(
+				'nonce' => wp_create_nonce( 'ai-assistant-content-nonce' ),
+			)
+		);
+		wp_enqueue_script( 'my_jetpack_ai_app' );
+	}
+
+	/**
+	 * Add AI block to the post content
+	 *
+	 * Used only from the link on the product page, the filter will insert an AI Assistant block in the post content.
+	 *
+	 * @param string  $content The post content.
+	 * @param WP_Post $post The post object.
+	 * @return string
+	 */
+	public static function add_ai_block( $content, $post ) {
+		wplog( 'executing filter: content' );
+		if ( isset( $_GET['use_ai_block'] ) && isset( $_GET['_wpnonce'] )
+			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'ai-assistant-content-nonce' )
+			&& current_user_can( 'edit_post', $post->ID )
+			&& '' === $content
+		) {
+			return '<!-- wp:jetpack/ai-assistant /-->';
+		}
+		return $content;
 	}
 }


### PR DESCRIPTION
Product page shows links to support docs and to create a post with an AI Assistant block

Fixes #36078 

## Proposed changes:
This PR adds a nonce script on product initialization and adds a link to create a post using GET parameters and a default_content filter. Props to @dhasilva 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the filter to enable the new page, this is done on the instance, not on backend. Download and use Code Snippets plugin if you're not testing on local env:

```php
add_filter( 'my_jetpack_use_new_ai_page', '__return_true' );
```

Visit `wp-admin/admin.php?page=my-jetpack#/jetpack-ai`. On the videos section there should be 3 links. Test them:
- "Create new post" should get you into the editor and there should be an AI Assistant block already inserted
- "Learn about forms" should point to support doc `https://jetpack.com/support/jetpack-blocks/contact-form/#forms-with-ai` and open on a new tab
- "Learn more" should point to support doc `https://jetpack.com/support/jetpack-blocks/jetpack-ai-assistant-block/` and open on a new tab