### PR TITLE
add bluesky share button

### DIFF
--- a/projects/plugins/jetpack/changelog/add-bluesky-share-button
+++ b/projects/plugins/jetpack/changelog/add-bluesky-share-button
@@ -1,0 +1,5 @@
+Significance: minor
+Type: enhancement
+
+Share buttons: Add a Bluesky sharing button
+

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -955,6 +955,45 @@ class Share_Nextdoor_Block extends Sharing_Source_Block {
 }
 
 /**
+ * Bluesky sharing button.
+ */
+class Share_Bluesky_Block extends Sharing_Source_Block {
+	/**
+	 * Service short name.
+	 *
+	 * @var string
+	 */
+	public $shortname = 'bluesky';
+
+	/**
+	 * Service name.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Bluesky', 'jetpack' );
+	}
+
+	/**
+	 * Process sharing request. Add actions that need to happen when sharing here.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @param array   $post_data Array of information about the post we're sharing.
+	 *
+	 * @return void
+	 */
+	public function process_request( $post, array $post_data ) {
+		// Record stats
+		parent::process_request( $post, $post_data );
+
+		$url  = 'https://bsky.app/intent/compose?text=';
+		$url .= rawurlencode( $this->get_share_title( $post->ID ) . ' ' . $this->get_share_url( $post->ID ) );
+
+		parent::redirect_request( $url );
+	}
+}
+
+/**
  * X sharing button.
  *
  * While the old Twitter button had an official button,

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -142,6 +142,7 @@ function get_services() {
 		'whatsapp'  => Jetpack_Share_WhatsApp_Block::class,
 		'mastodon'  => Share_Mastodon_Block::class,
 		'nextdoor'  => Share_Nextdoor_Block::class,
+		'bluesky'   => Share_Bluesky_Block::class,
 		'x'         => Share_X_Block::class,
 	);
 

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
@@ -171,6 +171,9 @@ li.service.share-nextdoor span:before {
 li.service.share-x span:before {
 	content: '\f10e';
 }
+li.service.share-bluesky span:before {
+	content: '\f10f';
+}
 
 /**
  * Preview section

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.js
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.js
@@ -167,6 +167,7 @@
 							! $( this ).hasClass( 'preview-email' ) &&
 							! $( this ).hasClass( 'preview-mastodon' ) &&
 							! $( this ).hasClass( 'preview-nextdoor' ) &&
+							! $( this ).hasClass( 'preview-bluesky' ) &&
 							! $( this ).hasClass( 'preview-print' ) &&
 							! $( this ).hasClass( 'preview-reddit' ) &&
 							! $( this ).hasClass( 'preview-telegram' ) &&

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -109,6 +109,7 @@ class Sharing_Service {
 			'mastodon'         => 'Share_Mastodon',
 			'nextdoor'         => 'Share_Nextdoor',
 			'x'                => 'Share_X',
+			'bluesky'          => 'Share_Bluesky',
 			// deprecated.
 			'skype'            => 'Share_Skype',
 		);

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -3348,3 +3348,66 @@ class Share_Nextdoor extends Sharing_Source {
 		parent::redirect_request( $url );
 	}
 }
+
+/**
+ * Bluesky sharing service.
+ */
+class Share_Bluesky extends Sharing_Source {
+	/**
+	 * Service short name.
+	 *
+	 * @var string
+	 */
+	public $shortname = 'bluesky';
+
+	/**
+	 * Service icon font code.
+	 *
+	 * @var string
+	 */
+	public $icon = '\f10f';
+
+	/**
+	 * Service name.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Bluesky', 'jetpack' );
+	}
+
+	/**
+	 * Get the markup of the sharing button.
+	 *
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return string
+	 */
+	public function get_display( $post ) {
+		return $this->get_link(
+			$this->get_process_request_url( $post->ID ),
+			_x( 'Bluesky', 'share to', 'jetpack' ),
+			__( 'Click to share on Bluesky', 'jetpack' ),
+			'share=bluesky',
+			'sharing-bluesky-' . $post->ID
+		);
+	}
+
+	/**
+	 * Process sharing request. Add actions that need to happen when sharing here.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @param array   $post_data Array of information about the post we're sharing.
+	 *
+	 * @return void
+	 */
+	public function process_request( $post, array $post_data ) {
+		// Record stats
+		parent::process_request( $post, $post_data );
+
+		$url  = 'https://bsky.app/intent/compose?text=';
+		$url .= rawurlencode( $this->get_share_title( $post->ID ) . ' ' . $this->get_share_url( $post->ID ) );
+
+		parent::redirect_request( $url );
+	}
+}

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -391,6 +391,20 @@ body .sd-content ul li.share-custom.no-icon a span {
 	color: #fff !important;
 }
 
+.sd-social-icon .sd-content ul li.share-bluesky a:before,
+.sd-social-text .sd-content ul li.share-bluesky a:before,
+.sd-content ul li.share-bluesky div.option.option-smart-off a:before,
+.sd-social-icon-text .sd-content li.share-bluesky a:before,
+.sd-social-official .sd-content li.share-bluesky a:before {
+	content: '\f10f';
+}
+.sd-social-official .sd-content li.share-bluesky a:before {
+	color: #1583fe;
+}
+.sd-social-icon .sd-content ul li[class*='share-'].share-bluesky a.sd-button {
+	background: #1583fe;
+	color: #fff !important;
+}
 
 .sd-social-icon .sd-content ul li.share-deprecated a:before,
 .sd-social-icon-text .sd-content li.share-deprecated a:before,


### PR DESCRIPTION
Fixes #32708

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* adds bluesky share button

Initial draft
### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)? N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that the Bluesky button is available. I'm not 100% sure how to test this
* It should appear in the social-buttons block and in the sharing buttons settings

