### PR TITLE
Add `is_managed` key to wp/v2/sites/%s/plugins REST API endpoint

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-rest-api-is-managed
+++ b/projects/packages/scheduled-updates/changelog/add-rest-api-is-managed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds an is_managed key to the wp/v2 sites/%s/plugins API. This key checks if the plugin is managed on Atomic by verifying if it's symlinked.

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Test class for Scheduled_Updates.
+ *
+ * @package automattic/scheduled-updates
+ */
+
+/**
+ * Test class for Scheduled_Updates.
+ *
+ * @coversDefaultClass Scheduled_Updates
+ */
+class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Set up.
+	 *
+	 * @before
+	 */
+	protected function set_up() {
+		parent::set_up_wordbless();
+		\WorDBless\Users::init()->clear_all_users();
+
+		// Initialize the WordPress filesystem variable.
+		global $wp_filesystem;
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		WP_Filesystem();
+		$this->wp_filesystem = $wp_filesystem;
+
+		$this->plugin_dir = WP_PLUGIN_DIR;
+		$this->admin_id   = wp_insert_user(
+			array(
+				'user_login' => 'dumasdasdasmy_user',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->admin_id );
+
+		// Ensure plugin directory exists.
+		$this->wp_filesystem->mkdir( $this->plugin_dir );
+
+		// init the hook
+		add_action( 'rest_api_init', array( 'Automattic\Jetpack\Scheduled_Updates', 'add_is_managed_extension_field' ) );
+
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Clean up after test
+	 *
+	 * @after
+	 */
+	protected function tear_down() {
+		// Clean up the temporary plugin directory
+		$this->wp_filesystem->rmdir( $this->plugin_dir, true );
+
+		parent::tear_down_wordbless();
+	}
+
+	/**
+	 * Simulate and test both managed and unmanaged plugins
+	 *
+	 * @covers ::add_is_managed_extension_field
+	 */
+	public function test_mixed_plugins() {
+		// direct
+		$plugin_name = '1-direct-plugin';
+		$this->wp_filesystem->mkdir( "$this->plugin_dir/$plugin_name" );
+		$this->populate_file_with_plugin_header( "$this->plugin_dir/$plugin_name/$plugin_name.php", 'direct-plugin' );
+
+		// managed
+		$plugin_name = '2-managed-plugin';
+		$target_dir  = "$this->plugin_dir/wordpress";
+		$this->wp_filesystem->mkdir( $target_dir );
+		$this->wp_filesystem->mkdir( "$target_dir/$plugin_name" );
+		$this->populate_file_with_plugin_header( "$target_dir/$plugin_name/$plugin_name.php", 'managed-plugin' );
+		symlink( "$target_dir/$plugin_name", "$this->plugin_dir/$plugin_name" );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/plugins' );
+
+		$result = rest_do_request( $request );
+		$this->assertSame( false, $result->get_data()[0]['is_managed'] );
+		$this->assertSame( true, $result->get_data()[1]['is_managed'] );
+	}
+
+	/**
+	 * Populates the plugin file with a plugin header so get_plugins() can find it.
+	 *
+	 * @param string $plugin_file Path to plugin file.
+	 * @param string $plugin_name The plugin name.
+	 */
+	private function populate_file_with_plugin_header( $plugin_file, $plugin_name ) {
+		$this->wp_filesystem->touch( $plugin_file );
+		$this->wp_filesystem->put_contents(
+			$plugin_file,
+			"/**
+				* Plugin Name: $plugin_name
+				* Plugin URI: https://jetpack.com/
+				* Description: $plugin_name
+				* Version: 4.0.0
+				* Author: Automattic
+				* Text Domain: $plugin_name
+				*/"
+		);
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5665

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds an `is_managed` key to  wp/v2/sites/%s/plugins REST API endpoint. This checks (dynamically, on the fly) if the plugin is managed on Atomic by checking it it's symlinked to a WordPress parent directory.

See: p9o2xV-3Nx-p2#comment-8728 for rationale.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you apply this patch either using Jetpack beta (WordPress.com Features) or `jetpack rsync mu-wpcom-plugin woa-site.wordpress.com@sftp.wp.com:htdocs/wp-content/plugins/jetpack-mu-wpcom-plugin-dev`
* Go to the developer console and the `/wp/v2/woa-site.wpcomstaging.com/plugins` endpoint
* You should see an `is_managed` key with correct entry. If managed is true, to verify, you can check `wp-admin/plugins.php`, that should also say `Managed by host`.
* To make a plugin managed or unmanaged, you can go to `wo-site/_cli` and do: ` wp wpcomsh plugin use-managed akismet`

Here's how an example response should look like:

![CleanShot 2024-03-01 at 09 34 07](https://github.com/Automattic/jetpack/assets/533/b3a4d77b-1656-4a9f-92a5-88f88db77293)
