### PR TITLE
The Customizer features should appear when users directly visit the Customizer link

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -102,7 +102,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @see https://github.com/Automattic/jetpack/pull/36017
 	 */
 	private function hide_customizer_menu_on_block_theme() {
-		if ( wp_is_block_theme() ) {
+		if ( wp_is_block_theme() && ! is_customize_preview() ) {
 			remove_action( 'customize_register', 'add_logotool_button', 20 );
 			remove_action( 'customize_register', 'footercredits_register', 99 );
 			remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );

--- a/projects/plugins/jetpack/changelog/fix-show-customizer-features
+++ b/projects/plugins/jetpack/changelog/fix-show-customizer-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+The features in Customizer should appear when users directly visit the Customizer link

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -48,7 +48,7 @@ function hide_customizer_menu_on_block_theme() {
 	add_action(
 		'init',
 		function () {
-			if ( wp_is_block_theme() ) {
+			if ( wp_is_block_theme() && ! is_customize_preview() ) {
 				remove_action( 'customize_register', 'add_logotool_button', 20 );
 				remove_action( 'customize_register', 'footercredits_register', 99 );
 				remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );


### PR DESCRIPTION
Related: https://github.com/Automattic/jetpack/pull/36017

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes the Customizer features was not available even when users directly visit the Customizer link. 
<img width="309" alt="Screenshot 2024-03-04 at 14 27 11" src="https://github.com/Automattic/jetpack/assets/5287479/a5900570-4c11-4f5c-ac7e-7faa82371e9b">

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Patch this change: https://github.com/Automattic/jetpack/pull/36146#issuecomment-1975523498
* Ensure the Customizer menu is hidden on the admin menu when you have a Block theme active
* Open the Customizer link directly via `wordpress.com/customize/<your-site>` or `<your-site>/wp-admin/customize.php`
* Ensure the Customizer feature is available (e.g., `Site Identity > Footer Credit`)