### PR TITLE
Revert "Hide the Customizer menu for block themes"

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -88,37 +88,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		// All globals need to be declared for menu items to properly register.
 		global $admin_page_hooks, $menu, $menu_order, $submenu, $_wp_menu_nopriv, $_wp_submenu_nopriv; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
-		$this->hide_customizer_menu_on_block_theme();
 		require_once ABSPATH . 'wp-admin/includes/admin.php';
 		require_once ABSPATH . 'wp-admin/menu.php';
 
 		return rest_ensure_response( $this->prepare_menu_for_response( $menu ) );
-	}
-
-	/**
-	 * Hides the Customizer menu items when the block theme is active by removing the dotcom-specific actions.
-	 * They are not needed for block themes.
-	 *
-	 * @see https://github.com/Automattic/jetpack/pull/36017
-	 */
-	private function hide_customizer_menu_on_block_theme() {
-		if ( wp_is_block_theme() ) {
-			remove_action( 'customize_register', 'add_logotool_button', 20 );
-			remove_action( 'customize_register', 'footercredits_register', 99 );
-			remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );
-
-			if ( class_exists( '\Jetpack_Fonts' ) ) {
-				$jetpack_fonts_instance = \Jetpack_Fonts::get_instance();
-				remove_action( 'customize_register', array( $jetpack_fonts_instance, 'register_controls' ) );
-				remove_action( 'customize_register', array( $jetpack_fonts_instance, 'maybe_prepopulate_option' ), 0 );
-			}
-
-			remove_action( 'customize_register', array( 'Jetpack_Fonts_Typekit', 'maybe_override_for_advanced_mode' ), 20 );
-
-			remove_action( 'customize_register', 'Automattic\Jetpack\Dashboard_Customizations\register_css_nudge_control' );
-
-			remove_action( 'customize_register', array( 'Jetpack_Custom_CSS_Enhancements', 'customize_register' ) );
-		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-hide-customizer-menu
+++ b/projects/plugins/jetpack/changelog/update-hide-customizer-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Hides the Customizer menu items for block themes

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -39,44 +39,11 @@ function should_customize_nav( $admin_menu_class ) {
 }
 
 /**
- * Hides the Customizer menu items when the block theme is active by removing the dotcom-specific actions.
- * They are not needed for block themes.
- *
- * @see https://github.com/Automattic/jetpack/pull/36017
- */
-function hide_customizer_menu_on_block_theme() {
-	add_action(
-		'init',
-		function () {
-			if ( wp_is_block_theme() ) {
-				remove_action( 'customize_register', 'add_logotool_button', 20 );
-				remove_action( 'customize_register', 'footercredits_register', 99 );
-				remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );
-
-				if ( class_exists( '\Jetpack_Fonts' ) ) {
-					$jetpack_fonts_instance = \Jetpack_Fonts::get_instance();
-					remove_action( 'customize_register', array( $jetpack_fonts_instance, 'register_controls' ) );
-					remove_action( 'customize_register', array( $jetpack_fonts_instance, 'maybe_prepopulate_option' ), 0 );
-				}
-
-				remove_action( 'customize_register', array( 'Jetpack_Fonts_Typekit', 'maybe_override_for_advanced_mode' ), 20 );
-
-				remove_action( 'customize_register', 'Automattic\Jetpack\Dashboard_Customizations\register_css_nudge_control' );
-
-				remove_action( 'customize_register', array( 'Jetpack_Custom_CSS_Enhancements', 'customize_register' ) );
-			}
-		}
-	);
-}
-
-/**
  * Gets the name of the class that customizes the admin menu.
  *
  * @return string Class name.
  */
 function get_admin_menu_class() {
-	hide_customizer_menu_on_block_theme();
-
 	// WordPress.com Atomic sites.
 	if ( ( new Host() )->is_woa_site() ) {
 


### PR DESCRIPTION
Reverts Automattic/jetpack#36017

There were concerns to be resolved before getting this to be merged;

- [x] The features in Customizer (Footer Credit, Favicon, Addtional CSS) should appear when users directly visit the Customizer link. This might be a bug.
	- p1709345807434079-slack-CRWCHQGUB
	- p1709242404065299-slack-C06DN6QQVAQ
	- [x] https://github.com/Automattic/jetpack/pull/36146
- [x] Additional CSS was accessible via `Appearance > Customize > Additional CSS`, but now that the Customize menu has been removed, should it be accessible via `Appearance > Additional CSS`?
	- p7DVsv-k5H-p2#comment-49384
	- -> We're already showing it to users with existing custom CSS. p7DVsv-k5H-p2#comment-49399