### PR TITLE
Boost: hide file warnings when checking if a directory is read-write

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -51,7 +51,7 @@ class Page_Cache_Setup {
 	 */
 	private static function verify_wp_content_writable() {
 		$filename = WP_CONTENT_DIR . '/' . uniqid() . '.txt';
-		$result   = file_put_contents( $filename, 'test' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$result   = @file_put_contents( $filename, 'test' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents, WordPress.PHP.NoSilencedErrors.Discouraged
 		wp_delete_file( $filename );
 
 		if ( $result === false ) {

--- a/projects/plugins/boost/changelog/fix-boost-cache-hide-file-warning
+++ b/projects/plugins/boost/changelog/fix-boost-cache-hide-file-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Boost: hide warnings when checking if a directory is RO or not.


### PR DESCRIPTION
The command file_put_contents() will issue a PHP warning if it cannot write to a RO directory. Since we're checking the return value of that command we can hide the PHP warning.

## Proposed changes:
* Hide warning by putting "@" in front of file_put_contents()

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Make wp-content RO
Try to enable the Cache module.
Check your PHP error_log before and after applying this PR.