### PR TITLE
Fix the subscription widget output escaping.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-widget-output-escaping
+++ b/projects/plugins/jetpack/changelog/fix-subscription-widget-output-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: improve security by better checks when displaying a Subscription form via a shortcode.

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -162,15 +162,35 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		if ( self::is_wpcom() && ! $show_only_email_and_button ) {
 			if ( self::is_current_user_subscribed() ) {
 				if ( ! empty( $instance['title_following'] ) ) {
-					echo $before_title . '<label for="subscribe-field' . ( self::$instance_count > 1 ? '-' . self::$instance_count : '' ) . '">' . esc_attr( $instance['title_following'] ) . '</label>' . $after_title . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					printf(
+						'%1$s<label for="subscribe-field%2$s">%3$s</label>%4$s%5$s',
+						$before_title, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						( self::$instance_count > 1 ? '-' . (int) self::$instance_count : '' ),
+						esc_html( $instance['title_following'] ),
+						$after_title, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						"\n"
+					);
 				}
 			} elseif ( ! empty( $instance['title'] ) ) {
-				echo $before_title . '<label for="subscribe-field' . ( self::$instance_count > 1 ? '-' . self::$instance_count : '' ) . '">' . $instance['title'] . '</label>' . $after_title . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				printf(
+					'%1$s<label for="subscribe-field%2$s">%3$s</label>%4$s%5$s',
+					$before_title, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					( self::$instance_count > 1 ? '-' . (int) self::$instance_count : '' ),
+					esc_html( $instance['title'] ),
+					$after_title, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					"\n"
+				);
 			}
 		}
 
 		if ( self::is_jetpack() && empty( $instance['show_only_email_and_button'] ) ) {
-			echo $args['before_title'] . $instance['title'] . $args['after_title'] . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			printf(
+				'%1$s%2$s%3$s%4$s',
+				$before_title, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				esc_html( $instance['title'] ),
+				$after_title, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				"\n"
+			);
 		}
 	}
 
@@ -338,7 +358,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$show_subscribers_total       = (bool) $instance['show_subscribers_total'];
 		$subscribers_total            = self::fetch_subscriber_count();
 		$subscribe_text               = empty( $instance['show_only_email_and_button'] ) ?
-			stripslashes( $instance['subscribe_text'] ) :
+			wp_kses_post( $instance['subscribe_text'] ) :
 			false;
 		$referer                      = esc_url_raw( ( is_ssl() ? 'https' : 'http' ) . '://' . ( isset( $_SERVER['HTTP_HOST'] ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : '' ) . ( isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '' ) );
 		$source                       = 'widget';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add extra escaping and better separate output to avoid too general phpcs ignores.

## Proposed changes:
* Refactors subscription block HTML code generation.
* Improves escaping of output.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p3btAN-2DW-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Go to Jetpack > Settings and enable the Subscriptions feature.
* In a new post, add a shortcode block like `[jetpack_subscription_form title="Some title" show_only_email_and_button="" subscribe_text="Subscribe to this blog!" ]
* Ensure the output on the frontend is correct.
