### PR TITLE
Boost: remove the ABSPATH from log messages in case logs are made public

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
@@ -102,6 +102,9 @@ class Logger {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$request_uri = htmlspecialchars( isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '<unknown request uri>', ENT_QUOTES, 'UTF-8' );
 
+		// don't log the ABSPATH constant. Logs may be copied to a public forum.
+		$message = str_replace( ABSPATH, 'ABSPATH/', $message );
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 		$line = json_encode(
 			array(

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
@@ -103,7 +103,7 @@ class Logger {
 		$request_uri = htmlspecialchars( isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '<unknown request uri>', ENT_QUOTES, 'UTF-8' );
 
 		// don't log the ABSPATH constant. Logs may be copied to a public forum.
-		$message = str_replace( ABSPATH, 'ABSPATH/', $message );
+		$message = str_replace( ABSPATH, '', $message );
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 		$line = json_encode(

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Logger.php
@@ -103,7 +103,7 @@ class Logger {
 		$request_uri = htmlspecialchars( isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '<unknown request uri>', ENT_QUOTES, 'UTF-8' );
 
 		// don't log the ABSPATH constant. Logs may be copied to a public forum.
-		$message = str_replace( ABSPATH, '', $message );
+		$message = str_replace( ABSPATH, '[...]/', $message );
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 		$line = json_encode(

--- a/projects/plugins/boost/changelog/update-boost-log-abspath
+++ b/projects/plugins/boost/changelog/update-boost-log-abspath
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Boost: remove the ABSPATH from log messages in case the logs are made public


### PR DESCRIPTION
Log messages can include the phrase "Deleted expired file: /var/www/html/....." which reveals the path to the web server. This information needs to be removed, as the site owner may copy and paste the log entries to a forum when looking for help. Revealing this information may make it easier for an attacker to gain access to a server.

That is not the only message that includes the ABSPATH, so the message parameter should simply replace ABSPATH with the string "ABSPATH/".

## Proposed changes:
* Add a str_replace to the log function that replaces ABSPATH with "ABSPATH/".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Make sure a page is cached and have logging enabled.
Edit that page and save any changes.
Look at the log and notice the full path to the cached file is there.
Apply this PR and repeat
The log file will show "ABSPATH/" instead of the non-visible part (before public_html or htdocs where the site lives) of the path to the file being deleted.