### PR TITLE
Add/campaign creation v1.1

### DIFF
--- a/projects/packages/blaze/changelog/add-campaign_creation_v1.1
+++ b/projects/packages/blaze/changelog/add-campaign_creation_v1.1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for running DSP Campaign Creation API endpoint v1.1 from DSP widget

--- a/projects/packages/blaze/composer.json
+++ b/projects/packages/blaze/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.18.x-dev"
+			"dev-trunk": "0.19.x-dev"
 		},
 		"textdomain": "jetpack-blaze",
 		"version-constants": {

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.18.1",
+	"version": "0.19.0-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -142,7 +142,7 @@ class Dashboard_REST_Controller {
 		);
 		register_rest_route(
 			static::$namespace,
-			sprintf( '/sites/%d/wordads/dsp/api/v1/campaigns(?P<sub_path>[a-zA-Z0-9-_\/]*)', $site_id ),
+			sprintf( '/sites/%d/wordads/dsp/api/(?P<api_version>v[0-9]+\.?[0-9]*)/campaigns(?P<sub_path>[a-zA-Z0-9-_\/]*)', $site_id ),
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'edit_dsp_campaigns' ),
@@ -662,7 +662,8 @@ class Dashboard_REST_Controller {
 	 * @return array|WP_Error
 	 */
 	public function edit_dsp_campaigns( $req ) {
-		return $this->edit_dsp_generic( 'v1/campaigns', $req, array( 'timeout' => 20 ) );
+		$version = $req->get_param( 'api_version' ) ?? 'v1';
+		return $this->edit_dsp_generic( "{$version}/campaigns", $req, array( 'timeout' => 20 ) );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.18.1';
+	const PACKAGE_VERSION = '0.19.0-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/plugins/jetpack/changelog/add-campaign_creation_v1.1
+++ b/projects/plugins/jetpack/changelog/add-campaign_creation_v1.1
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -456,7 +456,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/blaze",
-				"reference": "bfdacc73c97e46d2d229ef23b0b1ef3f0e84172e"
+				"reference": "89d402c8e09b090e61b089601946f772532c2b98"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -484,7 +484,7 @@
 					"link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.18.x-dev"
+					"dev-trunk": "0.19.x-dev"
 				},
 				"textdomain": "jetpack-blaze",
 				"version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to the PR Tumblr's A8C DSP repo (`/Tumblr/a8c-dsp/pull/914`).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Currently Jetpack supports requests to DSP API for campaign creation but it only includes using API `v1`, this PR proposes starting support for `v1.1` as well.

## Does this pull request change what data or activity we track or use?

The PR does not change any data or activity we track. The only change is to make Jetpack proxy to pass either `v1` or `v1.1` from the URL further to DSP API.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Note: to read more about running DSP in Jetpack locally, please consider reading the following P2: peeHDf-2t5-p2

### Preparation

- Disable "singleCallCampaignCreation" flag in DSP's `dsp/src/config/features/features.ts` by putting "false &&" at the beginning of the condition;
- Run DSP and DSP Widget;
- Build BlazePress App in Calypso (with local URL to widget);
- Build blaze package in Jetpack;
- Run Jetpack.

### The current version

- Open Tools > Advertising on Jetpack site;
- Open Browser's Dev Tools;
- Promote a post;
- Make sure `api/v1/campaigns` request worked as usual (again, `v1`, since we disabled the feature);
- Campaign creation should complete as usual.

https://github.com/Automattic/jetpack/assets/115007291/935057df-f936-4f3f-b1f1-6f2cb91a28a4

### The new version

- Enable "singleCallCampaignCreation" flag in DSP's `dsp/src/config/features/features.ts` by putting "true ||" at the condition;
- Make sure the widget was rebuilt;
- Promote a post again;
- Make sure that the new `api/v1.1/campaigns` request was used (`v1.1` is the new version);
- Campaign creation should complete as usual.

https://github.com/Automattic/jetpack/assets/115007291/6bdfde27-2c79-4fce-aa35-d5b866bd8f58
