### PR TITLE
My Jetpack: add Jetpack AI product page notices

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -66,6 +66,31 @@ export default function () {
 	const showRenewalNotice = isOverLimit && hasPaidTier;
 	const showUpgradeNotice = isOverLimit && isFree;
 
+	const noticeTitle = showRenewalNotice
+		? __( "You've reached your request limit for this month", 'jetpack-my-jetpack' )
+		: __( "You've used all your free requests", 'jetpack-my-jetpack' );
+
+	const noticeBody = showRenewalNotice
+		? sprintf(
+				// translators: %d is the number of days left in the month.
+				__(
+					'Wait for %d days to reset your limit, or upgrade now to a higher tier for additional requests and keep your work moving forward.',
+					'jetpack-my-jetpack'
+				),
+				Math.floor( ( new Date( usage[ 'next-start' ] ) - new Date() ) / ( 1000 * 60 * 60 * 24 ) )
+		  )
+		: __(
+				'Reach for More with Jetpack AI! Upgrade now for additional requests and keep your momentum going.',
+				'jetpack-my-jetpack'
+		  );
+	const noticeCta = showRenewalNotice
+		? sprintf(
+				// translators: %s is the next upgrade value
+				__( 'Get %s requests', 'jetpack-my-jetpack' ),
+				nextTier?.value || 'more'
+		  )
+		: __( 'Upgrade now', 'jetpack-my-jetpack' );
+
 	const navigateToPricingTable = useMyJetpackNavigate( '/add-jetpack-ai' );
 	const { recordEvent } = useAnalytics();
 
@@ -199,42 +224,14 @@ export default function () {
 								<Notice
 									actions={ [
 										<Button isPrimary onClick={ upgradeClickHandler }>
-											{ showRenewalNotice
-												? sprintf(
-														// translators: %s is the next upgrade value
-														__( 'Get %s requests', 'jetpack-my-jetpack' ),
-														nextTier?.value || 'more'
-												  )
-												: __( 'Upgrade now', 'jetpack-my-jetpack' ) }
+											{ noticeCta }
 										</Button>,
 									] }
 									onClose={ onNoticeClose }
 									level={ showRenewalNotice ? 'warning' : 'error' }
-									title={
-										showRenewalNotice
-											? __(
-													"You've reached your request limit for this month",
-													'jetpack-my-jetpack'
-											  )
-											: __( "You've used all your free requests", 'jetpack-my-jetpack' )
-									}
+									title={ noticeTitle }
 								>
-									{ showRenewalNotice
-										? sprintf(
-												// translators: %d is the number of days left in the month.
-												__(
-													'Wait for %d days to reset your limit, or upgrade now to a higher tier for additional requests and keep your work moving forward.',
-													'jetpack-my-jetpack'
-												),
-												Math.floor(
-													( new Date( usage[ 'next-start' ] ) - new Date() ) /
-														( 1000 * 60 * 60 * 24 )
-												)
-										  )
-										: __(
-												'Reach for More with Jetpack AI! Upgrade now for additional requests and keep your momentum going.',
-												'jetpack-my-jetpack'
-										  ) }
+									{ noticeBody }
 								</Notice>
 							</div>
 						) }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -8,13 +8,14 @@ import {
 	JetpackLogo,
 	AiIcon,
 	getRedirectUrl,
+	Notice,
 } from '@automattic/jetpack-components';
 import { Button, Card } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, plus, help, check } from '@wordpress/icons';
 import classnames from 'classnames';
 import debugFactory from 'debug';
-import { useCallback } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 /**
  * Internal dependencies
  */
@@ -26,6 +27,7 @@ import GoBackLink from '../../go-back-link';
 import styles from './style.module.scss';
 
 const debug = debugFactory( 'my-jetpack:product-interstitial:jetpack-ai-product-page' );
+
 /**
  * Product Page for Jetpack AI
  * @returns {object} React component for the product page
@@ -34,6 +36,7 @@ export default function () {
 	const { onClickGoBack } = useGoBack( 'jetpack-ai' );
 	const { detail } = useProduct( 'jetpack-ai' );
 	const { description, 'ai-assistant-feature': aiAssistantFeature } = detail;
+	const [ showNotice, setShowNotice ] = useState( false );
 
 	const videoTitle1 = __(
 		'Generate and edit content faster with Jetpack AI Assistant',
@@ -48,6 +51,7 @@ export default function () {
 		'current-tier': currentTier,
 		'next-tier': nextTier,
 		'usage-period': usage,
+		'is-over-limit': isOverLimit,
 	} = aiAssistantFeature || {};
 
 	const hasUnlimited = currentTier?.value === 1;
@@ -58,6 +62,9 @@ export default function () {
 	const showCurrentUsage = hasPaidTier && ! isFree;
 	const showAllTimeUsage = hasPaidTier || hasUnlimited;
 	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
+
+	const showRenewalNotice = isOverLimit && hasPaidTier;
+	const showUpgradeNotice = isOverLimit && isFree;
 
 	const navigateToPricingTable = useMyJetpackNavigate( '/add-jetpack-ai' );
 	const { recordEvent } = useAnalytics();
@@ -79,6 +86,12 @@ export default function () {
 		} );
 		navigateToPricingTable();
 	}, [ recordEvent, allTimeRequests, currentTier, navigateToPricingTable ] );
+
+	const onNoticeClose = useCallback( () => setShowNotice( false ), [] );
+
+	useEffect( () => {
+		setShowNotice( showRenewalNotice || showUpgradeNotice );
+	}, [ showRenewalNotice, showUpgradeNotice ] );
 
 	return (
 		<AdminPage showHeader={ false } showBackground={ true }>
@@ -143,7 +156,9 @@ export default function () {
 											{ __( 'Requests for this month', 'jetpack-my-jetpack' ) }
 										</div>
 										<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
-											{ currentTier.value - usage[ 'requests-count' ] }
+											{ currentTier.value - usage[ 'requests-count' ] >= 0
+												? currentTier.value - usage[ 'requests-count' ]
+												: 0 }
 										</div>
 									</div>
 								</Card>
@@ -179,6 +194,50 @@ export default function () {
 				</Col>
 				<Col className={ styles[ 'product-interstitial__section' ] }>
 					<div className={ styles[ 'product-interstitial__section-wrapper' ] }>
+						{ showNotice && (
+							<div className={ styles[ 'product-interstitial__ai-notice' ] }>
+								<Notice
+									actions={ [
+										<Button isPrimary onClick={ upgradeClickHandler }>
+											{ showRenewalNotice
+												? sprintf(
+														// translators: %s is the next upgrade value
+														__( 'Get %s requests', 'jetpack-my-jetpack' ),
+														nextTier?.value || 'more'
+												  )
+												: __( 'Upgrade now', 'jetpack-my-jetpack' ) }
+										</Button>,
+									] }
+									onClose={ onNoticeClose }
+									level={ showRenewalNotice ? 'warning' : 'error' }
+									title={
+										showRenewalNotice
+											? __(
+													"You've reached your request limit for this month",
+													'jetpack-my-jetpack'
+											  )
+											: __( "You've used all your free requests", 'jetpack-my-jetpack' )
+									}
+								>
+									{ showRenewalNotice
+										? sprintf(
+												// translators: %d is the number of days left in the month.
+												__(
+													'Wait for %d days to reset your limit, or upgrade now to a higher tier for additional requests and keep your work moving forward.',
+													'jetpack-my-jetpack'
+												),
+												Math.floor(
+													( new Date( usage[ 'next-start' ] ) - new Date() ) /
+														( 1000 * 60 * 60 * 24 )
+												)
+										  )
+										: __(
+												'Reach for More with Jetpack AI! Upgrade now for additional requests and keep your momentum going.',
+												'jetpack-my-jetpack'
+										  ) }
+								</Notice>
+							</div>
+						) }
 						<h2 className={ styles[ 'product-interstitial__section-heading' ] }>
 							{ __( 'AI Features', 'jetpack-my-jetpack' ) }
 						</h2>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -66,30 +66,30 @@ export default function () {
 	const showRenewalNotice = isOverLimit && hasPaidTier;
 	const showUpgradeNotice = isOverLimit && isFree;
 
-	const noticeTitle = showRenewalNotice
-		? __( "You've reached your request limit for this month", 'jetpack-my-jetpack' )
-		: __( "You've used all your free requests", 'jetpack-my-jetpack' );
+	const renewalNoticeTitle = __(
+		"You've reached your request limit for this month",
+		'jetpack-my-jetpack'
+	);
+	const upgradeNoticeTitle = __( "You've used all your free requests", 'jetpack-my-jetpack' );
 
-	const noticeBody = showRenewalNotice
-		? sprintf(
-				// translators: %d is the number of days left in the month.
-				__(
-					'Wait for %d days to reset your limit, or upgrade now to a higher tier for additional requests and keep your work moving forward.',
-					'jetpack-my-jetpack'
-				),
-				Math.floor( ( new Date( usage[ 'next-start' ] ) - new Date() ) / ( 1000 * 60 * 60 * 24 ) )
-		  )
-		: __(
-				'Reach for More with Jetpack AI! Upgrade now for additional requests and keep your momentum going.',
-				'jetpack-my-jetpack'
-		  );
-	const noticeCta = showRenewalNotice
-		? sprintf(
-				// translators: %s is the next upgrade value
-				__( 'Get %s requests', 'jetpack-my-jetpack' ),
-				nextTier?.value || 'more'
-		  )
-		: __( 'Upgrade now', 'jetpack-my-jetpack' );
+	const renewalNoticeBody = sprintf(
+		// translators: %d is the number of days left in the month.
+		__(
+			'Wait for %d days to reset your limit, or upgrade now to a higher tier for additional requests and keep your work moving forward.',
+			'jetpack-my-jetpack'
+		),
+		Math.floor( ( new Date( usage[ 'next-start' ] ) - new Date() ) / ( 1000 * 60 * 60 * 24 ) )
+	);
+	const upgradeNoticeBody = __(
+		'Reach for More with Jetpack AI! Upgrade now for additional requests and keep your momentum going.',
+		'jetpack-my-jetpack'
+	);
+	const renewalNoticeCta = sprintf(
+		// translators: %s is the next upgrade value
+		__( 'Get %s requests', 'jetpack-my-jetpack' ),
+		nextTier?.value || 'more'
+	);
+	const upgradeNoticeCta = __( 'Upgrade now', 'jetpack-my-jetpack' );
 
 	const navigateToPricingTable = useMyJetpackNavigate( '/add-jetpack-ai' );
 	const { recordEvent } = useAnalytics();
@@ -224,14 +224,14 @@ export default function () {
 								<Notice
 									actions={ [
 										<Button isPrimary onClick={ upgradeClickHandler }>
-											{ noticeCta }
+											{ showRenewalNotice ? renewalNoticeCta : upgradeNoticeCta }
 										</Button>,
 									] }
 									onClose={ onNoticeClose }
 									level={ showRenewalNotice ? 'warning' : 'error' }
-									title={ noticeTitle }
+									title={ showRenewalNotice ? renewalNoticeTitle : upgradeNoticeTitle }
 								>
-									{ noticeBody }
+									{ showRenewalNotice ? renewalNoticeBody : upgradeNoticeBody }
 								</Notice>
 							</div>
 						) }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
@@ -243,3 +243,7 @@
 		}
 	}
 }
+
+.product-interstitial__ai-notice {
+	margin-bottom: calc( var( --spacing-base ) * 8 );
+}

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-notices
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-notices
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack AI: add notices on product page for exhausted requests


### PR DESCRIPTION
The product page should communicate when available request limit has been reached, both for free and tier plans

## Proposed changes:
This PR adds the Notice component and logic to show it and the tier/plan data into it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit `wp-admin/admin.php?page=my-jetpack#/jetpack-ai`. Recommended to get a tier plan so some values are already there.

Then use the console to simulate scenarios:
```js
// get the product details
jetpackAi = wp.data.select( 'my-jetpack' ).getProduct( 'jetpack-ai' );

// then dispatch to mock a scenario
wp.data.dispatch('my-jetpack').setProduct( {
    ...jetpackAi,
    'ai-assistant-feature': {
        ...jetpackAi['ai-assistant-feature'],
        'is-over-limit': true, // this determines if the notice is shown or not
        'current-tier': {
          slug: 'some',
          value: 0, // 0 = free, 1 = unlimited, 100/200/500/750/1000 = tiers
        },
        'next-tier': {
          slug: 'some2',
          value: 100, // whatever value, will be used on the upgrade button on the notice
        'usage-period': {
          ...jetpackAi['ai-assistant-feature']['usage-period'],
          'requests-count': 101 // this will trigger the calculation for the remaining requests card
        }
    }
}  )
```

Verify the conditions:
- [ ] on free tier and `is-over-limit: true` the error notice should show
<img width="738" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/386b05d3-de82-4743-b0ba-b9d2dac3dea8">

- [ ] on paid tier and `is-over-limit: true` the warning (orange) notice should show
- [ ] the upgrade button should show the next tier value
- [ ] the notice should read how many days you should wait for the tier plan to reset the allowed requests
<img width="722" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/57c422f1-1d7c-406b-b4c1-add6d1d894cd">

At all times, the notices should be dismissible. 
The remaining requests card should never show a value lower than `0`
Verify the upgrade buttons take you to the pricing table