### PR TITLE
CRM: 3440 - add links to dash sales funnel

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -72,7 +72,7 @@ function jpcrm_render_dashboard_page() {
 			'count'          => $count,
 			'backfill_count' => $backfill_count,
 			'contact_status' => $contact_status,
-			'link'           => false,
+			'link'           => jpcrm_esc_link( $zbs->slugs['managecontacts'] . '&quickfilters=status_' . $contact_status ),
 		);
 	}
 

--- a/projects/plugins/crm/changelog/fix-crm-3440-add_links_to_dash_sales_funnel
+++ b/projects/plugins/crm/changelog/fix-crm-3440-add_links_to_dash_sales_funnel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Dashboard: Sales Funnel now links to contact list view.

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -4809,7 +4809,11 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 
         if ($inCompany) $whereArr['incompany'] = array('ID','IN','(SELECT DISTINCT zbsol_objid_from FROM '.$ZBSCRM_t['objlinks']." WHERE zbsol_objtype_from = ".ZBS_TYPE_CONTACT." AND zbsol_objtype_to = ".ZBS_TYPE_COMPANY." AND zbsol_objid_to = %d)",$inCompany);
 
-        if ($withStatus !== false && !empty($withStatus)) $whereArr['status'] = array('zbsc_status','=','%s',$withStatus);
+			// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			if ( $withStatus !== false && ! empty( $withStatus ) ) {
+				$whereArr['status'] = array( 'zbsc_status', '=', 'convert(%s using utf8mb4) collate utf8mb4_bin', $withStatus );
+			}
+			// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
         return $this->DAL()->getFieldByWHERE(array(
             'objtype' => ZBS_TYPE_CONTACT,

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -156,8 +156,8 @@ class zeroBSCRM_list{
             // set it whether legit? what'll this do on error urls people make up?
             // v2.2+ hone this + add multi-filter
             // v2.99.5 - ALWAYS lowercase :) 
-            $possibleQuickFilters = strtolower(sanitize_text_field($_GET['quickfilters']));
-            $listViewFilters['quickfilters'] = array($possibleQuickFilters);
+					$possible_quick_filters          = sanitize_text_field( $_GET['quickfilters'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+					$listViewFilters['quickfilters'] = array( $possible_quick_filters ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
         }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -701,9 +701,29 @@ class zeroBSCRM_list{
 		);
 
 		$current_quickfilter       = ( ! empty( $listview_filters['quickfilters'][0] ) ? $listview_filters['quickfilters'][0] : '' );
-		$current_quickfilter_label = ( ! empty( $all_quickfilters[ $current_quickfilter ][0] ) ? $all_quickfilters[ $current_quickfilter ][0] : '' );
-		$current_tag               = ( ! empty( $listview_filters['tags'][0] ) ? $listview_filters['tags'][0]['name'] : '' );
-		$current_search            = ( ! empty( $listview_filters['s'] ) ? $listview_filters['s'] : '' );
+		$current_quickfilter_label = '';
+
+		if ( $quickfilter_category_count > 0 ) {
+			$quickfilter_html = '<option disabled selected>' . esc_html__( 'Select filter', 'zero-bs-crm' ) . '</option>';
+			foreach ( $all_quickfilters as $category => $filters ) {
+				if ( $quickfilter_category_count > 1 ) {
+					$category_label    = array_key_exists( $category, $quickfilter_categories ) ? $quickfilter_categories[ $category ] : $category;
+					$quickfilter_html .= '<optgroup label="' . esc_attr( $category_label ) . '">';
+				}
+				foreach ( $filters as $filter_slug => $filter_label ) {
+					if ( $current_quickfilter === $filter_slug ) {
+						$current_quickfilter_label = $filter_label;
+					}
+					$quickfilter_html .= '<option value="' . esc_attr( $filter_slug ) . '">' . esc_html( $filter_label ) . '</option>';
+				}
+				if ( $quickfilter_category_count > 1 ) {
+					$quickfilter_html .= '</optgroup>';
+				}
+			}
+		}
+
+		$current_tag    = ( ! empty( $listview_filters['tags'][0] ) ? $listview_filters['tags'][0]['name'] : '' );
+		$current_search = ( ! empty( $listview_filters['s'] ) ? $listview_filters['s'] : '' );
 		?>
 
 		<jpcrm-listview-header id="jpcrm-listview-header">
@@ -717,20 +737,8 @@ class zeroBSCRM_list{
 				<?php
 				// add quickfilters filter if current object has quickfilters
 				if ( $quickfilter_category_count > 0 ) {
-					echo '<select class="filter-dropdown' . ( ! empty( $current_quickfilter_label ) ? ' hidden' : '' ) . '" data-filtertype="quickfilters">';
-					echo '<option disabled selected>' . esc_html__( 'Select filter', 'zero-bs-crm' ) . '</option>';
-					foreach ( $all_quickfilters as $category => $filters ) {
-						if ( $quickfilter_category_count > 1 ) {
-							$category_label = array_key_exists( $category, $quickfilter_categories ) ? $quickfilter_categories[ $category ] : $category;
-							echo '<optgroup label="' . esc_attr( $category_label ) . '">';
-						}
-						foreach ( $filters as $filter_slug => $filter_label ) {
-							echo '<option value="' . esc_attr( $filter_slug ) . '">' . esc_html( $filter_label ) . '</option>';
-						}
-						if ( $quickfilter_category_count > 1 ) {
-							echo '</optgroup>';
-						}
-					}
+					echo '<select class="filter-dropdown' . esc_attr( ! empty( $current_quickfilter_label ) ? ' hidden' : '' ) . '" data-filtertype="quickfilters">';
+					echo $quickfilter_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					echo '</select>';
 					echo '<div class="jpcrm-current-filter' . ( empty( $current_quickfilter_label ) ? ' hidden' : '' ) . '">';
 					echo '<button class="dashicons dashicons-remove" title="' . esc_attr__( 'Remove filter', 'zero-bs-crm' ) . '"></button>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3440 - add links to dash sales funnel

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This adds links to the sales funnel in the CRM dashboard:
![image](https://github.com/Automattic/jetpack/assets/32492176/c90234a4-1653-457f-ade7-5034b307146a)

Note that the funnel is cumulative, so the counts that show in the funnel are the sum of the given status and all statuses below it.

While testing, I also noticed there were a few follow-up tweaks:

* When using the URL param to filter the list view, the selected filter didn't show (regression from filter refactor in #35827). Fix: 07795b0de37953360d1db332c822085304b17966
* The contact count by status wasn't correct because it wasn't matching exact status names. Fix: 8b1c43eb45f218fe0506850d659b05792d49c191
* We were forcing lowercase on the status filter. Fix: 368abdacd775dd27ed0aedb0c8ac468143ec4f42

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add some statuses to the dash sales funnel: `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=fieldoptions`
2. View the funnel: `/wp-admin/admin.php?page=zerobscrm-dash`
3. Click on the statuses in the funnel.

In `trunk`, clicking does nothing.

In the `fix/crm/3440-add_links_to_dash_sales_funnel` branch, clicking sends one to the listview, filtered by the given status.
