### PR TITLE
Update Schedules: Account for plugins set to autoupdate when managing schedules

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-autoupdate-management
+++ b/projects/packages/scheduled-updates/changelog/add-autoupdate-management
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds plugins to and removes them from aut-updates when creating and deleting update schedules.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.0';
+	const PACKAGE_VERSION = '0.3.1-alpha';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -169,6 +169,13 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return $event;
 		}
 
+		if ( wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
+			// Remove the plugins that are now updated on a schedule from the auto-update list.
+			$auto_update_plugins = get_option( 'auto_update_plugins', array() );
+			$auto_update_plugins = array_diff( $auto_update_plugins, $plugins );
+			update_option( 'auto_update_plugins', $auto_update_plugins );
+		}
+
 		return rest_ensure_response( $this->generate_schedule_id( $plugins ) );
 	}
 
@@ -272,6 +279,14 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$result = wp_unschedule_event( $event->timestamp, 'jetpack_scheduled_update', $event->args, true );
 		if ( is_wp_error( $result ) ) {
 			return $result;
+		}
+
+		if ( wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
+			// Add the plugins that are no longer updated on a schedule to the auto-update list.
+			$auto_update_plugins = get_option( 'auto_update_plugins', array() );
+			$auto_update_plugins = array_unique( array_merge( $auto_update_plugins, $event->args ) );
+			usort( $auto_update_plugins, 'strnatcasecmp' );
+			update_option( 'auto_update_plugins', $auto_update_plugins );
 		}
 
 		return rest_ensure_response( true );

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -286,9 +286,17 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		require_once ABSPATH . 'wp-admin/includes/update.php';
 
 		if ( wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
+			unset( $events[ $request['schedule_id'] ] );
+
+			// Find the plugins that are not part of any other schedule.
+			$plugins = $event->args;
+			foreach ( wp_list_pluck( $events, 'args' ) as $args ) {
+				$plugins = array_diff( $plugins, $args );
+			}
+
 			// Add the plugins that are no longer updated on a schedule to the auto-update list.
 			$auto_update_plugins = get_option( 'auto_update_plugins', array() );
-			$auto_update_plugins = array_unique( array_merge( $auto_update_plugins, $event->args ) );
+			$auto_update_plugins = array_unique( array_merge( $auto_update_plugins, $plugins ) );
 			usort( $auto_update_plugins, 'strnatcasecmp' );
 			update_option( 'auto_update_plugins', $auto_update_plugins );
 		}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -169,6 +169,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return $event;
 		}
 
+		require_once ABSPATH . 'wp-admin/includes/update.php';
+
 		if ( wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
 			// Remove the plugins that are now updated on a schedule from the auto-update list.
 			$auto_update_plugins = get_option( 'auto_update_plugins', array() );
@@ -280,6 +282,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
+
+		require_once ABSPATH . 'wp-admin/includes/update.php';
 
 		if ( wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
 			// Add the plugins that are no longer updated on a schedule to the auto-update list.

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -258,6 +258,37 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
+	 * Removes plugins from the autoupdate list when creating a schedule.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_updating_autoupdate_plugins_on_create() {
+		$unscheduled_plugins = array( 'hello-dolly/hello-dolly.php' );
+		$plugins             = array(
+			'custom-plugin/custom-plugin.php',
+			'gutenberg/gutenberg.php',
+		);
+
+		update_option( 'auto_update_plugins', array( 'hello-dolly/hello-dolly.php', 'gutenberg/gutenberg.php' ) );
+
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => $plugins,
+				'schedule' => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
+				),
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		rest_do_request( $request );
+
+		$this->assertEquals( $unscheduled_plugins, get_option( 'auto_update_plugins' ) );
+	}
+
+	/**
 	 * Test get item.
 	 *
 	 * @covers ::get_item
@@ -438,6 +469,30 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$this->assertSame( 404, $result->get_status() );
 		$this->assertSame( 'rest_invalid_schedule', $result->get_data()['code'] );
+	}
+
+	/**
+	 * Adds plugins to the autoupdate list when deleting a schedule.
+	 *
+	 * @covers ::delete_item
+	 */
+	public function test_updating_autoupdate_plugins_on_delete() {
+		$auto_update = array( 'hello-dolly/hello-dolly.php' );
+		$plugins     = array(
+			'custom-plugin/custom-plugin.php',
+			'gutenberg/gutenberg.php',
+		);
+		$schedule_id = $this->generate_schedule_id( $plugins );
+
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+
+		update_option( 'auto_update_plugins', $auto_update );
+
+		$request = new WP_REST_Request( 'DELETE', '/wpcom/v2/update-schedules/' . $schedule_id );
+		wp_set_current_user( $this->admin_id );
+		rest_do_request( $request );
+
+		$this->assertEquals( array_merge( $plugins, $auto_update ), get_option( 'auto_update_plugins' ) );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -478,13 +478,22 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	 */
 	public function test_updating_autoupdate_plugins_on_delete() {
 		$auto_update = array( 'hello-dolly/hello-dolly.php' );
-		$plugins     = array(
+		$plugins_1   = array( 'custom-plugin/custom-plugin.php' );
+		$plugins_2   = array(
 			'custom-plugin/custom-plugin.php',
 			'gutenberg/gutenberg.php',
 		);
-		$schedule_id = $this->generate_schedule_id( $plugins );
 
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		// Existing auto-update list and deleted plugins that are not part of other schedules.
+		$expected_result = array(
+			'gutenberg/gutenberg.php',
+			'hello-dolly/hello-dolly.php',
+		);
+
+		$schedule_id = $this->generate_schedule_id( $plugins_2 );
+
+		wp_schedule_event( strtotime( 'next Tuesday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins_1 );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins_2 );
 
 		update_option( 'auto_update_plugins', $auto_update );
 
@@ -492,7 +501,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		wp_set_current_user( $this->admin_id );
 		rest_do_request( $request );
 
-		$this->assertEquals( array_merge( $plugins, $auto_update ), get_option( 'auto_update_plugins' ) );
+		$this->assertSame( $expected_result, get_option( 'auto_update_plugins' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes plugins from auto-updates option when they are part of a schedule that gets created.
* Adds all plugins to auto-updates when a schedule gets deleted that they are part of.
* Adds unit tests for new functionality.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unit test should cover it.

