### PR TITLE
Color Schema: Load Current Schema CSS on page load

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-color-schema-load-css
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-color-schema-load-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Load Color Schema CSS file on page load for nav redesign

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -41,6 +41,7 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_block_theme_previews' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_command_palette' ) );
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_color_schema' ) );
 
 		// This feature runs only on simple sites.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -261,5 +262,27 @@ class Jetpack_Mu_Wpcom {
 	 */
 	public static function load_wpcom_command_palette() {
 		require_once __DIR__ . '/features/wpcom-command-palette/wpcom-command-palette.php';
+	}
+
+	/**
+	 * Load WPCOM Color Schema for nav redesign.
+	 *
+	 * @return void
+	 */
+	public static function load_wpcom_color_schema() {
+		if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
+			return;
+		}
+
+		$core_color_schemes = array( 'blue', 'coffee', 'ectoplasm', 'fresh', 'light', 'midnight', 'modern', 'ocean', 'sunrise' );
+		$color_scheme       = get_user_option( 'admin_color' );
+		if ( in_array( $color_scheme, $core_color_schemes, true ) ) {
+			wp_enqueue_style(
+				'jetpack-core-color-schemes-overrides',
+				plugins_url( '_inc/build/masterbar/admin-color-schemes/colors/' . $color_scheme . '/colors.css', JETPACK__PLUGIN_FILE ),
+				array(),
+				JETPACK__VERSION
+			);
+		}
 	}
 }


### PR DESCRIPTION
Related to: https://github.com/Automattic/wpcomsh/pull/1669
Slack: p1706841241110869-slack-C06DN6QQVAQ

## Proposed changes:

The Color Schema CSS file was not loaded on page load but we added this functionality for Nav redesign sites.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/jetpack/assets/402286/501c1dc7-6e29-4474-9802-b100ffa80cd6) | ![image](https://github.com/Automattic/jetpack/assets/402286/ec1fea60-75d8-4010-9925-1ddfcca64fb3) |

#### Known bug
- When you select a new color schema, it will not replace the current color on the admin bar until you reload the page.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Apply this wpcomsh PR (https://github.com/Automattic/wpcomsh/pull/1669)
* Apply this PR 
* Go to `/wp-admin/profile.php`
* Change your Color Schema (the color should change)
* Reload the page
* The admin bar + wp-admin should have the new selected color.
* 