### PR TITLE
[Boost] add Page_Cache_Setup::activate function to setup caching if it is enabled

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -140,6 +140,7 @@ class Jetpack_Boost {
 		// Make sure user sees the "Get Started" when first time opening.
 		( new Getting_Started_Entry() )->set( true );
 		Analytics::record_user_event( 'activate_plugin' );
+		Page_Cache_Setup::activate();
 	}
 
 	/**

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -28,8 +28,11 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Site_Health;
+use Automattic\Jetpack_Boost\Lib\Status;
 use Automattic\Jetpack_Boost\Modules\Modules_Setup;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache_Setup;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\List_Site_Urls;
 use Automattic\Jetpack_Boost\REST_API\REST_API;
 
@@ -140,7 +143,11 @@ class Jetpack_Boost {
 		// Make sure user sees the "Get Started" when first time opening.
 		( new Getting_Started_Entry() )->set( true );
 		Analytics::record_user_event( 'activate_plugin' );
-		Page_Cache_Setup::activate();
+
+		$page_cache_status = new Status( Page_Cache::get_slug() );
+		if ( $page_cache_status->is_enabled() && Boost_Cache_Settings::get_instance()->get_enabled() ) {
+			Page_Cache_Setup::run_setup();
+		}
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -191,8 +191,7 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 	 * Fired when the plugin is activated.
 	 */
 	public static function activate() {
-		$settings = Boost_Cache_Settings::get_instance();
-		if ( $settings->get_enabled() ) {
+		if ( Boost_Cache_Settings::get_instance()->get_enabled() ) {
 			self::run_setup();
 		}
 		return true;

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -186,17 +186,6 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 		return true;
 	}
 
-	/**
-	 * Creates the advanced-cache.php file and adds the WP_CACHE define to wp-config.php
-	 * Fired when the plugin is activated.
-	 */
-	public static function activate() {
-		if ( Boost_Cache_Settings::get_instance()->get_enabled() ) {
-			self::run_setup();
-		}
-		return true;
-	}
-
 	/*
 	 * Removes the boost-cache directory, removing all cached files and the config file.
 	 * Fired when the plugin is uninstalled.

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -186,6 +186,18 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 		return true;
 	}
 
+	/**
+	 * Creates the advanced-cache.php file and adds the WP_CACHE define to wp-config.php
+	 * Fired when the plugin is activated.
+	 */
+	public static function activate() {
+		$settings = Boost_Cache_Settings::get_instance();
+		if ( $settings->get_enabled() ) {
+			self::run_setup();
+		}
+		return true;
+	}
+
 	/*
 	 * Removes the boost-cache directory, removing all cached files and the config file.
 	 * Fired when the plugin is uninstalled.

--- a/projects/plugins/boost/changelog/add-boost-cache-activation
+++ b/projects/plugins/boost/changelog/add-boost-cache-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Boost: added Cache activation function to set up caching if it's enabled


### PR DESCRIPTION
If the Caching module is enabled, then caching is enabled in the settings config file. That setting persists if the plugin is deactivated but not uninstalled.
However, wp-content/advanced-cache.php is removed when the plugin is deactivated so it must be restored if caching is enabled when the plugin is next activated. This PR does that.

## Proposed changes:
* Add Page_Cache_Setup::activate function to run setup if caching is enabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Apply this PR
* Deactivate the plugin while the Cache module is still enabled.
* Verify that wp-content/advanced-cache.php is gone.
* Enable the plugin again.
* Verify that wp-content/advanced-cache.php is back and caching works.