### PR TITLE
Fix/product interstitial loading state

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -198,6 +198,7 @@ export default function ProductInterstitial( {
 							clickHandler={ clickHandler }
 							onProductButtonClick={ clickHandler }
 							trackProductButtonClick={ trackProductClick }
+							isFetching={ isActivating }
 						/>
 					) : (
 						<Container

--- a/projects/packages/my-jetpack/changelog/fix-product-interstitial-loading-state
+++ b/projects/packages/my-jetpack/changelog/fix-product-interstitial-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Intersitital tables were not visibly loading when pressed


### PR DESCRIPTION
## Proposed changes:

* pass isFetching to the product detail table

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to `/wp-admin/admin.php?page=my-jetpack#/add-protect`
3. Click on "Get Jetpack Protect" and make sure you see the loading state
![image](https://github.com/Automattic/jetpack/assets/65001528/dbcb53cc-9b45-432d-bd50-747599e5202f)


