### PR TITLE
Subscriptions Widget: Fix Fatal when calculating custom padding

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-widget-fatal
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-widget-fatal
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Subscriptions Widget: Fix Fatal when calculating custom padding
+
+

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -914,9 +914,9 @@ function jetpack_do_subscription_form( $instance ) {
 	if ( isset( $instance['custom_padding'] ) && 'undefined' !== $instance['custom_padding'] ) {
 		$style = 'padding: ' .
 			$instance['custom_padding'] . 'px ' .
-			round( $instance['custom_padding'] * 1.5 ) . 'px ' .
+			round( floatval( $instance['custom_padding'] ) * 1.5 ) . 'px ' .
 			$instance['custom_padding'] . 'px ' .
-			round( $instance['custom_padding'] * 1.5 ) . 'px; ';
+			round( floatval( $instance['custom_padding'] ) * 1.5 ) . 'px; ';
 
 		$submit_button_styles .= $style;
 		$email_field_styles   .= $style;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a fatal that might occur when calculating the custom padding for the Subscriptions Widget

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Jetpack_Subscriptions_Widget`: Update `jetpack_do_subscription_form` to cast the `$instance['custom_padding']` to float before multiplying it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p3btAN-2DW-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
p3btAN-2DW-p2