### PR TITLE
Scheduled Updates: Always request updates

### DIFF
--- a/projects/packages/scheduled-updates/changelog/update-send-all-updates
+++ b/projects/packages/scheduled-updates/changelog/update-send-all-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sends update requests even if there are no plugins to be updated, so WP.com can keep track of that outcome of a schedule execution.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -69,11 +69,12 @@ class Scheduled_Updates {
 			}
 		);
 
-		( new Connection\Client() )->wpcom_json_api_request_as_user(
+		( new Connection\Client() )->wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
 			'2',
 			array( 'method' => 'POST' ),
-			array( 'plugins' => $plugins )
+			array( 'plugins' => $plugins ),
+			'wpcom'
 		);
 	}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -62,20 +62,18 @@ class Scheduled_Updates {
 	 */
 	public static function run_scheduled_update( ...$plugins ) {
 		$available_updates = get_site_transient( 'update_plugins' );
-		$plugins_to_update = array();
-
-		foreach ( $plugins as $plugin ) {
-			if ( isset( $available_updates->response[ $plugin ] ) ) {
-				$plugins_to_update[ $plugin ]              = $available_updates->response[ $plugin ];
-				$plugins_to_update[ $plugin ]->old_version = $available_updates->checked[ $plugin ];
+		$plugins           = array_filter(
+			$plugins,
+			function ( $plugin ) use ( $available_updates ) {
+				return isset( $available_updates->response[ $plugin ] );
 			}
-		}
+		);
 
 		( new Connection\Client() )->wpcom_json_api_request_as_user(
 			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
 			'2',
 			array( 'method' => 'POST' ),
-			array( 'plugins' => $plugins_to_update )
+			array( 'plugins' => $plugins )
 		);
 	}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -69,11 +69,13 @@ class Scheduled_Updates {
 			}
 		);
 
+		$body = empty( $plugins ) ? null : array( 'plugins' => $plugins );
+
 		( new Connection\Client() )->wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
 			'2',
 			array( 'method' => 'POST' ),
-			array( 'plugins' => $plugins ),
+			$body,
 			'wpcom'
 		);
 	}

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -71,14 +71,12 @@ class Scheduled_Updates {
 			}
 		}
 
-		if ( ! empty( $plugins_to_update ) ) {
-			( new Connection\Client() )->wpcom_json_api_request_as_user(
-				sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
-				'2',
-				array( 'method' => 'POST' ),
-				array( 'plugins' => $plugins_to_update )
-			);
-		}
+		( new Connection\Client() )->wpcom_json_api_request_as_user(
+			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
+			'2',
+			array( 'method' => 'POST' ),
+			array( 'plugins' => $plugins_to_update )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Sending update requests even if there are no plugins to update, allows WP.com to keep track of that result and display it in the Schedule Updates UI.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the conditional that prevents update requests from being sent when there are no updates.
* Removes the old version setting since it's no longer needed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D140867-code and sandbox public-api.
* Create a schedule with timestamp that triggers shortly.
* Visit a page on your test site to trigger the schedule.
* Make sure an empty request succeeds.

