### PR TITLE
Boost: Add speed score changed pop-out

### DIFF
--- a/projects/packages/boost-speed-score/changelog/add-hook-speed-score-success-response
+++ b/projects/packages/boost-speed-score/changelog/add-hook-speed-score-success-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add action to allow hooking after speed score success response is received.

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -326,6 +326,8 @@ class Speed_Score {
 
 			$response['scores']['isStale'] = $history->is_stale();
 
+			do_action( 'jetpack_boost_speed_score_response_success', $response, $url );
+
 		} elseif ( ( $score_request && $score_request->is_error() ) || ( $score_request_no_boost && $score_request_no_boost->is_error() ) ) {
 			// If either request ended up in error, we can just return the one with error so front-end can take action. The relevent url is available on the serialized object.
 			if ( $score_request->is_error() ) {

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/lib/stores.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/lib/stores.ts
@@ -1,0 +1,6 @@
+import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
+import { z } from 'zod';
+
+export function useSpeedScoresChange() {
+	return useDataSync( 'jetpack_boost_ds', 'speed_scores_change', z.number() );
+}

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
@@ -8,7 +8,7 @@ import { useDismissibleAlertState } from '$features/performance-history/lib/hook
 import { getRedirectUrl } from '@automattic/jetpack-components';
 
 type Props = {
-	scoreChange: number | false; // Speed score shift to show, or false if none.
+	scoreChange: number; // How many times the score has changed.
 };
 
 /**
@@ -55,9 +55,9 @@ const slowerMessage: ScoreChangeMessage = {
 
 function PopOut( { scoreChange }: Props ) {
 	/*
-	 * Determine if the score has changed enough to show the alert.
+	 * Determine if the score has changed enough times to show the alert.
 	 */
-	const hasScoreChanged = scoreChange !== false && Math.abs( scoreChange ) > 5;
+	const hasScoreChanged = scoreChange !== 0 && Math.abs( scoreChange ) >= 2;
 
 	/*
 	 * Determine which message to show based on the direction of score change.

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
@@ -8,13 +8,14 @@ import ErrorNotice from '$features/error-notice/error-notice';
 import classNames from 'classnames';
 import { useEffect, useMemo, useCallback } from 'react';
 import { useDebouncedRefreshScore, useSpeedScores } from './lib/hooks';
-
+import { useSpeedScoresChange } from './lib/stores';
 import styles from './speed-score.module.scss';
 import { useModulesState } from '$features/module/lib/stores';
 import { useCriticalCssState } from '$features/critical-css/lib/stores/critical-css-state';
 import { useLocalCriticalCssGeneratorStatus } from '$features/critical-css/local-generator/local-generator-provider';
 import { queryClient } from '@automattic/jetpack-react-data-sync-client';
 import ErrorBoundary from '$features/error-boundary/error-boundary';
+import PopOut from './pop-out/pop-out';
 
 const SpeedScore = () => {
 	const { site } = Jetpack_Boost;
@@ -24,6 +25,7 @@ const SpeedScore = () => {
 	const [ { data } ] = useModulesState();
 	const [ cssState ] = useCriticalCssState();
 	const { isGenerating: criticalCssIsGenerating } = useLocalCriticalCssGeneratorStatus();
+	const [ scoreChange ] = useSpeedScoresChange();
 
 	// Construct an array of current module states
 	const moduleStates = useMemo(
@@ -141,6 +143,8 @@ const SpeedScore = () => {
 				</div>
 				{ site.online && <PerformanceHistory /> }
 			</div>
+
+			<PopOut scoreChange={ scoreChange?.data || 0 } />
 		</>
 	);
 };

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -26,6 +26,7 @@ use Automattic\Jetpack_Boost\Lib\CLI;
 use Automattic\Jetpack_Boost\Lib\Connection;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
+use Automattic\Jetpack_Boost\Lib\Page_Speed_Change_Tracker;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Site_Health;
 use Automattic\Jetpack_Boost\Lib\Status;
@@ -126,6 +127,8 @@ class Jetpack_Boost {
 
 		// Setup Site Health panel functionality.
 		Site_Health::init();
+
+		Page_Speed_Change_Tracker::init();
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/Page_Speed_Tracker.php
+++ b/projects/plugins/boost/app/lib/Page_Speed_Tracker.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Lib;
+
+class Page_Speed_Change_Tracker {
+
+	public static function init() {
+		add_action( 'jetpack_boost_speed_score_response_success', array( __CLASS__, 'response_received' ) );
+	}
+
+	public static function response_received( $response ) {
+		// @todo - if prompt is dismissed, don't track anything.
+
+		$change = self::get_score_change( $response );
+
+		// Don't track small changes between scores.
+		if ( absint( $change ) <= 5 ) {
+			return;
+		}
+
+		$tracker = jetpack_boost_ds_get( 'speed_scores_change' );
+
+		if ( $change > 0 ) {
+			++$tracker;
+		} else {
+			--$tracker;
+		}
+
+		jetpack_boost_ds_set( 'speed_scores_change', $tracker );
+	}
+
+	public static function get_score_change( $response ) {
+		if ( empty( $response['scores'] ) ) {
+			return 0;
+		}
+
+		if ( empty( $response['scores']['current'] ) || empty( $response['scores']['noBoost'] ) ) {
+			return 0;
+		}
+
+		$current  = $response['scores']['current']['mobile'] + $response['scores']['current']['desktop'];
+		$no_boost = $response['scores']['noBoost']['mobile'] + $response['scores']['noBoost']['desktop'];
+
+		return $current - $no_boost;
+	}
+}

--- a/projects/plugins/boost/changelog/add-speed-score-changed-prompt
+++ b/projects/plugins/boost/changelog/add-speed-score-changed-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Page Speed: Add score changed prompt.

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -377,3 +377,6 @@ jetpack_boost_register_option(
 );
 
 jetpack_boost_register_action( 'page_cache', 'clear-page-cache', Schema::as_void(), new Clear_Page_Cache() );
+
+// Tracks the change in speed scores.
+jetpack_boost_register_option( 'speed_scores_change', Schema::as_number()->fallback( 0 ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36052

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add score changed popout back into Boost.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBA