### PR TITLE
Stats block: better looking loading state in the editor

### DIFF
--- a/projects/plugins/jetpack/changelog/update-stats-block-loading
+++ b/projects/plugins/jetpack/changelog/update-stats-block-loading
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Stats block: better looking loading state in the editor

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/edit.js
@@ -2,9 +2,10 @@ import { numberFormat } from '@automattic/jetpack-components';
 import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { InspectorControls, RichText } from '@wordpress/block-editor';
+import { Animate } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
-import { __, _n } from '@wordpress/i18n';
+import { _n } from '@wordpress/i18n';
 import { BlogStatsInspectorControls } from './controls';
 import { InactiveStatsPlaceholder } from './inactive-placeholder';
 
@@ -70,20 +71,30 @@ function BlogStatsEdit( { attributes, className, setAttributes } ) {
 			</InspectorControls>
 
 			<div className={ className }>
-				{ isLoadingModules || blogViews === null ? (
-					<p className="jetpack-blog-stats__loading">{ __( 'Loading stats…', 'jetpack' ) }</p>
-				) : (
-					<p>
-						<span>{ numberFormat( stats ) } </span>
-						<RichText
-							tagName="span"
-							placeholder={ statsData === 'visitors' ? visitorsPlaceholder : viewsPlaceholder }
-							value={ label }
-							allowedFormats={ [ 'core/bold', 'core/italic', 'core/link' ] }
-							onChange={ newLabel => setAttributes( { label: newLabel } ) }
-						/>
-					</p>
-				) }
+				<p>
+					{ isLoadingModules || blogViews === null ? (
+						<Animate type="loading">
+							{ ( { className: animateClassName } ) => (
+								<span
+									aria-busy="true"
+									aria-live="polite"
+									className={ `jetpack-blog-stats__loading ${ animateClassName }` }
+								>
+									0
+								</span>
+							) }
+						</Animate>
+					) : (
+						<span>{ numberFormat( stats ) }</span>
+					) }{ ' ' }
+					<RichText
+						tagName="span"
+						placeholder={ statsData === 'visitors' ? visitorsPlaceholder : viewsPlaceholder }
+						value={ label }
+						allowedFormats={ [ 'core/bold', 'core/italic', 'core/link' ] }
+						onChange={ newLabel => setAttributes( { label: newLabel } ) }
+					/>
+				</p>
 			</div>
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/editor.scss
@@ -1,7 +1,9 @@
+@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
+
 .wp-block-jetpack-blog-stats {
 	.jetpack-blog-stats__loading {
-		// Same as RichText component's placeholder opacity from Core.
-		opacity: 0.62;
+		color: $gray-100;
+		background: $gray-100;
 	}
 
 	.components-placeholder__fieldset {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Improves loading state visually.

## Proposed changes:

Before
<img width="459" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/dc5effeb-f096-4c19-9cf2-fecc90fdd0d6">


After

https://github.com/Automattic/jetpack/assets/87168/8c8d7156-d9db-43e9-ad54-89d16888313f

You can also edit the label already during loading state.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

