### PR TITLE
Scheduled Updates: Actually validate and sanitize plugin slugs

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-plugin-slugs
+++ b/projects/packages/scheduled-updates/changelog/fix-plugin-slugs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug where individual plugin slugs were not actually validated and sanitized.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.1';
+	const PACKAGE_VERSION = '0.3.2-alpha';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -305,6 +305,37 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	}
 
 	/**
+	 * Checks that the "plugins" parameter is a valid path.
+	 *
+	 * @param array $plugins List of plugins to update.
+	 * @return bool|WP_Error
+	 */
+	public function validate_plugins_param( $plugins ) {
+		foreach ( $plugins as $plugin ) {
+			if ( ! $this->validate_plugin_param( $plugin ) ) {
+				return new WP_Error(
+					'rest_invalid_plugin',
+					/* translators: %s: plugin file */
+					sprintf( __( 'The plugin "%s" is not a valid plugin file.', 'jetpack-scheduled-updates' ), $plugin ),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Sanitizes the plugin slugs contained in the "plugins" parameter.
+	 *
+	 * @param array $plugins List of plugins to update.
+	 * @return array
+	 */
+	public function sanitize_plugins_param( $plugins ) {
+		return array_map( array( $this, 'sanitize_plugin_param' ), $plugins );
+	}
+
+	/**
 	 * Checks that the "plugin" parameter is a valid path.
 	 *
 	 * @param string $file The plugin file parameter.
@@ -325,7 +356,11 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return string
 	 */
 	public function sanitize_plugin_param( $file ) {
-		return plugin_basename( sanitize_text_field( $file . '.php' ) );
+		if ( ! str_ends_with( $file, '.php' ) ) {
+			$file .= '.php';
+		}
+
+		return plugin_basename( sanitize_text_field( $file ) );
 	}
 
 	/**
@@ -431,15 +466,13 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	public function get_object_params() {
 		return array(
 			'plugins'  => array(
-				'description' => 'List of plugin slugs to update.',
-				'type'        => 'array',
-				'required'    => false,
-				'items'       => array(
-					'type'              => 'string',
-					'pattern'           => self::PATTERN,
-					'validate_callback' => array( $this, 'validate_plugin_param' ),
-					'sanitize_callback' => array( $this, 'sanitize_plugin_param' ),
+				'description'       => 'List of plugin slugs to update.',
+				'type'              => 'array',
+				'items'             => array(
+					'type' => 'string',
 				),
+				'validate_callback' => array( $this, 'validate_plugins_param' ),
+				'sanitize_callback' => array( $this, 'sanitize_plugins_param' ),
 			),
 			'themes'   => array(
 				'description'       => 'List of theme slugs to update.',


### PR DESCRIPTION
Validation and sanitization callbacks only work on the top-level request arg.
This PR breaks that down to the individual plugin slugs

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduces top-level validation/sanitization callbacks.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using REST API Console, create a new schedule and pass plugin slugs without `.php` file ending.
* Query the resulting event and make sure the slugs have `.php` file endings.

