### PR TITLE
Subscriptions: add block binding returning subscriber count

### DIFF
--- a/projects/plugins/jetpack/changelog/try-block-bindings-api-for-subscriptions
+++ b/projects/plugins/jetpack/changelog/try-block-bindings-api-for-subscriptions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack subscriptions: add block binding data source for subscriber count.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -80,6 +80,14 @@ function register_block() {
 		return;
 	}
 
+	register_block_bindings_source(
+		'jetpack/subscribers',
+		array(
+			'label'              => __( 'Jetpack Newsletter subscribers', 'jetpack' ),
+			'get_value_callback' => __NAMESPACE__ . '\bindings_subscribers_callback',
+		)
+	);
+
 	register_post_meta(
 		'post',
 		META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
@@ -204,6 +212,28 @@ add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
  */
 function is_wpcom() {
 	return defined( 'IS_WPCOM' ) && IS_WPCOM;
+}
+
+/**
+ * Gets values for subscriber counts
+ *
+ * @param array $source_attrs Array containing source arguments used to look up the value
+ *                            Examples: array( "key" => "count" ), array( "key" => "count-with-social-followers" ).
+ * @return mixed The value or null
+ */
+function bindings_subscribers_callback( $source_attrs ) {
+	if ( ! isset( $source_attrs['key'] ) ) {
+		return null;
+	}
+
+	if ( $source_attrs['key'] === 'count' || $source_attrs['key'] === 'count-with-social-followers' ) {
+		$with_social_followers = $source_attrs['key'] === 'count-with-social-followers';
+		$count                 = get_subscriber_count( $with_social_followers );
+
+		return esc_html( Jetpack_Memberships::get_join_others_text( $count ) );
+	}
+
+	return null;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -84,7 +84,7 @@ function register_block() {
 		register_block_bindings_source(
 			'jetpack/subscribers',
 			array(
-				'label'              => __( 'Jetpack Newsletter subscribers', 'jetpack' ),
+				'label'              => _x( 'Jetpack Newsletter subscribers', 'Block bindings source label', 'jetpack' ),
 				'get_value_callback' => __NAMESPACE__ . '\bindings_subscribers_callback',
 			)
 		);
@@ -217,10 +217,10 @@ function is_wpcom() {
 }
 
 /**
- * Gets values for subscriber counts
+ * Gets values for subscriber count
  *
  * @param array $source_attrs Array containing source arguments used to look up the value
- *                            Examples: array( "key" => "count" ), array( "key" => "count-with-social-followers" ).
+ *                            Examples: array( "key" => "count" ).
  * @return mixed The value or null
  */
 function bindings_subscribers_callback( $source_attrs ) {
@@ -228,10 +228,8 @@ function bindings_subscribers_callback( $source_attrs ) {
 		return null;
 	}
 
-	if ( $source_attrs['key'] === 'count' || $source_attrs['key'] === 'count-with-social-followers' ) {
-		$with_social_followers = $source_attrs['key'] === 'count-with-social-followers';
-		$count                 = get_subscriber_count( $with_social_followers );
-
+	if ( $source_attrs['key'] === 'count' ) {
+		$count = get_subscriber_count( false );
 		return esc_html( Jetpack_Memberships::get_join_others_text( $count ) );
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -88,6 +88,38 @@ function register_block() {
 				'get_value_callback' => __NAMESPACE__ . '\bindings_subscribers_callback',
 			)
 		);
+
+		register_block_pattern_category(
+			'jetpack/newsletter',
+			array(
+				'label'       => __( 'Newsletter', 'jetpack' ),
+				'description' => __( 'Jetpack Newsletter patterns', 'jetpack' ),
+			)
+		);
+
+		$pattern_content = Jetpack_Memberships::get_join_others_text( 10 );
+
+		// Paragraph pattern
+		register_block_pattern(
+			'jetpack/subscribers-count-paragraph',
+			array(
+				'title'       => __( 'Subscribers count paragraph', 'jetpack' ),
+				'description' => _x( 'Show newsletter subscribers count.', 'Block pattern description', 'jetpack' ),
+				'categories'  => array( 'jetpack/newsletter' ),
+				'content'     => '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"jetpack/subscribers","args":{"key":"count"}}}}} --><p>' . esc_html( $pattern_content ) . '</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		// Heading pattern
+		register_block_pattern(
+			'jetpack/subscribers-count-heading',
+			array(
+				'title'       => __( 'Subscribers count heading', 'jetpack' ),
+				'description' => _x( 'Show newsletter subscribers count.', 'Block pattern description', 'jetpack' ),
+				'categories'  => array( 'jetpack/newsletter' ),
+				'content'     => '<!-- wp:heading {"metadata":{"bindings":{"content":{"source":"jetpack/subscribers","args":{"key":"count"}}}}} --><h2 class="wp-block-heading">' . esc_html( $pattern_content ) . '</h2><!-- /wp:heading -->',
+			)
+		);
 	}
 
 	register_post_meta(

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -80,13 +80,15 @@ function register_block() {
 		return;
 	}
 
-	register_block_bindings_source(
-		'jetpack/subscribers',
-		array(
-			'label'              => __( 'Jetpack Newsletter subscribers', 'jetpack' ),
-			'get_value_callback' => __NAMESPACE__ . '\bindings_subscribers_callback',
-		)
-	);
+	if ( function_exists( 'register_block_bindings_source' ) ) {
+		register_block_bindings_source(
+			'jetpack/subscribers',
+			array(
+				'label'              => __( 'Jetpack Newsletter subscribers', 'jetpack' ),
+				'get_value_callback' => __NAMESPACE__ . '\bindings_subscribers_callback',
+			)
+		);
+	}
 
 	register_post_meta(
 		'post',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds new [block binding API](https://github.com/WordPress/gutenberg/issues/53300#issuecomment-1938463648) for subscriptions, available in WP 6.5. ([Dev note](https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/))

With block:
```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"jetpack/subscribers","args":{"key":"count"}}}}} -->
<p>Subscribers</p>
<!-- /wp:paragraph -->
```

You would get in the frontend of the post:

<img width="585" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/88d08667-6e6b-4ed0-9f51-902a678a9158">

Same text should appear in the editor, but at least for me I just see binding paragraph but no text:

<img width="877" alt="Screenshot 2024-03-07 at 13 26 24" src="https://github.com/Automattic/jetpack/assets/87168/9197e401-1670-4830-8edd-796325c63326">



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds new block binding API for subscriptions, available in WP 6.5 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You need to run WP 6.5 RC for this to work.
