### PR TITLE
Boost: Add prefix and comments to page cache filters

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -90,7 +90,7 @@ class Request {
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @param array $bypass_patterns An array of regex patterns that define URLs to be bypassed from caching.
+		 * @param array $bypass_patterns An array of regex patterns that define URLs that bypass caching.
 		 */
 		$bypass_patterns = apply_filters( 'jetpack_boost_cache_bypass_patterns', $bypass_patterns );
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -86,10 +86,7 @@ class Request {
 		$bypass_patterns = Boost_Cache_Settings::get_instance()->get_bypass_patterns();
 
 		/**
-		 * Filters the bypass patterns for the Jetpack Boost cache.
-		 *
-		 * Allows developers to modify the list of patterns used to bypass the cache. This could be used to add
-		 * new patterns or remove existing ones depending on specific needs.
+		 * Filters the bypass patterns for the page cache.
 		 *
 		 * @since $$next-version$$
 		 *
@@ -118,10 +115,9 @@ class Request {
 	 */
 	public function is_cacheable() {
 		/**
-		 * Determines if the request is considered cacheable by Jetpack Boost.
+		 * Determines if the request is considered cacheable.
 		 *
-		 * This filter allows developers to override the default cacheability logic of Jetpack Boost. It can be
-		 * used to make a request cacheable that would otherwise not be, or to prevent a request from being cached.
+		 * Can be used to prevent a request from being cached.
 		 *
 		 * @since $$next-version$$
 		 *
@@ -176,9 +172,10 @@ class Request {
 		/**
 		 * Filters the accept headers to determine if the request should be cached.
 		 *
-		 * This filter allows modification of the accepted headers for cacheable requests. Requests with headers
-		 * matching any in the filtered list will not be cached. This can be used to exclude certain types of
-		 * requests based on their Accept header value.
+		 * This filter allows modification of the content types that browsers send
+		 * to the server during a request. If the acceptable browser content type header (HTTP_ACCEPT)
+		 * matches one of these content types the request will not be cached,
+		 * or a cached file served to this visitor.
 		 *
 		 * @since $$next-version$$
 		 *

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -84,7 +84,18 @@ class Request {
 		}
 
 		$bypass_patterns = Boost_Cache_Settings::get_instance()->get_bypass_patterns();
-		$bypass_patterns = apply_filters( 'boost_cache_bypass_patterns', $bypass_patterns );
+
+		/**
+		 * Filters the bypass patterns for the Jetpack Boost cache.
+		 *
+		 * Allows developers to modify the list of patterns used to bypass the cache. This could be used to add
+		 * new patterns or remove existing ones depending on specific needs.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $bypass_patterns An array of regex patterns that define URLs to be bypassed from caching.
+		 */
+		$bypass_patterns = apply_filters( 'jetpack_boost_cache_bypass_patterns', $bypass_patterns );
 
 		$bypass_patterns[] = 'wp-.*\.php';
 		foreach ( $bypass_patterns as $expr ) {
@@ -106,7 +117,17 @@ class Request {
 	 * @return bool
 	 */
 	public function is_cacheable() {
-		if ( ! apply_filters( 'boost_cache_cacheable', $this->request_uri ) ) {
+		/**
+		 * Determines if the request is considered cacheable by Jetpack Boost.
+		 *
+		 * This filter allows developers to override the default cacheability logic of Jetpack Boost. It can be
+		 * used to make a request cacheable that would otherwise not be, or to prevent a request from being cached.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $request_uri The request URI to be evaluated for cacheability.
+		 */
+		if ( ! apply_filters( 'jetpack_boost_cache_cacheable', $this->request_uri ) ) {
 			return false;
 		}
 
@@ -152,7 +173,18 @@ class Request {
 			return false;
 		}
 
-		$accept_headers = apply_filters( 'boost_accept_headers', array( 'application/json', 'application/activity+json', 'application/ld+json' ) );
+		/**
+		 * Filters the accept headers to determine if the request should be cached.
+		 *
+		 * This filter allows modification of the accepted headers for cacheable requests. Requests with headers
+		 * matching any in the filtered list will not be cached. This can be used to exclude certain types of
+		 * requests based on their Accept header value.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $accept_headers An array of header values that should prevent a request from being cached.
+		 */
+		$accept_headers = apply_filters( 'jetpack_boost_accept_headers', array( 'application/json', 'application/activity+json', 'application/ld+json' ) );
 		$accept_headers = array_map( 'strtolower', $accept_headers );
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- $accept is checked and set below.

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -127,7 +127,7 @@ class Request {
 		 *
 		 * @param string $request_uri The request URI to be evaluated for cacheability.
 		 */
-		if ( ! apply_filters( 'jetpack_boost_cache_cacheable', $this->request_uri ) ) {
+		if ( ! apply_filters( 'jetpack_boost_cache_request_cacheable', $this->request_uri ) ) {
 			return false;
 		}
 
@@ -184,7 +184,7 @@ class Request {
 		 *
 		 * @param array $accept_headers An array of header values that should prevent a request from being cached.
 		 */
-		$accept_headers = apply_filters( 'jetpack_boost_accept_headers', array( 'application/json', 'application/activity+json', 'application/ld+json' ) );
+		$accept_headers = apply_filters( 'jetpack_boost_cache_accept_headers', array( 'application/json', 'application/activity+json', 'application/ld+json' ) );
 		$accept_headers = array_map( 'strtolower', $accept_headers );
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- $accept is checked and set below.

--- a/projects/plugins/boost/changelog/update-cache-filters-name-add-comments
+++ b/projects/plugins/boost/changelog/update-cache-filters-name-add-comments
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Update page cache filters and add comments.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add prefix to filters, to have a unified naming convention across Boost;
* Update some filter names;
* Add docblock comments to filters.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review comments and make sure they make sense.