### PR TITLE
Newsletter Settings in JP: Display Email settings on Newsletter settings page

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -1,7 +1,6 @@
 import { ToggleControl } from '@automattic/jetpack-components';
-import { ExternalLink, RadioControl } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { FormLegend } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -16,8 +15,6 @@ const subscriptionsAndNewslettersSupportUrl =
 	'https://wordpress.com/support/subscriptions-and-newsletters/';
 const FEATURED_IMAGE_IN_EMAIL_OPTION = 'wpcom_featured_image_in_email';
 const SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION = 'wpcom_subscription_emails_use_excerpt';
-const FULL_TEXT_VALUE = 'full_text';
-const EXCERPT_VALUE = 'excerpt';
 
 const EmailSetting = props => {
 	const {
@@ -36,12 +33,16 @@ const EmailSetting = props => {
 		);
 	}, [ isFeaturedImageInEmailEnabled, updateFormStateAndSaveOptionValue ] );
 
+	const handleSubscriptionEmailsUseFullTextChange = useCallback(
+		value => {
+			updateFormStateAndSaveOptionValue( SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION, ! value );
+		},
+		[ updateFormStateAndSaveOptionValue ]
+	);
+
 	const handleSubscriptionEmailsUseExcerptChange = useCallback(
 		value => {
-			updateFormStateAndSaveOptionValue(
-				SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION,
-				value === EXCERPT_VALUE
-			);
+			updateFormStateAndSaveOptionValue( SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION, value );
 		},
 		[ updateFormStateAndSaveOptionValue ]
 	);
@@ -51,7 +52,7 @@ const EmailSetting = props => {
 	return (
 		<SettingsCard
 			{ ...props }
-			header={ __( 'Email', 'jetpack' ) }
+			header={ __( 'Email configuration', 'jetpack' ) }
 			hideButton
 			module={ SUBSCRIPTIONS_MODULE_NAME }
 			saveDisabled={ disabled }
@@ -61,6 +62,13 @@ const EmailSetting = props => {
 				disableInOfflineMode
 				disableInSiteConnectionMode
 				module={ subscriptionsModule }
+				support={ {
+					link: featuredImageInEmailSupportUrl,
+					text: __(
+						"Includes your post's featured image in the email sent out to your readers.",
+						'jetpack'
+					),
+				} }
 			>
 				<ToggleControl
 					disabled={ disabled }
@@ -69,18 +77,6 @@ const EmailSetting = props => {
 					label={ __( 'Enable featured image on your new post emails', 'jetpack' ) }
 					onChange={ handleEnableFeaturedImageInEmailToggleChange }
 				/>
-
-				<p className="jp-form-setting-explanation">
-					{ createInterpolateElement(
-						__(
-							"Includes your post's featured image in the email sent out to your readers. <a>Learn more about the featured image</a>",
-							'jetpack'
-						),
-						{
-							a: <ExternalLink href={ featuredImageInEmailSupportUrl } />,
-						}
-					) }
-				</p>
 			</SettingsGroup>
 
 			<SettingsGroup
@@ -88,29 +84,33 @@ const EmailSetting = props => {
 				disableInOfflineMode
 				disableInSiteConnectionMode
 				module={ subscriptionsModule }
+				support={ {
+					link: subscriptionsAndNewslettersSupportUrl,
+					text: __(
+						'Sets whether email subscribers can read full posts in emails or just an excerpt and link to the full version of the post.',
+						'jetpack'
+					),
+				} }
 			>
-				<RadioControl
+				<FormLegend className="jp-form-label-wide">
+					{ __( 'For each new post email, include', 'jetpack' ) }
+				</FormLegend>
+
+				<ToggleControl
 					disabled={ disabled }
-					selected={ subscriptionEmailsUseExcerpt ? EXCERPT_VALUE : FULL_TEXT_VALUE }
-					label={ __( 'For each new post email, include', 'jetpack' ) }
-					options={ [
-						{ label: __( 'Full text', 'jetpack' ), value: FULL_TEXT_VALUE },
-						{ label: __( 'Excerpt', 'jetpack' ), value: EXCERPT_VALUE },
-					] }
-					onChange={ handleSubscriptionEmailsUseExcerptChange }
+					checked={ ! subscriptionEmailsUseExcerpt }
+					toogling={ isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] ) }
+					label={ __( 'Full text', 'jetpack' ) }
+					onChange={ handleSubscriptionEmailsUseFullTextChange }
 				/>
 
-				<p className="jp-form-setting-explanation">
-					{ createInterpolateElement(
-						__(
-							'Sets whether email subscribers can read full posts in emails or just an excerpt and link to the full version of the post. <a>Learn more about sending emails</a>',
-							'jetpack'
-						),
-						{
-							a: <ExternalLink href={ subscriptionsAndNewslettersSupportUrl } />,
-						}
-					) }
-				</p>
+				<ToggleControl
+					disabled={ disabled }
+					checked={ subscriptionEmailsUseExcerpt }
+					toogling={ isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] ) }
+					label={ __( 'Excerpt', 'jetpack' ) }
+					onChange={ handleSubscriptionEmailsUseExcerptChange }
+				/>
 			</SettingsGroup>
 		</SettingsCard>
 	);

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -26,18 +26,24 @@ const EmailSetting = props => {
 		unavailableInOfflineMode,
 		isFeaturedImageInEmailEnabled,
 		subscriptionEmailsUseExcerpt,
-		updateFormStateOptionValue,
+		updateFormStateAndSaveOptionValue,
 	} = props;
 
 	const handleEnableFeaturedImageInEmailToggleChange = useCallback( () => {
-		updateFormStateOptionValue( FEATURED_IMAGE_IN_EMAIL_OPTION, ! isFeaturedImageInEmailEnabled );
-	}, [ isFeaturedImageInEmailEnabled, updateFormStateOptionValue ] );
+		updateFormStateAndSaveOptionValue(
+			FEATURED_IMAGE_IN_EMAIL_OPTION,
+			! isFeaturedImageInEmailEnabled
+		);
+	}, [ isFeaturedImageInEmailEnabled, updateFormStateAndSaveOptionValue ] );
 
 	const handleSubscriptionEmailsUseExcerptChange = useCallback(
 		value => {
-			updateFormStateOptionValue( SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION, value === EXCERPT_VALUE );
+			updateFormStateAndSaveOptionValue(
+				SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION,
+				value === EXCERPT_VALUE
+			);
 		},
-		[ updateFormStateOptionValue ]
+		[ updateFormStateAndSaveOptionValue ]
 	);
 
 	const disabled = unavailableInOfflineMode || isSavingAnyOption( [ SUBSCRIPTIONS_MODULE_NAME ] );

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -22,33 +22,25 @@ const EXCERPT_VALUE = 'excerpt';
 const EmailSetting = props => {
 	const {
 		isSavingAnyOption,
-		isSubscriptionsActive,
 		subscriptionsModule,
 		unavailableInOfflineMode,
 		isFeaturedImageInEmailEnabled,
 		subscriptionEmailsUseExcerpt,
-		updateFormStateModuleOption,
+		updateFormStateOptionValue,
 	} = props;
 
 	const handleEnableFeaturedImageInEmailToggleChange = useCallback( () => {
-		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, FEATURED_IMAGE_IN_EMAIL_OPTION );
-	}, [ updateFormStateModuleOption ] );
+		updateFormStateOptionValue( FEATURED_IMAGE_IN_EMAIL_OPTION, ! isFeaturedImageInEmailEnabled );
+	}, [ isFeaturedImageInEmailEnabled, updateFormStateOptionValue ] );
 
 	const handleSubscriptionEmailsUseExcerptChange = useCallback(
 		value => {
-			updateFormStateModuleOption(
-				SUBSCRIPTIONS_MODULE_NAME,
-				SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION,
-				value === EXCERPT_VALUE
-			);
+			updateFormStateOptionValue( SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION, value === EXCERPT_VALUE );
 		},
-		[ updateFormStateModuleOption ]
+		[ updateFormStateOptionValue ]
 	);
 
-	const disabled =
-		! isSubscriptionsActive ||
-		unavailableInOfflineMode ||
-		isSavingAnyOption( [ SUBSCRIPTIONS_MODULE_NAME ] );
+	const disabled = unavailableInOfflineMode || isSavingAnyOption( [ SUBSCRIPTIONS_MODULE_NAME ] );
 
 	return (
 		<SettingsCard
@@ -123,7 +115,6 @@ export default withModuleSettingsFormHelpers(
 		return {
 			moduleName: ownProps.moduleName,
 			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
-			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
 			isSavingAnyOption: ownProps.isSavingAnyOption,
 			isFeaturedImageInEmailEnabled: ownProps.getOptionValue( FEATURED_IMAGE_IN_EMAIL_OPTION ),
 			subscriptionEmailsUseExcerpt: ownProps.getOptionValue(

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -1,0 +1,135 @@
+import { ToggleControl } from '@automattic/jetpack-components';
+import { ExternalLink, RadioControl } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { useCallback } from 'react';
+import { connect } from 'react-redux';
+import { isUnavailableInOfflineMode } from 'state/connection';
+import { getModule } from 'state/modules';
+import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
+
+const featuredImageInEmailSupportUrl = 'https://wordpress.com/support/featured-images/';
+const subscriptionsAndNewslettersSupportUrl =
+	'https://wordpress.com/support/subscriptions-and-newsletters/';
+const FEATURED_IMAGE_IN_EMAIL_OPTION = 'wpcom_featured_image_in_email';
+const SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION = 'wpcom_subscription_emails_use_excerpt';
+const FULL_TEXT_VALUE = 'full_text';
+const EXCERPT_VALUE = 'excerpt';
+
+const EmailSetting = props => {
+	const {
+		isSavingAnyOption,
+		isSubscriptionsActive,
+		subscriptionsModule,
+		unavailableInOfflineMode,
+		isFeaturedImageInEmailEnabled,
+		subscriptionEmailsUseExcerpt,
+		updateFormStateModuleOption,
+	} = props;
+
+	const handleEnableFeaturedImageInEmailToggleChange = useCallback( () => {
+		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, FEATURED_IMAGE_IN_EMAIL_OPTION );
+	}, [ updateFormStateModuleOption ] );
+
+	const handleSubscriptionEmailsUseExcerptChange = useCallback(
+		value => {
+			updateFormStateModuleOption(
+				SUBSCRIPTIONS_MODULE_NAME,
+				SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION,
+				value === EXCERPT_VALUE
+			);
+		},
+		[ updateFormStateModuleOption ]
+	);
+
+	const disabled =
+		! isSubscriptionsActive ||
+		unavailableInOfflineMode ||
+		isSavingAnyOption( [ SUBSCRIPTIONS_MODULE_NAME ] );
+
+	return (
+		<SettingsCard
+			{ ...props }
+			header={ __( 'Email', 'jetpack' ) }
+			hideButton
+			module={ SUBSCRIPTIONS_MODULE_NAME }
+			saveDisabled={ disabled }
+		>
+			<SettingsGroup
+				hasChild
+				disableInOfflineMode
+				disableInSiteConnectionMode
+				module={ subscriptionsModule }
+			>
+				<ToggleControl
+					disabled={ disabled }
+					checked={ isFeaturedImageInEmailEnabled }
+					toogling={ isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] ) }
+					label={ __( 'Enable featured image on your new post emails', 'jetpack' ) }
+					onChange={ handleEnableFeaturedImageInEmailToggleChange }
+				/>
+
+				<p className="jp-form-setting-explanation">
+					{ createInterpolateElement(
+						__(
+							"Includes your post's featured image in the email sent out to your readers. <a>Learn more about the featured image</a>",
+							'jetpack'
+						),
+						{
+							a: <ExternalLink href={ featuredImageInEmailSupportUrl } />,
+						}
+					) }
+				</p>
+			</SettingsGroup>
+
+			<SettingsGroup
+				hasChild
+				disableInOfflineMode
+				disableInSiteConnectionMode
+				module={ subscriptionsModule }
+			>
+				<RadioControl
+					disabled={ disabled }
+					selected={ subscriptionEmailsUseExcerpt ? EXCERPT_VALUE : FULL_TEXT_VALUE }
+					label={ __( 'For each new post email, include', 'jetpack' ) }
+					options={ [
+						{ label: __( 'Full text', 'jetpack' ), value: FULL_TEXT_VALUE },
+						{ label: __( 'Excerpt', 'jetpack' ), value: EXCERPT_VALUE },
+					] }
+					onChange={ handleSubscriptionEmailsUseExcerptChange }
+				/>
+
+				<p className="jp-form-setting-explanation">
+					{ createInterpolateElement(
+						__(
+							'Sets whether email subscribers can read full posts in emails or just an excerpt and link to the full version of the post. <a>Learn more about sending emails</a>',
+							'jetpack'
+						),
+						{
+							a: <ExternalLink href={ subscriptionsAndNewslettersSupportUrl } />,
+						}
+					) }
+				</p>
+			</SettingsGroup>
+		</SettingsCard>
+	);
+};
+
+export default withModuleSettingsFormHelpers(
+	connect( ( state, ownProps ) => {
+		return {
+			moduleName: ownProps.moduleName,
+			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
+			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
+			isSavingAnyOption: ownProps.isSavingAnyOption,
+			isFeaturedImageInEmailEnabled: ownProps.getOptionValue( FEATURED_IMAGE_IN_EMAIL_OPTION ),
+			subscriptionEmailsUseExcerpt: ownProps.getOptionValue(
+				SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION
+			),
+			unavailableInOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
+		};
+	} )( EmailSetting )
+);

--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { getModule } from 'state/modules';
 import { isModuleFound as isModuleFoundSelector } from 'state/search';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
+import EmailSettings from './email-settings';
 import MessagesSetting from './messages-setting';
 import NewsletterCategories from './newsletter-categories';
 import SubscriptionsSettings from './subscriptions-settings';
@@ -12,7 +13,7 @@ import SubscriptionsSettings from './subscriptions-settings';
 //Check for feature flag
 const urlParams = new URLSearchParams( window.location.search );
 const isNewsletterCategoriesEnabled = urlParams.get( 'enable-newsletter-categories' ) === 'true';
-
+const isEmailSettingsEnabled = urlParams.get( 'enable-email-settings' ) === 'true';
 /**
  * Newsletter Section.
  *
@@ -48,6 +49,7 @@ function Subscriptions( props ) {
 			{ foundSubscriptions && (
 				<SubscriptionsSettings siteRawUrl={ siteRawUrl } blogID={ blogID } />
 			) }
+			{ isEmailSettingsEnabled && <EmailSettings /> }
 			{ isNewsletterCategoriesEnabled && <NewsletterCategories /> }
 			<MessagesSetting { ...props } />
 		</div>

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2259,7 +2259,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		$options = array(
 			// Blocks.
-			'jetpack_blocks_disabled'              => array(
+			'jetpack_blocks_disabled'               => array(
 				'description'       => esc_html__( 'Jetpack Blocks disabled.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => false,
@@ -2268,7 +2268,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Carousel
-			'carousel_background_color'            => array(
+			'carousel_background_color'             => array(
 				'description'       => esc_html__( 'Color scheme.', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => 'black',
@@ -2283,7 +2283,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_list_item',
 				'jp_group'          => 'carousel',
 			),
-			'carousel_display_exif'                => array(
+			'carousel_display_exif'                 => array(
 				'description'       => wp_kses(
 					sprintf( __( 'Show photo metadata (<a href="https://en.wikipedia.org/wiki/Exchangeable_image_file_format" target="_blank">Exif</a>) in carousel, when available.', 'jetpack' ) ),
 					array(
@@ -2298,7 +2298,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'carousel',
 			),
-			'carousel_display_comments'            => array(
+			'carousel_display_comments'             => array(
 				'description'       => esc_html__( 'Show comments area in carousel', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
@@ -2307,14 +2307,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Comments.
-			'highlander_comment_form_prompt'       => array(
+			'highlander_comment_form_prompt'        => array(
 				'description'       => esc_html__( 'Greeting Text', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => esc_html__( 'Leave a Reply', 'jetpack' ),
 				'sanitize_callback' => 'sanitize_text_field',
 				'jp_group'          => 'comments',
 			),
-			'jetpack_comment_form_color_scheme'    => array(
+			'jetpack_comment_form_color_scheme'     => array(
 				'description'       => esc_html__( 'Color scheme', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => 'light',
@@ -2333,28 +2333,28 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Custom Content Types.
-			'jetpack_portfolio'                    => array(
+			'jetpack_portfolio'                     => array(
 				'description'       => esc_html__( 'Enable or disable Jetpack portfolio post type.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'custom-content-types',
 			),
-			'jetpack_portfolio_posts_per_page'     => array(
+			'jetpack_portfolio_posts_per_page'      => array(
 				'description'       => esc_html__( 'Number of entries to show at most in Portfolio pages.', 'jetpack' ),
 				'type'              => 'integer',
 				'default'           => 10,
 				'validate_callback' => __CLASS__ . '::validate_posint',
 				'jp_group'          => 'custom-content-types',
 			),
-			'jetpack_testimonial'                  => array(
+			'jetpack_testimonial'                   => array(
 				'description'       => esc_html__( 'Enable or disable Jetpack testimonial post type.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'custom-content-types',
 			),
-			'jetpack_testimonial_posts_per_page'   => array(
+			'jetpack_testimonial_posts_per_page'    => array(
 				'description'       => esc_html__( 'Number of entries to show at most in Testimonial pages.', 'jetpack' ),
 				'type'              => 'integer',
 				'default'           => 10,
@@ -2363,21 +2363,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// WAF.
-			'jetpack_waf_automatic_rules'          => array(
+			'jetpack_waf_automatic_rules'           => array(
 				'description'       => esc_html__( 'Enable automatic rules - Protect your site against untrusted traffic sources with automatic security rules.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => Waf_Compatibility::get_default_automatic_rules_option(),
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'waf',
 			),
-			'jetpack_waf_ip_list'                  => array(
+			'jetpack_waf_ip_list'                   => array(
 				'description'       => esc_html__( 'Allow / Block list - Block or allow a specific request IP.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'waf',
 			),
-			'jetpack_waf_ip_block_list'            => array(
+			'jetpack_waf_ip_block_list'             => array(
 				'description'       => esc_html__( 'Blocked IP addresses', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -2385,7 +2385,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'sanitize_callback' => 'esc_textarea',
 				'jp_group'          => 'waf',
 			),
-			'jetpack_waf_ip_allow_list'            => array(
+			'jetpack_waf_ip_allow_list'             => array(
 				'description'       => esc_html__( 'Always allowed IP addresses', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -2393,7 +2393,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'sanitize_callback' => 'esc_textarea',
 				'jp_group'          => 'settings',
 			),
-			'jetpack_waf_share_data'               => array(
+			'jetpack_waf_share_data'                => array(
 				'description'       => esc_html__( 'Share data with Jetpack.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2401,7 +2401,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'waf',
 			),
 			// Galleries.
-			'tiled_galleries'                      => array(
+			'tiled_galleries'                       => array(
 				'description'       => esc_html__( 'Display all your gallery pictures in a cool mosaic.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2409,7 +2409,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'tiled-gallery',
 			),
 
-			'gravatar_disable_hovercards'          => array(
+			'gravatar_disable_hovercards'           => array(
 				'description'       => esc_html__( "View people's profiles when you mouse over their Gravatars", 'jetpack' ),
 				'type'              => 'string',
 				'default'           => 'enabled',
@@ -2427,14 +2427,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Infinite Scroll.
-			'infinite_scroll'                      => array(
+			'infinite_scroll'                       => array(
 				'description'       => esc_html__( 'To infinity and beyond', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'infinite-scroll',
 			),
-			'infinite_scroll_google_analytics'     => array(
+			'infinite_scroll_google_analytics'      => array(
 				'description'       => esc_html__( 'Use Google Analytics with Infinite Scroll', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2443,7 +2443,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Likes.
-			'wpl_default'                          => array(
+			'wpl_default'                           => array(
 				'description'       => esc_html__( 'WordPress.com Likes are', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => 'on',
@@ -2458,7 +2458,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_list_item',
 				'jp_group'          => 'likes',
 			),
-			'social_notifications_like'            => array(
+			'social_notifications_like'             => array(
 				'description'       => esc_html__( 'Send email notification when someone likes a post', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
@@ -2467,14 +2467,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Markdown.
-			'wpcom_publish_comments_with_markdown' => array(
+			'wpcom_publish_comments_with_markdown'  => array(
 				'description'       => esc_html__( 'Use Markdown for comments.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'markdown',
 			),
-			'wpcom_publish_posts_with_markdown'    => array(
+			'wpcom_publish_posts_with_markdown'     => array(
 				'description'       => esc_html__( 'Use Markdown for posts.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2483,7 +2483,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Monitor.
-			'monitor_receive_notifications'        => array(
+			'monitor_receive_notifications'         => array(
 				'description'       => esc_html__( 'Receive Monitor Email Notifications.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2492,7 +2492,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Post by Email.
-			'post_by_email_address'                => array(
+			'post_by_email_address'                 => array(
 				'description'       => esc_html__( 'Email Address', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => 'noop',
@@ -2513,14 +2513,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Protect.
-			'jetpack_protect_key'                  => array(
+			'jetpack_protect_key'                   => array(
 				'description'       => esc_html__( 'Protect API key', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_alphanum',
 				'jp_group'          => 'protect',
 			),
-			'jetpack_protect_global_whitelist'     => array(
+			'jetpack_protect_global_whitelist'      => array(
 				'description'       => esc_html__( 'Protect global IP allow list', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -2530,7 +2530,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Sharing.
-			'sharing_services'                     => array(
+			'sharing_services'                      => array(
 				'description'       => esc_html__( 'Enabled Services and those hidden behind a button', 'jetpack' ),
 				'type'              => 'object',
 				'default'           => array(
@@ -2540,7 +2540,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_services',
 				'jp_group'          => 'sharedaddy',
 			),
-			'button_style'                         => array(
+			'button_style'                          => array(
 				'description'       => esc_html__( 'Button Style', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => 'icon',
@@ -2559,7 +2559,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_list_item',
 				'jp_group'          => 'sharedaddy',
 			),
-			'sharing_label'                        => array(
+			'sharing_label'                         => array(
 				'description'       => esc_html__( 'Sharing Label', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -2567,7 +2567,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'sanitize_callback' => 'esc_html',
 				'jp_group'          => 'sharedaddy',
 			),
-			'show'                                 => array(
+			'show'                                  => array(
 				'description'       => esc_html__( 'Views where buttons are shown', 'jetpack' ),
 				'type'              => 'array',
 				'items'             => array(
@@ -2577,7 +2577,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_sharing_show',
 				'jp_group'          => 'sharedaddy',
 			),
-			'jetpack-twitter-cards-site-tag'       => array(
+			'jetpack-twitter-cards-site-tag'        => array(
 				'description'       => esc_html__( "The Twitter username of the owner of this site's domain.", 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -2585,14 +2585,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'sanitize_callback' => 'esc_html',
 				'jp_group'          => 'sharedaddy',
 			),
-			'sharedaddy_disable_resources'         => array(
+			'sharedaddy_disable_resources'          => array(
 				'description'       => esc_html__( 'Disable CSS and JS', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'sharedaddy',
 			),
-			'custom'                               => array(
+			'custom'                                => array(
 				'description'       => esc_html__( 'Custom sharing services added by user.', 'jetpack' ),
 				'type'              => 'object',
 				'default'           => array(
@@ -2604,7 +2604,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'sharedaddy',
 			),
 			// Not an option, but an action that can be performed on the list of custom services passing the service ID.
-			'sharing_delete_service'               => array(
+			'sharing_delete_service'                => array(
 				'description'       => esc_html__( 'Delete custom sharing service.', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -2613,14 +2613,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// SSO.
-			'jetpack_sso_require_two_step'         => array(
+			'jetpack_sso_require_two_step'          => array(
 				'description'       => esc_html__( 'Require Two-Step Authentication', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'sso',
 			),
-			'jetpack_sso_match_by_email'           => array(
+			'jetpack_sso_match_by_email'            => array(
 				'description'       => esc_html__( 'Match by Email', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
@@ -2629,35 +2629,49 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Subscriptions.
-			'stb_enabled'                          => array(
+			'stb_enabled'                           => array(
 				'description'       => esc_html__( "Show a <em>'follow blog'</em> option in the comment form", 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
-			'stc_enabled'                          => array(
+			'stc_enabled'                           => array(
 				'description'       => esc_html__( "Show a <em>'follow comments'</em> option in the comment form", 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
-			'wpcom_newsletter_categories'          => array(
+			'wpcom_newsletter_categories'           => array(
 				'description'       => esc_html__( 'Array of post category ids that are marked as newsletter categories', 'jetpack' ),
 				'type'              => 'array',
 				'default'           => array(),
 				'validate_callback' => __CLASS__ . '::validate_array',
 				'jp_group'          => 'subscriptions',
 			),
-			'wpcom_newsletter_categories_enabled'  => array(
+			'wpcom_newsletter_categories_enabled'   => array(
 				'description'       => esc_html__( 'Whether the newsletter categories are enabled or not', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
-			'sm_enabled'                           => array(
+			'wpcom_featured_image_in_email'         => array(
+				'description'       => esc_html__( 'Whether to include the featured image in the email or not', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 1,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'subscriptions',
+			),
+			'wpcom_subscription_emails_use_excerpt' => array(
+				'description'       => esc_html__( 'Whether to use the excerpt in the email or not', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 1,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'subscriptions',
+			),
+			'sm_enabled'                            => array(
 				'description'       => esc_html__( 'Show popup Subscribe modal to readers.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2671,14 +2685,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
-			'social_notifications_subscribe'       => array(
+			'social_notifications_subscribe'        => array(
 				'description'       => esc_html__( 'Send email notification when someone subscribes to my blog', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
-			'subscription_options'                 => array(
+			'subscription_options'                  => array(
 				'description'       => esc_html__( 'Three options used in subscription email templates: \'invitation\', \'welcome\' and \'comment_follow\'.', 'jetpack' ),
 				'type'              => 'object',
 				'default'           => array(
@@ -2691,14 +2705,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Related Posts.
-			'show_headline'                        => array(
+			'show_headline'                         => array(
 				'description'       => esc_html__( 'Highlight related content with a heading', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'related-posts',
 			),
-			'show_thumbnails'                      => array(
+			'show_thumbnails'                       => array(
 				'description'       => esc_html__( 'Show a thumbnail image where available', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2707,7 +2721,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Search.
-			'instant_search_enabled'               => array(
+			'instant_search_enabled'                => array(
 				'description'       => esc_html__( 'Enable Instant Search', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2715,7 +2729,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'search',
 			),
 
-			'has_jetpack_search_product'           => array(
+			'has_jetpack_search_product'            => array(
 				'description'       => esc_html__( 'Has an active Jetpack Search product purchase', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2723,7 +2737,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
-			'search_auto_config'                   => array(
+			'search_auto_config'                    => array(
 				'description'       => esc_html__( 'Trigger an auto config of instant search', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2732,35 +2746,35 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Verification Tools.
-			'google'                               => array(
+			'google'                                => array(
 				'description'       => esc_html__( 'Google Search Console', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_verification_service',
 				'jp_group'          => 'verification-tools',
 			),
-			'bing'                                 => array(
+			'bing'                                  => array(
 				'description'       => esc_html__( 'Bing Webmaster Center', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_verification_service',
 				'jp_group'          => 'verification-tools',
 			),
-			'pinterest'                            => array(
+			'pinterest'                             => array(
 				'description'       => esc_html__( 'Pinterest Site Verification', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_verification_service',
 				'jp_group'          => 'verification-tools',
 			),
-			'yandex'                               => array(
+			'yandex'                                => array(
 				'description'       => esc_html__( 'Yandex Site Verification', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_verification_service',
 				'jp_group'          => 'verification-tools',
 			),
-			'facebook'                             => array(
+			'facebook'                              => array(
 				'description'       => esc_html__( 'Facebook Domain Verification', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -2769,63 +2783,63 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// WordAds.
-			'enable_header_ad'                     => array(
+			'enable_header_ad'                      => array(
 				'description'       => esc_html__( 'Display an ad unit at the top of each page.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_approved'                     => array(
+			'wordads_approved'                      => array(
 				'description'       => esc_html__( 'Is site approved for WordAds?', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_second_belowpost'             => array(
+			'wordads_second_belowpost'              => array(
 				'description'       => esc_html__( 'Display second ad below post?', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_display_front_page'           => array(
+			'wordads_display_front_page'            => array(
 				'description'       => esc_html__( 'Display ads on the front page?', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_display_post'                 => array(
+			'wordads_display_post'                  => array(
 				'description'       => esc_html__( 'Display ads on posts?', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_display_page'                 => array(
+			'wordads_display_page'                  => array(
 				'description'       => esc_html__( 'Display ads on pages?', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_display_archive'              => array(
+			'wordads_display_archive'               => array(
 				'description'       => esc_html__( 'Display ads on archive pages?', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_custom_adstxt_enabled'        => array(
+			'wordads_custom_adstxt_enabled'         => array(
 				'description'       => esc_html__( 'Custom ads.txt', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_custom_adstxt'                => array(
+			'wordads_custom_adstxt'                 => array(
 				'description'       => esc_html__( 'Custom ads.txt entries', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -2833,14 +2847,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'sanitize_callback' => 'sanitize_textarea_field',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_ccpa_enabled'                 => array(
+			'wordads_ccpa_enabled'                  => array(
 				'description'       => esc_html__( 'Enable support for California Consumer Privacy Act', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_ccpa_privacy_policy_url'      => array(
+			'wordads_ccpa_privacy_policy_url'       => array(
 				'description'       => esc_html__( 'Privacy Policy URL', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -2848,7 +2862,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'sanitize_callback' => 'sanitize_text_field',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_cmp_enabled'                  => array(
+			'wordads_cmp_enabled'                   => array(
 				'description'       => esc_html__( 'Enable GDPR Consent Management Banner for WordAds', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2857,7 +2871,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Google Analytics.
-			'google_analytics_tracking_id'         => array(
+			'google_analytics_tracking_id'          => array(
 				'description'       => esc_html__( 'Google Analytics', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -2866,21 +2880,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Stats.
-			'admin_bar'                            => array(
+			'admin_bar'                             => array(
 				'description'       => esc_html__( 'Include a small chart in your admin bar with a 48-hour traffic snapshot.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'stats',
 			),
-			'enable_odyssey_stats'                 => array(
+			'enable_odyssey_stats'                  => array(
 				'description'       => esc_html__( 'Preview the new Jetpack Stats experience (Experimental).', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'stats',
 			),
-			'roles'                                => array(
+			'roles'                                 => array(
 				'description'       => esc_html__( 'Select the roles that will be able to view stats reports.', 'jetpack' ),
 				'type'              => 'array',
 				'items'             => array(
@@ -2891,7 +2905,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'sanitize_callback' => __CLASS__ . '::sanitize_stats_allowed_roles',
 				'jp_group'          => 'stats',
 			),
-			'count_roles'                          => array(
+			'count_roles'                           => array(
 				'description'       => esc_html__( 'Count the page views of registered users who are logged in.', 'jetpack' ),
 				'type'              => 'array',
 				'items'             => array(
@@ -2901,28 +2915,28 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_stats_roles',
 				'jp_group'          => 'stats',
 			),
-			'blog_id'                              => array(
+			'blog_id'                               => array(
 				'description'       => esc_html__( 'Blog ID.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'stats',
 			),
-			'do_not_track'                         => array(
+			'do_not_track'                          => array(
 				'description'       => esc_html__( 'Do not track.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'stats',
 			),
-			'version'                              => array(
+			'version'                               => array(
 				'description'       => esc_html__( 'Version.', 'jetpack' ),
 				'type'              => 'integer',
 				'default'           => 9,
 				'validate_callback' => __CLASS__ . '::validate_posint',
 				'jp_group'          => 'stats',
 			),
-			'collapse_nudges'                      => array(
+			'collapse_nudges'                       => array(
 				'description'       => esc_html__( 'Collapse upgrade nudges', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2931,7 +2945,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Whether to share stats views with WordPress.com Reader.
-			'wpcom_reader_views_enabled'           => array(
+			'wpcom_reader_views_enabled'            => array(
 				'description'       => esc_html__( 'Show post views in the WordPress.com Reader.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
@@ -2940,7 +2954,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Akismet - Not a module, but a plugin. The options can be passed and handled differently.
-			'akismet_show_user_comments_approved'  => array(
+			'akismet_show_user_comments_approved'   => array(
 				'description'       => '',
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2948,7 +2962,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
-			'wordpress_api_key'                    => array(
+			'wordpress_api_key'                     => array(
 				'description'       => '',
 				'type'              => 'string',
 				'default'           => '',
@@ -2957,7 +2971,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Empty stats card dismiss.
-			'dismiss_empty_stats_card'             => array(
+			'dismiss_empty_stats_card'              => array(
 				'description'       => '',
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2966,7 +2980,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Backup Getting Started card on dashboard.
-			'dismiss_dash_backup_getting_started'  => array(
+			'dismiss_dash_backup_getting_started'   => array(
 				'description'       => '',
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2975,7 +2989,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Agencies Learn More card on dashboard.
-			'dismiss_dash_agencies_learn_more'     => array(
+			'dismiss_dash_agencies_learn_more'      => array(
 				'description'       => '',
 				'type'              => 'boolean',
 				'default'           => 0,
@@ -2983,14 +2997,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
-			'lang_id'                              => array(
+			'lang_id'                               => array(
 				'description' => esc_html__( 'Primary language for the site.', 'jetpack' ),
 				'type'        => 'string',
 				'default'     => 'en_US',
 				'jp_group'    => 'settings',
 			),
 
-			'onboarding'                           => array(
+			'onboarding'                            => array(
 				'description'       => '',
 				'type'              => 'object',
 				'default'           => array(
@@ -3013,7 +3027,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// SEO Tools.
-			'advanced_seo_front_page_description'  => array(
+			'advanced_seo_front_page_description'   => array(
 				'description'       => esc_html__( 'Front page meta description.', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
@@ -3021,7 +3035,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'seo-tools',
 			),
 
-			'advanced_seo_title_formats'           => array(
+			'advanced_seo_title_formats'            => array(
 				'description'       => esc_html__( 'SEO page title structures.', 'jetpack' ),
 				'type'              => 'object',
 				'default'           => array(
@@ -3037,7 +3051,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// VideoPress.
-			'videopress_private_enabled_for_site'  => array(
+			'videopress_private_enabled_for_site'   => array(
 				'description'       => esc_html__( 'Video Privacy: Restrict views to members of this site', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -984,6 +984,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				case 'stc_enabled':
 				case 'sm_enabled':
 				case 'wpcom_newsletter_categories_enabled':
+				case 'wpcom_featured_image_in_email':
+				case 'wpcom_subscription_emails_use_excerpt':
 				case 'jetpack_subscriptions_subscribe_post_end_enabled':
 					// Convert the false value to 0. This allows the option to be updated if it doesn't exist yet.
 					$sub_value = $value ? $value : 0;

--- a/projects/plugins/jetpack/changelog/add-email-settings
+++ b/projects/plugins/jetpack/changelog/add-email-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Display Email settings on Newsletter settings page


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/88308
Closes https://github.com/Automattic/wp-calypso/issues/88307
Closes https://github.com/Automattic/wp-calypso/issues/88306

## Proposed changes:

* Create EmailSettings component
* Display Email settings on Newsletter settings page
* Update API to support feature image and excerpt options

<img width="1089" alt="image" src="https://github.com/Automattic/jetpack/assets/3113712/de5749f8-0122-4e4c-833c-99ad946fdee0">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Apply this patch to your JT site
* Go to the Newsletter settings page with the feature flag enabled: `{your-site}/wp-admin/admin.php?enable-email-settings=true&page=jetpack#/newsletter`
* The Email settings module should be displayed
* Perform tests on both Featured Image and Excerpt inputs, verify if the data is correctly synced with the settings on wpcom
* Remove the feature flag to make sure it is not displayed without the flag

