### PR TITLE
Scheduled Updates: Fix allowlisting autoupdates

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-autoupdate-allowlist
+++ b/projects/packages/scheduled-updates/changelog/fix-autoupdate-allowlist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug where plugin autoupdates were no longer allowlisted after switching away from the jetpack_update_schedules option.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -90,10 +90,13 @@ class Scheduled_Updates {
 	 */
 	public static function allowlist_scheduled_plugins( $update, $item ) {
 		if ( Constants::get_constant( 'SCHEDULED_AUTOUPDATE' ) ) {
-			$schedules = get_option( 'jetpack_update_schedules', array() );
+			if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
+				require_once __DIR__ . '/pluggable.php';
+			}
 
-			foreach ( $schedules as $plugins ) {
-				if ( isset( $item->plugin ) && in_array( $item->plugin, $plugins, true ) ) {
+			$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+			foreach ( $events as $event ) {
+				if ( isset( $item->plugin ) && in_array( $item->plugin, $event->args, true ) ) {
 					return true;
 				}
 			}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Switches relying on the option we no longer use to the event as the source of truth.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this diff on a WoA site.
* Create a schedule that executes soon
* Manually edit a plugin that is part of the schedule to have a lower version and visit `/wp-admin/plugins.php` to trigger an update check.
* Once the schedule ran, make sure the plugin actually got updated.
