### PR TITLE
Plugin Scheduler: Add capabilities endpoint

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-schedued-updates-capabilities
+++ b/projects/packages/scheduled-updates/changelog/add-schedued-updates-capabilities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added a new endpoint /plugins/capabilities that returns whether we can update plugins.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.1';
+	const PACKAGE_VERSION = '0.3.2-alpha';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -2,7 +2,7 @@
 /**
  * Scheduled Updates
  *
- * @package automattic/jetpack-scheduled-updates
+ * @package automattic/scheduled-updates
  */
 
 namespace Automattic\Jetpack;
@@ -195,5 +195,87 @@ class Scheduled_Updates {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Return file and update modification capabilities for the site.
+	 *
+	 * @see Jetpack_JSON_API_Plugins_Endpoint::file_mod_capabilities
+	 */
+	public static function get_file_mod_capabilities() {
+		$reasons_can_not_autoupdate   = array();
+		$reasons_can_not_modify_files = array();
+
+		$has_file_system_write_access = self::file_system_write_access();
+		if ( ! $has_file_system_write_access ) {
+			$reasons_can_not_modify_files['has_no_file_system_write_access'] = __( 'The file permissions on this host prevent editing files.', 'jetpack-scheduled-updates' );
+		}
+
+		$disallow_file_mods = \Automattic\Jetpack\Constants::get_constant( 'DISALLOW_FILE_MODS' );
+		if ( $disallow_file_mods ) {
+			$reasons_can_not_modify_files['disallow_file_mods'] = __( 'File modifications are explicitly disabled by a site administrator.', 'jetpack-scheduled-updates' );
+		}
+
+		$automatic_updater_disabled = \Automattic\Jetpack\Constants::get_constant( 'AUTOMATIC_UPDATER_DISABLED' );
+		if ( $automatic_updater_disabled ) {
+			$reasons_can_not_autoupdate['automatic_updater_disabled'] = __( 'Any autoupdates are explicitly disabled by a site administrator.', 'jetpack-scheduled-updates' );
+		}
+
+		if ( is_multisite() ) {
+			// is it the main network ? is really is multi network
+			if ( Jetpack::is_multi_network() ) {
+				$reasons_can_not_modify_files['is_multi_network'] = __( 'Multi network install are not supported.', 'jetpack-scheduled-updates' );
+			}
+			// Is the site the main site here.
+			if ( ! is_main_site() ) {
+				$reasons_can_not_modify_files['is_sub_site'] = __( 'The site is not the main network site', 'jetpack-scheduled-updates' );
+			}
+		}
+
+		$file_mod_capabilities = array(
+			'modify_files'     => (bool) empty( $reasons_can_not_modify_files ), // install, remove, update
+			'autoupdate_files' => (bool) empty( $reasons_can_not_modify_files ) && empty( $reasons_can_not_autoupdate ), // enable autoupdates
+		);
+
+		$errors = array();
+
+		if ( ! empty( $reasons_can_not_modify_files ) ) {
+			foreach ( $reasons_can_not_modify_files as $error_code => $error_message ) {
+					$errors[] = array(
+						'code'    => $error_code,
+						'message' => $error_message,
+					);
+			}
+		}
+
+		if ( ! $file_mod_capabilities['autoupdate_files'] ) {
+			foreach ( $reasons_can_not_autoupdate as $error_code => $error_message ) {
+				$errors[] = array(
+					'code'    => $error_code,
+					'message' => $error_message,
+				);
+			}
+		}
+
+		$errors = array_unique( $errors );
+		if ( ! empty( $errors ) ) {
+			$file_mod_capabilities['errors'] = $errors;
+		}
+
+		return $file_mod_capabilities;
+	}
+
+	/**
+	 * Returns if the file system is writeable.
+	 * Used mostly for mocking during tests.
+	 *
+	 * @see Automattic\Jetpack\Sync\Functions::file_system_write_access
+	 */
+	private static function file_system_write_access() {
+		if ( ! class_exists( 'Automattic\Jetpack\Sync\Functions' ) ) {
+			return false;
+		}
+
+		return \Automattic\Jetpack\Sync\Functions::file_system_write_access();
 	}
 }

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -9,6 +9,7 @@
 
 // Load dependencies.
 require_once dirname( __DIR__ ) . '/pluggable.php';
+require_once dirname( __DIR__ ) . '/class-scheduled-updates.php';
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Update_Schedules
@@ -62,6 +63,18 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'args'                => $this->get_object_params(),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/capabilities',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_capabilities' ),
+					'permission_callback' => array( $this, 'get_capabilities_permissions_check' ),
+				),
 			)
 		);
 
@@ -375,6 +388,32 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Permission check for retrieving capabilities.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool|WP_Error
+	 */
+	public function get_capabilities_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+		}
+
+		return current_user_can( 'update_plugins' );
+	}
+
+	/**
+	 * Returns a list of capabilities for updating plugins, and errors if those capabilities are not met.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function get_capabilities( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$file_mod_capabilities = \Automattic\Jetpack\Scheduled_Updates::get_file_mod_capabilities();
+
+		return rest_ensure_response( $file_mod_capabilities );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -505,6 +505,31 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
+	 * Make sure unauthorized users can't get in to capabilities.
+	 *
+	 * @covers ::get_capabilities
+	 */
+	public function test_non_admin_user_capabilities() {
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules/capabilities' );
+		$result  = rest_do_request( $request );
+
+		$this->assertSame( 401, $result->get_status() );
+	}
+
+	/**
+	 * Make sure authorized users can see data for capabilities
+	 *
+	 * @covers ::get_capabilities
+	 */
+	public function test_admin_user_capabilities() {
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules/capabilities' );
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+	}
+
+	/**
 	 * Generates a unique schedule ID.
 	 *
 	 * @see wp_schedule_event()


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This adds a new endpoint to /wpcom/v2/sites/woa.wpcomstaging.com/plugins/capabilities

See discussion here: p1709630035350519-slack-C01A60HCGUA and here: https://github.com/Automattic/wp-calypso/pull/88124#discussion_r1512358476

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Install the Jetpack Debug plugin on the site and enable the REST API tester.
* Make sure you install this branch on the WoA site https://github.com/Automattic/jetpack/pull/36238#issuecomment-1982496173.
* Go to the REST API tester and test out `/wpcom/v2/update-schedules/capabilities`

![CleanShot 2024-03-07 at 11 35 37](https://github.com/Automattic/jetpack/assets/533/019ed513-f469-4788-b471-53052c66f4b5)