### PR TITLE
Subscription Site: Polishing the Subscribe block toggle

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -176,31 +176,26 @@ function SubscriptionsSettings( props ) {
 									</>
 								) }
 							</p>
+							{ isSubscriptionSiteFeatureEnabled && (
+								<>
+									<br />
+									<ToggleControl
+										checked={ isSubscriptionsActive && isSubscribePostEndEnabled }
+										disabled={ isDisabled }
+										toggling={ isSavingAnyOption( [
+											'jetpack_subscriptions_subscribe_post_end_enabled',
+										] ) }
+										onChange={ handleSubscribePostEndToggleChange }
+										label={ __(
+											'Enable automatic insertion of the Subscribe block into the theme at the end of each post',
+											'jetpack'
+										) }
+									/>
+								</>
+							) }
 						</FormFieldset>
 					}
 				</SettingsGroup>
-
-				{ isSubscriptionsActive && isSubscriptionSiteFeatureEnabled && (
-					<SettingsGroup
-						hasChild
-						disableInOfflineMode
-						disableInSiteConnectionMode
-						module={ subscriptions }
-					>
-						<p>Enable automatic insertion of the Subscribe block into the theme</p>
-						<FormFieldset>
-							<ToggleControl
-								checked={ isSubscriptionsActive && isSubscribePostEndEnabled }
-								disabled={ isDisabled }
-								toggling={ isSavingAnyOption( [
-									'jetpack_subscriptions_subscribe_post_end_enabled',
-								] ) }
-								onChange={ handleSubscribePostEndToggleChange }
-								label="End of each post"
-							/>
-						</FormFieldset>
-					</SettingsGroup>
-				) }
 
 				{ getSubClickableCard() }
 

--- a/projects/plugins/jetpack/changelog/update-subscription-site-toggle-polish
+++ b/projects/plugins/jetpack/changelog/update-subscription-site-toggle-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscription Site: Polishing the Subscribe block toggle


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/36021

## Proposed changes:

It moves the Subscribe block toggle to the Newsletter settings main section.

<img width="1055" alt="Screenshot 2024-03-05 at 12 33 10" src="https://github.com/Automattic/jetpack/assets/4068554/62499d20-b524-40f1-b2d0-b9471e1ed9bf">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- enable the Subscription Site feature by adding the following line to your `0-sandbox.php` file:
```php
add_filter( 'jetpack_subscription_site_enabled', '__return_true' );
```
- enable the Jetpack Newsletter Module
- go to Newsletter settings and make sure the Subscribe block after the post toggle looks sane

