### PR TITLE
Voice to Content: Add transcription event tracking

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-track-events
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-track-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: publish audio information on the validation success callback of the audio validation hook. 

--- a/projects/js-packages/ai-client/src/hooks/use-audio-validation/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-audio-validation/index.ts
@@ -28,9 +28,18 @@ export type UseAudioValidationReturn = {
 	isValidatingAudio: boolean;
 	validateAudio: (
 		audio: Blob,
-		successCallback: () => void,
+		successCallback: ( info?: ValidatedAudioInformation ) => void,
 		errorCallback: ( error: string ) => void
 	) => void;
+};
+
+/**
+ * The validated audio information.
+ */
+export type ValidatedAudioInformation = {
+	duration: number;
+	isFile: boolean;
+	size: number;
 };
 
 /**
@@ -42,7 +51,11 @@ export default function useAudioValidation(): UseAudioValidationReturn {
 	const [ isValidatingAudio, setIsValidatingAudio ] = useState< boolean >( false );
 
 	const validateAudio = useCallback(
-		( audio: Blob, successCallback: () => void, errorCallback: ( error: string ) => void ) => {
+		(
+			audio: Blob,
+			successCallback: ( info?: ValidatedAudioInformation ) => void,
+			errorCallback: ( error: string ) => void
+		) => {
 			setIsValidatingAudio( true );
 
 			// Check if the audio file is too large
@@ -54,7 +67,8 @@ export default function useAudioValidation(): UseAudioValidationReturn {
 			}
 
 			// When it's a file, check the media type
-			if ( audio instanceof File ) {
+			const isFile = audio instanceof File;
+			if ( isFile ) {
 				if ( ! ALLOWED_MEDIA_TYPES.includes( audio.type ) ) {
 					setIsValidatingAudio( false );
 					return errorCallback(
@@ -85,7 +99,7 @@ export default function useAudioValidation(): UseAudioValidationReturn {
 						);
 					}
 					setIsValidatingAudio( false );
-					return successCallback();
+					return successCallback( { duration, isFile, size: audio?.size } );
 				} );
 			} );
 		},

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -46,7 +46,10 @@ export type {
 	UseTranscriptionPostProcessingReturn,
 	PostProcessingAction,
 } from './hooks/use-transcription-post-processing/index.js';
-export type { UseAudioValidationReturn } from './hooks/use-audio-validation/index.js';
+export type {
+	UseAudioValidationReturn,
+	ValidatedAudioInformation,
+} from './hooks/use-audio-validation/index.js';
 
 /*
  * Hook constants

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-track-events
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-track-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Voice to Content: Track transcription started event.

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -4,11 +4,10 @@
 import {
 	useMediaRecording,
 	useAudioValidation,
-	RecordingState,
 	TRANSCRIPTION_POST_PROCESSING_ACTION_SIMPLE_DRAFT,
-	TranscriptionState,
 } from '@automattic/jetpack-ai-client';
 import { ThemeProvider } from '@automattic/jetpack-components';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Modal, Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
@@ -21,6 +20,14 @@ import ActionButtons from './components/action-buttons';
 import AudioStatusPanel from './components/audio-status-panel';
 import useTranscriptionCreator from './hooks/use-transcription-creator';
 import useTranscriptionInserter from './hooks/use-transcription-inserter';
+/**
+ * Types
+ */
+import type {
+	RecordingState,
+	TranscriptionState,
+	ValidatedAudioInformation,
+} from '@automattic/jetpack-ai-client';
 
 /**
  * Helper to determine the state of the transcription.
@@ -59,6 +66,9 @@ export default function VoiceToContentEdit( { clientId } ) {
 			dispatch.removeBlock( clientId );
 		}, 100 );
 	}, [ dispatch, clientId ] );
+
+	// Track the usage of the feature
+	const { tracks } = useAnalytics();
 
 	const { isValidatingAudio, validateAudio } = useAudioValidation();
 
@@ -109,13 +119,21 @@ export default function VoiceToContentEdit( { clientId } ) {
 		if ( audio ) {
 			validateAudio(
 				audio,
-				() => {
+				( audioInfo: ValidatedAudioInformation ) => {
+					// Track the transcription event
+					tracks.recordEvent( 'jetpack_ai_voice_to_content_transcription_started', {
+						action: TRANSCRIPTION_POST_PROCESSING_ACTION_SIMPLE_DRAFT,
+						type: audioInfo.isFile ? 'upload' : 'record',
+						duration: audioInfo.duration,
+						file_size: audioInfo.size,
+					} );
+
 					createTranscription( audio, TRANSCRIPTION_POST_PROCESSING_ACTION_SIMPLE_DRAFT );
 				},
 				onError
 			);
 		}
-	}, [ audio, validateAudio, createTranscription, onError ] );
+	}, [ audio, tracks, validateAudio, createTranscription, onError ] );
 
 	// Destructure controls
 	const {

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -122,10 +122,10 @@ export default function VoiceToContentEdit( { clientId } ) {
 				( audioInfo: ValidatedAudioInformation ) => {
 					// Track the transcription event
 					tracks.recordEvent( 'jetpack_ai_voice_to_content_transcription_started', {
-						action: TRANSCRIPTION_POST_PROCESSING_ACTION_SIMPLE_DRAFT,
+						post_processing_action: TRANSCRIPTION_POST_PROCESSING_ACTION_SIMPLE_DRAFT,
 						type: audioInfo.isFile ? 'upload' : 'record',
-						duration: audioInfo.duration,
-						file_size: audioInfo.size,
+						audio_duration: audioInfo.duration,
+						audio_file_size: audioInfo.size,
 					} );
 
 					createTranscription( audio, TRANSCRIPTION_POST_PROCESSING_ACTION_SIMPLE_DRAFT );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36093.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the audio validatio hook to publish the audio info when the validation is successful, since it already calculated the given info
   * The information available is: is it a file? what's the duration in seconds? what's the size in bytes?
* Change the Voice to Content block to captura this validation info and use it to register a track event called `jetpack_ai_voice_to_content_transcription_started`, containing the following metadata:
   * `type`: `upload` or `record`
   * `audio_file_size`
   * `audio_duration`
   * `post_processing_action`, today fixed to the only action available, a simple draft

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Data to track is listed here: p1HpG7-r5C-p2.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes, it starts tracking transcription events on the Voice to Content block.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open the browser development console on the network tab
* Insert a Voice to Content block and pick a file for transcription (or record something)
* Notice that, on the network tab, an event is being registered using the `t.gif` request
* Check the data on the event; it should contain the fields described on the changes section

<img width="600" alt="Screenshot 2024-02-29 at 19 21 56" src="https://github.com/Automattic/jetpack/assets/6760046/acf0a3e0-a2f0-463d-b55a-0f222ab5b3c7">

* Wait for some minutes and check if the event shows up on the events dashboard, with the correct metadata set on it