### PR TITLE
Boost: only cache pages when the Cache module is enabled

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -178,6 +178,10 @@ class Request {
 			return false;
 		}
 
+		if ( $this->is_module_disabled() ) {
+			return false;
+		}
+
 		/**
 		 * Filters the accept headers to determine if the request should be cached.
 		 *
@@ -296,5 +300,23 @@ class Request {
 		}
 
 		return \is_feed();
+	}
+
+	/**
+	 * Return true if the Page Cache module is disabled.
+	 * If Status and Page_Cache are not available, it means we are in a
+	 * pre-WordPress environment, so we assume the module is active.
+	 * This function will be called later when writing a cache file to disk.
+	 * It's then that we can check if the module is active.
+	 *
+	 * @return bool
+	 */
+	public function is_module_disabled() {
+		if ( class_exists( '\Automattic\Jetpack_Boost\Lib\Status' ) && class_exists( '\Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache' ) ) {
+			$page_cache_status = new \Automattic\Jetpack_Boost\Lib\Status( \Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache::get_slug() );
+			return ! $page_cache_status->is_enabled();
+		} else {
+			return false; // If the classes are not available, assume the module is active.
+		}
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -312,8 +312,13 @@ class Request {
 	 * @return bool
 	 */
 	public function is_module_disabled() {
-		if ( class_exists( '\Automattic\Jetpack_Boost\Lib\Status' ) && class_exists( '\Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache' ) ) {
-			$page_cache_status = new \Automattic\Jetpack_Boost\Lib\Status( \Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache::get_slug() );
+		if (
+			class_exists( '\Automattic\Jetpack_Boost\Lib\Status' ) &&
+			class_exists( '\Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache' )
+		) {
+			$page_cache_status = new \Automattic\Jetpack_Boost\Lib\Status(
+				\Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache::get_slug()
+			);
 			return ! $page_cache_status->is_enabled();
 		} else {
 			return false; // If the classes are not available, assume the module is active.

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -312,6 +312,12 @@ class Request {
 	 * @return bool
 	 */
 	public function is_module_disabled() {
+
+		// A simple check to make sure we're in the output buffer callback.
+		if ( ! function_exists( '\is_feed' ) ) {
+			return false;
+		}
+
 		if (
 			class_exists( '\Automattic\Jetpack_Boost\Lib\Status' ) &&
 			class_exists( '\Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache' )
@@ -321,7 +327,7 @@ class Request {
 			);
 			return ! $page_cache_status->is_enabled();
 		} else {
-			return false; // If the classes are not available, assume the module is active.
+			return true; // if the classes aren't available, the plugin isn't loaded.
 		}
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -303,19 +303,19 @@ class Request {
 	}
 
 	/**
-	 * Return true if the Page Cache module is disabled.
+	 * Return true if the Page Cache module is disabled, or null if we don't know yet.
 	 *
 	 * If Status and Page_Cache are not available, it means the plugin is not loaded.
 	 * This function will be called later when writing a cache file to disk.
 	 * It's then that we can check if the module is active.
 	 *
-	 * @return bool
+	 * @return null|bool
 	 */
 	public function is_module_disabled() {
 
 		// A simple check to make sure we're in the output buffer callback.
 		if ( ! function_exists( '\is_feed' ) ) {
-			return false;
+			return null;
 		}
 
 		if (

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -304,8 +304,8 @@ class Request {
 
 	/**
 	 * Return true if the Page Cache module is disabled.
-	 * If Status and Page_Cache are not available, it means we are in a
-	 * pre-WordPress environment, so we assume the module is active.
+	 *
+	 * If Status and Page_Cache are not available, it means the plugin is not loaded.
 	 * This function will be called later when writing a cache file to disk.
 	 * It's then that we can check if the module is active.
 	 *

--- a/projects/plugins/boost/changelog/update-boost-check-module-active
+++ b/projects/plugins/boost/changelog/update-boost-check-module-active
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+WP Super Cache: only save a cached file if the Page_Cache module is enabled

--- a/projects/plugins/boost/changelog/update-boost-check-module-active#2
+++ b/projects/plugins/boost/changelog/update-boost-check-module-active#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "3.1.2-alpha",
+	"version": "3.2.0-alpha",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -73,7 +73,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_1_2_alpha",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_2_0_alpha",
 		"allow-plugins": {
 			"roots/wordpress-core-installer": true,
 			"automattic/jetpack-autoloader": true,

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "475e80eb8ba2a121c0ff8a377954a01d",
+    "content-hash": "7d2b1830ca2f25bb0927698b64460454",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 3.1.2-alpha
+ * Version: 3.2.0-alpha
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'JETPACK_BOOST_VERSION', '3.1.2-alpha' );
+define( 'JETPACK_BOOST_VERSION', '3.2.0-alpha' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-boost",
-	"version": "3.1.2-alpha",
+	"version": "3.2.0-alpha",
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"directories": {
 		"test": "tests"


### PR DESCRIPTION
If you have a multisite it is possible that only one site has Boost activated, and caching enabled. On such a server, all the sites will have cached pages, but the cache can only be cleared on the site where the plugin is active.

This PR fixes that by checking if the Cache module is enabled.

Fixes [#35771](https://github.com/Automattic/jetpack/issues/35771)

## Proposed changes:
* Add a new function is_module_disabled() to Request that returns the Status of the Page_Cache module
* If those classes aren't available, it presumes the module is enabled.
* This function is called by is_cacheable()
* is_cacheable() is called at the start of the process and at the very end.
* At the very end the module check can be done..

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
You'll need a multisite installation of WordPress.
Add a second blog.
Install this branch of the plugin
Two tests needs to be done:

### Test 1
1. Only activate the plugin on one of the blogs.
2. Enable the Page Cache module.
3. Load a few pages on each blog in a private window.
4. Check the wp-content/boost-cache/cache/ directory for the blog that didn't have the plugin active, as it shouldn't be there.

### Test 2
1. Activate the plugin on both blogs.
2. Delete the wp-content/boost-cache/cache/ directory to start fresh.
3. Enable the Page Cache module on *one* blog only.
4. Load a few pages on each blog in a private window.
5. Check the wp-content/boost-cache/cache/ directory for the blog that didn't have the module active, as it shouldn't be there.
