### PR TITLE
WP Super Cache: don't serve a cached page when a POST request is made

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-stop-caching-post-requests
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-stop-caching-post-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: fixed serving a cached page on POST with late init enabled.

--- a/projects/plugins/super-cache/wp-cache-phase1.php
+++ b/projects/plugins/super-cache/wp-cache-phase1.php
@@ -135,9 +135,19 @@ if ( isset( $wp_cache_make_known_anon ) && $wp_cache_make_known_anon ) {
 // an init action wpsc plugins can hook on to.
 do_cacheaction( 'cache_init' );
 
+if ( ! $cache_enabled ) {
+	return true;
+}
+
 // don't cache or serve cached files for various URLs, including the Customizer.
-if ( ! $cache_enabled || ( isset( $_SERVER['REQUEST_METHOD'] ) && in_array( $_SERVER['REQUEST_METHOD'], array( 'POST', 'PUT', 'DELETE' ) ) ) || isset( $_GET['customize_changeset_uuid'] ) ) {
-	wp_cache_debug( 'Caching disabled.' );
+if ( isset( $_SERVER['REQUEST_METHOD'] ) && in_array( $_SERVER['REQUEST_METHOD'], array( 'POST', 'PUT', 'DELETE' ), true ) ) {
+	wp_cache_debug( 'Caching disabled for non GET request.' );
+	define( 'DONOTCACHEPAGE', 1 );
+	return true;
+}
+
+if ( isset( $_GET['customize_changeset_uuid'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	wp_cache_debug( 'Caching disabled for customizer.' );
 	define( 'DONOTCACHEPAGE', 1 );
 	return true;
 }

--- a/projects/plugins/super-cache/wp-cache-phase1.php
+++ b/projects/plugins/super-cache/wp-cache-phase1.php
@@ -109,6 +109,7 @@ if ( isset( $_SERVER['REQUEST_URI'] ) ) { // Cache this in case any plugin modif
 
 // don't cache in wp-admin
 if ( wpsc_is_backend() ) {
+	define( 'DONOTCACHEPAGE', 1 );
 	return true;
 }
 
@@ -122,6 +123,7 @@ if ( wpsc_is_rejected_cookie() ) {
 
 if ( wpsc_is_caching_user_disabled() ) {
 	wp_cache_debug( 'Caching disabled for logged in users on settings page.' );
+	define( 'DONOTCACHEPAGE', 1 );
 	return true;
 }
 
@@ -135,6 +137,8 @@ do_cacheaction( 'cache_init' );
 
 // don't cache or serve cached files for various URLs, including the Customizer.
 if ( ! $cache_enabled || ( isset( $_SERVER['REQUEST_METHOD'] ) && in_array( $_SERVER['REQUEST_METHOD'], array( 'POST', 'PUT', 'DELETE' ) ) ) || isset( $_GET['customize_changeset_uuid'] ) ) {
+	wp_cache_debug( 'Caching disabled.' );
+	define( 'DONOTCACHEPAGE', 1 );
 	return true;
 }
 

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -390,6 +390,11 @@ function wp_cache_postload() {
 	global $cache_enabled, $wp_super_cache_late_init;
 	global $wp_cache_request_uri;
 
+	if ( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE ) {
+		wp_cache_debug( 'wp_cache_postload: DONOTCACHEPAGE defined. Not running.' );
+		return false;
+	}
+
 	if ( empty( $wp_cache_request_uri ) ) {
 		wp_cache_debug( 'wp_cache_postload: no request uri configured. Not running.' );
 		return false;


### PR DESCRIPTION
It's possible for the plugin to serve a cached page under a certain set of circumstances:
1. Late init must be enabled.
2. A page must be cached already.

We don't want to serve a cached page because the POST action may have modified the contents of that page.

Reported: https://wordpress.org/support/topic/post-request-cached-with-late-init/


## Proposed changes:
* Add DONOTCACHEPAGE check to the wp_cache_postload() function and stop processing if defined.
* Set DONOTCACHEPAGE earlier on in wp-cache-phase1.php when we detect a non-GET request.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Enable logging in the debug page.
* Enable late init mode in the advanced settings page.
* Create an mu-plugin with this function:
```
function tester() {
?>
<form method='post'>
<input type='submit' value='Submit' />
</form>
<?php
}
add_action( 'init', 'tester' );
```
* That will add a small "Submit" button at the top of the page.
* Verify there is a cached page for the page you will test on.
* Click on the submit button and verify that a cached page was served by looking at the debug log and for the html comment at the end of the file.
* Apply this PR.
* Submit that form again
* Look for the caching html comment and you won't find it.
* Look in the debug log for "wp_cache_postload: DONOTCACHEPAGE defined. Not running."
