### PR TITLE
Add/meta for Firehose

### DIFF
--- a/projects/plugins/jetpack/changelog/add-meta-for--firehose
+++ b/projects/plugins/jetpack/changelog/add-meta-for--firehose
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Add metadata to the post to better diagnose need for Reader and Firehose

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -9,12 +9,15 @@ namespace Automattic\Jetpack\Extensions\Premium_Content;
 
 use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
+use WP_Post;
+use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_CONTAINS_PAID_CONTENT;
 
 require_once __DIR__ . '/_inc/access-check.php';
 require_once __DIR__ . '/logged-out-view/logged-out-view.php';
 require_once __DIR__ . '/subscriber-view/subscriber-view.php';
 require_once __DIR__ . '/buttons/buttons.php';
 require_once __DIR__ . '/login-button/login-button.php';
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/subscriptions/constants.php';
 
 /**
  * Registers the block for use in Gutenberg
@@ -37,6 +40,8 @@ function register_block() {
 			),
 		)
 	);
+
+	add_action( 'save_post_post', __NAMESPACE__ . '\maybe_add_paid_content_post_meta', 99, 2 );
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
@@ -109,5 +114,21 @@ function stripe_nudge( $checkout_url, $description, $button_text ) {
 			'description' => $description,
 			'buttonText'  => $button_text,
 		)
+	);
+}
+
+/**
+ * Add a meta to prevent publication on firehose, ES AI or Reader
+ *
+ * @param int     $post_id Post id.
+ * @param WP_Post $post Post being saved.
+ * @return void
+ */
+function maybe_add_paid_content_post_meta( int $post_id, WP_Post $post ) {
+	$contains_paid_content = has_block( 'premium-content/container', $post );
+	update_post_meta(
+		$post_id,
+		META_NAME_CONTAINS_PAID_CONTENT,
+		$contains_paid_content
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -67,7 +67,7 @@ function register_block() {
 		}
 	);
 
-	add_action( 'save_post_post', __NAMESPACE__ . '\maybe_add_paid_content_post_meta', 99, 2 );
+	add_action( 'save_post_post', __NAMESPACE__ . '\add_paid_content_post_meta', 99, 2 );
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
@@ -150,7 +150,7 @@ function stripe_nudge( $checkout_url, $description, $button_text ) {
  * @param WP_Post $post Post being saved.
  * @return void
  */
-function maybe_add_paid_content_post_meta( int $post_id, WP_Post $post ) {
+function add_paid_content_post_meta( int $post_id, WP_Post $post ) {
 	$contains_paid_content = has_block( 'premium-content/container', $post );
 	update_post_meta(
 		$post_id,

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -41,6 +41,32 @@ function register_block() {
 		)
 	);
 
+	register_post_meta(
+		'post',
+		META_NAME_CONTAINS_PAID_CONTENT,
+		array(
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'boolean',
+			'auth_callback' => function () {
+				return wp_get_current_user()->has_cap( 'edit_posts' );
+			},
+		)
+	);
+
+	// This ensures Jetpack will sync this post meta to WPCOM.
+	add_filter(
+		'jetpack_sync_post_meta_whitelist',
+		function ( $allowed_meta ) {
+			return array_merge(
+				$allowed_meta,
+				array(
+					META_NAME_CONTAINS_PAID_CONTENT,
+				)
+			);
+		}
+	);
+
 	add_action( 'save_post_post', __NAMESPACE__ . '\maybe_add_paid_content_post_meta', 99, 2 );
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/constants.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/constants.php
@@ -13,3 +13,5 @@ const NEWSLETTER_COLUMN_ID                     = 'newsletter_access';
 const META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS = '_jetpack_newsletter_access';
 const META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS    = '_jetpack_dont_email_post_to_subs';
 const META_NAME_FOR_POST_TIER_ID_SETTINGS      = '_jetpack_newsletter_tier_id';
+const META_NAME_CONTAINS_PAYWALLED_CONTENT     = '_jetpack_memberships_contains_paywalled_content';
+const META_NAME_CONTAINS_PAID_CONTENT          = '_jetpack_memberships_contains_paid_content';

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -171,7 +171,7 @@ function register_block() {
 
 	add_action( 'init', __NAMESPACE__ . '\maybe_prevent_super_cache_caching' );
 
-	add_action( 'save_post_post', __NAMESPACE__ . '\maybe_add_paywalled_content_post_meta', 99, 1 );
+	add_action( 'save_post_post', __NAMESPACE__ . '\add_paywalled_content_post_meta', 99, 1 );
 
 	Jetpack_Subscription_Site::init()->handle_subscribe_block_placements();
 }
@@ -208,7 +208,7 @@ function register_newsletter_access_column( $columns ) {
  * @param int $post_id Post id being saved.
  * @return void
  */
-function maybe_add_paywalled_content_post_meta( int $post_id ) {
+function add_paywalled_content_post_meta( int $post_id ) {
 	$access_level = get_post_meta( $post_id, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 
 	$is_paywalled = false;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -120,6 +120,19 @@ function register_block() {
 		)
 	);
 
+	register_post_meta(
+		'post',
+		META_NAME_CONTAINS_PAYWALLED_CONTENT,
+		array(
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'boolean',
+			'auth_callback' => function () {
+				return wp_get_current_user()->has_cap( 'edit_posts' );
+			},
+		)
+	);
+
 	// This ensures Jetpack will sync this post meta to WPCOM.
 	add_filter(
 		'jetpack_sync_post_meta_whitelist',
@@ -129,6 +142,7 @@ function register_block() {
 				array(
 					META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
 					META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS,
+					META_NAME_CONTAINS_PAYWALLED_CONTENT,
 				)
 			);
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Works alongside D141162-code

Based on @gibrown 's idea here:  p3btAN-2D0-p2#comment-20298


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add metada to the post depending if:
  * It has paid-content block
  * It is paywalled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync to your sandbox or docker
* Create a post paywalled post
* On your sandbox
```
 wp post meta list POST_ID --url=DOMAIN_URL
 ```
 Depending on your post content, you should see:
`_jetpack_memberships_contains_paywalled_content` empty or with `1` (not paywalled, paywalled)
`_jetpack_memberships_contains_paid_content` empty or with `1` (not contians paid-content block, does contain paid-content block)

* Values should change when updating the post, too.