### PR TITLE
Blog Stats Block: Update String Translation

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-stats-string
+++ b/projects/plugins/jetpack/changelog/fix-stats-string
@@ -1,4 +1,5 @@
-Significance: minor
-Type: enhancement
+Significance: patch
+Type: other
+
 Comment: No changelog needed - already included in changelog/update-blog-stats-disabled
 

--- a/projects/plugins/jetpack/changelog/fix-stats-string
+++ b/projects/plugins/jetpack/changelog/fix-stats-string
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
+Comment: No changelog needed - already included in changelog/update-blog-stats-disabled
 
-No changelog needed - already included in changelog/update-blog-stats-disabled

--- a/projects/plugins/jetpack/changelog/fix-stats-string
+++ b/projects/plugins/jetpack/changelog/fix-stats-string
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+No changelog needed - already included in changelog/update-blog-stats-disabled

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
@@ -52,15 +52,13 @@ function load_assets( $attributes ) {
 		if ( current_user_can( 'edit_theme_options' ) ) {
 			return sprintf(
 				'<p>%s</p>',
-				sprintf(
-					/* translators: placeholder is a link that says "enable Jetpack Stats". */
-					esc_html__( 'Please %s to use this block.', 'jetpack' ),
-					'<a href="' .
-						esc_url( admin_url( 'admin.php?page=jetpack_modules&module_tag=Jetpack%20Stats' ) ) .
-						'">' .
-						/* translators: appears in string that says "Please enable Jetpack Stats". */
-						esc_html__( 'enable Jetpack Stats', 'jetpack' ) .
-					'</a>'
+				wp_kses(
+					sprintf(
+						/* translators: placeholder %s is a link to enable Jetpack Stats.. */
+						__( 'Please <a href="%s">enable Jetpack Stats</a> to use this block.', 'jetpack' ),
+						esc_url( admin_url( 'admin.php?page=jetpack_modules&module_tag=Jetpack%20Stats' ) )
+					),
+					array( 'a' => array( 'href' => array() ) )
 				)
 			);
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/pull/36127#discussion_r1510886858

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the Blog Stats block string to make it easier for translators. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/36127#discussion_r1510886858

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
Same as the ones here: https://github.com/Automattic/jetpack/pull/36108

cc @simison - would you mind checking this is right? Not too familiar with this sort of thing, and would be good not to mess it up again!! :) 
