### PR TITLE
Untangle: Enable both Calypso & Core admin color schemes in Users -> Profile

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/untangle-color-schemes
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangle-color-schemes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Untangle: Enable both Calypso & Core admin color schemes in Users -> Profile

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -51,7 +51,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.16.x-dev"
+			"dev-trunk": "5.17.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.16.2-alpha",
+	"version": "5.17.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -72,6 +72,7 @@ class Jetpack_Mu_Wpcom {
 		// Please keep the features in alphabetical order.
 		require_once __DIR__ . '/features/100-year-plan/enhanced-ownership.php';
 		require_once __DIR__ . '/features/100-year-plan/locked-mode.php';
+		require_once __DIR__ . '/features/admin-color-schemes/admin-color-schemes.php';
 		require_once __DIR__ . '/features/block-patterns/block-patterns.php';
 		require_once __DIR__ . '/features/blog-privacy/blog-privacy.php';
 		require_once __DIR__ . '/features/error-reporting/error-reporting.php';

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.16.2-alpha';
+	const PACKAGE_VERSION = '5.17.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/admin-color-schemes/admin-color-schemes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/admin-color-schemes/admin-color-schemes.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Additional admin color schemes.
+ *
+ * The content of this file is mostly copied from projects/plugins/jetpack/modules/masterbar/admin-color-schemes/class-admin-color-schemes.php.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Get the admin color scheme URL based on the environment
+ *
+ * @param string $color_scheme  The color scheme to get the URL for.
+ * @return string
+ */
+function get_admin_color_scheme_url( $color_scheme ) {
+	// TODO: migrate these color scheme CSS files to jetpack-mu-wpcom as well.
+	return plugins_url( '_inc/build/masterbar/admin-color-schemes/colors/' . $color_scheme . '/colors.css', JETPACK__PLUGIN_FILE );
+}
+
+/**
+ * Registers Calypso admin color schemes.
+ */
+function register_calypso_admin_color_schemes() {
+	wp_admin_css_color(
+		'aquatic',
+		__( 'Aquatic', 'jetpack-mu-wpcom' ),
+		get_admin_color_scheme_url( 'aquatic' ),
+		array( '#135e96', '#007e65', '#043959', '#c5d9ed' ),
+		array(
+			'base'    => '#c5d9ed',
+			'focus'   => '#fff',
+			'current' => '#01263a',
+		)
+	);
+
+	wp_admin_css_color(
+		'classic-blue',
+		__( 'Classic Blue', 'jetpack-mu-wpcom' ),
+		get_admin_color_scheme_url( 'classic-blue' ),
+		array( '#135e96', '#b26200', '#dcdcde', '#646970' ),
+		array(
+			'base'    => '#646970',
+			'focus'   => '#2271b1',
+			'current' => '#fff',
+		)
+	);
+
+	wp_admin_css_color(
+		'classic-bright',
+		__( 'Classic Bright', 'jetpack-mu-wpcom' ),
+		get_admin_color_scheme_url( 'classic-bright' ),
+		array( '#135e96', '#c9256e', '#ffffff', '#e9eff5' ),
+		array(
+			'base'    => '#646970',
+			'focus'   => '#1d2327',
+			'current' => '#0a4b78',
+		)
+	);
+
+	wp_admin_css_color(
+		'classic-dark',
+		__( 'Classic Dark', 'jetpack-mu-wpcom' ),
+		get_admin_color_scheme_url( 'classic-dark' ),
+		array( '#101517', '#c9356e', '#32373c', '#0073aa' ),
+		array(
+			'base'    => '#a2aab2',
+			'focus'   => '#00b9eb',
+			'current' => '#fff',
+		)
+	);
+
+	wp_admin_css_color(
+		'contrast',
+		__( 'Contrast', 'jetpack-mu-wpcom' ),
+		get_admin_color_scheme_url( 'contrast' ),
+		array( '#101517', '#ffffff', '#32373c', '#b4b9be' ),
+		array(
+			'base'    => '#1d2327',
+			'focus'   => '#fff',
+			'current' => '#fff',
+		)
+	);
+
+	wp_admin_css_color(
+		'nightfall',
+		__( 'Nightfall', 'jetpack-mu-wpcom' ),
+		get_admin_color_scheme_url( 'nightfall' ),
+		array( '#00131c', '#043959', '#2271b1', '#9ec2e6' ),
+		array(
+			'base'    => '#9ec2e6',
+			'focus'   => '#fff',
+			'current' => '#fff',
+		)
+	);
+
+	wp_admin_css_color(
+		'powder-snow',
+		__( 'Powder Snow', 'jetpack-mu-wpcom' ),
+		get_admin_color_scheme_url( 'powder-snow' ),
+		array( '#101517', '#2271b1', '#dcdcde', '#646970' ),
+		array(
+			'base'    => '#646970',
+			'focus'   => '#135e96',
+			'current' => '#fff',
+		)
+	);
+
+	wp_admin_css_color(
+		'sakura',
+		__( 'Sakura', 'jetpack-mu-wpcom' ),
+		get_admin_color_scheme_url( 'sakura' ),
+		array( '#005042', '#f2ceda', '#2271b1', '#8c1749' ),
+		array(
+			'base'    => '#8c1749',
+			'focus'   => '#4f092a',
+			'current' => '#fff',
+		)
+	);
+
+	wp_admin_css_color(
+		'sunset',
+		__( 'Sunset', 'jetpack-mu-wpcom' ),
+		get_admin_color_scheme_url( 'sunset' ),
+		array( '#691c1c', '#b26200', '#f0c930', '#facfd2' ),
+		array(
+			'base'    => '#facfd2',
+			'focus'   => '#fff',
+			'current' => '#4f3500',
+		)
+	);
+}
+
+/**
+ * Re-enqueue Core color scheme CSS.
+ *
+ * Currently, the selected color scheme CSS (with id = "colors") is concatenated (by Jetpack Boost / Page Optimize),
+ * and is output before the default color scheme CSS, making it lose in specificity.
+ *
+ * As a workaround, we re-enqueue the color scheme CSS.
+ * In order for this one not to be concatenated again, we use the CSS file from an external URL, our CDN (s0.wp.com).
+ */
+function reenqueue_core_color_scheme() {
+	$core_color_schemes = array( 'blue', 'coffee', 'ectoplasm', 'fresh', 'light', 'midnight', 'modern', 'ocean', 'sunrise' );
+	$color_scheme       = get_user_option( 'admin_color' );
+	if ( in_array( $color_scheme, $core_color_schemes, true ) ) {
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_enqueue_style( 'jetpack-core-color-scheme', "https://s0.wp.com/wp-admin/css/colors/$color_scheme/colors.min.css" );
+	}
+}
+
+if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+	add_action( 'admin_init', 'register_calypso_admin_color_schemes' );
+	add_action( 'admin_enqueue_scripts', 'reenqueue_core_color_scheme' );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/admin-color-schemes/admin-color-schemes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/admin-color-schemes/admin-color-schemes.php
@@ -145,7 +145,7 @@ function reenqueue_core_color_scheme() {
 	$color_scheme       = get_user_option( 'admin_color' );
 	if ( in_array( $color_scheme, $core_color_schemes, true ) ) {
 		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-		wp_enqueue_style( 'jetpack-core-color-scheme', "https://s0.wp.com/wp-admin/css/colors/$color_scheme/colors.min.css" );
+		wp_enqueue_style( 'jetpack-core-color-scheme', "/wp-admin/css/colors/$color_scheme/colors.min.css" );
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/admin-color-schemes/admin-color-schemes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/admin-color-schemes/admin-color-schemes.php
@@ -145,7 +145,7 @@ function reenqueue_core_color_scheme() {
 	$color_scheme       = get_user_option( 'admin_color' );
 	if ( in_array( $color_scheme, $core_color_schemes, true ) ) {
 		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-		wp_enqueue_style( 'jetpack-core-color-scheme', "/wp-admin/css/colors/$color_scheme/colors.min.css" );
+		wp_enqueue_style( 'jetpack-core-color-scheme', "https://s0.wp.com/wp-admin/css/colors/$color_scheme/colors.min.css" );
 	}
 }
 

--- a/projects/plugins/jetpack/changelog/untangle-color-schemes
+++ b/projects/plugins/jetpack/changelog/untangle-color-schemes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Untangle: explicitly use Core admin bar color in Calypso color schemes

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_admin.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_admin.scss
@@ -393,14 +393,14 @@ ul#adminmenu > li.current > a.current:after {
 #wpadminbar a.ab-item,
 #wpadminbar > #wp-toolbar span.ab-label,
 #wpadminbar > #wp-toolbar span.noticon {
-	color: $menu-text;
+	color: #f0f0f1;
 }
 
 #wpadminbar .ab-icon,
 #wpadminbar .ab-icon:before,
 #wpadminbar .ab-item:before,
 #wpadminbar .ab-item:after {
-	color: $menu-icon;
+	color: #a7aaad;
 }
 
 #wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item,

--- a/projects/plugins/mu-wpcom-plugin/changelog/untangle-color-schemes
+++ b/projects/plugins/mu-wpcom-plugin/changelog/untangle-color-schemes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_4"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_5_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -129,7 +129,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "292adf12b20362ef0b72be8474ccb8c348ae87b7"
+                "reference": "006f3df8ce2166db6987e3db2dca8eaa2f67b7f8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -152,7 +152,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.16.x-dev"
+                    "dev-trunk": "5.17.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.4
+ * Version: 2.1.5-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.4",
+	"version": "2.1.5-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/5439
- https://github.com/Automattic/wpcomsh/pull/1669

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Together with the linked wpcomsh PR above, this PR enables Calypso admin color schemes (in addition to Core's) in `/wp-admin/profile.php`:

|Before|After|
|-|-|
|![image](https://github.com/Automattic/jetpack/assets/1525580/ff84ce1d-1437-4dbd-b6d7-3a8feb81102d)<br><br>V<br><br><img width="1043" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/d988ff9e-c58c-4a7a-b917-577b9af1a326">|<img width="1045" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/f8517a01-52eb-49c3-92b1-bad36571ed05">|

### Calypso admin color schemes

These additional Calypso scheme definitions live in the `Admin_Color_Schemes` class in the`masterbar` module. Since Classic view sites do not enable that module anymore, we (almost) copy-paste the contents to a new location in `jetpack-mu-wpcom` plugin.

We left the actual CSS files in the `masterbar` module because:

- to not make this PR too large, and
- somehow the CSS contents are mixed with some upsell nudge CSS. To not complicate things, I decided to just leave them be.

### Core admin color schemes

With re-enabling the admin color picker in `/wp-admin/profile.php`, we discovered an issue where the admin (top) bar is not using the color scheme, if the scheme is from Core. It turns out that the color scheme CSS is getting concatenated by Jetpack Boost and is output before the default color scheme, so the selected colors lose.

To work around this, I propose to re-enqueue the color scheme CSS file. In order for it not to be concatenated again, I am using the color files from our CDN (`s0.wp.com`) as opposed to the current site. See:

https://github.com/Automattic/jetpack/blob/5f8819e0a2badfd7100eb0d8192554fc9b77b837/projects/packages/jetpack-mu-wpcom/src/features/admin-color-schemes/admin-color-schemes.php#L134-L150

See more details in this comment: https://github.com/Automattic/wpcomsh/pull/1669#issuecomment-1985520438

The changes in `projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_admin.scss` is needed so that the admin bar color is previewed correctly when we pick a color scheme (before saving the form). Without it, when we pick a Calypso color scheme, the admin bar color will just follow the current color scheme.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

1. Prepare a WoA site.
2. Apply wpcomsh patch from https://github.com/Automattic/wpcomsh/pull/1669.
3. Using Jetpack Beta Tester, apply this branch to BOTH (both!!) `Jetpack` and `WordPress.com Features`.
4. Add `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` to `~/htdocs/wp-config.php`
5. Open Users -> Profile.
6. Verify that you can see all admin color schemes from Calypso (/me/account) and Core.
7. Click any color. Verify that you can preview the color changes (for both sidebar and admin top bar).
8. Click Update, verify that the color is applied successfully.
9. Also follow the test instructions from the linked wpcomsh PR above.