### PR TITLE
Boost: Fix `WP_CACHE` constant removal during uninstallation

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -141,12 +141,8 @@ $boost_cache->serve();
 	 * Adds the WP_CACHE define to wp-config.php
 	 */
 	private static function add_wp_cache_define() {
-		// Find the wp-config.php file.
-		if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
-			$config_file = ABSPATH . 'wp-config.php';
-		} elseif ( file_exists( dirname( ABSPATH ) . '/wp-config.php' ) && ! file_exists( dirname( ABSPATH ) . '/wp-settings.php' ) ) {
-			$config_file = dirname( ABSPATH ) . '/wp-config.php';
-		} else {
+		$config_file = self::find_wp_config();
+		if ( $config_file === false ) {
 			return new \WP_Error( 'wp-config-not-found' );
 		}
 
@@ -236,7 +232,12 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 	 * @return WP_Error if an error occurred.
 	 */
 	public static function delete_wp_cache_constant() {
-		$lines = file( ABSPATH . 'wp-config.php' );
+		$config_file = self::find_wp_config();
+		if ( $config_file === false ) {
+			return;
+		}
+
+		$lines = file( $config_file );
 		$found = false;
 		foreach ( $lines as $key => $line ) {
 			if ( preg_match( '#define\s*\(\s*[\'"]WP_CACHE[\'"]#', $line ) === 1 && strpos( $line, Page_Cache::ADVANCED_CACHE_SIGNATURE ) !== false ) {
@@ -248,9 +249,25 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 			return;
 		}
 		$content = implode( '', $lines );
-		file_put_contents( ABSPATH . 'wp-config.php', $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $config_file, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		if ( function_exists( 'opcache_invalidate' ) ) {
-			opcache_invalidate( ABSPATH . 'wp-config.php', true );
+			opcache_invalidate( $config_file, true );
 		}
+	}
+
+	/**
+	 * Find location of wp-config.php file.
+	 *
+	 * @return string|false - The path to the wp-config.php file, or false if it was not found.
+	 */
+	private static function find_wp_config() {
+		if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
+			return ABSPATH . 'wp-config.php';
+			// While checking one directory up, check for wp-settings.php as well similar to WordPress core, to avoid nested WordPress installations.
+		} elseif ( file_exists( dirname( ABSPATH ) . '/wp-config.php' ) && ! file_exists( dirname( ABSPATH ) . '/wp-settings.php' ) ) {
+			return dirname( ABSPATH ) . '/wp-config.php';
+		}
+
+		return false;
 	}
 }

--- a/projects/plugins/boost/changelog/fix-uninstall
+++ b/projects/plugins/boost/changelog/fix-uninstall
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Properly remove WP_CACHE constant while uninstalling boost
+
+


### PR DESCRIPTION
WordPress allows placing the wp-config.php file in the parent directory of WordPress installation. We recently addressed this issue in #36115. However, the uninstallation part wasn't covered.

## Proposed changes:
- Properly remove `WP_CACHE` constant during uninstallation even if wp-config.php is placed outside of WP directory.
- Reuse code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
This is possible to test in JN as JN has the wp-config file outside of wp directory.
* Start a JN site with "Include Drop-in Cache Plugins" unchecked to allow boost-cache.
* Activate cache and make sure caching works.
* Uninstall boost and make sure `WP_CACHE` constant is removed from wp-config.php file and `advanced-cache.php` is also deleted.

