### PR TITLE
Woo Analytics: bail early when WooCommerce is not active.

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-woo-analytics-bail-missing
+++ b/projects/packages/woocommerce-analytics/changelog/fix-woo-analytics-bail-missing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+General: bail early when WooCommerce is not active.

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -29,6 +29,10 @@ class Woocommerce_Analytics {
 	 * @return void
 	 */
 	public static function init() {
+		if ( ! self::should_track_store() ) {
+			return;
+		}
+
 		// loading _wca.
 		add_action( 'wp_head', array( __CLASS__, 'wp_head_top' ), 1 );
 


### PR DESCRIPTION
Follow-up to #35758 and #35756

## Proposed changes:

I missed this when bringing the codebase to the package and moving to a singleton.

This should fix errors like this one:

```
PHP Fatal error:  Uncaught Error: Call to undefined function Automattic\Woocommerce_Analytics\wc_get_page_id() in /usr/local/src/jetpack-monorepo/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php:171
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Load `trunk` on a site where WooCommerce is not active.
    * You should get a fatal error.
    * If you do not see the fatal error, it may be because the WooCommerce Analytics module was not auto-activated on your site. Run `jetpack docker wp jetpack module activate woocommerce-analytics`
* Switch to this branch
    * The Fatal error should be gone.
