### PR TITLE
My Jetpack: fix AI free flow

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -1,11 +1,14 @@
+import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ProductCard from '../connected-product-card';
+import { PRODUCT_STATUSES } from '../product-card/action-button';
 
 const AiCard = ( { admin } ) => {
 	const overrides = {
-		can_upgrade: {
+		[ PRODUCT_STATUSES.CAN_UPGRADE ]: {
 			href: '#/jetpack-ai',
+			label: __( 'View', 'jetpack-my-jetpack' ),
 		},
 	};
 	return (

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
@@ -15,7 +15,6 @@ import { useGoBack } from '../../../hooks/use-go-back';
 import GoBackLink from '../../go-back-link';
 import AiTierDetailTable from '../../product-detail-table/jetpack-ai';
 import jetpackAiImage from '../jetpack-ai.png';
-import { JetpackAIInterstitialMoreRequests } from './more-requests';
 import styles from './style.module.scss';
 
 const debug = debugFactory( 'my-jetpack:product-interstitial:jetpack-ai' );
@@ -35,13 +34,6 @@ export default function JetpackAiInterstitial() {
 
 	const { tiers, hasRequiredPlan } = detail;
 
-	// The user has a plan and there is not a next tier
-	if ( isRegistered && hasRequiredPlan && ! nextTier ) {
-		debug( 'user is on top tier' );
-		// When tiers, this is handled on the pricing table and the product page
-		return <JetpackAIInterstitialMoreRequests onClickGoBack={ onClickGoBack } />;
-	}
-
 	// Default to 100 requests if the site is not registered/connected.
 	const nextTierValue = isRegistered ? nextTier?.value : 100;
 	// Decide the quantity value for the upgrade, but ignore the unlimited tier.
@@ -50,9 +42,9 @@ export default function JetpackAiInterstitial() {
 	// Highlight the last feature in the table for all the tiers except the unlimited one.
 	const highlightLastFeature = nextTier?.value !== 1;
 
-	return tiers && tiers.length ? (
+	return tiers && tiers.length && ! detail ? (
 		<AdminPage showHeader={ false } showBackground={ true }>
-			<Container fluid horizontalSpacing={ 3 } horizontalGap={ 3 }>
+			<Container fluid horizontalSpacing={ 3 } horizontalGap={ 2 }>
 				<Col className={ styles[ 'product-interstitial__section' ] }>
 					<div className={ styles[ 'product-interstitial__section-wrapper-wide' ] }>
 						<GoBackLink onClick={ onClickGoBack } />

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
@@ -32,7 +32,7 @@ export default function JetpackAiInterstitial() {
 	debug( detail );
 	const nextTier = detail?.aiAssistantFeature?.nextTier || null;
 
-	const { tiers, hasRequiredPlan } = detail;
+	const { tiers } = detail;
 
 	// Default to 100 requests if the site is not registered/connected.
 	const nextTierValue = isRegistered ? nextTier?.value : 100;
@@ -75,7 +75,7 @@ export default function JetpackAiInterstitial() {
 			imageContainerClassName={ styles.aiImageContainer }
 			hideTOS={ true }
 			quantity={ quantity }
-			directCheckout={ hasRequiredPlan }
+			directCheckout={ false }
 			highlightLastFeature={ highlightLastFeature }
 		>
 			<img src={ jetpackAiImage } alt="Search" />

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -66,7 +66,7 @@ export default function () {
 	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
 
 	// isRegistered works as a flag to know if the page can link to a post creation or not
-	const newPostURL = isRegistered
+	const ctaURL = isRegistered
 		? 'post-new.php?use_ai_block=1&_wpnonce=' + window?.jetpackAi?.nonce
 		: '#/connection';
 	const newPostCta = __( 'Create new post', 'jetpack-my-jetpack' );
@@ -273,7 +273,7 @@ export default function () {
 									<Button
 										className={ styles[ 'product-interstitial__usage-videos-link' ] }
 										icon={ plus }
-										href={ newPostURL }
+										href={ ctaURL }
 									>
 										{ isRegistered ? newPostCta : installCta }
 									</Button>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -10,6 +10,7 @@ import {
 	getRedirectUrl,
 	Notice,
 } from '@automattic/jetpack-components';
+import { useConnection } from '@automattic/jetpack-connection';
 import { Button, Card } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, plus, help, check } from '@wordpress/icons';
@@ -37,6 +38,7 @@ export default function () {
 	const { detail } = useProduct( 'jetpack-ai' );
 	const { description, aiAssistantFeature } = detail;
 	const [ showNotice, setShowNotice ] = useState( false );
+	const { isRegistered } = useConnection();
 
 	const videoTitle1 = __(
 		'Generate and edit content faster with Jetpack AI Assistant',
@@ -62,7 +64,16 @@ export default function () {
 	const showCurrentUsage = hasPaidTier && ! isFree && usage;
 	const showAllTimeUsage = hasPaidTier || hasUnlimited;
 	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
-	const newPostURL = 'post-new.php?use_ai_block=1&_wpnonce=' + window?.jetpackAi?.nonce;
+
+	// isRegistered works as a flag to know if the page can link to a post creation or not
+	const newPostURL = isRegistered
+		? 'post-new.php?use_ai_block=1&_wpnonce=' + window?.jetpackAi?.nonce
+		: '#/connection';
+	const newPostCta = __( 'Create new post', 'jetpack-my-jetpack' );
+	const installCta = __(
+		'Connect to Jetpack to start using the AI Assistant',
+		'jetpack-my-jetpack'
+	);
 
 	const showRenewalNotice = isOverLimit && hasPaidTier;
 	const showUpgradeNotice = isOverLimit && isFree;
@@ -264,7 +275,7 @@ export default function () {
 										icon={ plus }
 										href={ newPostURL }
 									>
-										{ __( 'Create new post', 'jetpack-my-jetpack' ) }
+										{ isRegistered ? newPostCta : installCta }
 									</Button>
 								</div>
 							</div>

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-remain-free-flow
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-remain-free-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+My Jetpack: fix AI interstitial "remain free" flow

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -452,12 +452,39 @@ class Jetpack_Ai extends Product {
 	}
 
 	/**
+	 * Get the URL the user is taken after activating the product through the checkout
+	 *
+	 * @return ?string
+	 */
+	public static function get_post_activation_url() {
+		return '/wp-admin/admin.php?page=my-jetpack#/jetpack-ai';
+	}
+
+	/**
 	 * Get the URL where the user manages the product
 	 *
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
 		return '/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai';
+	}
+
+	/**
+	 * Checks whether the plugin is installed
+	 *
+	 * @return boolean
+	 */
+	public static function is_plugin_installed() {
+		return self::is_jetpack_plugin_installed();
+	}
+
+	/**
+	 * Checks whether the plugin is active
+	 *
+	 * @return boolean
+	 */
+	public static function is_plugin_active() {
+		return (bool) static::is_jetpack_plugin_active();
 	}
 
 	/**


### PR DESCRIPTION
The new AI interstitial needs to be capable of following the "remain free" option, handling any install needed

## Proposed changes:
This PR:

- rolls back to use the default interstitial
- changes backend product details for the interstitial to render properly
- switches the "Create post" link to "Connect to Jetpack" on cases where the product page is shown on a disconnected site
- changes the AI card button label to "View" when the customer already has a tier

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1709649221268149-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

The way to test these changes are basically forcing an instance where Jetpack is NOT installed, yet My Jetpack is present (aka: standalone plugin installation). To help with the process, #36182 was created with a single change on VP standalone plugin, hence carrying an updated version of My Jetpack.

- Get a JN instance from that PR, mind checking VP plugin on the JN options and UNCHECKING Jetpack (plugin):
<img width="722" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/7bff43f6-8d72-4814-a94f-d004d522a141">


- Once on the new site, verify Jetpack is not installed (Installed plugins), then visit My Jetpack page. You'll be offered to Connect, don't do it just yet.

- See the Jetpack AI card, its CTA should read "Learn more".
- Clicking it should take you to a pricing table.
- Choosing to "Continue for free" should take a moment and land you on the product page.
- The first feature should have a link that reads "Connect to Jetpack to start using the AI Assistant" 
<img width="492" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/62a5fce9-9890-4091-93a5-ffd901c82409">

- Before anything else, see that Jetpack is now installed and activated visiting the plugins page.
- Back to My Jetpack, the AI card should still read "Learn more", clicking will take you to the pricing table as long as you're a free user. Continue free to see the product page and, since you're still disconnected, the "Connect to..." link on the first feature item. 
- Click on the connect link, you'll be directed to the connection page, connect. Where you'll land after the connection is still a mystery to me, I've landed on different places on my tests. Hopefully it's just me.
- Back to My Jetpack, card still reads "Learn more" and takes you to the pricing table, choose "free" once more.
- The product page's first link should now be a "Create new post", clicking it should land you on the editor with a AI block inserted and ready to use.
- Back to My Jetpack, use the AI card and get an upgrade this time. After checkout process you should be taken back to My Jetpack. Now the AI card's CTA should read "View". Click it to get straight into the product page.
- The product page should now show your current period's remaining requests and your all time requests.
- Use the "Get more requests" to land back at the pricing table, test both remain free and upgrade flows
- Continue upgrading until you get to the highest tier (1000). The product page should show a "Contact us" button instead of the upgrade one.