### PR TITLE
Add/red bubble prototype

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-red-bubble-prototype
+++ b/projects/packages/my-jetpack/changelog/add-red-bubble-prototype
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a red bubble notification that shows if the site is disconnected

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -624,7 +624,12 @@ class Initializer {
 		$red_bubble_alerts = self::get_red_bubble_alerts();
 
 		// The Jetpack menu item should be on index 3
-		if ( ! empty( $red_bubble_alerts ) && isset( $menu[3] ) && $menu[3][0] === 'Jetpack' ) {
+		if (
+			! empty( $red_bubble_alerts ) &&
+			is_countable( $red_bubble_alerts ) &&
+			isset( $menu[3] ) &&
+			$menu[3][0] === 'Jetpack'
+		) {
 			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			$menu[3][0] .= sprintf( ' <span class="awaiting-mod">%d</span>', count( $red_bubble_alerts ) );
 		}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -624,7 +624,7 @@ class Initializer {
 		$red_bubble_alerts = self::get_red_bubble_alerts();
 
 		// The Jetpack menu item should be on index 3
-		if ( ! empty( $red_bubble_alerts ) && $menu[3][0] === 'Jetpack' ) {
+		if ( ! empty( $red_bubble_alerts ) && isset( $menu[3] ) && $menu[3][0] === 'Jetpack' ) {
 			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			$menu[3][0] .= sprintf( ' <span class="awaiting-mod">%d</span>', count( $red_bubble_alerts ) );
 		}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -633,7 +633,7 @@ class Initializer {
 	/**
 	 * Collect all possible alerts that we might use a red bubble notification for
 	 *
-	 * @return array|mixed|null
+	 * @return array
 	 */
 	public static function get_red_bubble_alerts() {
 		static $red_bubble_alerts = array();

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -654,7 +654,7 @@ class Initializer {
 	 * @param array $red_bubble_slugs - slugs that describe the reasons the red bubble is showing.
 	 * @return array
 	 */
-	public static function alert_if_missing_site_connection( $red_bubble_slugs ) {
+	public static function alert_if_missing_site_connection( array $red_bubble_slugs ) {
 		if ( ! ( new Connection_Manager() )->is_connected() ) {
 			$red_bubble_slugs[] = self::MISSING_SITE_CONNECTION_NOTIFICATION_KEY;
 		}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -57,6 +57,8 @@ class Initializer {
 
 	const MY_JETPACK_SITE_INFO_TRANSIENT_KEY = 'my-jetpack-site-info';
 
+	const MISSING_SITE_CONNECTION_NOTIFICATION_KEY = 'missing-site-connection';
+
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)
 	 *
@@ -101,6 +103,8 @@ class Initializer {
 		);
 
 		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
+		// This is later than the admin-ui package, which runs on 1000
+		add_action( 'admin_init', array( __CLASS__, 'maybe_show_red_bubble' ), 1001 );
 
 		// Sets up JITMS.
 		JITM::configure();
@@ -228,6 +232,7 @@ class Initializer {
 					'purchases'       => self::get_purchases(),
 					'modules'         => self::get_active_modules(),
 				),
+				'redBubbleAlerts'        => self::get_red_bubble_alerts(),
 				'isStatsModuleActive'    => $modules->is_active( 'stats' ),
 				'isUserFromKnownHost'    => self::is_user_from_known_host(),
 				'isCommercial'           => self::is_commercial_site(),
@@ -605,5 +610,55 @@ class Initializer {
 	 */
 	public static function get_idc_container_id() {
 		return static::IDC_CONTAINER_ID;
+	}
+
+	/**
+	 * Conditionally append the red bubble notification to the "Jetpack" menu item if there are alerts to show
+	 *
+	 * @return void
+	 */
+	public static function maybe_show_red_bubble() {
+		global $menu;
+		// filters for the items in this file
+		add_filter( 'my_jetpack_red_bubble_notification_slugs', array( __CLASS__, 'alert_if_missing_site_connection' ) );
+		$red_bubble_alerts = self::get_red_bubble_alerts();
+
+		// The Jetpack menu item should be on index 3
+		if ( ! empty( $red_bubble_alerts ) && $menu[3][0] === 'Jetpack' ) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$menu[3][0] .= sprintf( ' <span class="awaiting-mod">%d</span>', count( $red_bubble_alerts ) );
+		}
+	}
+
+	/**
+	 * Collect all possible alerts that we might use a red bubble notification for
+	 *
+	 * @return array|mixed|null
+	 */
+	public static function get_red_bubble_alerts() {
+		static $red_bubble_alerts = array();
+
+		// using a static cache since we call this function more than once in the class
+		if ( ! empty( $red_bubble_alerts ) ) {
+			return $red_bubble_alerts;
+		}
+		// go find the alerts
+		$red_bubble_alerts = apply_filters( 'my_jetpack_red_bubble_notification_slugs', $red_bubble_alerts );
+
+		return $red_bubble_alerts;
+	}
+
+	/**
+	 * Add an alert slug if the site is missing a site connection
+	 *
+	 * @param array $red_bubble_slugs - slugs that describe the reasons the red bubble is showing.
+	 * @return array
+	 */
+	public static function alert_if_missing_site_connection( $red_bubble_slugs ) {
+		if ( ! ( new Connection_Manager() )->is_connected() ) {
+			$red_bubble_slugs[] = self::MISSING_SITE_CONNECTION_NOTIFICATION_KEY;
+		}
+
+		return $red_bubble_slugs;
 	}
 }


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This diff displays a red bubble notification next to the Jetpack menu item when Jetpack is disconnected

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbNhbs-9R1-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch locally or using the beta plugin
* Note that, if your site is not connected, you should see a red bubble icon show next to "Jetpack" in the wp-admin menu
![Screenshot 2024-03-07 at 3 28 04 PM](https://github.com/Automattic/jetpack/assets/18016357/b7483218-745a-4e73-b14f-f28912cdd453)
* Click on the Jetpack menu item to go to My Jetpack.
* Connect your site
* Confirm that the red bubble notification goes away after the site is connected