### PR TITLE
Voice to Content: Close audio stream on hook destruction

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-close-stream
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-close-stream
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Voice to Content: Close audio stream on hook destruction

--- a/projects/js-packages/ai-client/src/hooks/use-media-recording/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-media-recording/index.ts
@@ -96,6 +96,8 @@ export default function useMediaRecording( {
 	const recordStartTimestamp = useRef< number >( 0 );
 	const [ duration, setDuration ] = useState< number >( 0 );
 
+	const audioStream = useRef< MediaStream | null >( null );
+
 	// The recorded blob
 	const [ blob, setBlob ] = useState< Blob | null >( null );
 
@@ -211,6 +213,7 @@ export default function useMediaRecording( {
 		navigator.mediaDevices
 			.getUserMedia( constraints )
 			.then( stream => {
+				audioStream.current = stream;
 				const source = audioCtx.createMediaStreamSource( stream );
 				source.connect( analyser.current );
 
@@ -299,11 +302,22 @@ export default function useMediaRecording( {
 		}
 	}
 
+	/**
+	 * Close the audio stream
+	 */
+	function closeStream() {
+		if ( audioStream.current ) {
+			const tracks = audioStream.current.getTracks();
+			tracks.forEach( track => track.stop() );
+		}
+	}
+
 	// Remove listeners and clear the recorded chunks
 	useEffect( () => {
 		reset();
 
 		return () => {
+			closeStream();
 			clearListeners();
 		};
 	}, [] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36085
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Closes the audio stream, removing the microphone icon from the browser tab

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Voice to Content block and go to another tab
* Check that the browser marks the tab as using a microphone (on FF it is a red mic icon)
* Close the modal and go to another tab
* Check that the microphone usage indication is no longer there
