### PR TITLE
Falllback to Mapbox when Mapkit encounters an error

### DIFF
--- a/projects/plugins/jetpack/changelog/draft-fallback-to-mapbox
+++ b/projects/plugins/jetpack/changelog/draft-fallback-to-mapbox
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Implement a fallback
+
+

--- a/projects/plugins/jetpack/extensions/blocks/map/map.php
+++ b/projects/plugins/jetpack/extensions/blocks/map/map.php
@@ -124,7 +124,7 @@ function load_assets( $attr, $content ) {
 
 	$map_provider = get_map_provider( $content );
 	if ( $map_provider === 'mapkit' ) {
-		return preg_replace( '/<div /', '<div data-map-provider="mapkit" data-blog-id="' . \Jetpack_Options::get_option( 'id' ) . '" ', $content, 1 );
+		return preg_replace( '/<div /', '<div data-map-provider="mapkit" data-api-key="' . esc_attr( $access_token['key'] ) . '"  data-blog-id="' . \Jetpack_Options::get_option( 'id' ) . '" ', $content, 1 );
 	}
 
 	return preg_replace( '/<div /', '<div data-map-provider="mapbox" data-api-key="' . esc_attr( $access_token['key'] ) . '" ', $content, 1 );

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit-utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit-utils/index.js
@@ -127,9 +127,6 @@ function fetchMapkitKey( mapkitObj, blogId, currentWindow ) {
 					}
 				},
 			} );
-			mapkitObj.addEventListener( 'error', function ( event ) {
-				reject( event );
-			} );
 		}
 	} );
 }

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit-utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit-utils/index.js
@@ -127,6 +127,9 @@ function fetchMapkitKey( mapkitObj, blogId, currentWindow ) {
 					}
 				},
 			} );
+			mapkitObj.addEventListener( 'error', function ( event ) {
+				reject( event );
+			} );
 		}
 	} );
 }

--- a/projects/plugins/jetpack/extensions/blocks/map/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/view.js
@@ -8,7 +8,10 @@ domReady( function () {
 		try {
 			if ( blockRoot.getAttribute( 'data-map-provider' ) === 'mapkit' ) {
 				const block = new MapkitBlock( blockRoot );
-				block.init();
+				block.init().catch( () => {
+					const fallback = new MapBoxBlock( blockRoot );
+					fallback.init();
+				} );
 			} else {
 				const block = new MapBoxBlock( blockRoot );
 				block.init();

--- a/projects/plugins/jetpack/extensions/blocks/map/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/view.js
@@ -8,10 +8,13 @@ domReady( function () {
 		try {
 			if ( blockRoot.getAttribute( 'data-map-provider' ) === 'mapkit' ) {
 				const block = new MapkitBlock( blockRoot );
-				block.init().catch( () => {
+				block.onError = () => {
+					// remove the mapkit container
+					blockRoot.innerHtml = '';
 					const fallback = new MapBoxBlock( blockRoot );
 					fallback.init();
-				} );
+				};
+				block.init();
 			} else {
 				const block = new MapBoxBlock( blockRoot );
 				block.init();

--- a/projects/plugins/jetpack/extensions/blocks/map/view/mapkit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/view/mapkit.js
@@ -17,6 +17,7 @@ class MapkitBlock {
 		this.scrollToZoom = this.root.getAttribute( 'data-scroll-to-zoom' ) === 'true';
 		this.mapStyle = this.root.getAttribute( 'data-map-style' ) || 'default';
 		this.mapHeight = this.root.getAttribute( 'data-map-height' ) || null;
+		this.onError = () => {};
 	}
 
 	async init() {
@@ -51,6 +52,10 @@ class MapkitBlock {
 		return new Promise( resolve => {
 			loadMapkitLibrary( document, window ).then( mapkit => {
 				this.mapkit = mapkit;
+				this.mapkit.addEventListener( 'error', event => {
+					// because Apple uses an event listener for errors, we need to jump through some hoops to catch them
+					this.onError( event );
+				} );
 				resolve();
 			} );
 		} );

--- a/projects/plugins/jetpack/extensions/blocks/map/view/mapkit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/view/mapkit.js
@@ -53,7 +53,7 @@ class MapkitBlock {
 			loadMapkitLibrary( document, window ).then( mapkit => {
 				this.mapkit = mapkit;
 				this.mapkit.addEventListener( 'error', event => {
-					// because Apple uses an event listener for errors, we need to jump through some hoops to catch them
+					// because Apple uses an event listener for errors, we can't just throw here
 					this.onError( event );
 				} );
 				resolve();


### PR DESCRIPTION
Related to p58i-gPm-p2 

## Proposed changes:
- Provides a fallback to Mapbox on the frontend when Mapkit encounters an error (invalid API key, request limit reached)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Apply this PR to your simple site
- Add a page/post containing a map block
- Using Chrome Devtools override the content of the call to `https://public-api.wordpress.com/wpcom/v2/mapkit` to return something invalid. You can also change the endpoint if that's more convenient -  fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Serfg%2Qncv%2Qcyhtvaf%2Sraqcbvagf%2Szncxvg.cuc%2320%2Q20-og
- A Mapbox map should render instead of a Apple Maps map