### PR TITLE
Add/registration nonce to connect screen

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
@@ -44,7 +44,7 @@ const ConnectionScreenFooter = () => {
 };
 
 const ConnectionScreen = () => {
-	const { apiRoot, apiNonce } = useMyJetpackConnection();
+	const { apiRoot, apiNonce, registrationNonce } = useMyJetpackConnection();
 	const returnToPage = useMyJetpackReturnToPage();
 
 	return (
@@ -66,6 +66,7 @@ const ConnectionScreen = () => {
 						loadingLabel={ __( 'Connecting your account…', 'jetpack-my-jetpack' ) }
 						apiRoot={ apiRoot }
 						apiNonce={ apiNonce }
+						registrationNonce={ registrationNonce }
 						images={ [ connectImage ] }
 						footer={ <ConnectionScreenFooter /> }
 						from="my-jetpack"

--- a/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
@@ -1,5 +1,6 @@
 /* global myJetpackInitialState */
 /* global myJetpackRest */
+/* global JP_CONNECTION_INITIAL_STATE */
 import { useConnection } from '@automattic/jetpack-connection';
 
 /**
@@ -11,6 +12,7 @@ export default function useMyJetpackConnection() {
 	const { apiRoot, apiNonce } = myJetpackRest;
 	const { topJetpackMenuItemUrl } = myJetpackInitialState;
 	const connectionData = useConnection( { apiRoot, apiNonce } );
+	const { registrationNonce } = JP_CONNECTION_INITIAL_STATE;
 
 	// Alias: https://github.com/Automattic/jetpack/blob/trunk/projects/packages/connection/src/class-rest-connector.php/#L315
 	const isSiteConnected = connectionData.isRegistered;
@@ -18,6 +20,7 @@ export default function useMyJetpackConnection() {
 	return {
 		apiNonce,
 		apiRoot,
+		registrationNonce,
 		...connectionData,
 		isSiteConnected,
 		topJetpackMenuItemUrl,

--- a/projects/packages/my-jetpack/changelog/add-registration-nonce-to-connect-screen
+++ b/projects/packages/my-jetpack/changelog/add-registration-nonce-to-connect-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add registration nonce to connect screen in My Jetpack

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.13.0",
+	"version": "4.13.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.13.0';
+	const PACKAGE_VERSION = '4.13.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
## Proposed changes:

* A console error was being thrown on the My Jetpack screen because `registrationNonce` is required by the `ConnectScreen` component. This pulls the nonce from the window state and uses it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. With an unconnected site, go to https://munson1996.jurassic.tube/wp-admin/admin.php?page=my-jetpack#/connection
3. Look in the console and make sure you don't see any React errors being thrown in the console
![image](https://github.com/Automattic/jetpack/assets/65001528/315f068a-a8ff-4f95-827c-d15743609a75)
4. Connect the site to make sure the connection still works

