### PR TITLE
Blog Stats Block: Add Frontend Message when Stats Module is Disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/update-blog-stats-disabled
+++ b/projects/plugins/jetpack/changelog/update-blog-stats-disabled
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Blog Stats block: Add message on the frontend when the Stats module is disabled.

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
@@ -47,6 +47,26 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 function load_assets( $attributes ) {
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
+	// For when Stats has been disabled subsequent to inserting the block.
+	if ( ! \Jetpack::is_module_active( 'stats' ) ) {
+		if ( current_user_can( 'edit_theme_options' ) ) {
+			return sprintf(
+				'<p>%s</p>',
+				sprintf(
+					/* translators: placeholder is a link that says "Stats module". */
+					esc_html__( 'Please enable the %s in Jetpack to use this block.', 'jetpack' ),
+					'<a href="' .
+						esc_url( admin_url( 'admin.php?page=jetpack_modules&s=Stats' ) ) .
+						'">' .
+						esc_html__( 'Stats module', 'jetpack' ) .
+					'</a>'
+				)
+			);
+		}
+
+		return;
+	}
+
 	$stats = 0;
 
 	// For when there's no post ID - eg. search pages.

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
@@ -56,7 +56,7 @@ function load_assets( $attributes ) {
 					/* translators: placeholder is a link that says "Stats module". */
 					esc_html__( 'Please enable the %s in Jetpack to use this block.', 'jetpack' ),
 					'<a href="' .
-						esc_url( admin_url( 'admin.php?page=jetpack_modules&s=Stats' ) ) .
+						esc_url( admin_url( 'admin.php?page=jetpack_modules&module_tag=Jetpack%20Stats' ) ) .
 						'">' .
 						esc_html__( 'Stats module', 'jetpack' ) .
 					'</a>'
@@ -66,8 +66,6 @@ function load_assets( $attributes ) {
 
 		return;
 	}
-
-	$stats = 0;
 
 	// For when there's no post ID - eg. search pages.
 	if ( $attributes['statsOption'] === 'post' && ! get_the_ID() ) {
@@ -81,6 +79,7 @@ function load_assets( $attributes ) {
 		return;
 	}
 
+	$stats       = 0;
 	$wpcom_stats = new WPCOM_Stats();
 
 	if ( $attributes['statsOption'] === 'post' ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36105

## Proposed changes:
We already add a prompt to activate the Stats module in the Editor, but that module can be disabled subsequent to the block being inserted. In that case, the block won't work. This adds a message on the front-end encouraging the user to re-activate the stats module. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See original issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

* Ensure the Stats module is active in order to insert the Blog Stats block (you'll need to enable Beta blocks for this)
* Publish a post with the block 
* Disable the Stats module
* Refresh the page
* Verify that the link takes you here: `/wp-admin/admin.php?page=jetpack_modules&module_tag=Jetpack%20Stats`. It should also only appear for site owners.

<img width="585" alt="Screenshot 2024-03-01 at 09 32 05" src="https://github.com/Automattic/jetpack/assets/43215253/d501425e-1261-4bfe-9817-107de6fbada6">
