### PR TITLE
My Jetpack: Fix Jetpack ai interstitial styles

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/jetpack-ai.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/jetpack-ai.jsx
@@ -185,7 +185,6 @@ AiTierDetailTableColumn.propTypes = {
 	onProductButtonClick: PropTypes.func.isRequired,
 	detail: PropTypes.object.isRequired,
 	tier: PropTypes.string.isRequired,
-	trackProductButtonClick: PropTypes.func.isRequired,
 };
 
 /**

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
@@ -51,12 +51,7 @@ export default function JetpackAiInterstitial() {
 
 	return tiers && tiers.length ? (
 		<AdminPage showHeader={ false } showBackground={ true }>
-			<Container
-				fluid
-				horizontalSpacing={ 3 }
-				horizontalGap={ 3 }
-				className={ styles[ 'product-interstitial__container' ] }
-			>
+			<Container fluid horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col className={ styles[ 'product-interstitial__section' ] }>
 					<div className={ styles[ 'product-interstitial__section-wrapper-wide' ] }>
 						<GoBackLink onClick={ onClickGoBack } />

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -122,12 +122,7 @@ export default function () {
 
 	return (
 		<AdminPage showHeader={ false } showBackground={ true }>
-			<Container
-				fluid
-				horizontalSpacing={ 3 }
-				horizontalGap={ 2 }
-				className={ styles[ 'product-interstitial__container' ] }
-			>
+			<Container fluid horizontalSpacing={ 3 } horizontalGap={ 2 }>
 				<Col className={ classnames( styles[ 'product-interstitial__section' ] ) }>
 					<div className={ styles[ 'product-interstitial__section-wrapper-wide' ] }>
 						<GoBackLink onClick={ onClickGoBack } />

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
@@ -14,10 +14,6 @@
 }
 
 /* Interstitial */
-.product-interstitial__container {
-	margin-top: -24px;
-}
-
 .product-interstitial__product-header {
 	display: flex;
 	flex-wrap: nowrap;

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-interstitial-styles
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-interstitial-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: new AI interstitial margin on admin page was messing with correct top spacing


### PR DESCRIPTION
The top margin on the admin page is using a negative value, causing it to mess with the default spacing

## Proposed changes:
This PR removes the negative margin on the AI interstitial as well as the use of the css classes on the components. Also, remove a required yet no longer used prop on the AI pricing table component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Enable the filter `my_jetpack_use_new_ai_page` and visit `/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai` and `/wp-admin/admin.php?page=my-jetpack#/jetpack-ai`, watch the spacing at the top of the page, it should be the same as visiting any other interstitial (space between the "Go back" link and the top)