### PR TITLE
Fix/post endpoint fail on revision date bug

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-post-endpoint-fail-on-revision-date-bug
+++ b/projects/plugins/jetpack/changelog/fix-post-endpoint-fail-on-revision-date-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+This fixes a minor bug in a recently shipped feature that makes it work more like expected

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -280,18 +280,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			}
 
 			if ( ! empty( $input['if_not_modified_since'] ) ) {
-				$post_modified_date = date_create( $post->post_modified_gmt );
-				$if_modified_date   = date_create( $input['if_not_modified_since'] );
-
-				if ( $post_modified_date === false ) {
-					return new WP_Error( 'unknown_last_modified_date', 'There is a revision of this post that is more recent.', 404 );
-				}
-
-				if ( $if_modified_date === false ) {
-					return new WP_Error( 'if_not_modified_since_error', 'Please send if_not_modified_since in the (ISO 8601 datetime) format', 400 );
-				}
-
-				if ( $post_modified_date->getTimestamp() > $if_modified_date->getTimestamp() ) {
+				if ( mysql2date( 'U', $post->post_modified_gmt ) > mysql2date( 'U', $input['if_not_modified_since'] ) ) {
 					return new WP_Error( 'old-revision', 'There is a revision of this post that is more recent.', 409 );
 				}
 			}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -280,7 +280,18 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			}
 
 			if ( ! empty( $input['if_not_modified_since'] ) ) {
-				if ( mysql2date( 'U', $post->post_modified_gmt ) > mysql2date( 'U', $input['if_not_modified_since'] ) ) {
+				$post_modified_date = date_create( $post->post_modified_gmt );
+				$if_modified_date   = date_create( $input['if_not_modified_since'] );
+
+				if ( $post_modified_date === false ) {
+					return new WP_Error( 'unknown_last_modified_date', 'There is a revision of this post that is more recent.', 404 );
+				}
+
+				if ( $if_modified_date === false ) {
+					return new WP_Error( 'if_not_modified_since_error', 'Please send if_not_modified_since in the (ISO 8601 datetime) format', 400 );
+				}
+
+				if ( $post_modified_date->getTimestamp() > $if_modified_date->getTimestamp() ) {
 					return new WP_Error( 'old-revision', 'There is a revision of this post that is more recent.', 409 );
 				}
 			}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -278,7 +278,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			if ( ! current_user_can( 'edit_post', $post->ID ) ) {
 				return new WP_Error( 'unauthorized', 'User cannot edit post', 403 );
 			}
-
+			// The input `if_not_modified_since` input is the format ISO 8601 datetime and get converted to `if_not_modified_since_gmt` and `if_not_modified_since`
 			if ( ! empty( $input['if_not_modified_since_gmt'] ) ) {
 				if ( mysql2date( 'U', $post->post_modified_gmt ) > mysql2date( 'U', $input['if_not_modified_since_gmt'] ) ) {
 					return new WP_Error( 'old-revision', 'There is a revision of this post that is more recent.', 409 );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -279,8 +279,8 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 				return new WP_Error( 'unauthorized', 'User cannot edit post', 403 );
 			}
 
-			if ( ! empty( $input['if_not_modified_since'] ) ) {
-				if ( mysql2date( 'U', $post->post_modified_gmt ) > mysql2date( 'U', $input['if_not_modified_since'] ) ) {
+			if ( ! empty( $input['if_not_modified_since_gmt'] ) ) {
+				if ( mysql2date( 'U', $post->post_modified_gmt ) > mysql2date( 'U', $input['if_not_modified_since_gmt'] ) ) {
 					return new WP_Error( 'old-revision', 'There is a revision of this post that is more recent.', 409 );
 				}
 			}


### PR DESCRIPTION
This PR fixes the ability to pass in a `ISO 8601 datetime` in  any timezone not just UTC for the `if_not_modified_since` API attribute.

A feature that shipped in https://github.com/Automattic/jetpack/pull/35526 Jetpack 13.2 and is being used to improve the Jetpack apps offline mode sync capabilities.

## Proposed changes:
Use the `if_not_modified_since_gmt` instead of `if_not_modified_since` 
the difference is that one returns the gmt value and the other is the same string but not. 



### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Apply this PR. 
* Make an api request to https://public-api.wordpress.com/rest/v1.2/sites/$site_id/posts/1
    with the parameter if_not_modified_since and notice that you pass in the last post modified timestamp that the post 

* updates as expected.
    but if you pass in the previous version of the post that

* we returns the error error:"old-revision" 
* notice that if you send the different timezone time that it still works as expected. 
* 
