### PR TITLE
Update/jetpack app qr code media

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-app-qr-code-media
+++ b/projects/plugins/jetpack/changelog/update-jetpack-app-qr-code-media
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: The change is a minor copy change, we plan on deploying it to .com to see if there is any difference in terms of usage
+
+

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/index.js
@@ -33,7 +33,7 @@ export const mediaSources = [
 	},
 	{
 		id: SOURCE_JETPACK_APP_MEDIA,
-		label: __( 'Jetpack Mobile App', 'jetpack' ),
+		label: __( 'Your Phone', 'jetpack' ),
 		icon: <JetpackMobileAppIcon className="components-menu-items__item-icon" />,
 		keyword: 'jetpack mobile app',
 	},


### PR DESCRIPTION
This PR is an experiment to see if using a different copy in the image source picker would help get more folks using this feature. 

As discussed with @hypest. 

## Proposed changes:
* Change the copy to "Your Phone" from Jetpack Mobile App. 

<img width="260" alt="Screenshot 2024-03-06 at 11 53 02 AM" src="https://github.com/Automattic/jetpack/assets/115071/43f73b17-bff0-4a01-94a1-7aa5710259e6">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Go to the editor. Add the image block. 
* Click Select Image
* Notice the new copy "Your Phone" 

