### PR TITLE
Jetpack Comments: Prevent iframe global variable declaration collision

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-comments-variable-declaration-collision
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-comments-variable-declaration-collision
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack Comments: Wrap iframe related script in IIFE to prevent declaration of global variables

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -556,50 +556,52 @@ HTML;
 		}
 		?>
 		<script type="text/javascript">
-			const iframe = document.getElementById( 'jetpack_remote_comment' );
-			<?php if ( get_option( 'thread_comments' ) && get_option( 'thread_comments_depth' ) ) : ?>
-			const watchReply = function() {
-				// Check addComment._Jetpack_moveForm to make sure we don't monkey-patch twice.
-				if ( 'undefined' !== typeof addComment && ! addComment._Jetpack_moveForm ) {
-					// Cache the Core function.
-					addComment._Jetpack_moveForm = addComment.moveForm;
-					const commentParent = document.getElementById( 'comment_parent' );
-					const cancel = document.getElementById( 'cancel-comment-reply-link' );
+			(function () {
+				const iframe = document.getElementById( 'jetpack_remote_comment' );
+				<?php if ( get_option( 'thread_comments' ) && get_option( 'thread_comments_depth' ) ) : ?>
+				const watchReply = function() {
+					// Check addComment._Jetpack_moveForm to make sure we don't monkey-patch twice.
+					if ( 'undefined' !== typeof addComment && ! addComment._Jetpack_moveForm ) {
+						// Cache the Core function.
+						addComment._Jetpack_moveForm = addComment.moveForm;
+						const commentParent = document.getElementById( 'comment_parent' );
+						const cancel = document.getElementById( 'cancel-comment-reply-link' );
 
-					function tellFrameNewParent ( commentParentValue ) {
-						const url = new URL( iframe.src );
-						if ( commentParentValue ) {
-							url.searchParams.set( 'replytocom', commentParentValue )
-						} else {
-							url.searchParams.delete( 'replytocom' );
-						}
-						if( iframe.src !== url.href ) {
-							iframe.src = url.href;
-						}
-					};
+						function tellFrameNewParent ( commentParentValue ) {
+							const url = new URL( iframe.src );
+							if ( commentParentValue ) {
+								url.searchParams.set( 'replytocom', commentParentValue )
+							} else {
+								url.searchParams.delete( 'replytocom' );
+							}
+							if( iframe.src !== url.href ) {
+								iframe.src = url.href;
+							}
+						};
 
-					cancel.addEventListener( 'click', function () {
-						tellFrameNewParent( false );
-					} );
+						cancel.addEventListener( 'click', function () {
+							tellFrameNewParent( false );
+						} );
 
-					addComment.moveForm = function ( _, parentId ) {
-						tellFrameNewParent( parentId );
-						return addComment._Jetpack_moveForm.apply( null, arguments );
-					};
+						addComment.moveForm = function ( _, parentId ) {
+							tellFrameNewParent( parentId );
+							return addComment._Jetpack_moveForm.apply( null, arguments );
+						};
+					}
 				}
-			}
-			document.addEventListener( 'DOMContentLoaded', watchReply );
-			// In WP 6.4+, the script is loaded asynchronously, so we need to wait for it to load before we monkey-patch the functions it introduces.
-			document.querySelector('#comment-reply-js')?.addEventListener( 'load', watchReply );
+				document.addEventListener( 'DOMContentLoaded', watchReply );
+				// In WP 6.4+, the script is loaded asynchronously, so we need to wait for it to load before we monkey-patch the functions it introduces.
+				document.querySelector('#comment-reply-js')?.addEventListener( 'load', watchReply );
 
-			<?php endif; ?>
+				<?php endif; ?>
 
-			window.addEventListener( 'message', function ( event ) {
-				if ( event.origin !== 'https://jetpack.wordpress.com' ) {
-					return;
-				}
-				iframe.style.height = event.data + 'px';
-			});
+				window.addEventListener( 'message', function ( event ) {
+					if ( event.origin !== 'https://jetpack.wordpress.com' ) {
+						return;
+					}
+					iframe.style.height = event.data + 'px';
+				});
+			})();
 		</script>
 		<?php
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to p1709222784107429-slack-C02T4NVL4JJ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The jetpack comments module declares a global `iframe` variable and adds it to the page footer within a script. This pollutes the global scope and causes variable collisions with other scripts.
These changes wrap the iframe-related logic in an Immediately invoked function expression to prevent assignment to global variables and potential collisions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add the following script to your site header/footer (You can use a plugin like WPCode Lite):
```
<script>
const iframe = 'test'
</script>
```
* Load a post and scroll down to the comment posting section. Open the browser console and you should a similar error message (you may need to refresh if you open the console after the page has already loaded):
`Uncaught SyntaxError: Identifier 'iframe' has already been declared`
* Click the comment textarea and expand its height by repeatedly clicking `Enter`. Verbum will eventually get cut off a certain height

<img width="813" alt="CleanShot 2024-03-01 at 09 56 26@2x" src="https://github.com/Automattic/jetpack/assets/10482592/3f3e66da-fa1e-499c-87c5-d4862bff8280">

* Sync this PR to your Atomic Site
* Refresh the same post and verify that you no longer seeing the `iframe` variable error.
* Verify that the comment section height does not get cut off and smoke test comment posting.