### PR TITLE
Contact Form: Update code references in docs and comments

### DIFF
--- a/projects/packages/forms/changelog/update-contact-form-doc-refs
+++ b/projects/packages/forms/changelog/update-contact-form-doc-refs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update code references in docs and comments

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -36,7 +36,7 @@ class Admin {
 	/**
 	 * Instantiates this singleton class
 	 *
-	 * @return Grunion_Admin The Grunion Admin class instance.
+	 * @return Admin The Admin class instance.
 	 */
 	public static function init() {
 		static $instance = false;
@@ -49,7 +49,7 @@ class Admin {
 	}
 
 	/**
-	 * Grunion_Admin constructor
+	 * Admin constructor
 	 */
 	public function __construct() {
 		add_action( 'media_buttons', array( $this, 'grunion_media_button' ), 999 );
@@ -1086,13 +1086,13 @@ class Admin {
 			$post->post_status = 'spam';
 			$status            = wp_insert_post( $post );
 
-			/** This action is already documented in modules/contact-form/admin.php */
+			/** This action is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 			do_action( 'contact_form_akismet', 'spam', $akismet_values );
 		} elseif ( $_POST['make_it'] === 'ham' ) {
 			$post->post_status = 'publish';
 			$status            = wp_insert_post( $post );
 
-			/** This action is already documented in modules/contact-form/admin.php */
+			/** This action is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 			do_action( 'contact_form_akismet', 'ham', $akismet_values );
 
 			$comment_author_email = false;
@@ -1432,7 +1432,7 @@ class Admin {
 						'post_status' => 'spam',
 					)
 				);
-				/** This action is already documented in modules/contact-form/admin.php */
+				/** This action is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 				do_action( 'contact_form_akismet', 'spam', $meta );
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -8,8 +8,8 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 /**
- * Class Grunion_Contact_Form_Endpoint
- * Used as 'rest_controller_class' parameter when 'feedback' post type is registered in modules/contact-form/grunion-contact-form.php.
+ * Class Contact_Form_Endpoint
+ * Used as 'rest_controller_class' parameter when 'feedback' post type is registered in \Automattic\Jetpack\Forms\ContactForm\Contact_Form.
  */
 class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -26,7 +26,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	/**
 	 * The parent form.
 	 *
-	 * @var Grunion_Contact_Form
+	 * @var Contact_Form
 	 */
 	public $form;
 
@@ -75,9 +75,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	/**
 	 * Constructor function.
 	 *
-	 * @param array                $attributes An associative array of shortcode attributes.  @see shortcode_atts().
-	 * @param null|string          $content Null for selfclosing shortcodes.  The inner content otherwise.
-	 * @param Grunion_Contact_Form $form The parent form.
+	 * @param array        $attributes An associative array of shortcode attributes.  @see shortcode_atts().
+	 * @param null|string  $content Null for selfclosing shortcodes.  The inner content otherwise.
+	 * @param Contact_Form $form The parent form.
 	 */
 	public function __construct( $attributes, $content = null, $form = null ) {
 		$attributes = shortcode_atts(

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -129,7 +129,7 @@ class Contact_Form_Plugin {
 	}
 
 	/**
-	 * Class uses singleton pattern; use Grunion_Contact_Form_Plugin::init() to initialize.
+	 * Class uses singleton pattern; use Contact_Form_Plugin::init() to initialize.
 	 */
 	protected function __construct() {
 		$this->add_shortcode();
@@ -612,7 +612,7 @@ class Contact_Form_Plugin {
 				);
 				// This is lamer - no API for outputting a given widget by ID
 				ob_start();
-				// Process the widget to populate Grunion_Contact_Form::$last
+				// Process the widget to populate Contact_Form::$last
 				call_user_func( $widget['callback'], $widget_args, $widget['params'][0] );
 				ob_end_clean();
 			}
@@ -667,13 +667,13 @@ class Contact_Form_Plugin {
 			// Ensure 'block_template' attribute is added to any shortcodes in the template.
 			$template = Util::grunion_contact_form_set_block_template_attribute( $template );
 
-			// Process the block template to populate Grunion_Contact_Form::$last
+			// Process the block template to populate Contact_Form::$last
 			get_the_block_template_html();
 		} elseif ( $is_block_template_part ) {
 			$block_template_part_id   = str_replace( 'block-template-part-', '', $id );
 			$bits                     = explode( '//', $block_template_part_id );
 			$block_template_part_slug = array_pop( $bits );
-			// Process the block part template to populate Grunion_Contact_Form::$last
+			// Process the block part template to populate Contact_Form::$last
 			$attributes = array(
 				'theme'   => wp_get_theme()->get_stylesheet(),
 				'slug'    => $block_template_part_slug,
@@ -684,7 +684,7 @@ class Contact_Form_Plugin {
 			// It's a form embedded in a post
 			$post = get_post( $id );
 
-			// Process the content to populate Grunion_Contact_Form::$last
+			// Process the content to populate Contact_Form::$last
 			if ( $post ) {
 				/** This filter is already documented in core. wp-includes/post-template.php */
 				apply_filters( 'the_content', $post->post_content );
@@ -768,7 +768,7 @@ class Contact_Form_Plugin {
 	 * Ensure the post author is always zero for contact-form feedbacks
 	 * Attached to `wp_insert_post_data`
 	 *
-	 * @see Grunion_Contact_Form::process_submission()
+	 * @see Contact_Form::process_submission()
 	 *
 	 * @param array $data the data to insert.
 	 * @param array $postarr the data sent to wp_insert_post().
@@ -993,7 +993,7 @@ class Contact_Form_Plugin {
 
 	/**
 	 * Submit contact-form data to Akismet to check for spam.
-	 * If you're accepting a new item via $_POST, run it Grunion_Contact_Form_Plugin::prepare_for_akismet() first
+	 * If you're accepting a new item via $_POST, run it Contact_Form_Plugin::prepare_for_akismet() first
 	 * Attached to `jetpack_contact_form_is_spam`
 	 *
 	 * @param bool  $is_spam - if the submission is spam.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -41,7 +41,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	/**
 	 * The most recent (inclusive) contact-form shortcode processed.
 	 *
-	 * @var Grunion_Contact_Form
+	 * @var Contact_Form
 	 */
 	public static $last;
 
@@ -126,9 +126,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'to'                     => $default_to,
 			'subject'                => $default_subject,
 			'show_subject'           => 'no', // only used in back-compat mode
-			'widget'                 => 0,    // Not exposed to the user. Works with Grunion_Contact_Form_Plugin::widget_atts()
+			'widget'                 => 0,    // Not exposed to the user. Works with Contact_Form_Plugin::widget_atts()
 			'block_template'         => null, // Not exposed to the user. Works with template_loader
-			'block_template_part'    => null, // Not exposed to the user. Works with Grunion_Contact_Form::parse()
+			'block_template_part'    => null, // Not exposed to the user. Works with Contact_Form::parse()
 			'id'                     => null, // Not exposed to the user. Set above.
 			'submit_button_text'     => __( 'Submit', 'jetpack-forms' ),
 			// These attributes come from the block editor, so use camel case instead of snake case.
@@ -251,7 +251,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$attributes['block_template_part'] = $GLOBALS['grunion_block_template_part_id'];
 			}
 		}
-		// Create a new Grunion_Contact_Form object (this class)
+		// Create a new Contact_Form object (this class)
 		$form = new Contact_Form( $attributes, $content );
 
 		$id = $form->get_attribute( 'id' );
@@ -445,8 +445,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	/**
 	 * Returns a success message to be returned if the form is sent via AJAX.
 	 *
-	 * @param int                         $feedback_id - the feedback ID.
-	 * @param object Grunion_Contact_Form $form - the contact form.
+	 * @param int                 $feedback_id - the feedback ID.
+	 * @param object Contact_Form $form - the contact form.
 	 *
 	 * @return string $message
 	 */
@@ -475,8 +475,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Returns a compiled form with labels and values in a form of  an array
 	 * of lines.
 	 *
-	 * @param int                         $feedback_id - the feedback ID.
-	 * @param object Grunion_Contact_Form $form - the form.
+	 * @param int                 $feedback_id - the feedback ID.
+	 * @param object Contact_Form $form - the form.
 	 *
 	 * @return array $lines
 	 */
@@ -568,8 +568,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Returns a compiled form with labels and values formatted for the email response
 	 * in a form of an array of lines.
 	 *
-	 * @param int                         $feedback_id - the feedback ID.
-	 * @param object Grunion_Contact_Form $form - the form.
+	 * @param int                 $feedback_id - the feedback ID.
+	 * @param object Contact_Form $form - the form.
 	 *
 	 * @return array $lines
 	 */
@@ -733,7 +733,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 	/**
 	 * The contact-field shortcode processor.
-	 * We use an object method here instead of a static Grunion_Contact_Form_Field class method to parse contact-field shortcodes so that we can tie them to the contact-form object.
+	 * We use an object method here instead of a static Contact_Form_Field class method to parse contact-field shortcodes so that we can tie them to the contact-form object.
 	 *
 	 * @param array       $attributes Key => Value pairs as parsed by shortcode_parse_atts().
 	 * @param string|null $content The shortcode's inner content: [contact-field]$content[/contact-field].
@@ -889,7 +889,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * other places where they accessed/used/saved.
 	 *
 	 * The safest way to add new fields is to add them to the dropdown and the
-	 * HTML list ( @see Grunion_Contact_Form_Field::render ) and don't add them
+	 * HTML list ( @see Contact_Form_Field::render ) and don't add them
 	 * to the list of allowed fields. This way they will become a part of the
 	 * `extra fields` which are saved in the post meta and will be properly
 	 * handled by the admin Feedback view and the CSV Export without any extra
@@ -900,15 +900,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 *
 	 *  - Below in the switch statement - so the field is recognized as allowed.
 	 *
-	 *  - Grunion_Contact_Form::process_submission - validation and logic.
+	 *  - Contact_Form::process_submission - validation and logic.
 	 *
-	 *  - Grunion_Contact_Form::process_submission - add the field as an additional
+	 *  - Contact_Form::process_submission - add the field as an additional
 	 *      field in the `post_content` when saving the feedback content.
 	 *
-	 *  - Grunion_Contact_Form_Plugin::parse_fields_from_content - add mapping
+	 *  - Contact_Form_Plugin::parse_fields_from_content - add mapping
 	 *      for the field, defined in the above method.
 	 *
-	 *  - Grunion_Contact_Form_Plugin::map_parsed_field_contents_of_post_to_field_names -
+	 *  - Contact_Form_Plugin::map_parsed_field_contents_of_post_to_field_names -
 	 *      add mapping of the field for the CSV Export. Otherwise it will be missing
 	 *      from the exported data.
 	 *
@@ -1180,7 +1180,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$akismet_values = $plugin->prepare_for_akismet( $akismet_vars );
 
 		// Is it spam?
-		/** This filter is already documented in modules/contact-form/admin.php */
+		/** This filter is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 		$is_spam = apply_filters( 'jetpack_contact_form_is_spam', false, $akismet_values );
 		if ( is_wp_error( $is_spam ) ) { // WP_Error to abort
 			return $is_spam; // abort
@@ -1279,7 +1279,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$all_values = array_merge( $all_values, $entry_values );
 
-		/** This filter is already documented in modules/contact-form/admin.php */
+		/** This filter is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 		$subject = apply_filters( 'contact_form_subject', $contact_form_subject, $all_values );
 
 		/*
@@ -1365,7 +1365,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @since 8.6.0
 		 *
 		 * @param integer $post_id The post id that contains the contact form data.
-		 * @param array   $this->fields An array containg the form's Grunion_Contact_Form_Field objects.
+		 * @param array   $this->fields An array containg the form's Contact_Form_Field objects.
 		 * @param boolean $is_spam Whether the form submission has been identified as spam.
 		 * @param array   $entry_values The feedback entry values.
 		 */

--- a/projects/packages/forms/src/contact-form/class-editor-view.php
+++ b/projects/packages/forms/src/contact-form/class-editor-view.php
@@ -120,7 +120,7 @@ class Editor_View {
 									'[contact-field label="' . __( 'Message', 'jetpack-forms' ) . '" type="textarea" /]',
 				'labels'                   => array(
 					'submit_button_text'  => __( 'Submit', 'jetpack-forms' ),
-					/** This filter is documented in modules/contact-form/grunion-contact-form.php */
+					/** This filter is documented in \Automattic\Jetpack\Forms\ContactForm\Contact_Form */
 					'required_field_text' => apply_filters( 'jetpack_required_field_text', __( '(required)', 'jetpack-forms' ) ),
 					'edit_close_ays'      => __( 'Are you sure you\'d like to stop editing this form without saving your changes?', 'jetpack-forms' ),
 					'quicktags_label'     => __( 'contact form', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -167,7 +167,7 @@ class Util {
 	 * Sets the $grunion_block_template_part_id global.
 	 *
 	 * This is part of the fix for Contact Form Blocks added to FSE _template parts_ (e.g footer).
-	 * The global is processed in Grunion_Contact_Form::parse().
+	 * The global is processed in Contact_Form::parse().
 	 *
 	 * @param string $template_part_id ID for the currently rendered template part.
 	 */

--- a/projects/packages/forms/src/contact-form/js/grunion.js
+++ b/projects/packages/forms/src/contact-form/js/grunion.js
@@ -82,7 +82,7 @@ FB.ContactForm = ( function () {
 	};
 	const debug = false; // will print errors to log if true
 	let grunionNewCount = 0; // increment for new fields
-	const maxNewFields = GrunionFB_i18n.maxNewFields; // See filter in ../grunion-form-view.php
+	const maxNewFields = GrunionFB_i18n.maxNewFields; // See filter in class-form-view.php
 	let optionsCache = {};
 	let optionsCount = 0; // increment for options
 	let shortcode; //eslint-disable-line no-unused-vars
@@ -781,7 +781,8 @@ FB.ContactForm = ( function () {
 	 * @param email
 	 */
 	function validateEmail( email ) {
-		const re = /^(?=[a-z0-9@.!#$%&'*+/=?^_`{|}~-]{6,254}$)(?=[a-z0-9.!#$%&'*+/=?^_`{|}~-]{1,64}@)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:(?=[a-z0-9-]{1,63}\.)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?=[a-z0-9-]{1,63}$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i;
+		const re =
+			/^(?=[a-z0-9@.!#$%&'*+/=?^_`{|}~-]{6,254}$)(?=[a-z0-9.!#$%&'*+/=?^_`{|}~-]{1,64}@)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:(?=[a-z0-9-]{1,63}\.)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?=[a-z0-9-]{1,63}$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i;
 		return re.test( email );
 	}
 	/**

--- a/projects/plugins/jetpack/changelog/update-contact-form-doc-refs
+++ b/projects/plugins/jetpack/changelog/update-contact-form-doc-refs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update code references in docs and comments

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -565,7 +565,7 @@ function render_block( $attributes ) {
 
 	$subscribe_email = Jetpack_Memberships::get_current_user_email();
 
-	/** This filter is documented in modules/contact-form/grunion-contact-form.php */
+	/** This filter is documented in \Automattic\Jetpack\Forms\ContactForm\Contact_Form */
 	if ( is_wpcom() || false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
 		$current_user    = wp_get_current_user();
 		$subscribe_email = ! empty( $current_user->user_email ) ? $current_user->user_email : '';
@@ -1168,7 +1168,7 @@ function is_user_auth(): bool {
 function get_paywall_blocks_subscribe_pending() {
 	$subscribe_email = Jetpack_Memberships::get_current_user_email();
 
-	/** This filter is documented in modules/contact-form/grunion-contact-form.php */
+	/** This filter is documented in \Automattic\Jetpack\Forms\ContactForm\Contact_Form */
 	if ( is_wpcom() || false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
 		$current_user    = wp_get_current_user();
 		$subscribe_email = ! empty( $current_user->user_email ) ? $current_user->user_email : '';

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -115,7 +115,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			return null;
 		}
 		if ( self::is_jetpack() &&
-			/** This filter is documented in modules/contact-form/grunion-contact-form.php */
+			/** This filter is documented in \Automattic\Jetpack\Forms\ContactForm\Contact_Form */
 			false === apply_filters( 'jetpack_auto_fill_logged_in_user', false )
 		) {
 			$subscribe_email = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35655

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates references to the Contact Form module to point to the Forms package instead, in the code comments and documentation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-Aj-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Nothing to test here.