### PR TITLE
My Jetpack: add Jetpack AI product page feedback link

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -11,7 +11,7 @@ import {
 	Notice,
 } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
-import { Button, Card } from '@wordpress/components';
+import { Button, Card, ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, plus, help, check } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -64,6 +64,7 @@ export default function () {
 	const showCurrentUsage = hasPaidTier && ! isFree && usage;
 	const showAllTimeUsage = hasPaidTier || hasUnlimited;
 	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
+	const feedbackURL = getRedirectUrl( 'jetpack-ai-feedback' );
 
 	// isRegistered works as a flag to know if the page can link to a post creation or not
 	const ctaURL = isRegistered
@@ -357,9 +358,9 @@ export default function () {
 								'Help us improving the accuracy of our results and feel free to give us ideas for future implementations and improvements.',
 								'jetpack-my-jetpack'
 							) }{ ' ' }
-							<a href="#" target="_blank" rel="noreferer noopener">
+							<ExternalLink href={ feedbackURL }>
 								{ __( 'Share your feedback!', 'jetpack-my-jetpack' ) }
-							</a>
+							</ExternalLink>
 						</p>
 					</div>
 				</Col>

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-feedback-link
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-feedback-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: add feedback link on Jetpack AI product page


### PR DESCRIPTION
New product page invites visitors to leave feedback

## Proposed changes:
Use Jetpack Redirect to point the link to the feedback form.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-qti-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Enable the filter:
```php
add_filter( 'my_jetpack_use_new_ai_page', '__return_true' );
```
Visit the new AI product page at `/wp-admin/admin.php?page=my-jetpack#/jetpack-ai`, look for the feedback section at the bottom. Clicking on the link should take you the AI feedback form.