### PR TITLE
Scheduled Updates: Account for multiple schedules in wp-admin

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-plugin-list-display
+++ b/projects/packages/scheduled-updates/changelog/fix-plugin-list-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+The plugin list now accounts for all schedules a plugin might be a part of.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -112,21 +112,43 @@ class Scheduled_Updates {
 	 * @param string $plugin_file Path to the plugin file relative to the plugin directory.
 	 */
 	public static function show_scheduled_updates( $html, $plugin_file ) {
-		$schedules = get_option( 'jetpack_update_schedules', array() );
+		if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
+			require_once __DIR__ . '/pluggable.php';
+		}
 
-		$schedule = false;
-		foreach ( $schedules as $plugins ) {
-			if ( in_array( $plugin_file, $plugins, true ) ) {
-				$schedule = wp_get_scheduled_event( 'jetpack_scheduled_update', $plugins );
-				break;
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+
+		$schedules = false;
+		foreach ( $events as $event ) {
+			if ( in_array( $plugin_file, $event->args, true ) ) {
+				$schedules[] = $event;
 			}
 		}
 
 		// Plugin is not part of an update schedule.
-		if ( ! $schedule ) {
+		if ( empty( $schedules ) ) {
 			return $html;
 		}
 
+		$text = array_map( array( __CLASS__, 'get_scheduled_update_text' ), $schedules );
+
+		$html  = '<p style="margin: 0 0 8px">' . implode( '<br>', $text ) . '</p>';
+		$html .= sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( 'https://wordpress.com/plugins/scheduled-updates/' . ( new Status() )->get_site_suffix() ),
+			esc_html__( 'Edit', 'jetpack-scheduled-updates' )
+		);
+
+		return $html;
+	}
+
+	/**
+	 * Get the text for a scheduled update.
+	 *
+	 * @param object $schedule The scheduled update.
+	 * @return string
+	 */
+	public static function get_scheduled_update_text( $schedule ) {
 		if ( DAY_IN_SECONDS === $schedule->interval ) {
 			$html = sprintf(
 				/* translators: %s is the time of day. Daily at 10 am. */
@@ -157,9 +179,6 @@ class Scheduled_Updates {
 				date_i18n( get_option( 'time_format' ), $schedule->timestamp )
 			);
 		}
-
-		$html  = '<p style="margin: 0 0 8px">' . $html . '</p>';
-		$html .= '<a href="' . esc_url( admin_url( 'admin.php?page=jetpack#jetpack-autoupdates' ) ) . '">' . esc_html__( 'Edit', 'jetpack-scheduled-updates' ) . '</a>';
 
 		return $html;
 	}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses WP Cron events directly to determine which events a plugin is part of.
* Creates a callback to get timing strings from.
* Updates the Edit URL to point to the right place.
* Accounts for all schedules a plugin might be part of.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a schedule in wordpress.com/plugins/scheduled-updates/SITE
* Create another schedule that includes one of the plugins from the first schedule.
* Navigate to `/wp-admin/plugins.php` and make sure the schedules are accurately reflected in the autoupdates column.
* Click the edit link and make sure it redirects you to the proper Calypso screen

