### PR TITLE
Top Posts & Pages Block: Prevent Disabling all Types

### DIFF
--- a/projects/plugins/jetpack/changelog/update-top-posts-toggle
+++ b/projects/plugins/jetpack/changelog/update-top-posts-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Top Posts & Pages Block: Require that one content type is always set to display. 

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/controls.js
@@ -1,10 +1,12 @@
 import {
+	Notice,
 	PanelBody,
 	RangeControl,
 	SelectControl,
 	ToggleControl,
 	ToolbarGroup,
 } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 export function TopPostsInspectorControls( {
@@ -17,17 +19,26 @@ export function TopPostsInspectorControls( {
 	const { displayAuthor, displayContext, displayDate, displayThumbnail, period, postsToShow } =
 		attributes;
 
+	const [ showErrorMessage, setShowErrorMessage ] = useState( false );
+
 	if ( ! postTypesData ) {
 		return;
 	}
 
 	const handleToggleChange = toggleId => isChecked => {
-		setToggleAttributes( prevAttributes => ( {
-			...prevAttributes,
+		const updatedAttributes = {
+			...toggleAttributes,
 			[ toggleId ]: isChecked,
-		} ) );
+		};
 
-		setAttributes( { postTypes: { ...toggleAttributes, [ toggleId ]: isChecked } } );
+		// Require at least one type to be selected.
+		if ( Object.values( updatedAttributes ).every( value => value === false ) ) {
+			return setShowErrorMessage( true );
+		}
+
+		setToggleAttributes( updatedAttributes );
+		setAttributes( { postTypes: updatedAttributes } );
+		setShowErrorMessage( false );
 	};
 
 	const periodOptions = [
@@ -70,6 +81,11 @@ export function TopPostsInspectorControls( {
 						onChange={ handleToggleChange( toggle.id ) }
 					/>
 				) ) }
+				{ showErrorMessage && (
+					<Notice className="jetpack-top-posts__error" status="error" isDismissible={ false }>
+						{ __( 'At least one item must be selected.', 'jetpack' ) }
+					</Notice>
+				) }
 			</PanelBody>
 			<PanelBody title={ __( 'Metadata settings', 'jetpack' ) }>
 				<ToggleControl

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/editor.scss
@@ -5,3 +5,7 @@
 .wp-block-jetpack-top-posts .components-placeholder__fieldset {
 	display: block;
 }
+
+.jetpack-top-posts__error {
+	margin: 0;
+}


### PR DESCRIPTION
Partly addresses #36109

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevents the user from disabling all content types under the "Items to display" section of the Top Posts & Page block.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See #36109.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
* Add a Top Posts and Pages block in the editor
* Try to disable all types
* Confirm that you see an error message when you do so upon trying to disable the final type

<img width="299" alt="Screenshot 2024-03-09 at 10 32 36" src="https://github.com/Automattic/jetpack/assets/43215253/52cd62ad-81e2-46ec-946c-344ab1b4bbcd">
 
