### PR TITLE
Boost: Fix critical css tooltip going off screen on mobile

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.module.scss
@@ -20,3 +20,15 @@
 .tooltip-wrapper p {
 	display: inline;
 }
+
+@media (max-width: 768px) {
+	.tooltip-wrapper :global(.icon-tooltip-wrapper) {
+		display: block;
+		margin-left: 50%;
+		left: -12px;
+
+		:global(.icon-tooltip-container .components-popover__content) {
+			width: 70vw;
+		}
+	}
+}

--- a/projects/plugins/boost/changelog/fix-critical-css-tooltip-mobile
+++ b/projects/plugins/boost/changelog/fix-critical-css-tooltip-mobile
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix critical css tooltip showing off screen on mobile.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35296

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the critical css tooltip to a new line under 768 pixels;
* Update the tooltip body to be 70% of the viewport.

<details><summary>previews</summary>

![CleanShot 2024-03-07 at 12 11 51](https://github.com/Automattic/jetpack/assets/11799079/99002555-c8e0-4b29-b5db-8e87b847b7d5)

![CleanShot 2024-03-07 at 12 12 04](https://github.com/Automattic/jetpack/assets/11799079/5f8551c7-3bfe-4b9b-8fdc-c441303e6cd8)

</details>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the tooltip looks good on mobile.