### PR TITLE
WP Super Cache: fix the output buffer check, and make logs pre-formatted to emphasize this log event

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-ob-level-check
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-ob-level-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: fix the output buffer check, and make debug logs pre-formatted.

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -1297,9 +1297,12 @@ foreach ( $debug_log as $t => $line ) {
 		}
 	}
 }
+echo "<pre>";
 foreach( $debug_log as $line ) {
-	echo htmlspecialchars( $line ) . "<br />";
-}';
+	echo htmlspecialchars( $line );
+}
+echo "</pre>";
+';
 		fwrite( $fp, $msg );
 		fclose( $fp );
 	}
@@ -1512,14 +1515,17 @@ function wp_cache_phase2() {
 		return false;
 	}
 
-	if ( ob_get_level() > 0 ) {
+	if ( ob_get_level() > 1 ) {
 		global $wp_super_cache_late_init;
-		$ob_warning = 'Already in an output buffer. Check your plugins, themes, mu-plugins, and other custom code. Exit.';
+		wp_cache_debug( '***********************************************************************************' );
+		wp_cache_debug( '* An output buffer has been detected. Check your plugins, themes, mu-plugins,     *' );
+		wp_cache_debug( '* and other custom code as this may interfere with caching.                       *' );
+
 		if ( isset( $wp_super_cache_late_init ) && $wp_super_cache_late_init ) {
-			$ob_warning = 'Late init enabled. Disable it. ' . $ob_warning;
+			wp_cache_debug( '* Late init is enabled. This allows third-party code to run before WP Super Cache *' );
+			wp_cache_debug( '* sets up an output buffer. That code may have set up the output buffer.          *' );
 		}
-		wp_cache_debug( 'wp_cache_phase2: ' . $ob_warning );
-		return;
+		wp_cache_debug( '***********************************************************************************' );
 	}
 
 	wp_cache_debug( 'In WP Cache Phase 2', 5 );

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -1518,8 +1518,8 @@ function wp_cache_phase2() {
 	if ( ob_get_level() > 1 ) {
 		global $wp_super_cache_late_init;
 		wp_cache_debug( '***********************************************************************************' );
-		wp_cache_debug( '* An output buffer has been detected. Check your plugins, themes, mu-plugins,     *' );
-		wp_cache_debug( '* and other custom code as this may interfere with caching.                       *' );
+		wp_cache_debug( '* An extra output buffer has been detected. Check your plugins, themes,           *' );
+		wp_cache_debug( '* mu-plugins, and other custom code as this may interfere with caching.           *' );
 
 		if ( isset( $wp_super_cache_late_init ) && $wp_super_cache_late_init ) {
 			wp_cache_debug( '* Late init is enabled. This allows third-party code to run before WP Super Cache *' );


### PR DESCRIPTION
The output buffer check created in #36124 didn't work correctly because many PHP installs use a 4096 byte output buffer by default. This was mentioned in the first comment on the [ob_get_level man page](https://www.php.net/manual/en/function.ob-get-level.php).
The check is now for `> 1` as the PHP setting output_buffering is enabled by default.

This PR also changes the debug log so it displays with `pre` tags before and after, so I could use "*" characters to surround this warning and make it more prominent.
Instead of returning and not caching anything, code is allowed to continue as this was the default behaviour before this.

## Proposed changes:
* Change the ob_level check to 1 from 0.
* The ob_level check won't stop the plugin attempting to cache, so it's just a warning.
* debug log now displays pre-formatted text.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Create an mu-plugin with this code in it:
```
function test_ob() {
        ob_start();
}
add_action( 'init', 'test_ob' );

function clean_ob() {
        ob_end_clean();
}
add_action( 'wp_head', 'clean_ob' );
```
Enable "late init" in wp super cache on the advanced settings page.
Enable debugging in the plugin.
Load and cache a page. It will only show a partial page, but the debug log will contain a warning about what went wrong.