### PR TITLE
WAF: Parse JSON parameters

### DIFF
--- a/projects/packages/waf/changelog/add-json-support-to-the-waf
+++ b/projects/packages/waf/changelog/add-json-support-to-the-waf
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add JSON parameter support to the Web Application Firewall.

--- a/projects/packages/waf/composer.json
+++ b/projects/packages/waf/composer.json
@@ -61,7 +61,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.14.x-dev"
+			"dev-trunk": "0.15.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/waf/src/class-waf-request.php
+++ b/projects/packages/waf/src/class-waf-request.php
@@ -147,6 +147,22 @@ class Waf_Request {
 	}
 
 	/**
+	 * Returns the value of a specific header that was sent with this request
+	 *
+	 * @param string $name The name of the header to retrieve.
+	 * @return string
+	 */
+	public function get_header( $name ) {
+		$name = $this->normalize_header_name( $name );
+		foreach ( $this->get_headers() as list( $header_name, $header_value ) ) {
+			if ( $header_name === $name ) {
+				return $header_value;
+			}
+		}
+		return '';
+	}
+
+	/**
 	 * Change a header name to all-lowercase and replace spaces and underscores with dashes.
 	 *
 	 * @param string $name The header name to normalize.
@@ -305,7 +321,8 @@ class Waf_Request {
 	 * @return array<string, mixed|array>
 	 */
 	public function get_get_vars() {
-		return flatten_array( $_GET );
+		$decode_json = $this->get_header( 'content-type' ) === 'application/json';
+		return flatten_array( $_GET, $decode_json ? 'json' : '', $decode_json );
 	}
 
 	/**
@@ -314,7 +331,8 @@ class Waf_Request {
 	 * @return array<string, mixed|array>
 	 */
 	public function get_post_vars() {
-		return flatten_array( $_POST );
+		$decode_json = $this->get_header( 'content-type' ) === 'application/json';
+		return flatten_array( $_POST, $decode_json ? 'json' : '', $decode_json );
 	}
 
 	/**

--- a/projects/packages/waf/src/class-waf-request.php
+++ b/projects/packages/waf/src/class-waf-request.php
@@ -331,7 +331,7 @@ class Waf_Request {
 	 */
 	public function get_post_vars() {
 		// Attempt to decode JSON requests.
-		if ( $this->get_header( 'content-type' ) === 'application/json' ) {
+		if ( str_contains( $this->get_header( 'content-type' ), 'application/json' ) ) {
 			$decoded_json = json_decode( $this->get_body(), true ) ?? array();
 			return flatten_array( $decoded_json, 'json', true );
 		}

--- a/projects/packages/waf/src/class-waf-request.php
+++ b/projects/packages/waf/src/class-waf-request.php
@@ -321,8 +321,7 @@ class Waf_Request {
 	 * @return array<string, mixed|array>
 	 */
 	public function get_get_vars() {
-		$decode_json = $this->get_header( 'content-type' ) === 'application/json';
-		return flatten_array( $_GET, $decode_json ? 'json' : '', $decode_json );
+		return flatten_array( $_GET );
 	}
 
 	/**
@@ -331,8 +330,13 @@ class Waf_Request {
 	 * @return array<string, mixed|array>
 	 */
 	public function get_post_vars() {
-		$decode_json = $this->get_header( 'content-type' ) === 'application/json';
-		return flatten_array( $_POST, $decode_json ? 'json' : '', $decode_json );
+		// Attempt to decode JSON requests.
+		if ( $this->get_header( 'content-type' ) === 'application/json' ) {
+			$decoded_json = json_decode( $this->get_body(), true ) ?? array();
+			return flatten_array( $decoded_json, 'json', true );
+		}
+
+		return flatten_array( $_POST );
 	}
 
 	/**

--- a/projects/packages/waf/src/class-waf-request.php
+++ b/projects/packages/waf/src/class-waf-request.php
@@ -331,7 +331,7 @@ class Waf_Request {
 	 */
 	public function get_post_vars() {
 		// Attempt to decode JSON requests.
-		if ( str_contains( $this->get_header( 'content-type' ), 'application/json' ) ) {
+		if ( strpos( $this->get_header( 'content-type' ), 'application/json' ) !== false ) {
 			$decoded_json = json_decode( $this->get_body(), true ) ?? array();
 			return flatten_array( $decoded_json, 'json', true );
 		}

--- a/projects/packages/waf/src/functions.php
+++ b/projects/packages/waf/src/functions.php
@@ -47,33 +47,25 @@ function wp_unslash( $value ) {
  *       [ "field2[2]", "f" ],
  * ]
  *
- * @param array  $array       An array that resembles one of the PHP superglobals like $_GET or $_POST.
- * @param string $key_prefix  String that should be prepended to the keys output by this function.
- *                             Usually only used internally as part of recursion when flattening a nested array.
- * @param bool   $decode_json If true, will attempt to decode JSON strings into arrays.
+ * @param array     $array      An array that resembles one of the PHP superglobals like $_GET or $_POST.
+ * @param string    $key_prefix    String that should be prepended to the keys output by this function.
+ *                                 Usually only used internally as part of recursion when flattening a nested array.
+ * @param bool|null $dot_notation  Whether to use dot notation instead of bracket notation.
  *
  * @return array{ 0: string, 1: scalar }[]  $key_prefix  An array of key/value tuples, one for each distinct value in the input array.
  */
-function flatten_array( $array, $key_prefix = '', $decode_json = false ) {
+function flatten_array( $array, $key_prefix = '', $dot_notation = null ) {
 	$return = array();
 	foreach ( $array as $source_key => $source_value ) {
-		$key = ( '' === $key_prefix )
-			// if this is the first level, the key name isn't enclosed in brackets
-			? $source_key
-			// for every level after the first, enclose the key name in brackets.
-			: $key_prefix . '[' . $source_key . ']';
-
-		if ( $decode_json && is_string( $source_value ) ) {
-			$decoded_value = json_decode( $source_value, true );
-			if ( null !== $decoded_value ) {
-				$source_value = $decoded_value;
-			}
+		$key = $source_key;
+		if ( ! empty( $key_prefix ) ) {
+			$key = $dot_notation ? "$key_prefix.$source_key" : $key_prefix . "[$source_key]";
 		}
 
-		if ( ! is_array( $source_value ) ) {
+		if ( ! is_array( $source_value ) && ! is_object( $source_value ) ) {
 			$return[] = array( $key, $source_value );
 		} else {
-			$return = array_merge( $return, flatten_array( $source_value, $key ) );
+			$return = array_merge( $return, flatten_array( $source_value, $key, $dot_notation ) );
 		}
 	}
 	return $return;

--- a/projects/packages/waf/src/functions.php
+++ b/projects/packages/waf/src/functions.php
@@ -47,7 +47,7 @@ function wp_unslash( $value ) {
  *       [ "field2[2]", "f" ],
  * ]
  *
- * @param array     $array      An array that resembles one of the PHP superglobals like $_GET or $_POST.
+ * @param array     $array         An array that resembles one of the PHP superglobals like $_GET or $_POST.
  * @param string    $key_prefix    String that should be prepended to the keys output by this function.
  *                                 Usually only used internally as part of recursion when flattening a nested array.
  * @param bool|null $dot_notation  Whether to use dot notation instead of bracket notation.
@@ -62,7 +62,7 @@ function flatten_array( $array, $key_prefix = '', $dot_notation = null ) {
 			$key = $dot_notation ? "$key_prefix.$source_key" : $key_prefix . "[$source_key]";
 		}
 
-		if ( ! is_array( $source_value ) && ! is_object( $source_value ) ) {
+		if ( ! is_array( $source_value ) ) {
 			$return[] = array( $key, $source_value );
 		} else {
 			$return = array_merge( $return, flatten_array( $source_value, $key, $dot_notation ) );

--- a/projects/packages/waf/src/functions.php
+++ b/projects/packages/waf/src/functions.php
@@ -50,9 +50,11 @@ function wp_unslash( $value ) {
  * @param array  $array       An array that resembles one of the PHP superglobals like $_GET or $_POST.
  * @param string $key_prefix  String that should be prepended to the keys output by this function.
  *                             Usually only used internally as part of recursion when flattening a nested array.
+ * @param bool   $decode_json If true, will attempt to decode JSON strings into arrays.
+ *
  * @return array{ 0: string, 1: scalar }[]  $key_prefix  An array of key/value tuples, one for each distinct value in the input array.
  */
-function flatten_array( $array, $key_prefix = '' ) {
+function flatten_array( $array, $key_prefix = '', $decode_json = false ) {
 	$return = array();
 	foreach ( $array as $source_key => $source_value ) {
 		$key = ( '' === $key_prefix )
@@ -60,6 +62,14 @@ function flatten_array( $array, $key_prefix = '' ) {
 			? $source_key
 			// for every level after the first, enclose the key name in brackets.
 			: $key_prefix . '[' . $source_key . ']';
+
+		if ( $decode_json && is_string( $source_value ) ) {
+			$decoded_value = json_decode( $source_value, true );
+			if ( null !== $decoded_value ) {
+				$source_value = $decoded_value;
+			}
+		}
+
 		if ( ! is_array( $source_value ) ) {
 			$return[] = array( $key, $source_value );
 		} else {

--- a/projects/packages/waf/tests/php/unit/test-waf-request.php
+++ b/projects/packages/waf/tests/php/unit/test-waf-request.php
@@ -278,6 +278,27 @@ class WafRequestTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * Test that the Waf_Request class returns $_GET data correctly decoded from JSON via Waf_Request::get_get_vars(),
+	 */
+	public function testGetVarsGetWithJson() {
+		$_SERVER['CONTENT_TYPE'] = 'application/json';
+
+		$_GET['get_var'] = 'test_value';
+		$_GET['get_num'] = array( 'value1' );
+		$_GET['get_2']   = array( 'child' => 'value' );
+		$_GET['json']    = json_encode( array( 'json' => 'value' ) );
+		$request         = new Waf_Request();
+		$value           = $request->get_get_vars( true );
+		$this->assertIsArray( $value );
+		$this->assertContains( array( 'json[get_var]', 'test_value' ), $value );
+		$this->assertContains( array( 'json[get_2][child]', 'value' ), $value );
+		$this->assertContains( array( 'json[get_num][0]', 'value1' ), $value );
+		$this->assertContains( array( 'json[json][json]', 'value' ), $value );
+
+		unset( $_SERVER['CONTENT_TYPE'] );
+	}
+
+	/**
 	 * Test that the Waf_Request class returns $_POST data correctly via Waf_Request::get_post_vars().
 	 */
 	public function testGetVarsPost() {
@@ -290,6 +311,27 @@ class WafRequestTest extends PHPUnit\Framework\TestCase {
 		$this->assertContains( array( 'test_var', 'test_value' ), $value );
 		$this->assertContains( array( 'test_2[child]', 'value' ), $value );
 		$this->assertContains( array( 'test_num[0]', 'value1' ), $value );
+	}
+
+	/**
+	 * Test that the Waf_Request class returns $_POST data correctly decoded from JSON via Waf_Request::get_post_vars().
+	 */
+	public function testGetVarsPostWithJson() {
+		$_SERVER['CONTENT_TYPE'] = 'application/json';
+
+		$_POST['test_var'] = 'test_value';
+		$_POST['test_num'] = array( 'value1' );
+		$_POST['test_2']   = array( 'child' => 'value' );
+		$_POST['json']     = json_encode( array( 'json' => 'value' ) );
+		$request           = new Waf_Request();
+		$value             = $request->get_post_vars();
+		$this->assertIsArray( $value );
+		$this->assertContains( array( 'json[test_var]', 'test_value' ), $value );
+		$this->assertContains( array( 'json[test_2][child]', 'value' ), $value );
+		$this->assertContains( array( 'json[test_num][0]', 'value1' ), $value );
+		$this->assertContains( array( 'json[json][json]', 'value' ), $value );
+
+		unset( $_SERVER['CONTENT_TYPE'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-waf-json-support
+++ b/projects/plugins/jetpack/changelog/add-waf-json-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2604,7 +2604,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/waf",
-				"reference": "14d1d943e21a1d7ec1e0395831770c37175fb1c4"
+				"reference": "12dc480f05fd60239d1aaa7d01d5c9c9ec1bb1bb"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2631,7 +2631,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.14.x-dev"
+					"dev-trunk": "0.15.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/protect/changelog/add-waf-json-support
+++ b/projects/plugins/protect/changelog/add-waf-json-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1597,7 +1597,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/waf",
-                "reference": "14d1d943e21a1d7ec1e0395831770c37175fb1c4"
+                "reference": "12dc480f05fd60239d1aaa7d01d5c9c9ec1bb1bb"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1624,7 +1624,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.14.x-dev"
+                    "dev-trunk": "0.15.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds support to the firewall for parsing `application/json` request bodies.
  * Whenever the `Content-Type` header includes "application/json", the `get_post_vars` method will attempt to decode the request body instead of using `$_POST`.
  * Decoded JSON parameters are prefixed with `json`, and can be targeted with `ARGS:json.param_name`.
  * Decoded JSON parameter names (`ARG_NAMES`) use full dot notation, including arrays, i.e. `ARGS:json.arr_param.0`, `ARGS:json.arr_param.1`.

## Limitations
* ModSecurity can handle malformed JSON, this implementation does not. If `json_decode` fails on the request body, no args are parsed.
* [SecRequestBodyJsonDepthLimit](https://href.li/?https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v2.x)#user-content-SecRequestBodyJsonDepthLimit) directive has not been implemented here.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p2-peb6dq-2fw 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Boot up your local site with `jetpack docker up -d` and `jetpack docker jt-up`.
2. Ensure the firewall is active, and upgrade your site to enable automatic rules.
3. Update `tools/docker/wordpress/wp-content/jetpack-waf/rules/automatic-rules.php` with the following:
```php
$rule = (object) array( 'id' => 99110039, 'reason' => '', 'tags' => array() );
try {
  if (
    $waf->match_targets(
      array( 0 => 'normalize_path' ), 
      array( 'args' => array( 'only' => array( 0 => 'json.foo' ) ) ), 
      'contains', 
      'bar', 
      false, 
      false 
    ) 
  ) {
    $rule->reason = 'Test rule '.htmlentities($waf->get_var('tx.0'), ENT_QUOTES, 'UTF-8') ;
    return $waf->block('block',$rule->id,$rule->reason,403);
  }
} catch ( \Throwable $t ) {
  error_log( 'Rule ' . $rule->id . ' failed: ' . $t );
} catch ( \Exception $e ) {
  error_log( 'Rule ' . $rule->id . ' failed: ' . $e );
}
```

(This is the result of the following SecRule):
```
SecRule ARGS:json.foo "@contains bar" "id:99110039,phase:2,block,logdata:'%{TX.0}',severity:'CRITICAL',msg:'Test rule',t:none,t:normalizePath"
``` 

4. Send a POST request to your site with `Content-Type: application/json` and a JSON body that contains a "foo" key with a string value containing "bar". I use [RapidAPI](https://paw.cloud/) to easily send these types of requests with a GUI.

```
POST / HTTP/1.1
Content-Type: application/x-www-form-urlencoded; charset=utf-8
Host: [your test site URL goes here]
Content-Length: 7

foo=bar
```

5. Validate that the request is blocked.

<img width="924" alt="Screenshot 2024-03-06 at 10 18 48 AM" src="https://github.com/Automattic/jetpack/assets/10933065/4c07259e-45cb-4fe8-b19b-f3182e437bf3">

6. Test for regressions and side effects. For example, this rule should not affect non-json content type requests.

<img width="925" alt="Screenshot 2024-03-06 at 10 20 12 AM" src="https://github.com/Automattic/jetpack/assets/10933065/afe34d35-de2a-42b3-8f8d-e4f0e768c97d">

