### PR TITLE
WP Super Cache: if there is an output buffer active do not create another one

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-check-for-ob
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-check-for-ob
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: don't create an output buffer if there's already one active

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -1512,6 +1512,16 @@ function wp_cache_phase2() {
 		return false;
 	}
 
+	if ( ob_get_level() > 0 ) {
+		global $wp_super_cache_late_init;
+		$ob_warning = 'Already in an output buffer. Check your plugins, themes, mu-plugins, and other custom code. Exit.';
+		if ( isset( $wp_super_cache_late_init ) && $wp_super_cache_late_init ) {
+			$ob_warning = 'Late init enabled. Disable it. ' . $ob_warning;
+		}
+		wp_cache_debug( 'wp_cache_phase2: ' . $ob_warning );
+		return;
+	}
+
 	wp_cache_debug( 'In WP Cache Phase 2', 5 );
 
 	$wp_cache_gmt_offset   = get_option( 'gmt_offset' ); // caching for later use when wpdb is gone. https://wordpress.org/support/topic/224349


### PR DESCRIPTION
If an output buffer is already active then don't create a new one because another plugin will probably try to end it, thinking it's their output buffer.
Instead, exit caching completely.
May fix problems like this when late init is enabled.

## Proposed changes:
* Check for output buffer in wp_cache_phase2() before the plugin creates a new one and exit if found.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply PR
* Enable debugging
* Enable late init mode in advanced settings.
* Create an mu-plugin with this code:
function test_ob() {
        ob_start();
}
add_action( 'init', 'test_ob' );
* check the debug log for the warning, `Late init defined. Already in an output buffer. Check your plugins, themes, mu-plugins. Exit. `

