### PR TITLE
Voice to Content: Cancel transcription on modal close and disable close on click outside

### DIFF
--- a/projects/plugins/jetpack/changelog/update-voice-to-content-modal-close
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-modal-close
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Voice to Content: Cancel transcription on modal close and disable close on click outside

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -60,10 +60,6 @@ export default function VoiceToContentEdit( { clientId } ) {
 		}, 100 );
 	}, [ dispatch, clientId ] );
 
-	const handleClose = () => {
-		destroyBlock();
-	};
-
 	const { isValidatingAudio, validateAudio } = useAudioValidation();
 
 	const { upsertTranscription } = useTranscriptionInserter();
@@ -83,6 +79,11 @@ export default function VoiceToContentEdit( { clientId } ) {
 				onError( error );
 			},
 		} );
+
+	const handleClose = () => {
+		cancelTranscription();
+		destroyBlock();
+	};
 
 	const { state, controls, error, onError, duration, analyser } = useMediaRecording( {
 		onDone: lastBlob => {
@@ -170,6 +171,8 @@ export default function VoiceToContentEdit( { clientId } ) {
 			onRequestClose={ handleClose }
 			title={ __( 'Jetpack AI Voice to content', 'jetpack' ) }
 			className="jetpack-ai-voice-to-content__modal"
+			shouldCloseOnEsc={ false }
+			shouldCloseOnClickOutside={ false }
 		>
 			<ThemeProvider>
 				<div className="jetpack-ai-voice-to-content__wrapper">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #35547 
Fixes #36083

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disables close on click outside and esc, forcing an explicit close action
* Cancel any ongoing transcription on modal close

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Voice to Content block
* Click outside the modal and press ESC
* Check that the modal does not close
* Start a transcription process
* Close the modal
* Check that the transcription is properly cancelled
