### PR TITLE
Fix Hosting external icon misaligned

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-hosting-external-icon-misaligned
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-hosting-external-icon-misaligned
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Hosting external icon misaligned

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -61,7 +61,7 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_menu_page(
 		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ) . ' <span class="dashicons dashicons-external" style="float: right;"></span>',
+		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ) . ' <span class="dashicons dashicons-external" style="float: right; font-size: 18px"></span>',
 		'manage_options',
 		$parent_slug,
 		null,


### PR DESCRIPTION
Slack: p1709675743906249-slack-C06DN6QQVAQ

## Proposed changes:
This fixes the misaligned external icon from Hosting menu by making it smaller.

| Before | After |
|-|-|
| ![image](https://github.com/Automattic/jetpack/assets/402286/b5f05042-433f-4dcf-9dad-05d92baadd26) | ![image](https://github.com/Automattic/jetpack/assets/402286/7dba52d6-bbb1-404d-8d55-3ed05380546e) |

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to `/wp-admin` using a Classic style site and proxied
* Check the alignment of the external icon in the Hosting menu (check screenshots)