### PR TITLE
Member login block: link to individual subscription management page with blog ID

### DIFF
--- a/projects/plugins/jetpack/changelog/update-login-block-manage-subscription-with-site-id
+++ b/projects/plugins/jetpack/changelog/update-login-block-manage-subscription-with-site-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Member login block: link to individual subscription management page

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -126,12 +126,10 @@ function render_block( $attributes ) {
 	}
 
 	if ( Jetpack_Memberships::is_current_user_subscribed() ) {
-		$blog_id = Jetpack_Options::get_option( 'id' );
-
 		return sprintf(
 			$block_template,
 			get_block_wrapper_attributes(),
-			'https://wordpress.com/read/site/subscription/' . $blog_id,
+			'https://wordpress.com/read/site/subscription/' . Jetpack_Memberships::get_blog_id(),
 			$manage_subscriptions_label
 		);
 	}

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -126,10 +126,12 @@ function render_block( $attributes ) {
 	}
 
 	if ( Jetpack_Memberships::is_current_user_subscribed() ) {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+
 		return sprintf(
 			$block_template,
 			get_block_wrapper_attributes(),
-			'https://wordpress.com/read/subscriptions?s=' . get_site_url(),
+			'https://wordpress.com/read/site/subscription/' . $blog_id,
 			$manage_subscriptions_label
 		);
 	}


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/34884

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to https://github.com/Automattic/jetpack/pull/36193 as we found a better way. :-)

## Proposed changes:

<img width="472" alt="Screenshot 2024-03-05 at 19 41 10" src="https://github.com/Automattic/jetpack/assets/87168/ae5f117b-a7e9-4cd8-8fad-91322ddf2d8f">
<img width="1277" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/f67fbd9d-6314-4cdd-a92d-120d8bb821ee">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With member login block on the site
* Login
* See manage -link

