### PR TITLE
Boost: Disable cache for Boost query parameters

### DIFF
--- a/projects/plugins/boost/app/modules/Modules_Setup.php
+++ b/projects/plugins/boost/app/modules/Modules_Setup.php
@@ -9,8 +9,6 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Regenerate;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Status;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
-use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
-use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Logger;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\REST_API;
 
@@ -81,7 +79,6 @@ class Modules_Setup implements Has_Setup {
 	 */
 	public function setup() {
 		add_action( 'plugins_loaded', array( $this, 'init_modules' ) );
-		add_filter( 'plugins_loaded', array( $this, 'disable_caching_if_module_disabled' ), 11, 2 );
 		add_action( 'jetpack_boost_module_status_updated', array( $this, 'on_module_status_update' ), 10, 2 );
 	}
 
@@ -108,21 +105,6 @@ class Modules_Setup implements Has_Setup {
 
 		if ( $module_slug === Cloud_CSS::get_slug() && $is_activated ) {
 			( new Regenerate() )->start();
-		}
-	}
-
-	/**
-	 * Disable caching if the module is disabled.
-	 * Cache is a special case because it starts working before WordPress and module setup happens.
-	 * So, we need to tell it to not cache the page if we find the module is disabled.
-	 */
-	public function disable_caching_if_module_disabled() {
-		// Check if the module is disabled via query parameter.
-		if ( ! array_key_exists( Page_Cache::get_slug(), $this->available_modules ) ) {
-			if ( ! defined( 'DONOTCACHEPAGE' ) ) {
-				define( 'DONOTCACHEPAGE', true );
-			}
-			Logger::debug( 'Page Cache module is disabled via query string, caching disabled' );
 		}
 	}
 }

--- a/projects/plugins/boost/app/modules/Modules_Setup.php
+++ b/projects/plugins/boost/app/modules/Modules_Setup.php
@@ -9,6 +9,8 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Regenerate;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Status;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Logger;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\REST_API;
 
@@ -79,6 +81,7 @@ class Modules_Setup implements Has_Setup {
 	 */
 	public function setup() {
 		add_action( 'plugins_loaded', array( $this, 'init_modules' ) );
+		add_filter( 'plugins_loaded', array( $this, 'disable_caching_if_module_disabled' ), 11, 2 );
 		add_action( 'jetpack_boost_module_status_updated', array( $this, 'on_module_status_update' ), 10, 2 );
 	}
 
@@ -105,6 +108,21 @@ class Modules_Setup implements Has_Setup {
 
 		if ( $module_slug === Cloud_CSS::get_slug() && $is_activated ) {
 			( new Regenerate() )->start();
+		}
+	}
+
+	/**
+	 * Disable caching if the module is disabled.
+	 * Cache is a special case because it starts working before WordPress and module setup happens.
+	 * So, we need to tell it to not cache the page if we find the module is disabled.
+	 */
+	public function disable_caching_if_module_disabled() {
+		// Check if the module is disabled via query parameter.
+		if ( ! array_key_exists( Page_Cache::get_slug(), $this->available_modules ) ) {
+			if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+				define( 'DONOTCACHEPAGE', true );
+			}
+			Logger::debug( 'Page Cache module is disabled via query string, caching disabled' );
 		}
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -83,6 +83,17 @@ class Request {
 			$request_uri = $this->request_uri;
 		}
 
+		// Check if the URL contains query parameters `jb-disable-modules` or `jb-generate-critical-css`
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+		$query_string = parse_url( $request_uri, PHP_URL_QUERY );
+		if ( is_string( $query_string ) ) {
+			$query = array();
+			parse_str( $query_string, $query );
+			if ( isset( $query['jb-disable-modules'] ) || isset( $query['jb-generate-critical-css'] ) ) {
+				return true;
+			}
+		}
+
 		$bypass_patterns = Boost_Cache_Settings::get_instance()->get_bypass_patterns();
 
 		/**

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -83,15 +83,14 @@ class Request {
 			$request_uri = $this->request_uri;
 		}
 
-		// Check if the URL contains query parameters `jb-disable-modules` or `jb-generate-critical-css`
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
-		$query_string = parse_url( $request_uri, PHP_URL_QUERY );
-		if ( is_string( $query_string ) ) {
-			$query = array();
-			parse_str( $query_string, $query );
-			if ( isset( $query['jb-disable-modules'] ) || isset( $query['jb-generate-critical-css'] ) ) {
-				return true;
-			}
+		// Check if the query parameters `jb-disable-modules` or `jb-generate-critical-css` exist.
+		if ( isset( $this->request_parameters['get'] ) &&
+			(
+				isset( $this->request_parameters['get']['jb-disable-modules'] ) ||
+				isset( $this->request_parameters['get']['jb-generate-critical-css'] )
+			)
+		) {
+			return true;
 		}
 
 		$bypass_patterns = Boost_Cache_Settings::get_instance()->get_bypass_patterns();

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -84,11 +84,9 @@ class Request {
 		}
 
 		// Check if the query parameters `jb-disable-modules` or `jb-generate-critical-css` exist.
-		if ( isset( $this->request_parameters['get'] ) &&
-			(
-				isset( $this->request_parameters['get']['jb-disable-modules'] ) ||
-				isset( $this->request_parameters['get']['jb-generate-critical-css'] )
-			)
+		$query_params = isset( $this->request_parameters['get'] ) ? $this->request_parameters['get'] : array();
+		if ( isset( $query_params ) &&
+			( isset( $query_params['jb-disable-modules'] ) || isset( $query_params['jb-generate-critical-css'] ) )
 		) {
 			return true;
 		}

--- a/projects/plugins/boost/changelog/add-disable-cache-with-query
+++ b/projects/plugins/boost/changelog/add-disable-cache-with-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Cache: Disable caching with `jb-disable-modules` query parameter.

--- a/projects/plugins/boost/changelog/add-disable-cache-with-query
+++ b/projects/plugins/boost/changelog/add-disable-cache-with-query
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Cache: Disable caching with `jb-disable-modules` query parameter.
+Cache: Disable caching when boost query parameters are present.


### PR DESCRIPTION
## Proposed changes:
We allow boost modules to be disabled using query parameter `jb-disable-modules`. This can be used to test something and by pagespeed to contrast between boost and no-boost scores. However, because the cache module starts working before module setup happens, it needs special handling to allow disabling caching with query param.

After some discussion, it seems like a good idea to skip caching if `jb-disable-modules` is present regardless of whether the cache module is addressed. I went one step further and disabled cache for `jb-generating-critical-css`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1710126153682139-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Enable cache
* From an incognito window visit any front-end page with `jb-disable-modules=all` and see the response header `X-Jetpack-Boost-Cache`, the value should be "miss". This will be "miss" even if the changes in the PR isn't working, since it doesn't have any cache on the first load.
* Refresh the page and ensure the value remains "miss".
* Check the same with `jb-generate-critical-css`.