### PR TITLE
WPCOM_JSON_API_Upload_Media_v1_1_Endpoint: Be defensive about uploads without $media_item['type'] set

### DIFF
--- a/projects/plugins/jetpack/changelog/update-upload-media-wpcom
+++ b/projects/plugins/jetpack/changelog/update-upload-media-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WPCOM_JSON_API_Upload_Media_v1_1_Endpoint: Fix errors on invalid post data

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
@@ -275,7 +275,7 @@ class WPCOM_JSON_API_Upload_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 		}
 
 		foreach ( $media_files as $media_item ) {
-			if ( ! preg_match( '@^video/@', $media_item['type'] ) ) {
+			if ( ! isset( $media_item['type'] ) || ! preg_match( '@^video/@', $media_item['type'] ) ) {
 				return false;
 			}
 		}


### PR DESCRIPTION
Fixes this fatal error:
```
 Fatal error: Uncaught TypeError: Cannot access offset of type string on string in (jetpack)/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php:278
```
This doesn't seem to happen in normal operation; it seems to only happen with malformed or suspicious posts.


## Proposed changes:

* In the case that `$media_item` is a string, or `$media_item['type']` is not set, exit early instead of running a regex against a non-existent `$media_item['type']`.

## Jetpack product discussion

<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Manual inspection, or
  * Old condition: `if ( ! preg_match( '@^video/@', $media_item['type'] ) ) `, an unset $media_item['type'] would cause the preg match to be false and the `if` condition to be true
  * New condition: `	if ( ! isset( $media_item['type'] ) || ! preg_match( '@^video/@', $media_item['type'] ) )`, same as before, an unset $media_item['type'] would cause the `if` condition to be true
* Alternatively, 
* Apply D141300-code, use a WoA dev site with the `JETPACK__SANDBOX_DOMAIN` pointed at your PHP 8 sandbox
* Visit the calypso media gallery and verify uploading images and videos still works

