### PR TITLE
Remove external-icon from Hosting menu

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-external-icon-from-hosting-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-external-icon-from-hosting-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove external-icon from Hosting menu

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -61,7 +61,7 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_menu_page(
 		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ) . ' <span class="dashicons dashicons-external" style="float: right;"></span>',
+		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		$parent_slug,
 		null,


### PR DESCRIPTION
Slack: p1709695888059749/1709675743.906249-slack-C06DN6QQVAQ
P2 comment: pfsHM7-hS-p2#comment-419

## Proposed changes:
Remove external-icon from Hosting menu

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/jetpack/assets/402286/02a80b1e-3ec0-4dd9-8fb2-5f0211eda37f) | ![image](https://github.com/Automattic/jetpack/assets/402286/63c1b4ae-f692-4ea1-837b-f21d1f84c4f5) |


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Follow instructions from here (https://github.com/Automattic/jetpack/pull/36221#issuecomment-1981046904) using this brach
* Using a site with Classic interface and proxied or with early access enabled
* Go to `/wp-admin`
* `Hosting` menu should not have external icon at the right (screenshot)
