### PR TITLE
Boost: Prevent directory listing in cache directories

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
@@ -158,7 +158,7 @@ class Filesystem_Utils {
 			$dir_created = @mkdir( $path, 0755, true );
 
 			if ( $dir_created ) {
-				self::create_empty_index_file( $path );
+				self::create_empty_index_files( $path );
 			}
 
 			return $dir_created;
@@ -171,8 +171,13 @@ class Filesystem_Utils {
 	 * Create an empty index.php file in the given directory.
 	 * This is done to prevent directory listing.
 	 */
-	private static function create_empty_index_file( $path ) {
-		return self::write_to_file( $path . '/index.php', '<?php' . PHP_EOL . '// Silence is golden' );
+	private static function create_empty_index_files( $path ) {
+		if ( self::is_boost_cache_directory( $path ) ) {
+			self::write_to_file( $path . '/index.php', '<?php' . PHP_EOL . '// Silence is golden' );
+
+			// Create an empty index.php file in the parent directory as well.
+			self::create_empty_index_files( dirname( $path ) );
+		}
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
@@ -39,8 +39,8 @@ class Filesystem_Utils {
 					if ( $file->isDir() ) {
 						Logger::debug( 'rmdir: ' . $file->getPathname() );
 						@rmdir( $file->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
-					} elseif ( $file->getFilename() !== 'index.php' ) {
-						// Delete all files except index.php. index.php is used to prevent directory listing.
+					} elseif ( $file->getFilename() !== 'index.html' ) {
+						// Delete all files except index.html. index.html is used to prevent directory listing.
 						Logger::debug( 'unlink: ' . $file->getPathname() );
 						@unlink( $file->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink, WordPress.PHP.NoSilencedErrors.Discouraged
 					}
@@ -48,8 +48,8 @@ class Filesystem_Utils {
 				@rmdir( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged,
 				break;
 			case self::DELETE_FILES: // delete all files in the given directory.
-				// Files to delete are all files in the given directory, except index.php. index.php is used to prevent directory listing.
-				$files = array_diff( scandir( $path ), array( '.', '..', 'index.php' ) );
+				// Files to delete are all files in the given directory, except index.html. index.html is used to prevent directory listing.
+				$files = array_diff( scandir( $path ), array( '.', '..', 'index.html' ) );
 				foreach ( $files as $file ) {
 					$file = $path . '/' . $file;
 					if ( is_file( $file ) ) {
@@ -104,7 +104,7 @@ class Filesystem_Utils {
 
 		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 		while ( false !== ( $file = readdir( $handle ) ) ) {
-			if ( $file === '.' || $file === '..' || $file === 'index.php' ) {
+			if ( $file === '.' || $file === '..' || $file === 'index.html' ) {
 				// Skip and continue to next file
 				continue;
 			}
@@ -142,8 +142,8 @@ class Filesystem_Utils {
 		}
 
 		if ( $is_dir_empty === true ) {
-			// Directory is considered empty even if it has an index.php file. Delete it it first.
-			self::delete_file( $directory . '/index.php' );
+			// Directory is considered empty even if it has an index.html file. Delete it it first.
+			self::delete_file( $directory . '/index.html' );
 
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
 			@rmdir( $directory );
@@ -173,14 +173,14 @@ class Filesystem_Utils {
 	}
 
 	/**
-	 * Create an empty index.php file in the given directory.
+	 * Create an empty index.html file in the given directory.
 	 * This is done to prevent directory listing.
 	 */
 	private static function create_empty_index_files( $path ) {
 		if ( self::is_boost_cache_directory( $path ) ) {
-			self::write_to_file( $path . '/index.php', '<?php' . PHP_EOL . '// Silence is golden' );
+			self::write_to_file( $path . '/index.html', '' );
 
-			// Create an empty index.php file in the parent directory as well.
+			// Create an empty index.html file in the parent directory as well.
 			self::create_empty_index_files( dirname( $path ) );
 		}
 	}
@@ -213,7 +213,7 @@ class Filesystem_Utils {
 			return new Boost_Cache_Error( 'directory_not_readable', 'Directory is not readable' );
 		}
 
-		$files = array_diff( scandir( $dir ), array( '.', '..', 'index.php' ) );
+		$files = array_diff( scandir( $dir ), array( '.', '..', 'index.html' ) );
 		return empty( $files );
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
@@ -104,7 +104,7 @@ class Filesystem_Utils {
 
 		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 		while ( false !== ( $file = readdir( $handle ) ) ) {
-			if ( $file === '.' || $file === '..' ) {
+			if ( $file === '.' || $file === '..' || $file === 'index.php' ) {
 				// Skip and continue to next file
 				continue;
 			}
@@ -142,6 +142,9 @@ class Filesystem_Utils {
 		}
 
 		if ( $is_dir_empty === true ) {
+			// Directory is considered empty even if it has an index.php file. Delete it it first.
+			self::delete_file( $directory . '/index.php' );
+
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
 			@rmdir( $directory );
 		}
@@ -210,7 +213,8 @@ class Filesystem_Utils {
 			return new Boost_Cache_Error( 'directory_not_readable', 'Directory is not readable' );
 		}
 
-		return ( count( scandir( $dir ) ) === 2 ); // All directories have '.' and '..'
+		$files = array_diff( scandir( $dir ), array( '.', '..', 'index.php' ) );
+		return empty( $files );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
@@ -155,10 +155,24 @@ class Filesystem_Utils {
 	public static function create_directory( $path ) {
 		if ( ! is_dir( $path ) ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.dir_mkdir_dirname, WordPress.WP.AlternativeFunctions.file_system_operations_mkdir, WordPress.PHP.NoSilencedErrors.Discouraged
-			return @mkdir( $path, 0755, true );
+			$dir_created = @mkdir( $path, 0755, true );
+
+			if ( $dir_created ) {
+				self::create_empty_index_file( $path );
+			}
+
+			return $dir_created;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Create an empty index.php file in the given directory.
+	 * This is done to prevent directory listing.
+	 */
+	private static function create_empty_index_file( $path ) {
+		return self::write_to_file( $path . '/index.php', '<?php' . PHP_EOL . '// Silence is golden' );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php
@@ -39,7 +39,8 @@ class Filesystem_Utils {
 					if ( $file->isDir() ) {
 						Logger::debug( 'rmdir: ' . $file->getPathname() );
 						@rmdir( $file->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged
-					} else {
+					} elseif ( $file->getFilename() !== 'index.php' ) {
+						// Delete all files except index.php. index.php is used to prevent directory listing.
 						Logger::debug( 'unlink: ' . $file->getPathname() );
 						@unlink( $file->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink, WordPress.PHP.NoSilencedErrors.Discouraged
 					}
@@ -47,7 +48,8 @@ class Filesystem_Utils {
 				@rmdir( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged,
 				break;
 			case self::DELETE_FILES: // delete all files in the given directory.
-				$files = array_diff( scandir( $path ), array( '.', '..' ) );
+				// Files to delete are all files in the given directory, except index.php. index.php is used to prevent directory listing.
+				$files = array_diff( scandir( $path ), array( '.', '..', 'index.php' ) );
 				foreach ( $files as $file ) {
 					$file = $path . '/' . $file;
 					if ( is_file( $file ) ) {

--- a/projects/plugins/boost/changelog/boost-cache-no-browsing
+++ b/projects/plugins/boost/changelog/boost-cache-no-browsing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Cache: Prevent directory listing in cache directories


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36100

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create index.php file while creating directories in all directories along the path.
* Account for this index.php file while clearing cache
* Account for this index.php file while garbage collecting

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Create some cache by browsing the site.
* Make sure each directory in `wp-content/boost-cache` directory has an `index.php` file.
* Clear the cache, make sure the index.php files remain in empty folders(Clearing cache doesn't delete directories).
* Run garbage collection.
* Make sure the empty directories(if it only contains index.php, it's empty) and any expired files apart from `index.php` files are deleted.

