### PR TITLE
Woo Analytics: avoid errors when Jetpack is loaded in mu-plugin

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-mu-plugins-woo-analytics
+++ b/projects/packages/woocommerce-analytics/changelog/fix-mu-plugins-woo-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid any issues when the package is loaded in an mu-plugin.

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -56,6 +56,11 @@ class Woocommerce_Analytics {
 	 * @return bool
 	 */
 	public static function should_track_store() {
+		// Ensure this is available, even with mu-plugins.
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		/**
 		 * Make sure WooCommerce is installed and active
 		 *


### PR DESCRIPTION
Follow-up to #36278, #35758, #35756.

## Proposed changes:

This should avoid errors like this one:

```
Fatal error: Uncaught Error: Call to undefined function Automattic\is_plugin_active()
in /var/www/wp-content/client-mu-plugins/jetpack/jetpack_vendor/automattic/woocommerce-analytics/src/class-woocommerce-analytics.php on line 64
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* No

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* This is easier to test on a VIP Go sandbox.
* Load `trunk`, see the fatal error above.
* Switch to this branch 
     * The Fatal error should be gone.
