### PR TITLE
Subscriber Login: Prevent the HTTP 301 redirection for Atomic sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-prevent-http-301-subscriber-login
+++ b/projects/plugins/jetpack/changelog/update-prevent-http-301-subscriber-login
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriber Login: Prevent the HTTP 301 redirection for Atomic sites

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -73,7 +73,6 @@ function get_current_url() {
 function get_subscriber_login_url( $redirect ) {
 	$redirect = ! empty( $redirect ) ? $redirect : get_site_url();
 
-	// Taken from projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php and simplified a bit
 	if ( ( new Host() )->is_wpcom_simple() ) {
 		// On WPCOM we will redirect immediately
 		return wpcom_logmein_redirect_url( $redirect, false, null, 'link', get_current_blog_id() );
@@ -88,7 +87,7 @@ function get_subscriber_login_url( $redirect ) {
 			'site_id'      => intval( Jetpack_Options::get_option( 'id' ) ),
 			'redirect_url' => rawurlencode( $redirect_url ),
 		),
-		'https://subscribe.wordpress.com/memberships/jwt'
+		'https://subscribe.wordpress.com/memberships/jwt/'
 	);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

It adds the `/` at the end of the URL to prevent the HTTP 301 redirection.

### Before

<img width="1376" alt="Screenshot 2024-03-11 at 10 11 02" src="https://github.com/Automattic/jetpack/assets/4068554/c7450b26-b81e-4f81-b8a0-b0ec6fe28691">

### After

<img width="1376" alt="Screenshot 2024-03-11 at 10 11 34" src="https://github.com/Automattic/jetpack/assets/4068554/102011c1-1089-499b-8412-cbafa6c766ab">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* open the Atomic site post with the Subscriber Login block in incognito
* open the Browser Dev Tools Network tab
* click the "Log in" link
* make sure there is no HTTP 301 redirect for `https://subscribe.wordpress.com/memberships/jwt/` URL

