### PR TITLE
Fix subscriptions paywall pending message showing empty email on WP.com

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-paywall-pending-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-paywall-pending-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: fix empty email for pending confirm paywall on .com

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1205,8 +1205,10 @@ function get_paywall_blocks_subscribe_pending() {
 
 	/** This filter is documented in modules/contact-form/grunion-contact-form.php */
 	if ( is_wpcom() || false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
-		$current_user    = wp_get_current_user();
-		$subscribe_email = ! empty( $current_user->user_email ) ? $current_user->user_email : '';
+		$current_user = wp_get_current_user();
+		if ( ! empty( $current_user->user_email ) ) {
+			$subscribe_email = $current_user->user_email;
+		}
 	}
 
 	$access_heading = esc_html__( 'Confirm your subscription to continue reading', 'jetpack' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes issue where on .com we would try to show empty email for "confirm your email" message also when user isn't logged in.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply diff at simple site
* Subscribe to site and see pending message

**Before**

<img width="740" alt="Screenshot 2024-03-11 at 13 54 30" src="https://github.com/Automattic/jetpack/assets/87168/ee58e966-6526-4eee-8c75-fa90347a4142">

**After**

<img width="728" alt="Screenshot 2024-03-11 at 13 54 19" src="https://github.com/Automattic/jetpack/assets/87168/7ceb7fd0-43b3-4724-a8aa-00a9967615a5">

