### PR TITLE
Backport mu-wpcom-plugin 2.1.2 Changes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.15.2] - 2024-03-11
+### Changed
+- External dependencies of the Command Palette are now explicitly declared. [#36184]
+- Jetpack MU WPCOM: Added Bytespider robots.txt [#36260]
+- Remove external-icon from Hosting menu [#36221]
+
+### Fixed
+- unregisters unnecessary items from the customizer for atomic sites on block theme [#36161]
+- Untangle: correctly show the current homepage when live-previewing another block theme [#36178]
+
 ## [5.15.1] - 2024-03-05
 ### Changed
 - Internal updates.
@@ -630,6 +640,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.15.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.15.1...v5.15.2
 [5.15.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.15.0...v5.15.1
 [5.15.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.14.1...v5.15.0
 [5.14.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.14.0...v5.14.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-site-migration-endpoint-jetpack
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-site-migration-endpoint-jetpack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Internal details about Migrate Guru integration
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-external-icon-from-hosting-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-external-icon-from-hosting-menu
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Remove external-icon from Hosting menu

--- a/projects/packages/jetpack-mu-wpcom/changelog/untangle-theme-preview
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangle-theme-preview
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Untangle: correctly show the current homepage when live-previewing another block theme

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-blocked-ai-bots
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-blocked-ai-bots
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Jetpack MU WPCOM: Added Bytespider robots.txt

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-command-palette-external-dependencies
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-command-palette-external-dependencies
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-External dependencies of the Command Palette are now explicitly declared.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-customizer-removal-to-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-customizer-removal-to-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-unregisters unnecessary items from the customizer for atomic sites on block theme

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.15.2-alpha",
+	"version": "5.15.2",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.15.2-alpha';
+	const PACKAGE_VERSION = '5.15.2';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2024-03-11
+### Added
+- Added a new endpoint /plugins/capabilities that returns whether we can update plugins. [#36238]
+- The plugin list now accounts for all schedules a plugin might be a part of. [#36259]
+
+### Changed
+- Sends update requests even if there are no plugins to be updated, so WP.com can keep track of that outcome of a schedule execution. [#36162]
+
+### Fixed
+- Fix: add check for wp_unschedule_event return value [#36248]
+- Fixed a bug where individual plugin slugs were not actually validated and sanitized. [#36231]
+- Fixed a bug where plugin autoupdates were no longer allowlisted after switching away from the jetpack_update_schedules option. [#36292]
+
 ## [0.3.1] - 2024-03-05
 ### Added
 - Adds plugins to and removes them from aut-updates when creating and deleting update schedules. [#36125]
@@ -41,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.3.2]: https://github.com/Automattic/scheduled-updates/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/scheduled-updates/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/scheduled-updates/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Automattic/scheduled-updates/compare/v0.2.0...v0.2.1

--- a/projects/packages/scheduled-updates/changelog/add-schedued-updates-capabilities
+++ b/projects/packages/scheduled-updates/changelog/add-schedued-updates-capabilities
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added a new endpoint /plugins/capabilities that returns whether we can update plugins.

--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-cron-check
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-cron-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix: add check for wp_unschedule_event return value

--- a/projects/packages/scheduled-updates/changelog/fix-autoupdate-allowlist
+++ b/projects/packages/scheduled-updates/changelog/fix-autoupdate-allowlist
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a bug where plugin autoupdates were no longer allowlisted after switching away from the jetpack_update_schedules option.

--- a/projects/packages/scheduled-updates/changelog/fix-plugin-list-display
+++ b/projects/packages/scheduled-updates/changelog/fix-plugin-list-display
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-The plugin list now accounts for all schedules a plugin might be a part of.

--- a/projects/packages/scheduled-updates/changelog/fix-plugin-slugs
+++ b/projects/packages/scheduled-updates/changelog/fix-plugin-slugs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a bug where individual plugin slugs were not actually validated and sanitized.

--- a/projects/packages/scheduled-updates/changelog/update-send-all-updates
+++ b/projects/packages/scheduled-updates/changelog/update-send-all-updates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Sends update requests even if there are no plugins to be updated, so WP.com can keep track of that outcome of a schedule execution.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.2-alpha';
+	const PACKAGE_VERSION = '0.3.2';
 
 	/**
 	 * Initialize the class.

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.2 - 2024-03-11
+### Changed
+- Internal updates.
+
 ## 2.1.1 - 2024-03-05
 ### Fixed
 - Updated dependencies. [#36170]

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_1"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_2"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.1
+ * Version: 2.1.2
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.2

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.