### PR TITLE
Show stats card in products table when large card isnt shown

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -95,7 +95,7 @@ const GlobalNotice = ( { message, options } ) => {
 export default function MyJetpackScreen() {
 	useConnectionWatcher();
 	const { hasBeenDismissed = false } = getMyJetpackWindowState( 'welcomeBanner' );
-	const { showJetpackStatsCard = false } = getMyJetpackWindowState( 'myJetpackFlags' );
+	const { showFullJetpackStatsCard = false } = getMyJetpackWindowState( 'myJetpackFlags' );
 	const { jetpackManage = {}, adminUrl } = getMyJetpackWindowState();
 
 	const { currentNotice } = useContext( NoticeContext );
@@ -163,7 +163,7 @@ export default function MyJetpackScreen() {
 					{ message && ( hasBeenDismissed || ! isNewUser ) && (
 						<Col>{ <GlobalNotice message={ message } options={ options } /> }</Col>
 					) }
-					{ showJetpackStatsCard && (
+					{ showFullJetpackStatsCard && (
 						<Col
 							className={ classnames( {
 								[ styles.stats ]: statsDetails?.status !== PRODUCT_STATUSES.ERROR,

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -10,6 +10,7 @@ import CrmCard from './crm-card';
 import ProtectCard from './protect-card';
 import SearchCard from './search-card';
 import SocialCard from './social-card';
+import StatsCard from './stats-card';
 import styles from './style.module.scss';
 import VideopressCard from './videopress-card';
 
@@ -20,6 +21,7 @@ import VideopressCard from './videopress-card';
  */
 const ProductCardsSection = () => {
 	const { isAtomic = false, userIsAdmin = false } = getMyJetpackWindowState();
+	const { showFullJetpackStatsCard = false } = getMyJetpackWindowState( 'myJetpackFlags' );
 
 	const items = {
 		backups: BackupCard,
@@ -28,7 +30,8 @@ const ProductCardsSection = () => {
 		boost: BoostCard,
 		search: SearchCard,
 		videopress: VideopressCard,
-		// Stats card is shown in the <StatsSection/> component.
+		// If we aren't showing the big stats card, we show the smaller one with the rest.
+		stats: ! showFullJetpackStatsCard ? StatsCard : null,
 		crm: CrmCard,
 		creator: ! isAtomic ? CreatorCard : null,
 		social: SocialCard,

--- a/projects/packages/my-jetpack/changelog/update-show-stats-card-in-products-table-when-large-card-isnt-shown
+++ b/projects/packages/my-jetpack/changelog/update-show-stats-card-in-products-table-when-large-card-isnt-shown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Show small stats card in table if large stats card isn't showing

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -22,7 +22,7 @@ interface Window {
 		loadAddLicenseScreen: string;
 		myJetpackCheckoutUri: string;
 		myJetpackFlags: {
-			showJetpackStatsCard: boolean;
+			showFullJetpackStatsCard: boolean;
 			videoPressStats: boolean;
 		};
 		lifecycleStats: {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -396,8 +396,8 @@ class Initializer {
 	 */
 	public static function get_my_jetpack_flags() {
 		$flags = array(
-			'videoPressStats'      => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED' ),
-			'showJetpackStatsCard' => class_exists( 'Jetpack' ),
+			'videoPressStats'          => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED' ),
+			'showFullJetpackStatsCard' => class_exists( 'Jetpack' ),
 		);
 
 		return $flags;


### PR DESCRIPTION
## Proposed changes:

* Show small stats card when large stats card isn't shown
* Rename global variable to specify large stats

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin without Jetpack installed
2. Go to My Jetpack and make sure the small Stats card is showing
![image](https://github.com/Automattic/jetpack/assets/65001528/b9460025-b1ab-4f9d-9c1a-a85acc33ce1b)
3. Install the Jetpack plugin and make sure the small stats card doesn't show anymore
![image](https://github.com/Automattic/jetpack/assets/65001528/63d6c7e2-26cc-4cf4-beb6-e3a2218c929e)

