### PR TITLE
My Jetpack: direct straight into AI product page once opted for the free version

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -6,7 +6,6 @@ import ProductCard from '../connected-product-card';
 import { PRODUCT_STATUSES } from '../product-card/action-button';
 
 const AiCard = ( { admin } ) => {
-	// const [ userOverrides, setUserOverrides ] = useState( {} );
 	const { userConnectionData } = useConnection();
 	const { currentUser } = userConnectionData;
 	const { wpcomUser } = currentUser;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -1,22 +1,37 @@
+import { useConnection } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
-import React from 'react';
+import { useRef } from 'react';
 import ProductCard from '../connected-product-card';
 import { PRODUCT_STATUSES } from '../product-card/action-button';
 
 const AiCard = ( { admin } ) => {
-	const overrides = {
+	// const [ userOverrides, setUserOverrides ] = useState( {} );
+	const { userConnectionData } = useConnection();
+	const { currentUser } = userConnectionData;
+	const { wpcomUser } = currentUser;
+	const userId = currentUser?.id || 0;
+	const blogId = currentUser?.blogId || 0;
+	const wpcomUserId = wpcomUser?.ID || 0;
+	const userOptKey = `jetpack_ai_optfree_${ userId }_${ blogId }_${ wpcomUserId }`;
+	const userOptFree = useRef( localStorage.getItem( userOptKey ) );
+
+	const userOverrides = {
 		[ PRODUCT_STATUSES.CAN_UPGRADE ]: {
 			href: '#/jetpack-ai',
 			label: __( 'View', 'jetpack-my-jetpack' ),
 		},
+		[ PRODUCT_STATUSES.NEEDS_PURCHASE ]: {
+			href: userOptFree.current ? '#/jetpack-ai' : '#/add-jetpack-ai',
+		},
 	};
+
 	return (
 		<ProductCard
 			admin={ admin }
 			slug="jetpack-ai"
 			upgradeInInterstitial={ true }
-			primaryActionOverride={ overrides }
+			primaryActionOverride={ userOverrides }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -43,6 +43,7 @@ import videoPressImage from './videopress.png';
  * @param {number} [props.quantity]              - The quantity of the product to purchase
  * @param {number} [props.directCheckout]        - Whether to go straight to the checkout page, e.g. for products with usage tiers
  * @param {boolean} [props.highlightLastFeature] - Whether to highlight the last feature in the list of features
+ * @param {object} [props.ctaCallback]           - Callback when the product CTA is clicked. Triggered before any activation/checkout process occurs
  * @returns {object}                               ProductInterstitial react component.
  */
 export default function ProductInterstitial( {
@@ -59,6 +60,7 @@ export default function ProductInterstitial( {
 	quantity = null,
 	directCheckout = false,
 	highlightLastFeature = false,
+	ctaCallback = null,
 } ) {
 	const { detail } = useProduct( slug );
 	const { activate, isPending: isActivating } = useActivate( slug );
@@ -116,6 +118,8 @@ export default function ProductInterstitial( {
 				? product?.postCheckoutUrl
 				: myJetpackCheckoutUri;
 
+			ctaCallback?.( { slug, product, tier } );
+
 			if ( product?.isBundle || directCheckout ) {
 				// Get straight to the checkout page.
 				checkout?.();
@@ -163,7 +167,14 @@ export default function ProductInterstitial( {
 				}
 			);
 		},
-		[ directCheckout, activate, navigateToMyJetpackOverviewPage, slug, myJetpackCheckoutUri ]
+		[
+			directCheckout,
+			activate,
+			navigateToMyJetpackOverviewPage,
+			slug,
+			myJetpackCheckoutUri,
+			ctaCallback,
+		]
 	);
 
 	return (

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-pricing-table-once
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-pricing-table-once
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: AI pricing table is skipped once the user has opted for the free version


### PR DESCRIPTION
After opting for the free version, visitor should not be spammed with the pricing table again.

## Proposed changes:
This PR adds the mechanics to register the _opt out/free_ action from the user and then direct him straight into the product page from the AI card.

- add a new `ctaCallback` function prop on interstitial, something any product can provide
- `ctaCallback` is triggered almost at the top of the interstitial's CTA buttons with `{ productSlug, productDetails, tier }` signature. It shouldn't be able to cancel the process (unless you throw inside of it)
- use this new callback on AI interstitial to write a localStorage key
- let the AI card read the localStorage key to decide if a free user should be directed to the pricing or product page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/36235#issuecomment-1983695878

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Enable the filter:
```php
add_filter( 'my_jetpack_use_new_ai_page', '__return_true' );
```

Visit My Jetpack section while on the free tier. The AI card should take you to the pricing page. Choose to stay free.
Go back to My Jetpack section, this time, the AI card should direct you straight into the product page.