### PR TITLE
Update/remove lifecycle stats from redux

### DIFF
--- a/projects/packages/my-jetpack/_inc/data/utils/get-guessed-site-lifecycle-status.ts
+++ b/projects/packages/my-jetpack/_inc/data/utils/get-guessed-site-lifecycle-status.ts
@@ -1,5 +1,9 @@
-const getGuessedSiteLifecycleStatus = () => {
-	const lifecycleStats = window?.myJetpackInitialState?.lifecycleStats;
+type lifecycleStatsType = Window[ 'myJetpackInitialState' ][ 'lifecycleStats' ];
+
+const getGuessedSiteLifecycleStatus = ( lifecycleStats: lifecycleStatsType ) => {
+	if ( ! lifecycleStats ) {
+		return 'unknown';
+	}
 
 	const {
 		modules,

--- a/projects/packages/my-jetpack/_inc/data/utils/get-guessed-site-lifecycle-status.ts
+++ b/projects/packages/my-jetpack/_inc/data/utils/get-guessed-site-lifecycle-status.ts
@@ -1,6 +1,6 @@
-type lifecycleStatsType = Window[ 'myJetpackInitialState' ][ 'lifecycleStats' ];
-
-const getGuessedSiteLifecycleStatus = ( lifecycleStats: lifecycleStatsType ) => {
+const getGuessedSiteLifecycleStatus = (
+	lifecycleStats: Window[ 'myJetpackInitialState' ][ 'lifecycleStats' ]
+) => {
 	if ( ! lifecycleStats ) {
 		return 'unknown';
 	}

--- a/projects/packages/my-jetpack/_inc/data/utils/get-guessed-site-lifecycle-status.ts
+++ b/projects/packages/my-jetpack/_inc/data/utils/get-guessed-site-lifecycle-status.ts
@@ -1,0 +1,35 @@
+const getGuessedSiteLifecycleStatus = () => {
+	const lifecycleStats = window?.myJetpackInitialState?.lifecycleStats;
+
+	const {
+		modules,
+		purchases,
+		jetpackPlugins: plugins,
+		isSiteConnected,
+		isUserConnected,
+	} = lifecycleStats;
+
+	// 'new' = no purchases + less than 3 modules
+	if ( purchases.length === 0 && modules.length < 3 ) {
+		// 'brand-new' = 'new' + (no user or site connection + no modules + only one plugin)
+		if (
+			( ! isUserConnected || ! isSiteConnected ) &&
+			modules.length === 0 &&
+			plugins.length === 1
+		) {
+			return 'brand-new';
+		}
+
+		return 'new';
+	}
+
+	// 'settling-in' = 1 purchase and less than 10 modules
+	if ( purchases.length === 1 && modules.length < 10 ) {
+		return 'settling-in';
+	}
+
+	// 'established' = 2 or more purchases or 10 or more modules
+	return 'established';
+};
+
+export default getGuessedSiteLifecycleStatus;

--- a/projects/packages/my-jetpack/_inc/state/reducers.js
+++ b/projects/packages/my-jetpack/_inc/state/reducers.js
@@ -75,19 +75,11 @@ const welcomeBanner = ( state = {}, action ) => {
 	}
 };
 
-const lifecycleStats = ( state = {}, action ) => {
-	switch ( action.type ) {
-		default:
-			return state;
-	}
-};
-
 const reducers = combineReducers( {
 	notices,
 	plugins,
 	statsCounts,
 	welcomeBanner,
-	lifecycleStats,
 } );
 
 export default reducers;

--- a/projects/packages/my-jetpack/_inc/state/selectors.js
+++ b/projects/packages/my-jetpack/_inc/state/selectors.js
@@ -2,39 +2,8 @@ const getStatsCounts = state => {
 	return state.statsCounts?.data;
 };
 
-const getLifecycleStats = state => {
-	return state.lifecycleStats;
-};
-
 const noticeSelectors = {
 	getGlobalNotice: state => state.notices?.global,
-};
-
-const getGuessedSiteLifecycleStatus = state => {
-	const { modules, purchases, plugins, isSiteConnected, isUserConnected } =
-		getLifecycleStats( state );
-
-	// 'new' = no purchases + less than 3 modules
-	if ( purchases.length === 0 && modules.length < 3 ) {
-		// 'brand-new' = 'new' + (no user or site connection + no modules + only one plugin)
-		if (
-			( ! isUserConnected || ! isSiteConnected ) &&
-			modules.length === 0 &&
-			plugins.length === 1
-		) {
-			return 'brand-new';
-		}
-
-		return 'new';
-	}
-
-	// 'settling-in' = 1 purchase and less than 10 modules
-	if ( purchases.length === 1 && modules.length < 10 ) {
-		return 'settling-in';
-	}
-
-	// 'established' = 2 or more purchases or 10 or more modules
-	return 'established';
 };
 
 const isFetchingStatsCounts = state => {
@@ -54,7 +23,6 @@ const selectors = {
 	...statsCountsSelectors,
 	...noticeSelectors,
 	getWelcomeBannerHasBeenDismissed,
-	getGuessedSiteLifecycleStatus,
 };
 
 export default selectors;

--- a/projects/packages/my-jetpack/changelog/update-remove-lifecycle-stats-from-redux
+++ b/projects/packages/my-jetpack/changelog/update-remove-lifecycle-stats-from-redux
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Moved lifecycle stats function out of redux

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -25,6 +25,13 @@ interface Window {
 			showJetpackStatsCard: boolean;
 			videoPressStats: boolean;
 		};
+		lifecycleStats: {
+			isSiteConnected: boolean;
+			isUserConnected: boolean;
+			jetpackPlugins: Array< string >;
+			modules: Array< string >;
+			purchases: Array< string >;
+		};
 		myJetpackUrl: string;
 		myJetpackVersion: string;
 		plugins: {


### PR DESCRIPTION
## Proposed changes:

* Move lifecycle stats out of redux
* This function is not being used yet as far as I can tell, so this is just to get it out of redux

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-rcF-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This function was not being used but I think it is planned to be used in the future. This is just removing it from redux and putting it into a util function

If you'd like to test you can:
1. Checkout this branch locally
2. Import the `getGuessedSiteLifecycleStatus` function into the `useProduct` tanstack query hook
3. call the function and make sure the function returns the expected result for you (to check your lifecycle stats you can check `myJetpackInitialState.lifecycleStats` in the console)
Here is sample code you can just paste into the `project/packages/my-jetpack/_inc/data/products/use-product.ts` file
```ts
import { useCallback } from 'react';
import { REST_API_SITE_PRODUCTS_ENDPOINT } from '../constants';
import useSimpleQuery from '../use-simple-query';
import getGuessedSiteLifecycleStatus from '../utils/get-guessed-site-lifecycle-status';
import mapObjectKeysToCamel from '../utils/to-camel';
import type { ProductCamelCase, ProductSnakeCase } from '../types';
import type { RefetchOptions, QueryObserverResult } from '@tanstack/react-query';

const getFullPricePerMonth = ( product: ProductCamelCase ) => {
	return product.pricingForUi.productTerm === 'year'
		? Math.round( ( product.pricingForUi.fullPrice / 12 ) * 100 ) / 100
		: product.pricingForUi.fullPrice;
};

const getDiscountPricePerMonth = ( product: ProductCamelCase ) => {
	return product.pricingForUi.productTerm === 'year'
		? Math.round( ( product.pricingForUi.discountPrice / 12 ) * 100 ) / 100
		: product.pricingForUi.discountPrice;
};

export const useAllProducts = () => {
	const initialState = window?.myJetpackInitialState;
	const products = initialState?.products?.items || {};

	return products;
};

// Create query to fetch new product data from the server
const useFetchProduct = ( productId: string ) => {
	const queryResult = useSimpleQuery< ProductSnakeCase >(
		'product',
		{
			path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }`,
		},
		{ enabled: false }
	);

	return queryResult;
};

// Fetch the product data from the server and update the global state
const refetchProduct = async (
	productId: string,
	refetch: ( options?: RefetchOptions ) => Promise< QueryObserverResult< ProductSnakeCase, Error > >
) => {
	const { data: refetchedProduct } = await refetch();

	window.myJetpackInitialState.products.items[ productId ] = refetchedProduct;
};

const prepareProductData = ( product: ProductSnakeCase ) => {
	// The mapObjectKeysToCamel is typed correctly, however we are adding new fields
	// to the product object that don't exist on the global state object
	// Therefore we still need to cast the object to the correct type
	const camelProduct = mapObjectKeysToCamel( product ) as ProductCamelCase;

	camelProduct.features = camelProduct.features || [];
	camelProduct.supportedProducts = camelProduct.supportedProducts || [];

	camelProduct.pricingForUi.fullPricePerMonth = getFullPricePerMonth( camelProduct );
	camelProduct.pricingForUi.discountPricePerMonth = getDiscountPricePerMonth( camelProduct );

	return camelProduct;
};

const useProduct = ( productId: string ) => {
	const guessed = getGuessedSiteLifecycleStatus();
	console.log( guessed );
	const allProducts = useAllProducts();
	const product = allProducts?.[ productId ];
	const camelProduct = prepareProductData( product );
	const { refetch, isLoading } = useFetchProduct( productId );

	return {
		detail: camelProduct,
		refetch: useCallback( () => refetchProduct( productId, refetch ), [ productId, refetch ] ),
		isLoading,
	};
};

export default useProduct;
```