### PR TITLE
Newsletter Settings in JP: Fixes disable state for Newsletter settings inputs while saving

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -6,7 +6,7 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { useCallback } from 'react';
 import { connect } from 'react-redux';
-import { isUnavailableInOfflineMode } from 'state/connection';
+import { isUnavailableInOfflineMode, isUnavailableInSiteConnectionMode } from 'state/connection';
 import { getModule } from 'state/modules';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
@@ -24,6 +24,7 @@ const EmailSetting = props => {
 		isFeaturedImageInEmailEnabled,
 		subscriptionEmailsUseExcerpt,
 		updateFormStateAndSaveOptionValue,
+		unavailableInSiteConnectionMode,
 	} = props;
 
 	const handleEnableFeaturedImageInEmailToggleChange = useCallback( () => {
@@ -47,7 +48,10 @@ const EmailSetting = props => {
 		[ updateFormStateAndSaveOptionValue ]
 	);
 
-	const disabled = unavailableInOfflineMode || isSavingAnyOption( [ SUBSCRIPTIONS_MODULE_NAME ] );
+	const disabled = unavailableInOfflineMode || unavailableInSiteConnectionMode;
+	const featuredImageDisabled = disabled || isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] );
+	const excerptDisabled =
+		disabled || isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] );
 
 	return (
 		<SettingsCard
@@ -71,7 +75,7 @@ const EmailSetting = props => {
 				} }
 			>
 				<ToggleControl
-					disabled={ disabled }
+					disabled={ featuredImageDisabled }
 					checked={ isFeaturedImageInEmailEnabled }
 					toogling={ isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] ) }
 					label={ __( 'Enable featured image on your new post emails', 'jetpack' ) }
@@ -97,7 +101,7 @@ const EmailSetting = props => {
 				</FormLegend>
 
 				<ToggleControl
-					disabled={ disabled }
+					disabled={ excerptDisabled }
 					checked={ ! subscriptionEmailsUseExcerpt }
 					toogling={ isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] ) }
 					label={ __( 'Full text', 'jetpack' ) }
@@ -105,7 +109,7 @@ const EmailSetting = props => {
 				/>
 
 				<ToggleControl
-					disabled={ disabled }
+					disabled={ excerptDisabled }
 					checked={ subscriptionEmailsUseExcerpt }
 					toogling={ isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] ) }
 					label={ __( 'Excerpt', 'jetpack' ) }
@@ -127,6 +131,10 @@ export default withModuleSettingsFormHelpers(
 				SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION
 			),
 			unavailableInOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
+			unavailableInSiteConnectionMode: isUnavailableInSiteConnectionMode(
+				state,
+				SUBSCRIPTIONS_MODULE_NAME
+			),
 		};
 	} )( EmailSetting )
 );

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -49,8 +49,9 @@ const EmailSetting = props => {
 	);
 
 	const disabled = unavailableInOfflineMode || unavailableInSiteConnectionMode;
-	const featuredImageDisabled = disabled || isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] );
-	const excerptDisabled =
+	const featuredImageInputDisabled =
+		disabled || isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] );
+	const excerptInputDisabled =
 		disabled || isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] );
 
 	return (
@@ -75,7 +76,7 @@ const EmailSetting = props => {
 				} }
 			>
 				<ToggleControl
-					disabled={ featuredImageDisabled }
+					disabled={ featuredImageInputDisabled }
 					checked={ isFeaturedImageInEmailEnabled }
 					toogling={ isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] ) }
 					label={ __( 'Enable featured image on your new post emails', 'jetpack' ) }
@@ -101,7 +102,7 @@ const EmailSetting = props => {
 				</FormLegend>
 
 				<ToggleControl
-					disabled={ excerptDisabled }
+					disabled={ excerptInputDisabled }
 					checked={ ! subscriptionEmailsUseExcerpt }
 					toogling={ isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] ) }
 					label={ __( 'Full text', 'jetpack' ) }
@@ -109,7 +110,7 @@ const EmailSetting = props => {
 				/>
 
 				<ToggleControl
-					disabled={ excerptDisabled }
+					disabled={ excerptInputDisabled }
 					checked={ subscriptionEmailsUseExcerpt }
 					toogling={ isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] ) }
 					label={ __( 'Excerpt', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -14,6 +14,7 @@ import SubscriptionsSettings from './subscriptions-settings';
 const urlParams = new URLSearchParams( window.location.search );
 const isNewsletterCategoriesEnabled = urlParams.get( 'enable-newsletter-categories' ) === 'true';
 const isEmailSettingsEnabled = urlParams.get( 'enable-email-settings' ) === 'true';
+
 /**
  * Newsletter Section.
  *
@@ -47,11 +48,13 @@ function Subscriptions( props ) {
 					  ) }
 			</h2>
 			{ foundSubscriptions && (
-				<SubscriptionsSettings siteRawUrl={ siteRawUrl } blogID={ blogID } />
+				<>
+					<SubscriptionsSettings siteRawUrl={ siteRawUrl } blogID={ blogID } />
+					{ isEmailSettingsEnabled && <EmailSettings /> }
+					{ isNewsletterCategoriesEnabled && <NewsletterCategories /> }
+					<MessagesSetting { ...props } />
+				</>
 			) }
-			{ isEmailSettingsEnabled && <EmailSettings /> }
-			{ isNewsletterCategoriesEnabled && <NewsletterCategories /> }
-			<MessagesSetting { ...props } />
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/messages-setting.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/messages-setting.jsx
@@ -5,12 +5,22 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
+import { isUnavailableInOfflineMode, isUnavailableInSiteConnectionMode } from 'state/connection';
 import { getModule } from 'state/modules';
 import Textarea from '../components/textarea';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
+const SUBSCRIPTION_OPTIONS = 'subscription_options';
+
 const MessagesSetting = props => {
-	const { getOptionValue, isSavingAnyOption, subscriptionsModule, onOptionChange } = props;
+	const {
+		isSavingAnyOption,
+		subscriptionsModule,
+		onOptionChange,
+		welcomeMessage,
+		unavailableInOfflineMode,
+		unavailableInSiteConnectionMode,
+	} = props;
 
 	const changeWelcomeMessageState = useCallback(
 		event => {
@@ -22,14 +32,17 @@ const MessagesSetting = props => {
 		[ onOptionChange ]
 	);
 
-	const welcomeMessage = getOptionValue( 'subscription_options' )?.welcome || '';
+	const disabled =
+		unavailableInOfflineMode ||
+		unavailableInSiteConnectionMode ||
+		isSavingAnyOption( [ SUBSCRIPTION_OPTIONS ] );
 
 	return (
 		<SettingsCard
 			{ ...props }
 			header={ __( 'Messages', 'jetpack' ) }
 			module={ SUBSCRIPTIONS_MODULE_NAME }
-			saveDisabled={ isSavingAnyOption( [ 'subscription_options' ] ) }
+			saveDisabled={ disabled }
 		>
 			<SettingsGroup
 				hasChild
@@ -48,7 +61,8 @@ const MessagesSetting = props => {
 						{ __( 'Welcome email message', 'jetpack' ) }
 					</span>
 					<Textarea
-						name={ 'subscription_options' }
+						disabled={ disabled }
+						name={ SUBSCRIPTION_OPTIONS }
 						value={ welcomeMessage }
 						onChange={ changeWelcomeMessageState }
 					/>
@@ -68,10 +82,15 @@ export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
 			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
-			getOptionValue: ownProps.getOptionValue,
 			isSavingAnyOption: ownProps.isSavingAnyOption,
 			moduleName: ownProps.moduleName,
 			onOptionChange: ownProps.onOptionChange,
+			welcomeMessage: ownProps.getOptionValue( SUBSCRIPTION_OPTIONS )?.welcome || '',
+			unavailableInOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
+			unavailableInSiteConnectionMode: isUnavailableInSiteConnectionMode(
+				state,
+				SUBSCRIPTIONS_MODULE_NAME
+			),
 		};
 	} )( MessagesSetting )
 );

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -17,6 +17,9 @@ import { withModuleSettingsFormHelpers } from '../components/module-settings/wit
 import TreeDropdown from '../components/tree-dropdown';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
+const NEWSLETTER_CATEGORIES_ENABLED_OPTION = 'wpcom_newsletter_categories_enabled';
+const NEWSLETTER_CATEGORIES_OPTION = 'wpcom_newsletter_categories';
+
 const mapCategoriesIds = category => {
 	switch ( typeof category ) {
 		case 'number':
@@ -40,15 +43,15 @@ function NewsletterCategories( props ) {
 		isNewsletterCategoriesEnabled,
 		newsletterCategories,
 		categories,
-		isUnavailableDueOfflineMode,
-		isUnavailableDueSiteConnectionMode,
+		unavailableInOfflineMode,
+		unavailableInSiteConnectionMode,
 		subscriptionsModule,
 		updateFormStateOptionValue,
 		isSavingAnyOption,
 	} = props;
 
 	const handleEnableNewsletterCategoriesToggleChange = useCallback( () => {
-		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, 'wpcom_newsletter_categories_enabled' );
+		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, NEWSLETTER_CATEGORIES_ENABLED_OPTION );
 	}, [ updateFormStateModuleOption ] );
 
 	const checkedCategoriesIds = newsletterCategories.map( mapCategoriesIds );
@@ -73,17 +76,22 @@ function NewsletterCategories( props ) {
 			} else {
 				newCheckedCategoriesIds = checkedCategoriesIds.filter( category => category !== id );
 			}
-			updateFormStateOptionValue( 'wpcom_newsletter_categories', newCheckedCategoriesIds );
+			updateFormStateOptionValue( NEWSLETTER_CATEGORIES_OPTION, newCheckedCategoriesIds );
 		},
 		[ checkedCategoriesIds, updateFormStateOptionValue ]
 	);
+
+	const disabled =
+		unavailableInOfflineMode ||
+		unavailableInSiteConnectionMode ||
+		isSavingAnyOption( [ NEWSLETTER_CATEGORIES_ENABLED_OPTION, NEWSLETTER_CATEGORIES_OPTION ] );
 
 	return (
 		<SettingsCard
 			{ ...props }
 			header={ __( 'Newsletter categories', 'jetpack' ) }
 			module={ SUBSCRIPTIONS_MODULE_NAME }
-			saveDisabled={ isSavingAnyOption( [ 'subscription_options' ] ) }
+			saveDisabled={ disabled }
 		>
 			<SettingsGroup
 				hasChild
@@ -106,7 +114,7 @@ function NewsletterCategories( props ) {
 				</p>
 				<div className="newsletter-categories-toggle-wrapper">
 					<ToggleControl
-						disabled={ isUnavailableDueOfflineMode || isUnavailableDueSiteConnectionMode }
+						disabled={ disabled }
 						checked={ isNewsletterCategoriesEnabled }
 						onChange={ handleEnableNewsletterCategoriesToggleChange }
 						label={ __( 'Enable newsletter categories', 'jetpack' ) }
@@ -121,7 +129,7 @@ function NewsletterCategories( props ) {
 						items={ mappedCategories }
 						selectedItems={ checkedCategoriesIds }
 						onChange={ onSelectedCategoryChange }
-						disabled={ isSavingAnyOption( [ 'wpcom_newsletter_categories' ] ) }
+						disabled={ disabled }
 					/>
 				</div>
 			</SettingsGroup>
@@ -148,13 +156,13 @@ export default withModuleSettingsFormHelpers(
 		return {
 			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
 			isNewsletterCategoriesEnabled: ownProps.getOptionValue(
-				'wpcom_newsletter_categories_enabled'
+				NEWSLETTER_CATEGORIES_ENABLED_OPTION
 			),
-			newsletterCategories: ownProps.getOptionValue( 'wpcom_newsletter_categories' ),
+			newsletterCategories: ownProps.getOptionValue( NEWSLETTER_CATEGORIES_OPTION ),
 			categories: ownProps.getOptionValue( 'categories' ),
 			requiresConnection: requiresConnection( state, SUBSCRIPTIONS_MODULE_NAME ),
-			isUnavailableDueOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
-			isUnavailableDueSiteConnectionMode: isUnavailableInSiteConnectionMode(
+			unavailableInOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
+			unavailableInSiteConnectionMode: isUnavailableInSiteConnectionMode(
 				state,
 				SUBSCRIPTIONS_MODULE_NAME
 			),

--- a/projects/plugins/jetpack/changelog/fix-newsletter-settings-disable-state
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-settings-disable-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix disable state for newsletter setting inputs. Components under feature flag.
+
+


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/88350

## Proposed changes:

* Fixes disable state for Newsletter settings inputs while saving
  * The inputs are now disabled based on their context
  * Disabled if it's related to what is being saved
  * Other unrelated fields remain enabled, same behavior as other JP settings

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Apply this PR to your JT site
* Go to the Newsletter Settings page with both flags enabled `wp-admin/admin.php?enable-email-settings=true&enable-newsletter-categories=true&page=jetpack#/newsletter`
* Perform tests on all cards and check if the disable state is consistent
* Perform regression tests