### PR TITLE
Scheduled Updates: Use permission checks as such

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-allow-headers-calls
+++ b/projects/packages/scheduled-updates/changelog/fix-allow-headers-calls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Moved schedule validation into its own callbacks so permission callbacks just check permissions.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -341,7 +341,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same time as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 
-			if ( $event->args === $request['plugins'] ) {
+			if ( $event->args === $plugins ) {
 				return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create a schedule with the same plugins as an existing schedule.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 			}
 		}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -161,10 +161,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			}
 		}
 
-		if ( ! empty( $request['themes'] ) ) {
-			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not schedule theme updates at this time.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
-		}
-
 		return current_user_can( 'update_plugins' );
 	}
 
@@ -250,10 +246,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			}
 		}
 
-		if ( ! empty( $request['themes'] ) ) {
-			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not schedule theme updates at this time.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
-		}
-
 		return current_user_can( 'update_plugins' );
 	}
 
@@ -334,6 +326,20 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	}
 
 	/**
+	 * Checks that the "themes" parameter is empty.
+	 *
+	 * @param array $themes List of themes to update.
+	 * @return bool|WP_Error
+	 */
+	public function validate_themes_param( $themes ) {
+		if ( ! empty( $themes ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not schedule theme updates at this time.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Retrieves the update schedule's schema, conforming to JSON Schema.
 	 *
 	 * @return array Item schema data.
@@ -398,9 +404,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				),
 			),
 			'themes'   => array(
-				'description' => 'List of theme slugs to update.',
-				'type'        => 'array',
-				'required'    => false,
+				'description'       => 'List of theme slugs to update.',
+				'type'              => 'array',
+				'required'          => false,
+				'validate_callback' => array( $this, 'validate_themes_param' ),
 			),
 			'schedule' => array(
 				'description' => 'Update schedule.',

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -327,10 +327,13 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$plugins = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
+		$editable_methods  = explode( ', ', WP_REST_Server::EDITABLE );
+		$is_update_request = in_array( $request->get_method(), $editable_methods, true );
+
 		foreach ( $events as $key => $event ) {
 
 			// We'll update this schedule, so none of the checks apply.
-			if ( 'PUT' === $request->get_method() && $key === $request['schedule_id'] ) {
+			if ( $is_update_request && $key === $request['schedule_id'] ) {
 				continue;
 			}
 

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -327,13 +327,14 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$plugins = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
-		$editable_methods  = explode( ', ', WP_REST_Server::EDITABLE );
-		$is_update_request = in_array( $request->get_method(), $editable_methods, true );
+		if ( empty( $request['schedule_id'] ) && count( $events ) >= 2 ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create more than two schedules at this time.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+		}
 
 		foreach ( $events as $key => $event ) {
 
 			// We'll update this schedule, so none of the checks apply.
-			if ( $is_update_request && $key === $request['schedule_id'] ) {
+			if ( isset( $request['schedule_id'] ) && $key === $request['schedule_id'] ) {
 				continue;
 			}
 

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -184,7 +184,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	/**
 	 * Can't have multiple schedules for the same time.
 	 *
-	 * @covers ::create_item_permissions_check
+	 * @covers ::validate_schedule
 	 */
 	public function test_creating_schedules_for_same_time() {
 		$plugins = array(
@@ -216,7 +216,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	/**
 	 * Can't have more than two schedules.
 	 *
-	 * @covers ::create_item_permissions_check
+	 * @covers ::validate_schedule
 	 */
 	public function test_creating_more_than_two_schedules() {
 		$plugins = array(
@@ -242,6 +242,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 				),
 			)
 		);
+
+		wp_set_current_user( $this->admin_id );
 		$result = rest_do_request( $request );
 
 		$this->assertSame( 403, $result->get_status() );

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -60,6 +60,18 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		wp_delete_user( $this->admin_id );
+		wp_delete_user( $this->editor_id );
+
+		wp_clear_scheduled_hook( 'jetpack_scheduled_update' );
+	}
+
+	/**
 	 * Test get_items.
 	 *
 	 * @covers ::get_items
@@ -219,14 +231,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	 * @covers ::validate_schedule
 	 */
 	public function test_creating_more_than_two_schedules() {
-		$plugins = array(
-			'gutenberg/gutenberg.php',
-			'custom-plugin/custom-plugin.php',
-		);
-
 		// Create two schedules.
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
-		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_update', $plugins );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', array( 'gutenberg/gutenberg.php' ) );
+		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_update', array( 'custom-plugin/custom-plugin.php' ) );
 
 		// Number 3.
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );


### PR DESCRIPTION
After processing an API request, WordPress populates ALLOW headers for the response by calling all permission checks registered in the requested endpoint. #36071 created a fatal error as it expected requests parameters to be present for create and update permission checks that GET requests would not provide.

It's a good reminder to keep permission checks to be what they are intended to be: Checking permissions! Not also validating schedule creation.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves theme parameter validation from permission checks into its own validation callback.
* Moves schedule validation into its own validation callback and runs it from request callbacks.
* Maintains unit tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the diff to your test site through Jetpack Beta.
* Use the REST API Console plugin to send a get request to `/wpcom/v2/update-schedules`.
* Make sure it doesn't return an error.

