### PR TITLE
SSO: Guard against null body received

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sso-malformed-body-check
+++ b/projects/plugins/jetpack/changelog/fix-sso-malformed-body-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Edge case safety check
+
+

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -843,7 +843,13 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 					);
 
 					if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
-						$body                 = json_decode( $response['body'], true );
+						$body = json_decode( $response['body'], true );
+
+						// ensure array_merge happens with the right parameters
+						if ( empty( $body ) ) {
+							$body = array();
+						}
+
 						self::$cached_invites = array_merge( self::$cached_invites, $body );
 					}
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # p1709673415159969-slack-C02T4NVL4JJ
We received a report that our invite check endpoint can return null value.
This PR handles this scenario 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add check for empty response and ensure that array_merge happens with the correct parameters.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*