### PR TITLE
Colors: update @automattic/calypso-color-schemes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2236,8 +2236,8 @@ importers:
   projects/packages/search:
     dependencies:
       '@automattic/calypso-color-schemes':
-        specifier: 3.1.1
-        version: 3.1.1
+        specifier: 3.1.2
+        version: 3.1.2
       '@automattic/color-studio':
         specifier: 2.5.0
         version: 2.5.0
@@ -2512,8 +2512,8 @@ importers:
         version: 2.3.0
     devDependencies:
       '@automattic/calypso-color-schemes':
-        specifier: 3.1.1
-        version: 3.1.1
+        specifier: 3.1.2
+        version: 3.1.2
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*
         version: link:../../js-packages/webpack-config
@@ -2605,8 +2605,8 @@ importers:
   projects/packages/wordads:
     dependencies:
       '@automattic/calypso-color-schemes':
-        specifier: 3.1.1
-        version: 3.1.1
+        specifier: 3.1.2
+        version: 3.1.2
       '@automattic/color-studio':
         specifier: 2.5.0
         version: 2.5.0
@@ -3137,8 +3137,8 @@ importers:
   projects/plugins/jetpack:
     dependencies:
       '@automattic/calypso-color-schemes':
-        specifier: 3.1.1
-        version: 3.1.1
+        specifier: 3.1.2
+        version: 3.1.2
       '@automattic/format-currency':
         specifier: 1.0.1
         version: 1.0.1
@@ -3755,8 +3755,8 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@automattic/calypso-color-schemes':
-        specifier: 3.1.1
-        version: 3.1.1
+        specifier: 3.1.2
+        version: 3.1.2
       '@automattic/color-studio':
         specifier: 2.5.0
         version: 2.5.0
@@ -4381,8 +4381,8 @@ packages:
     resolution: {integrity: sha512-dRmLP0Ytf2oDNbUbO8MXLKYnPZfqhtFQ8v1hgDo2Fde1Y0bUz2Ll1UmUOHdyZudnrN/8Zt95cG/fIOJ0dxHi8Q==}
     dev: false
 
-  /@automattic/calypso-color-schemes@3.1.1:
-    resolution: {integrity: sha512-jPSMyaYn79MZRvBokkfmL/yeqYQJZEVXpKyzY/aoo/oCW5EjAQsERsQY+aQKsOrMrd5Es+Gf9tbq9OMrzzCb8g==}
+  /@automattic/calypso-color-schemes@3.1.2:
+    resolution: {integrity: sha512-tp1zRUHqtC+R/sIvUHdVFat7pJPRiMyb0z4/hKlqvby3/McRraSmDkK1GtIJCPYiX7C/whwXQGb49hGJIGeshw==}
 
   /@automattic/color-studio@2.5.0:
     resolution: {integrity: sha512-gZWaJbx3p1oennAIoJtMGluTmoM95Efk4rc44TSBxWSZZ8gH3Am2eh1o3i1NhrZmg2Zt3AiVFeZZ4AJccIpBKQ==}

--- a/projects/packages/search/changelog/update-calypso-color-schemes-release-312
+++ b/projects/packages/search/changelog/update-calypso-color-schemes-release-312
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update to the most recent version of the @automattic/calypso-color-schemes package.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.43.4",
+	"version": "0.43.5-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {
@@ -32,7 +32,7 @@
 	},
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/search/#readme",
 	"dependencies": {
-		"@automattic/calypso-color-schemes": "3.1.1",
+		"@automattic/calypso-color-schemes": "3.1.2",
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/format-currency": "1.0.1",
 		"@automattic/jetpack-analytics": "workspace:*",

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.43.4';
+	const VERSION = '0.43.5-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/videopress/changelog/update-calypso-color-schemes-release-312
+++ b/projects/packages/videopress/changelog/update-calypso-color-schemes-release-312
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update to the most recent version of the @automattic/calypso-color-schemes package.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.7",
+	"version": "0.23.8-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {
@@ -23,7 +23,7 @@
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest"
 	},
 	"devDependencies": {
-		"@automattic/calypso-color-schemes": "3.1.1",
+		"@automattic/calypso-color-schemes": "3.1.2",
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@babel/core": "7.24.0",

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.7';
+	const PACKAGE_VERSION = '0.23.8-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/changelog/update-calypso-color-schemes-release-312
+++ b/projects/packages/wordads/changelog/update-calypso-color-schemes-release-312
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update to the most recent version of the @automattic/calypso-color-schemes package.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.10",
+	"version": "0.3.11-alpha",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",
@@ -30,7 +30,7 @@
 		"watch": "concurrently 'pnpm:build-dashboard --watch'"
 	},
 	"dependencies": {
-		"@automattic/calypso-color-schemes": "3.1.1",
+		"@automattic/calypso-color-schemes": "3.1.2",
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-api": "workspace:*",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.10';
+	const VERSION = '0.3.11-alpha';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-calypso-color-schemes-release-312
+++ b/projects/plugins/jetpack/changelog/update-calypso-color-schemes-release-312
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+General: update to the most recent version of @automattic/calypso-color-schemes

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -44,7 +44,7 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
-		"@automattic/calypso-color-schemes": "3.1.1",
+		"@automattic/calypso-color-schemes": "3.1.2",
 		"@automattic/format-currency": "1.0.1",
 		"@automattic/jetpack-ai-client": "workspace:*",
 		"@automattic/jetpack-analytics": "workspace:*",

--- a/projects/plugins/social/changelog/update-calypso-color-schemes-release-312
+++ b/projects/plugins/social/changelog/update-calypso-color-schemes-release-312
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update to the most recent version of the @automattic/calypso-color-schemes package.

--- a/projects/plugins/social/package.json
+++ b/projects/plugins/social/package.json
@@ -43,7 +43,7 @@
 		"react-dom": "18.2.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-color-schemes": "3.1.1",
+		"@automattic/calypso-color-schemes": "3.1.2",
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@babel/core": "7.24.0",


### PR DESCRIPTION
## Proposed changes:

This will allow us to use the new colors in #36181.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

* Not much to test as of yet, but you can test that the existing colors still work.
* Go to Appearance > Site Editor > Templates > Single Posts
* Add a Sharing buttons block
* Add a few blocks like the Facebook sharing block.
* On the frontend and in the editor, ensure that the Facebook button is still blue.
