### PR TITLE
Update/jetpack app qr code media dropdown list

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-app-qr-code-media-dropdown-list
+++ b/projects/plugins/jetpack/changelog/update-jetpack-app-qr-code-media-dropdown-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+minot change the the menu for selecting images

--- a/projects/plugins/jetpack/changelog/update-jetpack-app-qr-code-media-dropdown-list
+++ b/projects/plugins/jetpack/changelog/update-jetpack-app-qr-code-media-dropdown-list
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-minot change the the menu for selecting images
+minor change the the menu for selecting images

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-sources.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-sources.js
@@ -1,13 +1,27 @@
 import { MenuItem } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { mediaSources } from '../sources';
+import { internalMediaSources, externalMediaSources } from '../sources';
 
 function MediaSources( { originalButton = null, onClick = () => {}, open, setSource } ) {
 	return (
 		<Fragment>
 			{ originalButton && originalButton( { open } ) }
+			{ internalMediaSources.map( ( { icon, id, label } ) => (
+				<MenuItem
+					icon={ icon }
+					key={ id }
+					onClick={ () => {
+						onClick();
+						setSource( id );
+					} }
+				>
+					{ label }
+				</MenuItem>
+			) ) }
 
-			{ mediaSources.map( ( { icon, id, label } ) => (
+			<hr style={ { marginLeft: '-8px', marginRight: '-8px' } } />
+
+			{ externalMediaSources.map( ( { icon, id, label } ) => (
 				<MenuItem
 					icon={ icon }
 					key={ id }

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/index.js
@@ -12,7 +12,16 @@ import JetpackAppMedia from './jetpack-app-media';
 import OpenverseMedia from './openverse';
 import PexelsMedia from './pexels';
 
-export const mediaSources = [
+export const internalMediaSources = [
+	{
+		id: SOURCE_JETPACK_APP_MEDIA,
+		label: __( 'Your Phone', 'jetpack' ),
+		icon: <JetpackMobileAppIcon className="components-menu-items__item-icon" />,
+		keyword: 'jetpack mobile app',
+	},
+];
+
+export const externalMediaSources = [
 	{
 		id: SOURCE_GOOGLE_PHOTOS,
 		label: __( 'Google Photos', 'jetpack' ),
@@ -31,13 +40,9 @@ export const mediaSources = [
 		icon: <OpenverseIcon className="components-menu-items__item-icon" />,
 		keyword: 'openverse',
 	},
-	{
-		id: SOURCE_JETPACK_APP_MEDIA,
-		label: __( 'Your Phone', 'jetpack' ),
-		icon: <JetpackMobileAppIcon className="components-menu-items__item-icon" />,
-		keyword: 'jetpack mobile app',
-	},
 ];
+
+export const mediaSources = externalMediaSources.concat( internalMediaSources );
 
 export function canDisplayPlaceholder( props ) {
 	const { disableMediaButtons, dropZoneUIOnly } = props;

--- a/projects/plugins/jetpack/extensions/shared/icons.js
+++ b/projects/plugins/jetpack/extensions/shared/icons.js
@@ -237,9 +237,16 @@ export const JetpackLogo = ( { size = 24, border = 0, className, color = COLOR_J
 	);
 };
 
-export const JetpackMobileAppIcon = () => {
+export const JetpackMobileAppIcon = props => {
 	return (
-		<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<SVG
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			{ ...props }
+		>
 			<Rect width="24" height="24" rx="5" fill="#069E08" />
 			<G clipPath="url(#clip0_2_1297)">
 				<Path


### PR DESCRIPTION
This PR implementes the change suggested here https://github.com/Automattic/jetpack/pull/36233#issuecomment-1983131762

Before:
<img width="678" alt="Screenshot 2024-03-08 at 10 06 27 AM" src="https://github.com/Automattic/jetpack/assets/115071/56da2fab-ab48-4c34-ab51-42108da05fcb">


After:
<img width="600" alt="Screenshot 2024-03-15 at 11 03 00 AM" src="https://github.com/Automattic/jetpack/assets/115071/04061b39-7a00-4887-bc87-3c7efd475c5b">


Note: I tried to use the MenuGroup https://developer.wordpress.org/block-editor/reference-guides/components/menu-group/ component but it didn't work out. See

<img width="639" alt="Screenshot 2024-03-08 at 10 14 13 AM" src="https://github.com/Automattic/jetpack/assets/115071/43eda960-8abf-48b8-bae5-cc4d1ccd6a2e">

## Proposed changes:
* Groups Media Library and Your Phone and the external media sources. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Load the editor. 
Insert a Image block. 
Click select image button. 

Notice the new grouping. 


