### PR TITLE
Newsletter Settings in JP: Add newsletter category creation tracking.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -141,7 +141,7 @@ function NewsletterCategories( props ) {
 				<Card
 					compact
 					className="jp-settings-card__configure-link"
-					href="/wp-admin/edit-tags.php?taxonomy=category"
+					href="/wp-admin/edit-tags.php?taxonomy=category&referer=newsletter-categories"
 					target="_blank"
 				>
 					{ __( 'Add New Category', 'jetpack' ) }

--- a/projects/plugins/jetpack/changelog/add-newsletter-category-creation-tracking
+++ b/projects/plugins/jetpack/changelog/add-newsletter-category-creation-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Track newsletter category creation.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -143,6 +143,9 @@ class Jetpack_Subscriptions {
 				return Jetpack::admin_url( array( 'page' => 'jetpack#/newsletter' ) );
 			}
 		);
+
+		// Track categories created through the category editor page
+		add_action( 'wp_ajax_add-tag', array( $this, 'track_newsletter_category_creation' ), 1 );
 	}
 
 	/**
@@ -1149,6 +1152,36 @@ class Jetpack_Subscriptions {
 			esc_url( $link ),
 			null
 		);
+	}
+
+	/**
+	 * Record tracks event if categories is created when user enters
+	 * the edit category page through the newsletter settings page.
+	 *
+	 * @return void
+	 */
+	public function track_newsletter_category_creation() {
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		if ( empty( $_POST['_wp_http_referer'] ) ) {
+			return;
+		}
+
+		if ( strpos( sanitize_url( wp_unslash( $_POST['_wp_http_referer'] ) ), 'referer=newsletter-categories' ) > -1 ) {
+
+			$parent = filter_var( empty( $_POST['parent'] ) ? 0 : wp_unslash( $_POST['parent'] ), FILTER_SANITIZE_NUMBER_INT );
+
+			$is_child_category = $parent > 0;
+
+			$tracking = new Automattic\Jetpack\Tracking();
+			$tracking->tracks_record_event(
+				wp_get_current_user(),
+				'jetpack_newsletter_add_category',
+				array(
+					'is_child_category' => $is_child_category,
+				)
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/88304

## Proposed changes:

* This records a tracks event when a newsletter category is created.
* The `referer=newsletter-categories` param is added to the edit category page to determine that this is coming from newsletter settings page.
* On the backend, when a category is created, it uses the `_wp_http_referer` with the existence of the param above to determine whether to record the tracks event `jetpack_newsletter_add_category`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Test for referer=newsletter-categories param**
* Go to `/wp-admin/admin.php?page=jetpack#/newsletter`.
* Click on **Newsletter Categories > Add New Category**.
* It should open in a new tab with `referer=newsletter-categories` in the url param.

**Test for tracks event recording**
* Add a category.
* Add a child category.
* Go to `https://<mc_hostname_here>/tracks/live/?eventname=jetpack_newsletter_add_category`.
* Inspect the tracks event for the categories you've created.

<img width="803" alt="image" src="https://github.com/Automattic/jetpack/assets/1287077/17bc68ef-c1f4-4c59-b15a-58f610eaecf6">
