### PR TITLE
Fix/use of use fetching error notice

### DIFF
--- a/projects/packages/my-jetpack/_inc/data/use-jetpack-api-query.ts
+++ b/projects/packages/my-jetpack/_inc/data/use-jetpack-api-query.ts
@@ -30,7 +30,11 @@ const useJetpackApiQuery = < T >(
 	} );
 
 	const { isError, isLoading } = queryResult;
-	useFetchingErrorNotice( name, ! isLoading && isError, errorMessage );
+	useFetchingErrorNotice( {
+		infoName: name,
+		isError: ! isLoading && isError,
+		overrideMessage: errorMessage,
+	} );
 
 	return queryResult;
 };

--- a/projects/packages/my-jetpack/changelog/fix-use-of-use-fetching-error-notice
+++ b/projects/packages/my-jetpack/changelog/fix-use-of-use-fetching-error-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixing the use of a hoook
+
+


### PR DESCRIPTION
## Proposed changes:

* We changed how useFetchingErrorNotice receives data, this fixes a use case that was not updated

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

N/A
