### PR TITLE
My Jetpack: Fix Boost score card not working with standalone plugins

### DIFF
--- a/projects/packages/boost-speed-score/changelog/fix-how-boost-score-api-loaded
+++ b/projects/packages/boost-speed-score/changelog/fix-how-boost-score-api-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add gereric Jetpack_Boost_Modules class for when Boost is uninstalled/not activated.

--- a/projects/packages/boost-speed-score/src/class-jetpack-boost-modules.php
+++ b/projects/packages/boost-speed-score/src/class-jetpack-boost-modules.php
@@ -3,12 +3,13 @@
 /**
  * Jetpack Boost Active Modules
  *
- * Since the speed scores API will only be used in the Jetpack plugin if Jetpack Boost is uninstalled
- * all we need is to pass along this placeholder class for the modules that essentially tells the API
- * the user doesn't have any Boost modules active.
+ * Since the speed scores API will be used in the Jetpack plugin and in the My Jetpack, if Jetpack Boost
+ * is uninstalled, all we need is to pass along this placeholder class for the modules that essentially
+ * tells the API the user doesn't have any Boost modules active.
  *
- * @package automattic/jetpack
+ * @package automattic/jetpack/boost_speed_score
  */
+namespace Automattic\Jetpack\Boost_Speed_Score;
 
 /**
  * Jetpack Boost Modules

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -23,7 +23,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.3.4';
+	const PACKAGE_VERSION = '0.3.5-alpha';
 
 	/**
 	 * An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup passed to the constructor

--- a/projects/packages/my-jetpack/changelog/fix-how-boost-score-api-loaded
+++ b/projects/packages/my-jetpack/changelog/fix-how-boost-score-api-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Instanciate the Boost Score API (new Speed_Score()) in My Jetpack.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\My_Jetpack;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Boost_Speed_Score\Jetpack_Boost_Modules;
+use Automattic\Jetpack\Boost_Speed_Score\Speed_Score;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score_History;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
@@ -81,6 +83,10 @@ class Initializer {
 		if ( self::is_licensing_ui_enabled() ) {
 			Licensing::instance()->initialize();
 		}
+
+		// Initialize Boost Speed Score
+		$boost_modules = Jetpack_Boost_Modules::init();
+		new Speed_Score( $boost_modules, 'jetpack-my-jetpack' );
 
 		// Add custom WP REST API endoints.
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_endpoints' ) );

--- a/projects/plugins/jetpack/changelog/fix-how-boost-score-api-loaded
+++ b/projects/plugins/jetpack/changelog/fix-how-boost-score-api-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Move Jetpack_Boost_Modules class to the boost-score-api package.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -8,6 +8,7 @@
  */
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Boost_Speed_Score\Jetpack_Boost_Modules;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score;
 use Automattic\Jetpack\Config;
 use Automattic\Jetpack\Connection\Client;

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -29,7 +29,6 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-client-server.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-user-agent.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-post-images.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-heartbeat.php';
-require_once JETPACK__PLUGIN_DIR . 'class.jetpack-boost-modules.php';
 require_once JETPACK__PLUGIN_DIR . 'class.photon.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.photon.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.global.php';


### PR DESCRIPTION
Prior to this PR, The Boost score bar in My Jetpack (within the Boost product card) was not working for standalone plugins. It was only working when the Jetpack plugin was activated.

This PR fixes the way in which the Boost Score API is loaded within My Jetpack so that the Boost Score within the My Jetpack Boost product card is not dependent on the Jetpack plugin being installed and activated for it to work.

Hoping we can cherry-pick this one into the upcoming release.. 😬

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to PR: https://github.com/Automattic/jetpack/pull/35606

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the Jetpack_Boost_Modules class to the shared Boost-score-api package.
* Then have both the Jetpack plugin as well as My Jetpack use that Modules class when instantiating `new Speed_Score( $modules, $client)'.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: My Jetpack: Add Boost speed score into boost product card: pbNhbs-9Nt-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this branch on a standalone plugin (i.e.- VaultPress Backup or Social) with the Beta plugin on a Jurassic Ninja site.  Make sure **not** to include the Jetpack plugin.
* Connect the standalone plugin. (purchase a plan if needed).
* Go to My Jetpack page.
* Verify the Boost Score bar and grade within the Boost product card are displaying and working properly with no errors.
* Install & activate the Jetpack plugin.
* Deactivate the standalone plugin you used above.
* Within the Beta plugin, run this branch with the Jetpack plugin.
* Go to the At-A-Glance (Dashboard) page.
* Verify Boost Speed Score within the Boost card is working properly with no errors.
* Go to the My Jetpack page.
* Verify the Boost Score bar and grade within the Boost product card are displaying and working properly with no errors.