### PR TITLE
Untangle: add site option wpcom_classic_early_release

### DIFF
--- a/projects/packages/sync/changelog/untangle-wpcom_classic_early_release
+++ b/projects/packages/sync/changelog/untangle-wpcom_classic_early_release
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Whitelist the new wpcom_classic_early_release site option

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.8.x-dev"
+			"dev-trunk": "2.9.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -181,6 +181,7 @@ class Defaults {
 		'wp_mobile_featured_images',
 		'wp_page_for_privacy_policy',
 		'wpcom_ai_site_prompt',
+		'wpcom_classic_early_release',
 		'wpcom_featured_image_in_email',
 		'wpcom_gifting_subscription',
 		'wpcom_is_fse_activated',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.8.1';
+	const PACKAGE_VERSION = '2.9.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/backup/changelog/untangle-wpcom_classic_early_release
+++ b/projects/plugins/backup/changelog/untangle-wpcom_classic_early_release
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1544,7 +1544,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
+                "reference": "86e9c73cf42f93dc2834162700676d8f5dc2393f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1576,7 +1576,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.8.x-dev"
+                    "dev-trunk": "2.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/untangle-wpcom_classic_early_release
+++ b/projects/plugins/boost/changelog/untangle-wpcom_classic_early_release
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1534,7 +1534,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
+                "reference": "86e9c73cf42f93dc2834162700676d8f5dc2393f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1566,7 +1566,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.8.x-dev"
+                    "dev-trunk": "2.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/untangle-wpcom_classic_early_release
+++ b/projects/plugins/jetpack/changelog/untangle-wpcom_classic_early_release
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Untangle: add site option wpcom_classic_early_release

--- a/projects/plugins/jetpack/changelog/untangle-wpcom_classic_early_release#2
+++ b/projects/plugins/jetpack/changelog/untangle-wpcom_classic_early_release#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2457,7 +2457,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
+				"reference": "86e9c73cf42f93dc2834162700676d8f5dc2393f"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2489,7 +2489,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.8.x-dev"
+					"dev-trunk": "2.9.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -209,6 +209,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_commercial',
 		'is_commercial_reasons',
 		'wpcom_admin_interface',
+		'wpcom_classic_early_release',
 	);
 
 	/**
@@ -281,6 +282,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_commercial',
 		'is_commercial_reasons',
 		'wpcom_admin_interface',
+		'wpcom_classic_early_release',
 	);
 
 	/**
@@ -923,6 +925,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'wpcom_admin_interface':
 					$options[ $key ] = $site->get_wpcom_admin_interface();
+					break;
+				case 'wpcom_classic_early_release':
+					$options[ $key ] = $site->get_wpcom_classic_early_release();
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1577,4 +1577,13 @@ abstract class SAL_Site {
 	public function get_wpcom_admin_interface() {
 		return (string) get_option( 'wpcom_admin_interface' );
 	}
+
+	/**
+	 * Returns whether the site is part of the classic view early release.
+	 *
+	 * @return string
+	 **/
+	public function get_wpcom_classic_early_release() {
+		return (string) get_option( 'wpcom_classic_early_release' );
+	}
 }

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1581,9 +1581,9 @@ abstract class SAL_Site {
 	/**
 	 * Returns whether the site is part of the classic view early release.
 	 *
-	 * @return string
+	 * @return bool
 	 **/
 	public function get_wpcom_classic_early_release() {
-		return (string) get_option( 'wpcom_classic_early_release' );
+		return ! empty( get_option( 'wpcom_classic_early_release' ) );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -247,6 +247,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_verbum_subscription_modal'            => true,
 			'jetpack_blocks_disabled'                      => false,
 			'wpcom_ai_site_prompt'                         => '',
+			'wpcom_classic_early_release'                  => true,
 			'jetpack_package_versions'                     => array(),
 			'jetpack_newsletters_publishing_default_frequency' => 'weekly',
 		);

--- a/projects/plugins/migration/changelog/untangle-wpcom_classic_early_release
+++ b/projects/plugins/migration/changelog/untangle-wpcom_classic_early_release
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1544,7 +1544,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
+                "reference": "86e9c73cf42f93dc2834162700676d8f5dc2393f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1576,7 +1576,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.8.x-dev"
+                    "dev-trunk": "2.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/untangle-wpcom_classic_early_release
+++ b/projects/plugins/protect/changelog/untangle-wpcom_classic_early_release
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1457,7 +1457,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
+                "reference": "86e9c73cf42f93dc2834162700676d8f5dc2393f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1489,7 +1489,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.8.x-dev"
+                    "dev-trunk": "2.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/untangle-wpcom_classic_early_release
+++ b/projects/plugins/search/changelog/untangle-wpcom_classic_early_release
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1545,7 +1545,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
+                "reference": "86e9c73cf42f93dc2834162700676d8f5dc2393f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1577,7 +1577,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.8.x-dev"
+                    "dev-trunk": "2.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/untangle-wpcom_classic_early_release
+++ b/projects/plugins/social/changelog/untangle-wpcom_classic_early_release
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1539,7 +1539,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
+				"reference": "86e9c73cf42f93dc2834162700676d8f5dc2393f"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1571,7 +1571,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.8.x-dev"
+					"dev-trunk": "2.9.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/starter-plugin/changelog/untangle-wpcom_classic_early_release
+++ b/projects/plugins/starter-plugin/changelog/untangle-wpcom_classic_early_release
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1400,7 +1400,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
+                "reference": "86e9c73cf42f93dc2834162700676d8f5dc2393f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1432,7 +1432,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.8.x-dev"
+                    "dev-trunk": "2.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/untangle-wpcom_classic_early_release
+++ b/projects/plugins/videopress/changelog/untangle-wpcom_classic_early_release
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1400,7 +1400,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "1d3cf7151604d39d427b411189cbb08a61ac9a5e"
+                "reference": "86e9c73cf42f93dc2834162700676d8f5dc2393f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1432,7 +1432,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.8.x-dev"
+                    "dev-trunk": "2.9.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/dotcom-forge/issues/5857

## Proposed changes:

This PR adds the site option `wpcom_classic_early_release` to the wpcom `/sites/:siteId` endpoint response.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this branch.
2. Go to `yoursite/_cli`
3. Run `wp option update wpcom_classic_early_release 1`
4. Go to https://developer.wordpress.com/docs/api/console/
5. Hit WPCOM API 1.1: `GET /sites/$site`
6. Verify you see the `wpcom_classic_early_release` option in the response as follows:

<img width="572" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/d3199150-b08b-4af7-b64e-5c49fd2f3069">
