### PR TITLE
Subscriptions: update configuration URL.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriptions-settings-url
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-settings-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: update the settings screen URL.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -135,6 +135,14 @@ class Jetpack_Subscriptions {
 
 		// Add Subscribers menu to Jetpack navigation.
 		add_action( 'jetpack_admin_menu', array( $this, 'add_subscribers_menu' ) );
+
+		// Customize the configuration URL to lead to the Subscriptions settings.
+		add_filter(
+			'jetpack_module_configuration_url_subscriptions',
+			function () {
+				return Jetpack::admin_url( array( 'page' => 'jetpack#/newsletter' ) );
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

Now that we have a dedicated page for subscriptions in the Jetpack settings, let's link to that when possible!

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings 
* Click on "Modules" at the bottom of the page.
* Search for the Subscriptions module
* If the module is not active, activate it.
* Click on the configure link
    * You should be redirected to the Newsletter tab in Jetpack settings.
