### PR TITLE
Scheduled Updates: Send full update objects to the updates API

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-plugins-update-payload
+++ b/projects/packages/scheduled-updates/changelog/fix-plugins-update-payload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug where only plugin slugs were send to the update handler instead of full update objects.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.3';
+	const PACKAGE_VERSION = '0.3.4-alpha';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -62,20 +62,18 @@ class Scheduled_Updates {
 	 */
 	public static function run_scheduled_update( ...$plugins ) {
 		$available_updates = get_site_transient( 'update_plugins' );
-		$plugins           = array_filter(
-			$plugins,
-			function ( $plugin ) use ( $available_updates ) {
-				return isset( $available_updates->response[ $plugin ] );
-			}
-		);
+		$plugins_to_update = $available_updates->response ?? array();
+		$plugins_to_update = array_intersect_key( $plugins_to_update, array_flip( $plugins ) );
 
-		$body = empty( $plugins ) ? null : array( 'plugins' => $plugins );
+		if ( empty( $plugins_to_update ) ) {
+			return;
+		}
 
 		( new Connection\Client() )->wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
 			'2',
 			array( 'method' => 'POST' ),
-			$body,
+			array( 'plugins' => $plugins_to_update ),
 			'wpcom'
 		);
 	}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use response array as base for determining plugin updates.
* Bail early when there are no updates to send.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a schedule with timestamp that triggers shortly.
* Visit a page on your test site to trigger the schedule.
* Make sure updates work as expected.
