### PR TITLE
Add scheduled updates option with last statuses

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-scheduled-update-last-run
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-update-last-run
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add scheduled updates option with last statuses.

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -49,7 +49,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.3.x-dev"
+			"dev-trunk": "0.4.x-dev"
 		},
 		"textdomain": "jetpack-scheduled-updates",
 		"version-constants": {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -125,22 +125,13 @@ class Scheduled_Updates {
 	}
 
 	/**
-	 * Get the last statuses of a scheduled updates.
-	 *
-	 * @return array|null Last statuses of the scheduled updates.
-	 */
-	public static function get_scheduled_update_statuses() {
-		return get_option( 'jetpack_scheduled_update_statuses', array() );
-	}
-
-	/**
 	 * Retrieves a list of schedule events with their last statuses.
 	 *
 	 * @return array The scheduled events with their last statuses.
 	 */
 	public static function get_scheduled_events_with_statuses() {
 		$events   = wp_get_scheduled_events( 'jetpack_scheduled_update' );
-		$statuses = self::get_scheduled_update_statuses();
+		$statuses = get_option( 'jetpack_scheduled_update_statuses', array() );
 		$output   = array();
 
 		foreach ( array_keys( $events ) as $schedule_id ) {
@@ -160,7 +151,7 @@ class Scheduled_Updates {
 	 */
 	public static function get_scheduled_event_with_status( $schedule_id, $events = null, $statuses = null ) {
 		$events   = $events ?? wp_get_scheduled_events( 'jetpack_scheduled_update' );
-		$statuses = $statuses ?? self::get_scheduled_update_statuses();
+		$statuses = $statuses ?? get_option( 'jetpack_scheduled_update_statuses', array() );
 
 		if ( empty( $events[ $schedule_id ] ) ) {
 			return false;

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -91,9 +91,9 @@ class Scheduled_Updates {
 	/**
 	 * Updates last status of a scheduled update.
 	 *
-	 * @param string $schedule_id Request ID.
-	 * @param int    $timestamp   Timestamp of the last run.
-	 * @param string $status      Status of the last run.
+	 * @param string      $schedule_id Request ID.
+	 * @param int|null    $timestamp   Timestamp of the last run.
+	 * @param string|null $status      Status of the last run.
 	 * @return false|array Updated statuses or false if not found.
 	 */
 	public static function set_scheduled_update_status( $schedule_id, $timestamp, $status ) {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -61,9 +61,7 @@ class Scheduled_Updates {
 	 * @param string ...$plugins List of plugins to update.
 	 */
 	public static function run_scheduled_update( ...$plugins ) {
-		// Save the last run schedule ID.
-		set_site_transient( 'jetpack_scheduled_update_last_run', self::generate_schedule_id( $plugins ) );
-
+		$schedule_id       = self::generate_schedule_id( $plugins );
 		$available_updates = get_site_transient( 'update_plugins' );
 		$plugins_to_update = $available_updates->response ?? array();
 		$plugins_to_update = array_intersect_key( $plugins_to_update, array_flip( $plugins ) );
@@ -73,7 +71,7 @@ class Scheduled_Updates {
 		}
 
 		( new Connection\Client() )->wpcom_json_api_request_as_blog(
-			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
+			sprintf( '/sites/%d/hosting/scheduled-update/%s', \Jetpack_Options::get_option( 'id' ), $schedule_id ),
 			'2',
 			array( 'method' => 'POST' ),
 			array( 'plugins' => $plugins_to_update ),

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -70,7 +70,7 @@ class Scheduled_Updates {
 		}
 
 		// Save the last run schedule ID.
-		set_transient( 'jetpack_scheduled_update_last_run', self::generate_schedule_id( $plugins ) );
+		set_site_transient( 'jetpack_scheduled_update_last_run', self::generate_schedule_id( $plugins ) );
 
 		( new Connection\Client() )->wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -98,7 +98,6 @@ class Scheduled_Updates {
 
 		if ( empty( $events[ $schedule_id ] ) ) {
 			// Scheduled update not found.
-			echo "not found\n";
 			return false;
 		}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -61,6 +61,9 @@ class Scheduled_Updates {
 	 * @param string ...$plugins List of plugins to update.
 	 */
 	public static function run_scheduled_update( ...$plugins ) {
+		// Save the last run schedule ID.
+		set_site_transient( 'jetpack_scheduled_update_last_run', self::generate_schedule_id( $plugins ) );
+
 		$available_updates = get_site_transient( 'update_plugins' );
 		$plugins_to_update = $available_updates->response ?? array();
 		$plugins_to_update = array_intersect_key( $plugins_to_update, array_flip( $plugins ) );
@@ -68,9 +71,6 @@ class Scheduled_Updates {
 		if ( empty( $plugins_to_update ) ) {
 			return;
 		}
-
-		// Save the last run schedule ID.
-		set_site_transient( 'jetpack_scheduled_update_last_run', self::generate_schedule_id( $plugins ) );
 
 		( new Connection\Client() )->wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -91,13 +91,14 @@ class Scheduled_Updates {
 	 * @param string $schedule_id Request ID.
 	 * @param int    $timestamp   Timestamp of the last run.
 	 * @param string $status      Status of the last run.
-	 * @return bool|mixed Updated schedule or false if not found.
+	 * @return false|array Updated statuses or false if not found.
 	 */
 	public static function set_scheduled_update_status( $schedule_id, $timestamp, $status ) {
 		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
 
 		if ( empty( $events[ $schedule_id ] ) ) {
 			// Scheduled update not found.
+			echo "not found\n";
 			return false;
 		}
 
@@ -121,51 +122,7 @@ class Scheduled_Updates {
 
 		update_option( 'jetpack_scheduled_update_statuses', $option );
 
-		return $option[ $schedule_id ];
-	}
-
-	/**
-	 * Retrieves a list of schedule events with their last statuses.
-	 *
-	 * @return array The scheduled events with their last statuses.
-	 */
-	public static function get_scheduled_events_with_statuses() {
-		$events   = wp_get_scheduled_events( 'jetpack_scheduled_update' );
-		$statuses = get_option( 'jetpack_scheduled_update_statuses', array() );
-		$output   = array();
-
-		foreach ( array_keys( $events ) as $schedule_id ) {
-			$output[ $schedule_id ] = self::get_scheduled_event_with_status( $schedule_id, $events, $statuses );
-		}
-
-		return $output;
-	}
-
-	/**
-	 * Retrieves a schedule event with its last status.
-	 *
-	 * @param string $schedule_id Schedule ID.
-	 * @param array  $events      Optional. List of scheduled events.
-	 * @param array  $statuses    Optional. List of statuses.
-	 * @return object The scheduled event with its last status.
-	 */
-	public static function get_scheduled_event_with_status( $schedule_id, $events = null, $statuses = null ) {
-		$events   = $events ?? wp_get_scheduled_events( 'jetpack_scheduled_update' );
-		$statuses = $statuses ?? get_option( 'jetpack_scheduled_update_statuses', array() );
-
-		if ( empty( $events[ $schedule_id ] ) ) {
-			return false;
-		}
-
-		if ( is_array( $statuses ) && ! empty( $statuses[ $schedule_id ] ) ) {
-			$events[ $schedule_id ]->last_run_timestamp = $statuses[ $schedule_id ]['last_run_timestamp'];
-			$events[ $schedule_id ]->last_run_status    = $statuses[ $schedule_id ]['last_run_status'];
-		} else {
-			$events[ $schedule_id ]->last_run_timestamp = null;
-			$events[ $schedule_id ]->last_run_status    = null;
-		}
-
-		return $events[ $schedule_id ];
+		return $option;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.5-alpha';
+	const PACKAGE_VERSION = '0.4.0-alpha';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -69,6 +69,9 @@ class Scheduled_Updates {
 			return;
 		}
 
+		// Save the last run schedule ID.
+		set_transient( 'jetpack_scheduled_update_last_run', self::generate_schedule_id( $plugins ) );
+
 		( new Connection\Client() )->wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
 			'2',
@@ -282,6 +285,18 @@ class Scheduled_Updates {
 		}
 
 		return $file_mod_capabilities;
+	}
+
+	/**
+	 * Generates a unique schedule ID.
+	 *
+	 * @see wp_schedule_event()
+	 *
+	 * @param array $args Schedule arguments.
+	 * @return string
+	 */
+	public static function generate_schedule_id( $args ) {
+		return md5( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -105,11 +105,11 @@ class Scheduled_Updates {
 		$option   = array();
 
 		// Reset the last statuses for the schedule.
-		foreach ( array_keys( $events ) as $schedule_id ) {
-			if ( ! empty( $statuses[ $schedule_id ] ) ) {
-				$option[ $schedule_id ] = $statuses[ $schedule_id ];
+		foreach ( array_keys( $events ) as $status_id ) {
+			if ( ! empty( $statuses[ $status_id ] ) ) {
+				$option[ $status_id ] = $statuses[ $status_id ];
 			} else {
-				$option[ $schedule_id ] = null;
+				$option[ $status_id ] = null;
 			}
 		}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -7,6 +7,9 @@
 
 namespace Automattic\Jetpack;
 
+// Load dependencies.
+require_once __DIR__ . '/pluggable.php';
+
 /**
  * Scheduled Updates class.
  */
@@ -136,7 +139,7 @@ class Scheduled_Updates {
 	 * @return array The scheduled events with their last statuses.
 	 */
 	public static function get_scheduled_events_with_statuses() {
-		$events   = $events ?? wp_get_scheduled_events( 'jetpack_scheduled_update' );
+		$events   = wp_get_scheduled_events( 'jetpack_scheduled_update' );
 		$statuses = self::get_scheduled_update_statuses();
 		$output   = array();
 
@@ -158,21 +161,20 @@ class Scheduled_Updates {
 	public static function get_scheduled_event_with_status( $schedule_id, $events = null, $statuses = null ) {
 		$events   = $events ?? wp_get_scheduled_events( 'jetpack_scheduled_update' );
 		$statuses = $statuses ?? self::get_scheduled_update_statuses();
-		$event    = $events[ $schedule_id ];
 
-		if ( empty( $event ) ) {
+		if ( empty( $events[ $schedule_id ] ) ) {
 			return false;
 		}
 
 		if ( is_array( $statuses ) && ! empty( $statuses[ $schedule_id ] ) ) {
-			$event->last_run_timestamp = $statuses[ $schedule_id ]['last_run_timestamp'];
-			$event->last_run_status    = $statuses[ $schedule_id ]['last_run_status'];
+			$events[ $schedule_id ]->last_run_timestamp = $statuses[ $schedule_id ]['last_run_timestamp'];
+			$events[ $schedule_id ]->last_run_status    = $statuses[ $schedule_id ]['last_run_status'];
 		} else {
-			$event->last_run_timestamp = null;
-			$event->last_run_status    = null;
+			$events[ $schedule_id ]->last_run_timestamp = null;
+			$events[ $schedule_id ]->last_run_status    = null;
 		}
 
-		return $event;
+		return $events[ $schedule_id ];
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -77,10 +77,13 @@ class Scheduled_Updates {
 		}
 
 		( new Connection\Client() )->wpcom_json_api_request_as_blog(
-			sprintf( '/sites/%d/hosting/scheduled-update/%s', \Jetpack_Options::get_option( 'id' ), $schedule_id ),
+			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
 			'2',
 			array( 'method' => 'POST' ),
-			array( 'plugins' => $plugins_to_update ),
+			array(
+				'plugins'     => $plugins_to_update,
+				'schedule_id' => $schedule_id,
+			),
 			'wpcom'
 		);
 	}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -326,10 +326,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$last_statuses = get_option( 'jetpack_scheduled_update_last_statuses', array() );
 		$option        = array();
 
-		if ( ! is_array( $last_statuses ) ) {
-			$last_statuses = array();
-		}
-
 		// Reset the last statuses for the schedule.
 		foreach ( array_keys( $events ) as $schedule_id ) {
 			if ( ! empty( $last_statuses[ $schedule_id ] ) ) {

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -88,7 +88,19 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'update_last_status' ),
 					'permission_callback' => array( $this, 'update_last_status_permissions_check' ),
-					'args'                => $this->get_last_status_params(),
+					'args'                => array(
+						'last_run_timestamp' => array(
+							'description' => 'Unix timestamp (UTC) for when the last run occurred.',
+							'type'        => 'integer',
+							'required'    => true,
+						),
+						'last_run_status'    => array(
+							'description' => 'Status of last run.',
+							'type'        => 'string',
+							'enum'        => array( 'success', 'failure-and-rollback', 'failure-and-rollback-fail' ),
+							'required'    => true,
+						),
+					),
 				),
 			)
 		);
@@ -654,27 +666,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 						'required'    => true,
 					),
 				),
-			),
-		);
-	}
-
-	/**
-	 * Retrieves the query params for last status update.
-	 *
-	 * @return array[] Array of query parameters.
-	 */
-	public function get_last_status_params() {
-		return array(
-			'last_run_timestamp' => array(
-				'description' => 'Unix timestamp (UTC) for when the last run occurred.',
-				'type'        => 'integer',
-				'required'    => true,
-			),
-			'last_run_status'    => array(
-				'description' => 'Status of last run.',
-				'type'        => 'string',
-				'enum'        => array( 'success', 'failure-and-rollback', 'failure-and-rollback-fail' ),
-				'required'    => true,
 			),
 		);
 	}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -160,7 +160,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			$output[ $schedule_id ] = $this->get_scheduled_event_with_status( $schedule_id, $events, $last_statuses );
 		}
 
-		return rest_ensure_response( wp_get_scheduled_events( 'jetpack_scheduled_update' ) );
+		return rest_ensure_response( $output );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -8,7 +8,6 @@
  */
 
 // Load dependencies.
-require_once dirname( __DIR__ ) . '/pluggable.php';
 require_once dirname( __DIR__ ) . '/class-scheduled-updates.php';
 
 use Automattic\Jetpack\Scheduled_Updates;

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -7,9 +7,6 @@
  * @package automattic/scheduled-updates
  */
 
-// Load dependencies.
-require_once dirname( __DIR__ ) . '/class-scheduled-updates.php';
-
 use Automattic\Jetpack\Scheduled_Updates;
 
 /**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -550,6 +550,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		if ( is_array( $last_statuses ) && ! empty( $last_statuses[ $schedule_id ] ) ) {
 			$event->last_run_timestamp = $last_statuses[ $schedule_id ]['last_run_timestamp'];
 			$event->last_run_status    = $last_statuses[ $schedule_id ]['last_run_status'];
+		} else {
+			$event->last_run_timestamp = null;
+			$event->last_run_status    = null;
 		}
 
 		return $event;

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -243,12 +243,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 
 		$last_statuses = get_option( 'jetpack_scheduled_update_last_statuses', array() );
 
-		if ( is_array( $last_statuses ) && ! empty( $last_statuses[ $request['schedule_id'] ] ) ) {
-			$last_status = $last_statuses[ $request['schedule_id'] ];
-			$events[ $request['schedule_id'] ]->last_run_timestamp = $last_status['last_run_timestamp'];
-			$events[ $request['schedule_id'] ]->last_run_status    = $last_status['last_run_status'];
-		}
-
 		return rest_ensure_response( $this->get_scheduled_event_with_status( $request['schedule_id'], $events, $last_statuses ) );
 	}
 

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -217,7 +217,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			update_option( 'auto_update_plugins', $auto_update_plugins );
 		}
 
-		return rest_ensure_response( Scheduled_Updates::generate_schedule_id( $plugins ) );
+		$id = Scheduled_Updates::generate_schedule_id( $plugins );
+
+		// Set an empty status of a schedule on creation/modify.
+		Scheduled_Updates::set_scheduled_update_status( $id, null, null );
+
+		return rest_ensure_response( $id );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -153,7 +153,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			$object_type,
 			'last_run_timestamp',
 			array(
-				'get_callback'    => array( $this, 'add_last_run_field' ),
+				'get_callback'    => array( $this, 'get_last_run_field' ),
 				'update_callback' => null,
 				'schema'          => array(
 					'description' => 'Unix timestamp (UTC) for when the last run occurred.',
@@ -166,7 +166,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			$object_type,
 			'last_run_status',
 			array(
-				'get_callback'    => array( $this, 'add_last_run_field' ),
+				'get_callback'    => array( $this, 'get_last_run_field' ),
 				'update_callback' => null,
 				'schema'          => array(
 					'description' => 'Status of last run.',
@@ -380,7 +380,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @param string          $object_type Object type.
 	 * @return object|null
 	 */
-	public function add_last_run_field( $item, $field_name, $request, $object_type ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function get_last_run_field( $item, $field_name, $request, $object_type ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$option = get_option( 'jetpack_scheduled_update_statuses', array() );
 
 		if ( ! empty( $option[ $item['schedule_id'] ] ) ) {

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -88,6 +88,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'update_last_status' ),
 					'permission_callback' => array( $this, 'update_last_status_permissions_check' ),
+					'args'                => $this->get_last_status_params(),
 				),
 			)
 		);
@@ -307,7 +308,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$last_run = get_site_transient( 'jetpack_scheduled_update_last_run' );
 
 		if ( false === $last_run || ! isset( $events[ $last_run ] ) ) {
-			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_invalid_schedule', __( 'The last schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
 		}
 
 		$last_statuses = get_option( 'jetpack_scheduled_update_last_statuses', array() );
@@ -328,8 +329,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 
 		// Update the last status for the schedule.
 		$option[ $last_run ] = array(
-			'last_run_timestamp' => $request['timestamp'],
-			'last_run_status'    => $request['status'],
+			'last_run_timestamp' => $request['last_run_timestamp'],
+			'last_run_status'    => $request['last_run_status'],
 		);
 
 		update_option( 'jetpack_scheduled_update_last_statuses', $option );
@@ -653,6 +654,27 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 						'required'    => true,
 					),
 				),
+			),
+		);
+	}
+
+	/**
+	 * Retrieves the query params for last status update.
+	 *
+	 * @return array[] Array of query parameters.
+	 */
+	public function get_last_status_params() {
+		return array(
+			'last_run_timestamp' => array(
+				'description' => 'Unix timestamp (UTC) for when the last run occurred.',
+				'type'        => 'integer',
+				'required'    => true,
+			),
+			'last_run_status'    => array(
+				'description' => 'Status of last run.',
+				'type'        => 'string',
+				'enum'        => array( 'success', 'failure-and-rollback', 'failure-and-rollback-fail' ),
+				'required'    => true,
 			),
 		);
 	}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -381,7 +381,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	/**
 	 * Get the last run value of a schedule.
 	 *
-	 * @param object          $item        Prepared response object.
+	 * @param array           $item        Prepared response object.
 	 * @param string          $field_name  Field name.
 	 * @param WP_REST_Request $request     Full details about the request.
 	 * @param string          $object_type Object type.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -35,13 +35,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	public $rest_base = 'update-schedules';
 
 	/**
-	 * Statuses saved in the 'jetpack_scheduled_update_statuses' option.
-	 *
-	 * @var array|null
-	 */
-	private $scheduled_update_statuses = null;
-
-	/**
 	 * WPCOM_REST_API_V2_Endpoint_Atomic_Hosting_Update_Schedule constructor.
 	 */
 	public function __construct() {

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -164,59 +164,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test valid statuses.
-	 *
-	 * @covers ::get_scheduled_events_with_statuses
-	 */
-	public function test_get_scheduled_events_with_statuses() {
-		$plugins = array( 'gutenberg/gutenberg.php' );
-		$id      = Scheduled_Updates::generate_schedule_id( $plugins );
-		$events  = $this->schedule_event( strtotime( 'next Monday 8:00' ), $plugins );
-
-		$this->assertIsArray( $events );
-		$this->arrayHasKey( $id, $events );
-		$this->assertNull( $events[ $id ]->last_run_timestamp );
-		$this->assertNull( $events[ $id ]->last_run_status );
-	}
-
-	/**
-	 * Test set scheduled update status.
-	 *
-	 * @covers ::set_scheduled_update_status
-	 */
-	public function test_set_scheduled_update_status() {
-		$this->assertFalse( Scheduled_Updates::set_scheduled_update_status( 'test', 0, '' ) );
-
-		$plugins = array( 'gutenberg/gutenberg.php' );
-		$id_1    = Scheduled_Updates::generate_schedule_id( $plugins );
-
-		$this->schedule_event( strtotime( 'next Monday 8:00' ), $plugins );
-
-		$updated_schedule = Scheduled_Updates::set_scheduled_update_status( $id_1, 1, 'success' );
-
-		$this->assertIsArray( $updated_schedule );
-		$this->assertSame( 1, $updated_schedule['last_run_timestamp'] );
-		$this->assertSame( 'success', $updated_schedule['last_run_status'] );
-
-		$plugins = array( 'hello-dolly/hello.php' );
-		$id_2    = Scheduled_Updates::generate_schedule_id( $plugins );
-
-		$this->schedule_event( strtotime( 'next Monday 9:00' ), $plugins );
-		$updated_schedule = Scheduled_Updates::set_scheduled_update_status( $id_2, 2, 'failure-and-rollback' );
-
-		$this->assertIsArray( $updated_schedule );
-		$this->assertSame( 2, $updated_schedule['last_run_timestamp'] );
-		$this->assertSame( 'failure-and-rollback', $updated_schedule['last_run_status'] );
-
-		$events = Scheduled_Updates::get_scheduled_events_with_statuses();
-
-		$this->arrayHasKey( $id_1, $events );
-		$this->arrayHasKey( $id_2, $events );
-		$this->assertSame( 1, $events[ $id_1 ]->last_run_timestamp );
-		$this->assertSame( 2, $events[ $id_2 ]->last_run_timestamp );
-	}
-
-	/**
 	 * Populates the plugin file with a plugin header so get_plugins() can find it.
 	 *
 	 * @param string $plugin_file Path to plugin file.
@@ -235,19 +182,5 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 				* Text Domain: $plugin_name
 				*/"
 		);
-	}
-
-	/**
-	 * Schedule an event.
-	 *
-	 * @param int    $timestamp  The timestamp to schedule the event.
-	 * @param array  $plugins    The plugins to schedule the event for.
-	 * @param string $recurrence The recurrence of the event.
-	 * @return array The scheduled events.
-	 */
-	private function schedule_event( $timestamp, $plugins, $recurrence = 'weekly' ) {
-		wp_schedule_event( $timestamp, $recurrence, 'jetpack_scheduled_update', $plugins );
-
-		return Scheduled_Updates::get_scheduled_events_with_statuses();
 	}
 }

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -77,6 +77,9 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		// Clean up the plugins cache created by get_plugins()
 		wp_cache_delete( 'plugins', 'plugins' );
 
+		wp_clear_scheduled_hook( 'jetpack_scheduled_update' );
+		delete_option( 'jetpack_scheduled_update_statuses' );
+
 		parent::tear_down_wordbless();
 	}
 
@@ -161,6 +164,69 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test no statuses.
+	 *
+	 * @covers ::get_scheduled_update_statuses
+	 */
+	public function test_empty_scheduled_update_statuses() {
+		$this->assertSame( array(), Scheduled_Updates::get_scheduled_update_statuses() );
+		$this->assertFalse( Scheduled_Updates::get_scheduled_event_with_status( 'test' ) );
+	}
+
+	/**
+	 * Test valid statuses.
+	 *
+	 * @covers ::get_scheduled_events_with_statuses
+	 */
+	public function test_get_scheduled_events_with_statuses() {
+		$plugins = array( 'gutenberg/gutenberg.php' );
+		$id      = Scheduled_Updates::generate_schedule_id( $plugins );
+		$events  = $this->schedule_event( strtotime( 'next Monday 8:00' ), $plugins );
+
+		$this->assertIsArray( $events );
+		$this->arrayHasKey( $id, $events );
+		$this->assertNull( $events[ $id ]->last_run_timestamp );
+		$this->assertNull( $events[ $id ]->last_run_status );
+	}
+
+	/**
+	 * Test set scheduled update status.
+	 *
+	 * @covers ::set_scheduled_update_status
+	 */
+	public function test_set_scheduled_update_status() {
+		$this->assertFalse( Scheduled_Updates::set_scheduled_update_status( 'test', 0, '' ) );
+
+		$plugins = array( 'gutenberg/gutenberg.php' );
+		$id_1    = Scheduled_Updates::generate_schedule_id( $plugins );
+
+		$this->schedule_event( strtotime( 'next Monday 8:00' ), $plugins );
+
+		$updated_schedule = Scheduled_Updates::set_scheduled_update_status( $id_1, 1, 'success' );
+
+		$this->assertIsArray( $updated_schedule );
+		$this->assertSame( 1, $updated_schedule['last_run_timestamp'] );
+		$this->assertSame( 'success', $updated_schedule['last_run_status'] );
+
+		$plugins = array( 'hello-dolly/hello.php' );
+		$id_2    = Scheduled_Updates::generate_schedule_id( $plugins );
+
+		$this->schedule_event( strtotime( 'next Monday 9:00' ), $plugins );
+		$updated_schedule = Scheduled_Updates::set_scheduled_update_status( $id_2, 2, 'failure-and-rollback' );
+
+		$this->assertIsArray( $updated_schedule );
+		$this->assertSame( 2, $updated_schedule['last_run_timestamp'] );
+		$this->assertSame( 'failure-and-rollback', $updated_schedule['last_run_status'] );
+
+		$events = Scheduled_Updates::get_scheduled_events_with_statuses();
+
+		$this->arrayHasKey( $id_1, $events );
+		$this->arrayHasKey( $id_2, $events );
+		$this->assertSame( 1, $events[ $id_1 ]->last_run_timestamp );
+		$this->assertSame( 2, $events[ $id_2 ]->last_run_timestamp );
+	}
+
+	/**
 	 * Populates the plugin file with a plugin header so get_plugins() can find it.
 	 *
 	 * @param string $plugin_file Path to plugin file.
@@ -179,5 +245,19 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 				* Text Domain: $plugin_name
 				*/"
 		);
+	}
+
+	/**
+	 * Schedule an event.
+	 *
+	 * @param int    $timestamp  The timestamp to schedule the event.
+	 * @param array  $plugins    The plugins to schedule the event for.
+	 * @param string $recurrence The recurrence of the event.
+	 * @return array The scheduled events.
+	 */
+	private function schedule_event( $timestamp, $plugins, $recurrence = 'weekly' ) {
+		wp_schedule_event( $timestamp, $recurrence, 'jetpack_scheduled_update', $plugins );
+
+		return Scheduled_Updates::get_scheduled_events_with_statuses();
 	}
 }

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -164,16 +164,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test no statuses.
-	 *
-	 * @covers ::get_scheduled_update_statuses
-	 */
-	public function test_empty_scheduled_update_statuses() {
-		$this->assertSame( array(), Scheduled_Updates::get_scheduled_update_statuses() );
-		$this->assertFalse( Scheduled_Updates::get_scheduled_event_with_status( 'test' ) );
-	}
-
-	/**
 	 * Test valid statuses.
 	 *
 	 * @covers ::get_scheduled_events_with_statuses

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -116,18 +116,22 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertEquals(
 			array(
 				Scheduled_Updates::generate_schedule_id( array( 'hello-dolly/hello-dolly.php' ) ) => (object) array(
-					'hook'      => 'jetpack_scheduled_update',
-					'args'      => array( 'hello-dolly/hello-dolly.php' ),
-					'timestamp' => strtotime( 'next Tuesday 9:00' ),
-					'schedule'  => 'daily',
-					'interval'  => DAY_IN_SECONDS,
+					'hook'               => 'jetpack_scheduled_update',
+					'args'               => array( 'hello-dolly/hello-dolly.php' ),
+					'timestamp'          => strtotime( 'next Tuesday 9:00' ),
+					'schedule'           => 'daily',
+					'interval'           => DAY_IN_SECONDS,
+					'last_run_timestamp' => null,
+					'last_run_status'    => null,
 				),
 				Scheduled_Updates::generate_schedule_id( $plugins ) => (object) array(
-					'hook'      => 'jetpack_scheduled_update',
-					'args'      => $plugins,
-					'timestamp' => strtotime( 'next Monday 8:00' ),
-					'schedule'  => 'weekly',
-					'interval'  => WEEK_IN_SECONDS,
+					'hook'               => 'jetpack_scheduled_update',
+					'args'               => $plugins,
+					'timestamp'          => strtotime( 'next Monday 8:00' ),
+					'schedule'           => 'weekly',
+					'interval'           => WEEK_IN_SECONDS,
+					'last_run_timestamp' => null,
+					'last_run_status'    => null,
 				),
 			),
 			$result->get_data()
@@ -362,11 +366,13 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertEquals(
 			(object) array(
-				'hook'      => 'jetpack_scheduled_update',
-				'args'      => $plugins,
-				'timestamp' => strtotime( 'next Monday 8:00' ),
-				'schedule'  => 'weekly',
-				'interval'  => WEEK_IN_SECONDS,
+				'hook'               => 'jetpack_scheduled_update',
+				'args'               => $plugins,
+				'timestamp'          => strtotime( 'next Monday 8:00' ),
+				'schedule'           => 'weekly',
+				'interval'           => WEEK_IN_SECONDS,
+				'last_run_timestamp' => null,
+				'last_run_status'    => null,
 			),
 			$result->get_data()
 		);

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -5,6 +5,8 @@
  * @package automattic/scheduled-updates
  */
 
+use Automattic\Jetpack\Scheduled_Updates;
+
 /**
  * Test class for WPCOM_REST_API_V2_Endpoint_Update_Schedules.
  *
@@ -113,14 +115,14 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertEquals(
 			array(
-				$this->generate_schedule_id( array( 'hello-dolly/hello-dolly.php' ) ) => (object) array(
+				Scheduled_Updates::generate_schedule_id( array( 'hello-dolly/hello-dolly.php' ) ) => (object) array(
 					'hook'      => 'jetpack_scheduled_update',
 					'args'      => array( 'hello-dolly/hello-dolly.php' ),
 					'timestamp' => strtotime( 'next Tuesday 9:00' ),
 					'schedule'  => 'daily',
 					'interval'  => DAY_IN_SECONDS,
 				),
-				$this->generate_schedule_id( $plugins ) => (object) array(
+				Scheduled_Updates::generate_schedule_id( $plugins ) => (object) array(
 					'hook'      => 'jetpack_scheduled_update',
 					'args'      => $plugins,
 					'timestamp' => strtotime( 'next Monday 8:00' ),
@@ -151,7 +153,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 				),
 			)
 		);
-		$schedule_id = $this->generate_schedule_id( $request->get_body_params()['plugins'] );
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $request->get_body_params()['plugins'] );
 
 		// Unauthenticated request.
 		$result = rest_do_request( $request );
@@ -335,7 +337,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'gutenberg/gutenberg.php',
 			'custom-plugin/custom-plugin.php',
 		);
-		$schedule_id = $this->generate_schedule_id( $plugins );
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
 
 		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
 
@@ -378,7 +380,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	public function test_get_invalid_item() {
 		wp_set_current_user( $this->admin_id );
 
-		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules/' . $this->generate_schedule_id( array() ) );
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules/' . Scheduled_Updates::generate_schedule_id( array() ) );
 		$result  = rest_do_request( $request );
 
 		$this->assertSame( 404, $result->get_status() );
@@ -395,7 +397,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'custom-plugin/custom-plugin.php',
 			'gutenberg/gutenberg.php',
 		);
-		$schedule_id = $this->generate_schedule_id( $plugins );
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
 
 		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
 
@@ -438,7 +440,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	public function test_update_invalid_item() {
 		wp_set_current_user( $this->admin_id );
 
-		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $this->generate_schedule_id( array() ) );
+		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . Scheduled_Updates::generate_schedule_id( array() ) );
 		$request->set_body_params(
 			array(
 				'plugins'  => array(),
@@ -464,7 +466,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'gutenberg/gutenberg.php',
 			'custom-plugin/custom-plugin.php',
 		);
-		$schedule_id = $this->generate_schedule_id( $plugins );
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
 
 		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
 
@@ -501,7 +503,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	public function test_delete_invalid_item() {
 		wp_set_current_user( $this->admin_id );
 
-		$request = new WP_REST_Request( 'DELETE', '/wpcom/v2/update-schedules/' . $this->generate_schedule_id( array() ) );
+		$request = new WP_REST_Request( 'DELETE', '/wpcom/v2/update-schedules/' . Scheduled_Updates::generate_schedule_id( array() ) );
 		$result  = rest_do_request( $request );
 
 		$this->assertSame( 404, $result->get_status() );
@@ -527,7 +529,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'hello-dolly/hello-dolly.php',
 		);
 
-		$schedule_id = $this->generate_schedule_id( $plugins_2 );
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins_2 );
 
 		wp_schedule_event( strtotime( 'next Tuesday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins_1 );
 		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins_2 );
@@ -564,17 +566,5 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$result = rest_do_request( $request );
 
 		$this->assertSame( 200, $result->get_status() );
-	}
-
-	/**
-	 * Generates a unique schedule ID.
-	 *
-	 * @see wp_schedule_event()
-	 *
-	 * @param array $args Schedule arguments.
-	 * @return string
-	 */
-	private function generate_schedule_id( $args ) {
-		return md5( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 	}
 }

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -116,7 +116,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertEquals(
 			array(
-				Scheduled_Updates::generate_schedule_id( array( 'hello-dolly/hello-dolly.php' ) ) => (object) array(
+				Scheduled_Updates::generate_schedule_id( array( 'hello-dolly/hello-dolly.php' ) ) => array(
 					'hook'               => 'jetpack_scheduled_update',
 					'args'               => array( 'hello-dolly/hello-dolly.php' ),
 					'timestamp'          => strtotime( 'next Tuesday 9:00' ),
@@ -125,7 +125,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 					'last_run_timestamp' => null,
 					'last_run_status'    => null,
 				),
-				Scheduled_Updates::generate_schedule_id( $plugins ) => (object) array(
+				Scheduled_Updates::generate_schedule_id( $plugins ) => array(
 					'hook'               => 'jetpack_scheduled_update',
 					'args'               => $plugins,
 					'timestamp'          => strtotime( 'next Monday 8:00' ),
@@ -324,7 +324,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertEquals(
 			array(
-				Scheduled_Updates::generate_schedule_id( $plugins ) => (object) array(
+				Scheduled_Updates::generate_schedule_id( $plugins ) => array(
 					'hook'               => 'jetpack_scheduled_update',
 					'args'               => $plugins,
 					'timestamp'          => strtotime( 'next Wednesday 10:00' ),
@@ -384,8 +384,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$this->assertIsArray( $events );
 		$this->arrayHasKey( $id_1, $events );
-		$this->assertSame( 1, $events[ $id_1 ]->last_run_timestamp );
-		$this->assertSame( 'success', $events[ $id_1 ]->last_run_status );
+		$this->assertSame( 1, $events[ $id_1 ]['last_run_timestamp'] );
+		$this->assertSame( 'success', $events[ $id_1 ]['last_run_status'] );
 
 		$plugins = array(
 			'hello-dolly/hello.php',
@@ -411,10 +411,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$events = $result->get_data();
 
-		$this->assertSame( 1, $events[ $id_1 ]->last_run_timestamp );
-		$this->assertSame( 2, $events[ $id_2 ]->last_run_timestamp );
-		$this->assertSame( 'success', $events[ $id_1 ]->last_run_status );
-		$this->assertSame( 'failure-and-rollback', $events[ $id_2 ]->last_run_status );
+		$this->assertSame( 1, $events[ $id_1 ]['last_run_timestamp'] );
+		$this->assertSame( 2, $events[ $id_2 ]['last_run_timestamp'] );
+		$this->assertSame( 'success', $events[ $id_1 ]['last_run_status'] );
+		$this->assertSame( 'failure-and-rollback', $events[ $id_2 ]['last_run_status'] );
 	}
 
 	/**
@@ -488,7 +488,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertEquals(
-			(object) array(
+			array(
 				'hook'               => 'jetpack_scheduled_update',
 				'args'               => $plugins,
 				'timestamp'          => strtotime( 'next Monday 8:00' ),

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -383,7 +383,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$events = $result->get_data();
 
 		$this->assertIsArray( $events );
-		$this->arrayHasKey( $id_1, $events );
+		$this->assertArrayHasKey( $id_1, $events );
 		$this->assertSame( 1, $events[ $id_1 ]['last_run_timestamp'] );
 		$this->assertSame( 'success', $events[ $id_1 ]['last_run_status'] );
 
@@ -411,7 +411,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$events = $result->get_data();
 
+		$this->assertArrayHasKey( $id_1, $events );
 		$this->assertSame( 1, $events[ $id_1 ]['last_run_timestamp'] );
+		$this->assertArrayHasKey( $id_2, $events );
 		$this->assertSame( 2, $events[ $id_2 ]['last_run_timestamp'] );
 		$this->assertSame( 'success', $events[ $id_1 ]['last_run_status'] );
 		$this->assertSame( 'failure-and-rollback', $events[ $id_2 ]['last_run_status'] );

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -71,6 +71,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		wp_delete_user( $this->editor_id );
 
 		wp_clear_scheduled_hook( 'jetpack_scheduled_update' );
+		delete_option( 'jetpack_scheduled_update_statuses' );
 	}
 
 	/**
@@ -295,9 +296,52 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
-	 * Removes plugins from the autoupdate list when creating a schedule.
+	 * Can't have more than two schedules.
 	 *
-	 * @covers ::create_item
+	 * @covers ::create
+	 */
+	public function test_empty_last_run() {
+		$plugins = array( 'gutenberg/gutenberg.php' );
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => $plugins,
+				'schedule' => array(
+					'timestamp' => strtotime( 'next Wednesday 10:00' ),
+					'interval'  => 'daily',
+				),
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules' );
+		$result  = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertEquals(
+			array(
+				Scheduled_Updates::generate_schedule_id( $plugins ) => (object) array(
+					'hook'               => 'jetpack_scheduled_update',
+					'args'               => $plugins,
+					'timestamp'          => strtotime( 'next Wednesday 10:00' ),
+					'schedule'           => 'daily',
+					'interval'           => DAY_IN_SECONDS,
+					'last_run_timestamp' => null,
+					'last_run_status'    => null,
+				),
+			),
+			$result->get_data()
+		);
+	}
+
+	/**
+	 * Update event status.
+	 *
+	 * @covers ::update_status
 	 */
 	public function test_update_event_status() {
 		$plugins = array(
@@ -331,7 +375,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 1, $result->get_data()['last_run_timestamp'] );
 		$this->assertSame( 'success', $result->get_data()['last_run_status'] );
 
-		$events = Scheduled_Updates::get_scheduled_events_with_statuses();
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules' );
+		$result  = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+
+		$events = $result->get_data();
 
 		$this->assertIsArray( $events );
 		$this->arrayHasKey( $id_1, $events );
@@ -352,9 +401,16 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules/' . $id_2 . '/status' );
 		$request->set_body_params( $body );
 		$result = rest_do_request( $request );
-		$events = Scheduled_Updates::get_scheduled_events_with_statuses();
 
 		$this->assertSame( 200, $result->get_status() );
+
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules' );
+		$result  = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+
+		$events = $result->get_data();
+
 		$this->assertSame( 1, $events[ $id_1 ]->last_run_timestamp );
 		$this->assertSame( 2, $events[ $id_2 ]->last_run_timestamp );
 		$this->assertSame( 'success', $events[ $id_1 ]->last_run_status );

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-update-last-run
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-update-last-run
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -198,7 +198,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "650b442ad8357bd4353970a2014a40e126d180d8"
+                "reference": "547990a79f495469469a4799e10f950ce4f4fc16"
             },
             "require": {
                 "php": ">=7.0"
@@ -221,7 +221,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 },
                 "textdomain": "jetpack-scheduled-updates",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5963

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add new `wpcom/v2/update-schedules/<id>/status` endpoint
* Add a new option with last statuses
* Populate `wpcom/v2/update-schedules/` with last statuses
* Move `generate_schedule_id` to another class, to be reusable

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the instructions found in D141591-code.