### PR TITLE
Fix is_managed value for `/wordpress` root symlink

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-wordpress-root-symlink
+++ b/projects/packages/scheduled-updates/changelog/fix-wordpress-root-symlink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed scheduled updates returning is_managed = true for non-root symlinks to /wordpress directory.

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -10,7 +10,8 @@
 		"yoast/phpunit-polyfills": "1.1.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/wordbless": "@dev",
-		"automattic/jetpack-plans": "@dev"
+		"automattic/jetpack-plans": "@dev",
+		"php-mock/php-mock-phpunit": "^2.10"
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -185,9 +185,9 @@ class Scheduled_Updates {
 				*/
 				'get_callback' => function ( $data ) {
 					$folder = WP_PLUGIN_DIR . '/' . strtok( $data['plugin'], '/' );
-					$target = is_link( $folder ) ? readlink( $folder ) : false;
+					$target = is_link( $folder ) ? realpath( $folder ) : false;
 
-					return $target && false !== strpos( $target, '/wordpress/' );
+					return $target && 0 === strpos( $target, '/wordpress/' );
 				},
 				'schema'       => array(
 					'description' => 'Whether the plugin is managed by the host.',

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.0';
+	const PACKAGE_VERSION = '0.3.1-alpha';
 
 	/**
 	 * Initialize the class.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-composer
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-composer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Updated dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_0"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_1_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -198,7 +198,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "dfd9f527692091535d2959930461894c6c91864c"
+                "reference": "650b442ad8357bd4353970a2014a40e126d180d8"
             },
             "require": {
                 "php": ">=7.0"
@@ -207,6 +207,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/wordbless": "@dev",
+                "php-mock/php-mock-phpunit": "^2.10",
                 "yoast/phpunit-polyfills": "1.1.0"
             },
             "suggest": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.0
+ * Version: 2.1.1-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.0",
+	"version": "2.1.1-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
Relates to https://github.com/Automattic/jetpack/pull/35940

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* See this https://github.com/Automattic/jetpack/pull/35940.
* `is_managed` should only be true if the symlink is from a root `/wordpress` directory and not from anywhere in between.
* This PR fixes the situation and adds tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
NA

## Does this pull request change what data or activity we track or use?
NA

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `jetpack build packages/jetpack-mu-wpcom plugins/mu-wpcom-plugin`
* `jetpack rsync --watch mu-wpcom-plugin woa-site@sftp.wp.com:htdocs/wp-content/plugins/jetpack-mu-wpcom-plugin-dev`
* Or apply the changes using the latest Jetpack Beta WordPress.com Features and select this branch.
* Make sure the https://developer.wordpress.com/docs/api/console/ `wp/v2/sites/woa.wpcomstaging.com/plugins` continue to return correct results.