### PR TITLE
Blog Stats Block: Update Disabled Module String

### DIFF
--- a/projects/plugins/jetpack/changelog/update-blog-stats-string
+++ b/projects/plugins/jetpack/changelog/update-blog-stats-string
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+No changelog needed - already included in changelog/update-blog-stats-disabled

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
@@ -53,12 +53,13 @@ function load_assets( $attributes ) {
 			return sprintf(
 				'<p>%s</p>',
 				sprintf(
-					/* translators: placeholder is a link that says "Stats module". */
-					esc_html__( 'Please enable the %s in Jetpack to use this block.', 'jetpack' ),
+					/* translators: placeholder is a link that says "enable Jetpack Stats". */
+					esc_html__( 'Please %s to use this block.', 'jetpack' ),
 					'<a href="' .
 						esc_url( admin_url( 'admin.php?page=jetpack_modules&module_tag=Jetpack%20Stats' ) ) .
 						'">' .
-						esc_html__( 'Stats module', 'jetpack' ) .
+						/* translators: appears in string that says "Please enable Jetpack Stats". */
+						esc_html__( 'enable Jetpack Stats', 'jetpack' ) .
 					'</a>'
 				)
 			);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to https://github.com/Automattic/jetpack/pull/36108#discussion_r1508833467

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Updates the string in that PR from "Please enable the Stats module in Jetpack to use this block" to "Please enable Jetpack Stats to use this block". I've also moved the link to the action verb, where it makes more sense.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/36108#discussion_r1508833467

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
Same as the ones here: https://github.com/Automattic/jetpack/pull/36108