### PR TITLE
WP Super Cache: add constants to modify preload timings

### DIFF
--- a/projects/plugins/super-cache/changelog/update-super-cache-preload-constants
+++ b/projects/plugins/super-cache/changelog/update-super-cache-preload-constants
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+WP Super Cache: added WPSC_PRELOAD_POST_INTERVAL and WPSC_PRELOAD_LOOP_INTERVAL to modify preload timings

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -5,8 +5,6 @@
  * It has all the code for caching and serving requests.
  */
 
-define( 'WPSC_PRELOAD_POST_COUNT', 10 );
-
 // phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- TODO: Fix or determine for sure that these should not be fixed.
 // phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- TODO: Fix or determine for sure that these should not be fixed.
 

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -45,6 +45,27 @@ if ( ! defined( 'PHP_VERSION_ID' ) ) {
 	unset( $wpsc_php_version );
 }
 
+/**
+ * Defines how many posts to preload per loop.
+ */
+if ( ! defined( 'WPSC_PRELOAD_POST_COUNT' ) ) {
+	define( 'WPSC_PRELOAD_POST_COUNT', 10 );
+}
+
+/**
+ * Defines the interval in seconds between preloading pages.
+ */
+if ( ! defined( 'WPSC_PRELOAD_POST_INTERVAL' ) ) {
+	define( 'WPSC_PRELOAD_POST_INTERVAL', 1 );
+}
+
+/**
+ * Defines the interval in seconds between preloading loops.
+ */
+if ( ! defined( 'WPSC_PRELOAD_LOOP_INTERVAL' ) ) {
+	define( 'WPSC_PRELOAD_LOOP_INTERVAL', 0 );
+}
+
 function wpsc_init() {
 	global $wp_cache_config_file, $wp_cache_config_file_sample, $wpsc_advanced_cache_dist_filename, $wp_cache_check_wp_config, $wpsc_advanced_cache_filename, $wpsc_promo_links;
 
@@ -3470,7 +3491,7 @@ function wp_cron_preload_cache() {
 						)
 					);
 					wp_cache_debug( "wp_cron_preload_cache: fetched $url" );
-					sleep( 1 );
+					sleep( WPSC_PRELOAD_POST_INTERVAL );
 
 					if ( ! wpsc_is_preload_active() ) {
 						wp_cache_debug( 'wp_cron_preload_cache: cancelling preload process.' );
@@ -3505,6 +3526,7 @@ function wp_cron_preload_cache() {
 
 		if ( $preload_more_taxonomies === true ) {
 			wpsc_schedule_next_preload();
+			sleep( WPSC_PRELOAD_LOOP_INTERVAL );
 			return true;
 		}
 	} elseif ( $c === 0 && $wp_cache_preload_email_me ) {
@@ -3594,7 +3616,7 @@ function wp_cron_preload_cache() {
 			wp_remote_get( $url, array('timeout' => 60, 'blocking' => true ) );
 			wp_cache_debug( "wp_cron_preload_cache: fetched $url", 5 );
 			++$count;
-			sleep( 1 );
+			sleep( WPSC_PRELOAD_POST_INTERVAL );
 		}
 
 		if ( $wp_cache_preload_email_me && ( $wp_cache_preload_email_volume === 'medium' || $wp_cache_preload_email_volume === 'many' ) ) {
@@ -3603,8 +3625,8 @@ function wp_cron_preload_cache() {
 		}
 
 		wpsc_schedule_next_preload();
-
 		wpsc_delete_files( get_supercache_dir() );
+		sleep( WPSC_PRELOAD_LOOP_INTERVAL );
 	} else {
 		$msg = '';
 		wpsc_reset_preload_counter();


### PR DESCRIPTION
Preload is fairly conservative and slow right now on purpose. By default, it processes 10 pages, with a 1 second pause in between. Then it schedules another loop for 3 seconds later.

This PR adds two new constants and fixes the definition of an existing one:

Added:
WPSC_PRELOAD_POST_INTERVAL: interval in seconds between fetching a post to preload
WPSC_PRELOAD_LOOP_INTERVAL: interval in seconds between preload loops

This PR fixes WPSC_PRELOAD_POST_COUNT because there was no `defined()` check on it, so it wasn't possible to change, without modifying the source.

## Proposed changes:
* Add WPSC_PRELOAD_POST_INTERVAL and WPSC_PRELOAD_LOOP_INTERVAL defines in wp-cache.php
* Add sleep() commands to the `wp_cron_preload_cache()` function.
* Add a defined() check before setting WPSC_PRELOAD_POST_COUNT and move it to wp-cache.php

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Define those constants and run a preload to check if it makes any difference when running.
* Try this in wp-config.php:
```
define( 'WPSC_PRELOAD_POST_INTERVAL', 0 );
define( 'WPSC_PRELOAD_POST_COUNT', 100 );
```