### PR TITLE
Update/migrate dismiss welcome banner to tanstack

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/welcome-banner/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-banner/index.jsx
@@ -3,9 +3,9 @@ import { useConnection } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { useEffect, useCallback, useState } from 'react';
-import useWelcomeBanner from '../../data/welcome-banner/use-welcome-banner';
 import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
+import useWelcomeBanner from '../../hooks/use-welcome-banner';
 import { CardWrapper } from '../card';
 import styles from './style.module.scss';
 
@@ -17,10 +17,10 @@ import styles from './style.module.scss';
 const WelcomeBanner = () => {
 	const isNewUser = window.myJetpackInitialState.userIsNewToJetpack === '1';
 	const { recordEvent } = useAnalytics();
-	const { isDismissed, dismissWelcomeBanner } = useWelcomeBanner();
+	const { hasBeenDismissed, dismissWelcomeBanner } = useWelcomeBanner();
 	const { isRegistered, isUserConnected } = useConnection();
 	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
-	const [ bannerVisible, setBannerVisible ] = useState( ! isDismissed && isNewUser );
+	const [ bannerVisible, setBannerVisible ] = useState( ! hasBeenDismissed && isNewUser );
 	const shouldDisplayConnectionButton = ! isRegistered || ! isUserConnected;
 
 	useEffect( () => {

--- a/projects/packages/my-jetpack/_inc/components/welcome-banner/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-banner/index.jsx
@@ -3,9 +3,9 @@ import { useConnection } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { useEffect, useCallback, useState } from 'react';
+import useWelcomeBanner from '../../data/welcome-banner/use-welcome-banner';
 import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
-import useWelcomeBanner from '../../hooks/use-welcome-banner';
 import { CardWrapper } from '../card';
 import styles from './style.module.scss';
 
@@ -17,10 +17,10 @@ import styles from './style.module.scss';
 const WelcomeBanner = () => {
 	const isNewUser = window.myJetpackInitialState.userIsNewToJetpack === '1';
 	const { recordEvent } = useAnalytics();
-	const { hasBeenDismissed, dismissWelcomeBanner } = useWelcomeBanner();
+	const { isDismissed, dismissWelcomeBanner } = useWelcomeBanner();
 	const { isRegistered, isUserConnected } = useConnection();
 	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
-	const [ bannerVisible, setBannerVisible ] = useState( ! hasBeenDismissed && isNewUser );
+	const [ bannerVisible, setBannerVisible ] = useState( ! isDismissed && isNewUser );
 	const shouldDisplayConnectionButton = ! isRegistered || ! isUserConnected;
 
 	useEffect( () => {

--- a/projects/packages/my-jetpack/_inc/data/constants.ts
+++ b/projects/packages/my-jetpack/_inc/data/constants.ts
@@ -7,3 +7,4 @@ export const REST_API_CHAT_AVAILABILITY_ENDPOINT = `${ REST_API_NAMESPACE }/chat
 export const REST_API_CHAT_AUTHENTICATION_ENDPOINT = `${ REST_API_NAMESPACE }/chat/authentication`;
 export const REST_API_SITE_PRODUCTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/products`;
 export const REST_API_VIDEOPRESS_FEATURED_STATS = 'videopress/v1/stats/featured';
+export const REST_API_SITE_DISMISS_BANNER = `${ REST_API_NAMESPACE }/site/dismiss-welcome-banner`;

--- a/projects/packages/my-jetpack/_inc/data/welcome-banner/use-welcome-banner.ts
+++ b/projects/packages/my-jetpack/_inc/data/welcome-banner/use-welcome-banner.ts
@@ -1,0 +1,29 @@
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { REST_API_SITE_DISMISS_BANNER } from '../../data/constants';
+import useSimpleMutation from '../use-simple-mutation';
+
+const useWelcomeBanner = () => {
+	const hasBeenDismissed = window?.myJetpackInitialState?.welcomeBanner?.hasBeenDismissed;
+	const [ isDismissed, setIsDismissed ] = useState( hasBeenDismissed );
+
+	const { mutate: dismissWelcomeBanner } = useSimpleMutation(
+		'dismissWelcomeBanner',
+		{
+			path: REST_API_SITE_DISMISS_BANNER,
+			method: 'POST',
+		},
+		{
+			onSuccess: () => setIsDismissed( true ),
+		},
+		null,
+		__( 'Failed to dismiss the welcome banner. Please try again', 'jetpack-my-jetpack' )
+	);
+
+	return {
+		dismissWelcomeBanner,
+		isDismissed,
+	};
+};
+
+export default useWelcomeBanner;

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -1,13 +1,8 @@
-import apiFetch from '@wordpress/api-fetch';
-import { REST_API_SITE_DISMISS_BANNER } from './constants';
-
 /*
  * Action constants
  */
 const SET_STATS_COUNTS_IS_FETCHING = 'SET_STATS_COUNTS_IS_FETCHING';
 const SET_STATS_COUNTS = 'SET_STATS_COUNTS';
-const SET_DISMISSED_WELCOME_BANNER_IS_FETCHING = 'SET_DISMISSED_WELCOME_BANNER_IS_FETCHING';
-const SET_DISMISSED_WELCOME_BANNER = 'SET_DISMISSED_WELCOME_BANNER';
 
 const setStatsCountsIsFetching = isFetching => {
 	return { type: SET_STATS_COUNTS_IS_FETCHING, isFetching };
@@ -15,46 +10,9 @@ const setStatsCountsIsFetching = isFetching => {
 
 const setStatsCounts = statsCounts => ( { type: SET_STATS_COUNTS, statsCounts } );
 
-const setDismissedWelcomeBannerIsFetching = isFetching => {
-	return { type: SET_DISMISSED_WELCOME_BANNER_IS_FETCHING, isFetching };
-};
-
-const setDismissedWelcomeBanner = hasBeenDismissed => {
-	return { type: SET_DISMISSED_WELCOME_BANNER, hasBeenDismissed };
-};
-
-/**
- * Request to set the welcome banner as dismissed
- *
- * @returns {Promise} - Promise which resolves when the banner is dismissed.
- */
-const dismissWelcomeBanner = () => async store => {
-	const { dispatch } = store;
-
-	dispatch( setDismissedWelcomeBannerIsFetching( true ) );
-
-	return apiFetch( {
-		path: REST_API_SITE_DISMISS_BANNER,
-		method: 'POST',
-	} )
-		.then( () => {
-			dispatch( setDismissedWelcomeBanner( true ) );
-		} )
-		.finally( () => {
-			dispatch( setDismissedWelcomeBannerIsFetching( false ) );
-		} );
-};
-
 const actions = {
 	setStatsCounts,
 	setStatsCountsIsFetching,
-	dismissWelcomeBanner,
 };
 
-export {
-	SET_STATS_COUNTS_IS_FETCHING,
-	SET_STATS_COUNTS,
-	SET_DISMISSED_WELCOME_BANNER_IS_FETCHING,
-	SET_DISMISSED_WELCOME_BANNER,
-	actions as default,
-};
+export { SET_STATS_COUNTS_IS_FETCHING, SET_STATS_COUNTS, actions as default };

--- a/projects/packages/my-jetpack/_inc/state/constants.js
+++ b/projects/packages/my-jetpack/_inc/state/constants.js
@@ -1,7 +1,4 @@
-const REST_API_NAMESPACE = 'my-jetpack/v1';
 const ODYSSEY_STATS_API_NAMESPACE = 'jetpack/v4/stats-app';
-
-export const REST_API_SITE_DISMISS_BANNER = `${ REST_API_NAMESPACE }/site/dismiss-welcome-banner`;
 
 export const getStatsHighlightsEndpoint = blogId =>
 	`${ ODYSSEY_STATS_API_NAMESPACE }/sites/${ blogId }/stats/highlights`;

--- a/projects/packages/my-jetpack/_inc/state/reducers.js
+++ b/projects/packages/my-jetpack/_inc/state/reducers.js
@@ -1,10 +1,5 @@
 import { combineReducers } from '@wordpress/data';
-import {
-	SET_STATS_COUNTS_IS_FETCHING,
-	SET_STATS_COUNTS,
-	SET_DISMISSED_WELCOME_BANNER_IS_FETCHING,
-	SET_DISMISSED_WELCOME_BANNER,
-} from './actions';
+import { SET_STATS_COUNTS_IS_FETCHING, SET_STATS_COUNTS } from './actions';
 
 const plugins = ( state = {} ) => {
 	return state;
@@ -29,29 +24,9 @@ const statsCounts = ( state = {}, action ) => {
 	}
 };
 
-const welcomeBanner = ( state = {}, action ) => {
-	switch ( action.type ) {
-		case SET_DISMISSED_WELCOME_BANNER_IS_FETCHING:
-			return {
-				...state,
-				isFetching: action.isFetching,
-			};
-
-		case SET_DISMISSED_WELCOME_BANNER:
-			return {
-				...state,
-				hasBeenDismissed: action.hasBeenDismissed,
-			};
-
-		default:
-			return state;
-	}
-};
-
 const reducers = combineReducers( {
 	plugins,
 	statsCounts,
-	welcomeBanner,
 } );
 
 export default reducers;

--- a/projects/packages/my-jetpack/_inc/state/selectors.js
+++ b/projects/packages/my-jetpack/_inc/state/selectors.js
@@ -11,13 +11,8 @@ const statsCountsSelectors = {
 	isFetchingStatsCounts,
 };
 
-const getWelcomeBannerHasBeenDismissed = state => {
-	return state.welcomeBanner?.hasBeenDismissed;
-};
-
 const selectors = {
 	...statsCountsSelectors,
-	getWelcomeBannerHasBeenDismissed,
 };
 
 export default selectors;

--- a/projects/packages/my-jetpack/changelog/update-migrate-dismiss-welcome-banner-to-tanstack
+++ b/projects/packages/my-jetpack/changelog/update-migrate-dismiss-welcome-banner-to-tanstack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Migrate dismiss welcome banner to tanstack


### PR DESCRIPTION
## Proposed changes:

* Migrate the dismissal of the welcome banner to tanstack
* Remove from redux

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-rcF-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Make sure you are labelled as a new user, this should be the case if it's a new site and you are not connected yet. However if you'd like to run this locally, you can go to `projects/packages/my-jetpack/_inc/components/welcome-banner/index.jsx` and update line 18 to 
```jsx
const isNewUser = true
```
and you should be able to test this
3. Make sure the welcome banner shows up
![image](https://github.com/Automattic/jetpack/assets/65001528/bdabb783-956a-46de-bb4e-98483fa04ca2)
4. Dismiss the banner and make sure it goes away immediately
![image](https://github.com/Automattic/jetpack/assets/65001528/723f4e9f-1d11-4c5b-a29e-0a2ea37cf399)
5. Refresh the page and make sure it is still gone

