### PR TITLE
Command Palette: load on wpcom platforms only

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-cmd-palette-load-on-wpcom-only
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-cmd-palette-load-on-wpcom-only
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Load the cmd palatte only on wpcom platforms.
+
+

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.15.0",
+	"version": "5.15.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.15.0';
+	const PACKAGE_VERSION = '5.15.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-command-palette/wpcom-command-palette.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-command-palette/wpcom-command-palette.php
@@ -11,6 +11,11 @@
  * @return bool
  */
 function should_load_wpcom_command_palette() {
+	// Only load on the WPcom platform.
+	if ( ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
+		return false;
+	}
+
 	global $pagenow;
 	$excluded_pages = array(
 		'post.php',


### PR DESCRIPTION
## Proposed changes:

Command Palette: load on wpcom platforms only

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/wpcomsh/pull/1731

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Proofread & test package on WoA & simple, see: PCYsg-Osp-p2