### PR TITLE
Scheduled Update: Fix bool to array conversion

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-array-conversion
+++ b/projects/packages/scheduled-updates/changelog/fix-array-conversion
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor code cleanup
+
+

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.2';
+	const PACKAGE_VERSION = '0.3.3-alpha';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -120,7 +120,7 @@ class Scheduled_Updates {
 
 		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
 
-		$schedules = false;
+		$schedules = array();
 		foreach ( $events as $event ) {
 			if ( in_array( $plugin_file, $event->args, true ) ) {
 				$schedules[] = $event;


### PR DESCRIPTION
Fixes #36349


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set schedules as an empty array by default

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Code review

