### PR TITLE
Backport mu-wpcom-plugin 2.1.3, jetpack 13.3-a.1 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2024-03-12
+### Changed
+- Fix typescript errors [#35904]
+- Updated package dependencies. [#36325]
+
+### Fixed
+- AI Client: Fix audio recording where WebM is not supported (iOS for example). [#36160]
+
 ## [0.8.2] - 2024-03-04
 ### Added
 - AI Client: add audio validation hook. [#36043]
@@ -247,6 +255,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.9.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/Automattic/jetpack-ai-client/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.7.0...v0.8.0

--- a/projects/js-packages/ai-client/changelog/fix-extensions-typescript
+++ b/projects/js-packages/ai-client/changelog/fix-extensions-typescript
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Fix typescript errors

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/changelog/update-voice-to-content-fix-audio-recording-on-ios
+++ b/projects/js-packages/ai-client/changelog/update-voice-to-content-fix-audio-recording-on-ios
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Client: Fix audio recording where WebM is not supported (iOS for example).

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.9.0-alpha",
+	"version": "0.9.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.17.2] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [0.17.1] - 2024-03-04
 ### Changed
 - Updated package dependencies. [#36095]
@@ -306,6 +310,7 @@
 - Add the API methods left behind by the previous PR.
 - Initial release of jetpack-api package
 
+[0.17.2]: https://github.com/Automattic/jetpack-api/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Automattic/jetpack-api/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Automattic/jetpack-api/compare/v0.16.10...v0.17.0
 [0.16.10]: https://github.com/Automattic/jetpack-api/compare/v0.16.9...v0.16.10

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.17.2-alpha",
+	"version": "0.17.2",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.19] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [0.6.18] - 2024-03-04
 ### Changed
 - Updated package dependencies. [#36095]
@@ -254,6 +258,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.19]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.18...0.6.19
 [0.6.18]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.17...0.6.18
 [0.6.17]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.16...0.6.17
 [0.6.16]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.15...0.6.16

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.19-alpha",
+	"version": "0.6.19",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.26] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [0.1.25] - 2024-03-04
 ### Changed
 - Updated package dependencies. [#36095]
@@ -115,6 +119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.26]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.24...v0.1.25
 [0.1.24]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.23...v0.1.24
 [0.1.23]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.22...v0.1.23

--- a/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.26-alpha",
+	"version": "0.1.26",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.50.1] - 2024-03-12
+### Added
+- Social Logos: add new SMS icon. [#36176]
+
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [0.50.0] - 2024-03-07
 ### Added
 - Fix typescript errors [#35904]
@@ -971,6 +978,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.50.1]: https://github.com/Automattic/jetpack-components/compare/0.50.0...0.50.1
 [0.50.0]: https://github.com/Automattic/jetpack-components/compare/0.49.2...0.50.0
 [0.49.2]: https://github.com/Automattic/jetpack-components/compare/0.49.1...0.49.2
 [0.49.1]: https://github.com/Automattic/jetpack-components/compare/0.49.0...0.49.1

--- a/projects/js-packages/components/changelog/add-sms-icon-social-logos
+++ b/projects/js-packages/components/changelog/add-sms-icon-social-logos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Social Logos: add new SMS icon.

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.50.1-alpha",
+	"version": "0.50.1",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.33.3] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [0.33.2] - 2024-03-07
 ### Changed
 - Update dependencies.
@@ -726,6 +730,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.33.3]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.2...v0.33.3
 [0.33.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.1...v0.33.2
 [0.33.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.32.4...v0.33.0

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.33.3-alpha",
+	"version": "0.33.3",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.47] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [2.0.46] - 2024-03-04
 ### Changed
 - Updated package dependencies. [#36095]
@@ -213,6 +217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.47]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.46...v2.0.47
 [2.0.46]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.45...v2.0.46
 [2.0.45]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.44...v2.0.45
 [2.0.44]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.43...v2.0.44

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.47-alpha",
+	"version": "2.0.47",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.66 - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## 0.10.65 - 2024-03-07
 ### Changed
 - Update dependencies.

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.66-alpha",
+	"version": "0.10.66",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.6 - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## 0.12.5 - 2024-03-07
 ### Changed
 - Update dependencies.

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.12.6-alpha",
+	"version": "0.12.6",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.72 - 2024-03-12
+### Changed
+- Update dependencies. [#36243]
+- Updated package dependencies. [#36325]
+
 ## 0.2.71 - 2024-03-04
 ### Changed
 - Update dependencies. [#36113]

--- a/projects/js-packages/partner-coupon/changelog/force-a-release
+++ b/projects/js-packages/partner-coupon/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.72-alpha",
+	"version": "0.2.72",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.4] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [0.48.3] - 2024-03-07
 ### Changed
 - Update dependencies. [#36156]
@@ -616,6 +620,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.48.4]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.48.3...v0.48.4
 [0.48.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.48.2...v0.48.3
 [0.48.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.48.1...v0.48.2
 [0.48.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.48.0...v0.48.1

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.48.4-alpha",
+	"version": "0.48.4",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.7] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [0.14.6] - 2024-03-07
 ### Changed
 - Update dependencies.
@@ -356,6 +360,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.14.7]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.6...0.14.7
 [0.14.6]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.5...0.14.6
 [0.14.5]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.4...0.14.5
 [0.14.4]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.3...0.14.4

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.14.7-alpha",
+	"version": "0.14.7",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.2.2 - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## 3.2.1 - 2024-03-04
 ### Changed
 - Updated package dependencies.

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.2.2-alpha",
+	"version": "3.2.2",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [2.1.2] - 2024-03-04
 ### Changed
 - Updated package dependencies. [#36095]
@@ -411,6 +415,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[2.1.3]: https://github.com/Automattic/jetpack-assets/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/Automattic/jetpack-assets/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/Automattic/jetpack-assets/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/Automattic/jetpack-assets/compare/v2.0.4...v2.1.0

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2024-03-12
+### Changed
+- Update dependencies. [#36243]
+- Updated package dependencies. [#36325]
+
 ## [3.3.0] - 2024-03-04
 ### Added
 - Add endpoint to query backup preflight checks [#36032]
@@ -576,6 +581,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.3.1]: https://github.com/Automattic/jetpack-backup/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/Automattic/jetpack-backup/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/Automattic/jetpack-backup/compare/v3.1.5...v3.2.0
 [3.1.5]: https://github.com/Automattic/jetpack-backup/compare/v3.1.4...v3.1.5

--- a/projects/packages/backup/changelog/force-a-release
+++ b/projects/packages/backup/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.1-alpha';
+	const PACKAGE_VERSION = '3.3.1';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
+### Fixed
+- Fixes the response body for the errors returned by the Blaze controller [#36134]
+
 ## [0.19.0] - 2024-03-04
 ### Added
 - Add support for running DSP Campaign Creation API endpoint v1.1 from DSP widget [#36120]
@@ -312,6 +319,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.19.1]: https://github.com/automattic/jetpack-blaze/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/automattic/jetpack-blaze/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/automattic/jetpack-blaze/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/automattic/jetpack-blaze/compare/v0.17.0...v0.18.0

--- a/projects/packages/blaze/changelog/fix-blaze-controller-error-responses
+++ b/projects/packages/blaze/changelog/fix-blaze-controller-error-responses
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixes the response body for the errors returned by the Blaze controller

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.19.1-alpha",
+	"version": "0.19.1",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.19.1-alpha';
+	const PACKAGE_VERSION = '0.19.1';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2024-03-12
+### Added
+- Sync:Now Sync uses rest api endpoint for enabled sites [#36210]
+
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [2.3.4] - 2024-03-04
 ### Changed
 - Updated package dependencies. [#36095]
@@ -976,6 +983,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.4.0]: https://github.com/Automattic/jetpack-connection/compare/v2.3.4...v2.4.0
 [2.3.4]: https://github.com/Automattic/jetpack-connection/compare/v2.3.3...v2.3.4
 [2.3.3]: https://github.com/Automattic/jetpack-connection/compare/v2.3.2...v2.3.3
 [2.3.2]: https://github.com/Automattic/jetpack-connection/compare/v2.3.1...v2.3.2

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/changelog/update-sync-using-new-rest-api-endpoint
+++ b/projects/packages/connection/changelog/update-sync-using-new-rest-api-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Sync:Now Sync uses rest api endpoint for enabled sites

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.4.0-alpha';
+	const PACKAGE_VERSION = '2.4.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.10] - 2024-03-12
+### Changed
+- Update code references in docs and comments [#36234]
+- Updated package dependencies. [#36325]
+
 ## [0.30.9] - 2024-03-12
 ### Fixed
 - Performance: avoid querying for posts on all pages of the dashboard, and only do so on Feedback admin pages. [#36230]
@@ -509,6 +514,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.10]: https://github.com/automattic/jetpack-forms/compare/v0.30.9...v0.30.10
 [0.30.9]: https://github.com/automattic/jetpack-forms/compare/v0.30.8...v0.30.9
 [0.30.8]: https://github.com/automattic/jetpack-forms/compare/v0.30.7...v0.30.8
 [0.30.7]: https://github.com/automattic/jetpack-forms/compare/v0.30.6...v0.30.7

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/changelog/update-contact-form-doc-refs
+++ b/projects/packages/forms/changelog/update-contact-form-doc-refs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update code references in docs and comments

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.10-alpha",
+	"version": "0.30.10",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.10-alpha';
+	const PACKAGE_VERSION = '0.30.10';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [0.17.1] - 2024-03-04
 ### Changed
 - Updated package dependencies.
@@ -495,6 +499,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.17.2]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.15.1...v0.16.0

--- a/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.17.2-alpha",
+	"version": "0.17.2",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.17.2-alpha';
+	const PACKAGE_VERSION = '0.17.2';
 
 	/**
 	 * Persistent WPCOM blog ID that stays in the options after disconnect.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.16.0] - 2024-03-12
+### Added
+- Added Connections to the Hosting menu [#36302]
+
+### Changed
+- Updated package dependencies. [#36325]
+
 ## [5.15.2] - 2024-03-11
 ### Changed
 - External dependencies of the Command Palette are now explicitly declared. [#36184]
@@ -640,6 +647,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.16.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.15.2...v5.16.0
 [5.15.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.15.1...v5.15.2
 [5.15.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.15.0...v5.15.1
 [5.15.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.14.1...v5.15.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-connections-hosting-menu-item
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-connections-hosting-menu-item
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added Connections to the Hosting menu

--- a/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.16.0-alpha",
+	"version": "5.16.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.16.0-alpha';
+	const PACKAGE_VERSION = '5.16.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2024-03-12
+### Changed
+- Performance: only enqueue the JITM JavaScript on pages where it will be used. [#35997]
+- Updated package dependencies. [#36325]
+
 ## [3.0.5] - 2024-03-04
 ### Changed
 - Updated package dependencies. [#36095]
@@ -674,6 +679,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.1.0]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.5...v3.1.0
 [3.0.5]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.4...v3.0.5
 [3.0.4]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.3...v3.0.4
 [3.0.3]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.2...v3.0.3

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jitm/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/packages/jitm/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Performance: only enqueue the JITM JavaScript on pages where it will be used.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.1.0-alpha';
+	const PACKAGE_VERSION = '3.1.0';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.
@@ -134,7 +134,7 @@ class JITM {
 	 * Check if the current page is a Jetpack or WooCommerce admin page.
 	 * Noting that this is a very basic check, and pages from other plugins may also match.
 	 *
-	 * @since $$next-version$$
+	 * @since 3.1.0
 	 *
 	 * @return bool True if the current page is a Jetpack or WooCommerce admin page, else false.
 	 */
@@ -199,10 +199,10 @@ class JITM {
 	 * @since 1.1.0
 	 * @since-jetpack 8.0.0
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 3.1.0
 	 */
 	public function is_gutenberg_page() {
-		_deprecated_function( __METHOD__, '$$next-version$$' );
+		_deprecated_function( __METHOD__, '3.1.0' );
 		$current_screen = get_current_screen();
 		return ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() );
 	}

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.16.0] - 2024-03-12
+### Added
+- Add a red bubble notification that shows if the site is disconnected [#36263]
+- Add README to data directory [#36301]
+- Add whitelist to show errors only for certain queries [#36261]
+
+### Changed
+- Migrate Stats counts out of redux and into tanstack queries [#36195]
+- Replace window state calls with util function [#36271]
+- Rewrite My Jetpack utils to typescript [#36296]
+- Show small stats card in table if large stats card isn't showing [#36136]
+- Updated package dependencies. [#36325]
+- Update query hooks for my-jetpack data" [#36257]
+- Update useMyJetpackConnection hook to TypeScript [#36300]
+
+### Removed
+- Removing redux store [#36256]
+
 ## [4.15.0] - 2024-03-07
 ### Added
 - Refactor My Jetpack's backup related redux state to react query. [#35982]
@@ -1325,6 +1343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.16.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.15.0...4.16.0
 [4.15.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.14.0...4.15.0
 [4.14.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.13.0...4.14.0
 [4.13.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.12.1...4.13.0

--- a/projects/packages/my-jetpack/changelog/add-error-notice-whitelist
+++ b/projects/packages/my-jetpack/changelog/add-error-notice-whitelist
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add whitelist to show errors only for certain queries

--- a/projects/packages/my-jetpack/changelog/add-readme-to-data-directory
+++ b/projects/packages/my-jetpack/changelog/add-readme-to-data-directory
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add README to data directory

--- a/projects/packages/my-jetpack/changelog/add-red-bubble-prototype
+++ b/projects/packages/my-jetpack/changelog/add-red-bubble-prototype
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a red bubble notification that shows if the site is disconnected

--- a/projects/packages/my-jetpack/changelog/remove-redux-store
+++ b/projects/packages/my-jetpack/changelog/remove-redux-store
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Removing redux store

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/update-migrate-stats-counts-to-tanstack
+++ b/projects/packages/my-jetpack/changelog/update-migrate-stats-counts-to-tanstack
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Migrate Stats counts out of redux and into tanstack queries

--- a/projects/packages/my-jetpack/changelog/update-rewrite-use-my-jetpack-connection-hook-to-typescript
+++ b/projects/packages/my-jetpack/changelog/update-rewrite-use-my-jetpack-connection-hook-to-typescript
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update useMyJetpackConnection hook to TypeScript

--- a/projects/packages/my-jetpack/changelog/update-show-stats-card-in-products-table-when-large-card-isnt-shown
+++ b/projects/packages/my-jetpack/changelog/update-show-stats-card-in-products-table-when-large-card-isnt-shown
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Show small stats card in table if large stats card isn't showing

--- a/projects/packages/my-jetpack/changelog/update-update-query-hooks-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-update-query-hooks-my-jetpack
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update query hooks for my-jetpack data"

--- a/projects/packages/my-jetpack/changelog/update-utils-to-typescript
+++ b/projects/packages/my-jetpack/changelog/update-utils-to-typescript
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Rewrite My Jetpack utils to typescript

--- a/projects/packages/my-jetpack/changelog/update-window-state-calls-with-new-function
+++ b/projects/packages/my-jetpack/changelog/update-window-state-calls-with-new-function
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Replace window state calls with util function

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.16.0-alpha",
+	"version": "4.16.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.16.0-alpha';
+	const PACKAGE_VERSION = '4.16.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.5] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
+### Fixed
+- REST requests: avoid potential warnings with custom objects. [#36315]
+
 ## [0.42.4] - 2024-03-04
 ### Security
 - Added new tests for the OG image optimization logic [#35987]
@@ -491,6 +498,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.42.5]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.4...v0.42.5
 [0.42.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.3...v0.42.4
 [0.42.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.2...v0.42.3
 [0.42.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.1...v0.42.2

--- a/projects/packages/publicize/changelog/fix-warnings-custom-obj-rest-field
+++ b/projects/packages/publicize/changelog/fix-warnings-custom-obj-rest-field
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-REST requests: avoid potential warnings with custom objects.

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.5-alpha",
+	"version": "0.42.5",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2024-03-12
+### Fixed
+- Fixed a bug where timezone difference where not taken into account when displaying schedule run times in wp-admin. [#36335]
+
 ## [0.3.2] - 2024-03-11
 ### Added
 - Added a new endpoint /plugins/capabilities that returns whether we can update plugins. [#36238]
@@ -54,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.3.3]: https://github.com/Automattic/scheduled-updates/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Automattic/scheduled-updates/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/scheduled-updates/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/scheduled-updates/compare/v0.2.1...v0.3.0

--- a/projects/packages/scheduled-updates/changelog/fix-array-conversion
+++ b/projects/packages/scheduled-updates/changelog/fix-array-conversion
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Minor code cleanup
-
-

--- a/projects/packages/scheduled-updates/changelog/fix-time-display
+++ b/projects/packages/scheduled-updates/changelog/fix-time-display
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a bug where timezone difference where not taken into account when displaying schedule run times in wp-admin.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.3-alpha';
+	const PACKAGE_VERSION = '0.3.3';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.5] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+- Update to the most recent version of the @automattic/calypso-color-schemes package. [#36187]
+- Update to the most recent version of the @automattic/calypso-color-schemes package. [#36227]
+
 ## [0.43.4] - 2024-03-04
 ### Changed
 - Update dependencies. [#36113]
@@ -907,6 +913,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.43.5]: https://github.com/Automattic/jetpack-search/compare/v0.43.4...v0.43.5
 [0.43.4]: https://github.com/Automattic/jetpack-search/compare/v0.43.3...v0.43.4
 [0.43.3]: https://github.com/Automattic/jetpack-search/compare/v0.43.2...v0.43.3
 [0.43.2]: https://github.com/Automattic/jetpack-search/compare/v0.43.1...v0.43.2

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/update-calypso-color-schemes-release-312
+++ b/projects/packages/search/changelog/update-calypso-color-schemes-release-312
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update to the most recent version of the @automattic/calypso-color-schemes package.

--- a/projects/packages/search/changelog/update-calypso-color-schemes-release-313
+++ b/projects/packages/search/changelog/update-calypso-color-schemes-release-313
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update to the most recent version of the @automattic/calypso-color-schemes package.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.43.5-alpha",
+	"version": "0.43.5",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.43.5-alpha';
+	const VERSION = '0.43.5';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - 2024-03-12
+### Added
+- Sync:Now Sync uses rest api endpoint for enabled sites [#36210]
+
 ## [2.9.0] - 2024-03-04
 ### Added
 - Sync: Add feature flag for enabling the use of rest api for sending the sync data [#36118]
@@ -1064,6 +1068,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.10.0]: https://github.com/Automattic/jetpack-sync/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/Automattic/jetpack-sync/compare/v2.8.1...v2.9.0
 [2.8.1]: https://github.com/Automattic/jetpack-sync/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/Automattic/jetpack-sync/compare/v2.7.0...v2.8.0

--- a/projects/packages/sync/changelog/update-sync-using-new-rest-api-endpoint
+++ b/projects/packages/sync/changelog/update-sync-using-new-rest-api-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Sync:Now Sync uses rest api endpoint for enabled sites

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.10.0-alpha';
+	const PACKAGE_VERSION = '2.10.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.9] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+
+### Fixed
+- REST requests: avoid potential warnings with custom objects. [#36315]
+
 ## [0.23.8] - 2024-03-07
 ### Changed
 - Update to the most recent version of the @automattic/calypso-color-schemes package. [#36187]
@@ -1283,6 +1290,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.9]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.8...v0.23.9
 [0.23.8]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.7...v0.23.8
 [0.23.7]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.6...v0.23.7
 [0.23.6]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.5...v0.23.6

--- a/projects/packages/videopress/changelog/fix-warnings-custom-obj-rest-field
+++ b/projects/packages/videopress/changelog/fix-warnings-custom-obj-rest-field
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-REST requests: avoid potential warnings with custom objects.

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.9-alpha",
+	"version": "0.23.9",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.9-alpha';
+	const PACKAGE_VERSION = '0.23.9';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2024-03-12
+### Added
+- Add JSON parameter support to the Web Application Firewall. [#36169]
+
 ## [0.14.2] - 2024-03-04
 ### Fixed
 - Fixed base64 transforms to better conform with the modsecurity runtime [#35693]
@@ -273,6 +277,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.15.0]: https://github.com/Automattic/jetpack-waf/compare/v0.14.2...v0.15.0
 [0.14.2]: https://github.com/Automattic/jetpack-waf/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/Automattic/jetpack-waf/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/Automattic/jetpack-waf/compare/v0.13.0...v0.14.0

--- a/projects/packages/waf/changelog/add-json-support-to-the-waf
+++ b/projects/packages/waf/changelog/add-json-support-to-the-waf
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add JSON parameter support to the Web Application Firewall.

--- a/projects/packages/waf/changelog/update-waf-utf8-unicode-transform
+++ b/projects/packages/waf/changelog/update-waf-utf8-unicode-transform
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Improved accuracy of the WAF utf8_to_unicode transform.
-
-

--- a/projects/packages/woocommerce-analytics/CHANGELOG.md
+++ b/projects/packages/woocommerce-analytics/CHANGELOG.md
@@ -5,3 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2024-03-12
+### Added
+- General: add main classes to the package. [#35756]
+- Initial version. [#35754]
+
+### Fixed
+- Avoid any issues when the package is loaded in an mu-plugin. [#36287]
+- Fix namespace issue with WooCommerce class reference. [#35857]
+- General: bail early when WooCommerce is not active. [#36278]

--- a/projects/packages/woocommerce-analytics/changelog/add-codebase-woo-analytics
+++ b/projects/packages/woocommerce-analytics/changelog/add-codebase-woo-analytics
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-General: add main classes to the package.

--- a/projects/packages/woocommerce-analytics/changelog/fix-mu-plugins-woo-analytics
+++ b/projects/packages/woocommerce-analytics/changelog/fix-mu-plugins-woo-analytics
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Avoid any issues when the package is loaded in an mu-plugin.

--- a/projects/packages/woocommerce-analytics/changelog/fix-woo-analytics-bail-missing
+++ b/projects/packages/woocommerce-analytics/changelog/fix-woo-analytics-bail-missing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-General: bail early when WooCommerce is not active.

--- a/projects/packages/woocommerce-analytics/changelog/fix-woo-analytics-namespace-error
+++ b/projects/packages/woocommerce-analytics/changelog/fix-woo-analytics-namespace-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix namespace issue with WooCommerce class reference.

--- a/projects/packages/woocommerce-analytics/changelog/initial-version
+++ b/projects/packages/woocommerce-analytics/changelog/initial-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Initial version.

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -20,7 +20,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 
 	/**
 	 * Initializer.

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.11] - 2024-03-12
+### Changed
+- Updated package dependencies. [#36325]
+- Update to the most recent version of the @automattic/calypso-color-schemes package. [#36187]
+- Update to the most recent version of the @automattic/calypso-color-schemes package. [#36227]
+
 ## [0.3.10] - 2024-03-04
 ### Changed
 - Update dependencies. [#36113]
@@ -316,6 +322,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.11]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.10...v0.3.11
 [0.3.10]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.9...v0.3.10
 [0.3.9]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.7...v0.3.8

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/changelog/update-calypso-color-schemes-release-312
+++ b/projects/packages/wordads/changelog/update-calypso-color-schemes-release-312
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update to the most recent version of the @automattic/calypso-color-schemes package.

--- a/projects/packages/wordads/changelog/update-calypso-color-schemes-release-313
+++ b/projects/packages/wordads/changelog/update-calypso-color-schemes-release-313
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update to the most recent version of the @automattic/calypso-color-schemes package.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.11-alpha",
+	"version": "0.3.11",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.11-alpha';
+	const VERSION = '0.3.11';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.3-a.1 - 2024-03-12
+### Enhancements
+- Display Email settings on Newsletter settings page [#36290]
+- Login block: Link to subscription management page with site URL as search query.
+- Member login block: link to individual subscription management page [#36200]
+- Pass API parameter to indicate when deleting a memberships product should cancel subscriptions [#35735]
+- Sharing: add a Threads sharing button and a Threads sharing button block. [#36220]
+- Social Menu & Social Media Icons: Add support for an SMS button. [#36176]
+- Uncheck users-new.php Invite user on load if WooCommerce plugin is activated [#36140]
+
+### Improved compatibility
+- Add metadata to the post to better diagnose need for Reader and Firehose [#36254]
+
+### Bug fixes
+- Sharing: avoid PHP warnings when using custom post types. [#36315]
+- Sharing: fix the display of the sharing block in some classic themes. [#36283]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add site migration endpoint [#36253]
+- Compile typescript extensions in Jetpack [#35904]
+- Contact Form: add deprecation warnings to Contact Form module codebase [#36040]
+- Contact Form: refactor editor to use forms package [#36089]
+- Contact Form: refactor endpoints to use forms package [#36087]
+- Editor: Update to the most recent version of the @automattic/calypso-color-schemes package. [#36227]
+- General: update to the most recent version of @automattic/calypso-color-schemes [#36187]
+- Newsletter settings: update section title to "subscriptions" [#36343]
+- Paywall: Use Subscriber Login block for the login link [#36308]
+- Pinterest Block: deprecate in favor of the Core Pinterest embed block. [#36075]
+- Refactor user_is_paid_subscriber to compare against tiers [#35587]
+- Removed the feature flag for newsletter categories settings. [#36073]
+- RNMobile: Remove code associated with Story block for the mobile native version. [#36151]
+- Show Browse sites when wp-admin interface is selected and using nav unification [#36198]
+- Subscriber Login: Prevent the HTTP 301 redirection for Atomic sites [#36311]
+- Subscriber Login: Remove the premium content cookie specified for the blog on logging out [#35441]
+- Subscriptions: fix empty email for pending confirm paywall on .com [#36321]
+- Subscriptions: Track newsletter category creation. [#36326]
+- Subscriptions: update the settings screen URL. [#36323]
+- Subscription Site: Polishing Newsletter settings [#36218]
+- Subscription Site: Polishing the Subscribe block toggle [#36177]
+- Subscription Site: Update Subscribe block after the post nudge [#36107]
+- Update code references in docs and comments [#36234]
+- Updated package dependencies. [#36309]
+- Updated package dependencies. [#36325]
+- Update lockfiles [#36195]
+- Use JS and CSS tooltips instead of HTML title. [#36222]
+- Voice to Content: Fix file upload file type selection for iOS devices, listing all the extensions allowed. [#36165]
+- Voice to Content: restrict block to internal P2 sites and open it to non-proxied connections. [#36163]
+- WooCommerce Anlytics: require package instead of using the classes that ship with the Jetpack plugin. [#35758]
+- WPCOM_JSON_API_Upload_Media_v1_1_Endpoint: Fix errors on invalid post data [#36291]
+
 ## 13.2.1 - 2024-03-12
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
 - Subscriptions: improve security checks when displaying a Subscription form via a shortcode. [#36347]
@@ -9926,6 +9976,7 @@ Other bugfixes and enhancements at https://github.com/Automattic/jetpack/commits
 ## [1.1] - 2011-03-09
 
 - Initial release
+
 [13.2]: https://wp.me/p1moTy-15UC
 [13.1]: https://wp.me/p1moTy-12e0
 [13.0]: https://wp.me/p1moTy-10Xp

--- a/projects/plugins/jetpack/changelog/Improve SSO tooltips
+++ b/projects/plugins/jetpack/changelog/Improve SSO tooltips
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Use JS and CSS tooltips instead of HTML title.

--- a/projects/plugins/jetpack/changelog/add-email-settings
+++ b/projects/plugins/jetpack/changelog/add-email-settings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Display Email settings on Newsletter settings page

--- a/projects/plugins/jetpack/changelog/add-meta-for--firehose
+++ b/projects/plugins/jetpack/changelog/add-meta-for--firehose
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Add metadata to the post to better diagnose need for Reader and Firehose

--- a/projects/plugins/jetpack/changelog/add-newsletter-category-creation-tracking
+++ b/projects/plugins/jetpack/changelog/add-newsletter-category-creation-tracking
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Track newsletter category creation.

--- a/projects/plugins/jetpack/changelog/add-product-delete-cancel-subscriptions
+++ b/projects/plugins/jetpack/changelog/add-product-delete-cancel-subscriptions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Pass API parameter to indicate when deleting a memberships product should cancel subscriptions

--- a/projects/plugins/jetpack/changelog/add-sharing-threads
+++ b/projects/plugins/jetpack/changelog/add-sharing-threads
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Sharing: add a Threads sharing button and a Threads sharing button block.

--- a/projects/plugins/jetpack/changelog/add-site-migration-endpoint-jetpack
+++ b/projects/plugins/jetpack/changelog/add-site-migration-endpoint-jetpack
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add site migration endpoint

--- a/projects/plugins/jetpack/changelog/add-sms-icon-social-logos
+++ b/projects/plugins/jetpack/changelog/add-sms-icon-social-logos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Social Menu & Social Media Icons: Add support for an SMS button.

--- a/projects/plugins/jetpack/changelog/add-waf-json-support
+++ b/projects/plugins/jetpack/changelog/add-waf-json-support
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/draft-fallback-to-mapbox
+++ b/projects/plugins/jetpack/changelog/draft-fallback-to-mapbox
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Implement a fallback
-
-

--- a/projects/plugins/jetpack/changelog/fix-extensions-typescript
+++ b/projects/plugins/jetpack/changelog/fix-extensions-typescript
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Compile typescript extensions in Jetpack

--- a/projects/plugins/jetpack/changelog/fix-memberships-token-expiry-and-http
+++ b/projects/plugins/jetpack/changelog/fix-memberships-token-expiry-and-http
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-

--- a/projects/plugins/jetpack/changelog/fix-newsletter-settings-disable-state
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-settings-disable-state
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix disable state for newsletter setting inputs. Components under feature flag.
-
-

--- a/projects/plugins/jetpack/changelog/fix-sharing-block-services-conditional
+++ b/projects/plugins/jetpack/changelog/fix-sharing-block-services-conditional
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Sharing block: avoid error when a service is not available.
-
-

--- a/projects/plugins/jetpack/changelog/fix-sharing-buttons-link-color
+++ b/projects/plugins/jetpack/changelog/fix-sharing-buttons-link-color
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Sharing: fix the display of the sharing block in some classic themes.

--- a/projects/plugins/jetpack/changelog/fix-show-all-sites
+++ b/projects/plugins/jetpack/changelog/fix-show-all-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Show Browse sites when wp-admin interface is selected and using nav unification

--- a/projects/plugins/jetpack/changelog/fix-subscriptions-paywall-pending-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-paywall-pending-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: fix empty email for pending confirm paywall on .com

--- a/projects/plugins/jetpack/changelog/fix-warnings-custom-obj-rest-field
+++ b/projects/plugins/jetpack/changelog/fix-warnings-custom-obj-rest-field
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Sharing: avoid PHP warnings when using custom post types.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.3-a.2
+
+

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/refactor-memberships-user-is-paid-subscriber
+++ b/projects/plugins/jetpack/changelog/refactor-memberships-user-is-paid-subscriber
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Refactor user_is_paid_subscriber to compare against tiers

--- a/projects/plugins/jetpack/changelog/remove-feature-flags-newsletter-settings
+++ b/projects/plugins/jetpack/changelog/remove-feature-flags-newsletter-settings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Removed the feature flag for newsletter categories settings.

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/require-wooanalytics-jetpack
+++ b/projects/plugins/jetpack/changelog/require-wooanalytics-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WooCommerce Anlytics: require package instead of using the classes that ship with the Jetpack plugin.

--- a/projects/plugins/jetpack/changelog/rnmobile-remove-story-block
+++ b/projects/plugins/jetpack/changelog/rnmobile-remove-story-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-RNMobile: Remove code associated with Story block for the mobile native version.

--- a/projects/plugins/jetpack/changelog/update-calypso-color-schemes-release-312
+++ b/projects/plugins/jetpack/changelog/update-calypso-color-schemes-release-312
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-General: update to the most recent version of @automattic/calypso-color-schemes

--- a/projects/plugins/jetpack/changelog/update-calypso-color-schemes-release-313
+++ b/projects/plugins/jetpack/changelog/update-calypso-color-schemes-release-313
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Editor: Update to the most recent version of the @automattic/calypso-color-schemes package.

--- a/projects/plugins/jetpack/changelog/update-contact-form-doc-refs
+++ b/projects/plugins/jetpack/changelog/update-contact-form-doc-refs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update code references in docs and comments

--- a/projects/plugins/jetpack/changelog/update-contact-form-module-depreacted-fn
+++ b/projects/plugins/jetpack/changelog/update-contact-form-module-depreacted-fn
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Contact Form: add deprecation warnings to Contact Form module codebase

--- a/projects/plugins/jetpack/changelog/update-contact-form-module-editor
+++ b/projects/plugins/jetpack/changelog/update-contact-form-module-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Contact Form: refactor editor to use forms package

--- a/projects/plugins/jetpack/changelog/update-contact-form-module-endpoint
+++ b/projects/plugins/jetpack/changelog/update-contact-form-module-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Contact Form: refactor endpoints to use forms package

--- a/projects/plugins/jetpack/changelog/update-jetpack-app-qr-code-media
+++ b/projects/plugins/jetpack/changelog/update-jetpack-app-qr-code-media
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: The change is a minor copy change, we plan on deploying it to .com to see if there is any difference in terms of usage
-
-

--- a/projects/plugins/jetpack/changelog/update-jitm-jetpack-woo-enqueue
+++ b/projects/plugins/jetpack/changelog/update-jitm-jetpack-woo-enqueue
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-login-block
+++ b/projects/plugins/jetpack/changelog/update-login-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Login block: Link to subscription management page with site URL as search query.

--- a/projects/plugins/jetpack/changelog/update-login-block-manage-subscription-with-site-id
+++ b/projects/plugins/jetpack/changelog/update-login-block-manage-subscription-with-site-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Member login block: link to individual subscription management page

--- a/projects/plugins/jetpack/changelog/update-migrate-stats-counts-to-tanstack
+++ b/projects/plugins/jetpack/changelog/update-migrate-stats-counts-to-tanstack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update lockfiles

--- a/projects/plugins/jetpack/changelog/update-newsletter-settings-section-header
+++ b/projects/plugins/jetpack/changelog/update-newsletter-settings-section-header
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Newsletter settings: update section title to "subscriptions"

--- a/projects/plugins/jetpack/changelog/update-paywall-subscriber-login
+++ b/projects/plugins/jetpack/changelog/update-paywall-subscriber-login
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Paywall: Use Subscriber Login block for the login link

--- a/projects/plugins/jetpack/changelog/update-pinterest-block-deprecate
+++ b/projects/plugins/jetpack/changelog/update-pinterest-block-deprecate
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Pinterest Block: deprecate in favor of the Core Pinterest embed block.

--- a/projects/plugins/jetpack/changelog/update-prevent-http-301-subscriber-login
+++ b/projects/plugins/jetpack/changelog/update-prevent-http-301-subscriber-login
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriber Login: Prevent the HTTP 301 redirection for Atomic sites

--- a/projects/plugins/jetpack/changelog/update-products-state-to-tanstack
+++ b/projects/plugins/jetpack/changelog/update-products-state-to-tanstack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-sso-user-admin-default-invite-checkbox
+++ b/projects/plugins/jetpack/changelog/update-sso-user-admin-default-invite-checkbox
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Uncheck users-new.php Invite user on load if WooCommerce plugin is activated

--- a/projects/plugins/jetpack/changelog/update-subscribe-after-post-content
+++ b/projects/plugins/jetpack/changelog/update-subscribe-after-post-content
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscription Site: Update Subscribe block after the post nudge

--- a/projects/plugins/jetpack/changelog/update-subscriber-login-logout-fix
+++ b/projects/plugins/jetpack/changelog/update-subscriber-login-logout-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriber Login: Remove the premium content cookie specified for the blog on logging out

--- a/projects/plugins/jetpack/changelog/update-subscription-site-settings-template-link
+++ b/projects/plugins/jetpack/changelog/update-subscription-site-settings-template-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscription Site: Polishing Newsletter settings

--- a/projects/plugins/jetpack/changelog/update-subscription-site-toggle-polish
+++ b/projects/plugins/jetpack/changelog/update-subscription-site-toggle-polish
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscription Site: Polishing the Subscribe block toggle

--- a/projects/plugins/jetpack/changelog/update-subscriptions-settings-url
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-settings-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: update the settings screen URL.

--- a/projects/plugins/jetpack/changelog/update-sync-using-new-rest-api-endpoint
+++ b/projects/plugins/jetpack/changelog/update-sync-using-new-rest-api-endpoint
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-upload-media-wpcom
+++ b/projects/plugins/jetpack/changelog/update-upload-media-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WPCOM_JSON_API_Upload_Media_v1_1_Endpoint: Fix errors on invalid post data

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-fix-file-picker-on-ios
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-fix-file-picker-on-ios
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Voice to Content: Fix file upload file type selection for iOS devices, listing all the extensions allowed.

--- a/projects/plugins/jetpack/changelog/update-voice-to-content-register-on-automattic-p2-only
+++ b/projects/plugins/jetpack/changelog/update-voice-to-content-register-on-automattic-p2-only
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Voice to Content: restrict block to internal P2 sites and open it to non-proxied connections.

--- a/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
+++ b/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
@@ -2,7 +2,7 @@
 /**
  * Jetpack's Pre-Connection JITMs class.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  *
  * @package jetpack
  */
@@ -12,19 +12,19 @@ use Automattic\Jetpack\Redirect;
 /**
  * Jetpack's Pre-Connection JITMs. These can be displayed with the JITM package.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  */
 class Jetpack_Pre_Connection_JITMs {
 
 	/**
 	 * Returns all the pre-connection messages.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @return array An array containing the pre-connection JITM messages.
 	 */
 	private function get_raw_messages() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3' );
 		return array();
 	}
 
@@ -35,7 +35,7 @@ class Jetpack_Pre_Connection_JITMs {
 	 * but do not use the standard message defined in jetpack_render_tos_blurb.
 	 * Instead, they use their own custom messages.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param string $description Description string with placeholders.
 	 *
@@ -64,19 +64,19 @@ class Jetpack_Pre_Connection_JITMs {
 	 *
 	 * @since 10.4
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @return array An array containing the pre-connection JITM messages.
 	 */
 	private function maybe_get_raw_partnership_messages() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3' );
 		return array();
 	}
 
 	/**
 	 * Adds the input query arguments to the admin url.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param array $args The query arguments.
 	 *
@@ -90,14 +90,14 @@ class Jetpack_Pre_Connection_JITMs {
 	/**
 	 * Add the Jetpack pre-connection JITMs to the list of pre-connection JITM messages.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param array $pre_connection_messages An array of pre-connection JITMs.
 	 *
 	 * @return array The array of pre-connection JITMs.
 	 */
 	public function add_pre_connection_jitms( $pre_connection_messages ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3' );
 		return $pre_connection_messages;
 	}
 }

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_0",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.3-a.0
+ * Version: 13.3-a.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.3-a.0' );
+define( 'JETPACK__VERSION', '13.3-a.1' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.3-a.1
+ * Version: 13.3-a.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.3-a.1' );
+define( 'JETPACK__VERSION', '13.3-a.2' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -2,7 +2,7 @@
 /**
  * Contact form elements in the admin area. Used with Classic Editor.
  *
- * @deprecated $$next-version$$ Use automattic/jetpack-forms
+ * @deprecated 13.3 Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -20,11 +20,11 @@ add_action( 'media_buttons', 'grunion_media_button', 999 );
 /**
  * Build contact form button.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_media_button
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_media_button
  * @return void
  */
 function grunion_media_button() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_media_button' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_media_button' );
 
 	global $post_ID, $temp_ID, $pagenow;// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
@@ -48,11 +48,11 @@ add_action( 'wp_ajax_grunion_form_builder', 'grunion_display_form_view' );
 /**
  * Display edit form view.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view
  * @return void
  */
 function grunion_display_form_view() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_display_form_view' );
 
 	if ( current_user_can( 'edit_posts' ) ) {
 		require_once GRUNION_PLUGIN_DIR . 'grunion-form-view.php';
@@ -65,11 +65,11 @@ add_action( 'admin_print_styles', 'grunion_admin_css' );
 /**
  * Enqueue styles.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css
  * @return void
  */
 function grunion_admin_css() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_css' );
 
 	global $current_screen;
 	if (
@@ -92,11 +92,11 @@ add_action( 'admin_print_scripts', 'grunion_admin_js' );
 /**
  * Enqueue scripts.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js
  * @return void
  */
 function grunion_admin_js() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_js' );
 
 	global $current_screen;
 	if (
@@ -118,10 +118,10 @@ add_action( 'admin_head', 'grunion_add_bulk_edit_option' );
  * There isn't a better way to do this until
  * https://core.trac.wordpress.org/changeset/17297 is resolved
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option
  */
 function grunion_add_bulk_edit_option() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_bulk_edit_option' );
 
 	$screen = get_current_screen();
 
@@ -161,10 +161,10 @@ add_action( 'admin_init', 'grunion_handle_bulk_spam' );
 /**
  * Handle a bulk spam report
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam
  */
 function grunion_handle_bulk_spam() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_handle_bulk_spam' );
 
 	global $pagenow;
 
@@ -225,11 +225,11 @@ function grunion_handle_bulk_spam() {
 /**
  * Display spam message.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam
  * @return void
  */
 function grunion_message_bulk_spam() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_message_bulk_spam' );
 
 	echo '<div class="updated"><p>' . esc_html__( 'Feedback(s) marked as spam', 'jetpack' ) . '</p></div>';
 }
@@ -238,12 +238,12 @@ add_filter( 'bulk_actions-edit-feedback', 'grunion_admin_bulk_actions' );
 /**
  * Unset edit option when bulk editing.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions
  * @param array $actions List of actions available.
  * @return array $actions
  */
 function grunion_admin_bulk_actions( $actions ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_bulk_actions' );
 
 	global $current_screen;
 	if (
@@ -261,12 +261,12 @@ add_filter( 'views_edit-feedback', 'grunion_admin_view_tabs' );
 /**
  * Unset publish button when editing feedback.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs
  * @param array $views List of post views.
  * @return array $views
  */
 function grunion_admin_view_tabs( $views ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_admin_view_tabs' );
 
 	global $current_screen;
 	if (
@@ -290,12 +290,12 @@ add_filter( 'manage_feedback_posts_columns', 'grunion_post_type_columns_filter' 
 /**
  * Build Feedback admin page columns.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter
  * @param array $cols List of available columns.
  * @return array
  */
 function grunion_post_type_columns_filter( $cols ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_post_type_columns_filter' );
 
 	return array(
 		'cb'                => '<input type="checkbox" />',
@@ -309,11 +309,11 @@ function grunion_post_type_columns_filter( $cols ) { // phpcs:ignore VariableAna
 /**
  * Displays the value for the source column. (This function runs within the loop.)
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date
  * @return void
  */
 function grunion_manage_post_column_date() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_date' );
 
 	echo esc_html( date_i18n( 'Y/m/d', get_the_time( 'U' ) ) );
 }
@@ -321,12 +321,12 @@ function grunion_manage_post_column_date() {
 /**
  * Displays the value for the from column.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from
  * @param  \WP_Post $post Current post.
  * @return void
  */
 function grunion_manage_post_column_from( $post ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_from' );
 
 	$content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $post->ID );
 
@@ -355,12 +355,12 @@ function grunion_manage_post_column_from( $post ) {
 /**
  * Displays the value for the response column.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response
  * @param  \WP_Post $post Current post.
  * @return void
  */
 function grunion_manage_post_column_response( $post ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_response' );
 
 	$content_fields     = array();
 	$non_printable_keys = array(
@@ -429,12 +429,12 @@ function grunion_manage_post_column_response( $post ) {
 /**
  * Displays the value for the source column.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source
  * @param  \WP_Post $post Current post.
  * @return void
  */
 function grunion_manage_post_column_source( $post ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_column_source' );
 
 	if ( ! isset( $post->post_parent ) ) {
 		return;
@@ -454,13 +454,13 @@ add_action( 'manage_posts_custom_column', 'grunion_manage_post_columns', 10, 2 )
 /**
  * Parse message content and display in appropriate columns.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns
  * @param array $col List of columns available on admin page.
  * @param int   $post_id The current post ID.
  * @return void
  */
 function grunion_manage_post_columns( $col, $post_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_columns' );
 
 	global $post;
 
@@ -491,11 +491,11 @@ add_action( 'restrict_manage_posts', 'grunion_source_filter' );
 /**
  * Add a post filter dropdown at the top of the admin page.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter
  * @return void
  */
 function grunion_source_filter() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter' );
 
 	$screen = get_current_screen();
 
@@ -511,12 +511,12 @@ add_action( 'pre_get_posts', 'grunion_source_filter_results' );
 /**
  * Filter feedback posts by parent_id if present.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results
  * @param WP_Query $query Current query.
  * @return void
  */
 function grunion_source_filter_results( $query ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_source_filter_results' );
 
 	$parent_id = intval( isset( $_GET['jetpack_form_parent_id'] ) ? $_GET['jetpack_form_parent_id'] : 0 ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
@@ -536,12 +536,12 @@ add_filter( 'post_row_actions', 'grunion_manage_post_row_actions', 10, 2 );
 /**
  * Add actions to feedback response rows in WP Admin.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions
  * @param string[] $actions Default actions.
  * @return string[]
  */
 function grunion_manage_post_row_actions( $actions ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_manage_post_row_actions' );
 
 	global $post;
 
@@ -598,12 +598,12 @@ function grunion_manage_post_row_actions( $actions ) {
 /**
  * Escape grunion attributes.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr
  * @param string $attr - the attribute we're escaping.
  * @return string
  */
 function grunion_esc_attr( $attr ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_esc_attr' );
 
 	$out = esc_attr( $attr );
 	// we also have to entity-encode square brackets so they don't interfere with the shortcode parser
@@ -616,13 +616,13 @@ function grunion_esc_attr( $attr ) {
 /**
  * Sort grunion items.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects
  * @param array $a - the first item we're sorting.
  * @param array $b - the second item we're sorting.
  * @return string
  */
 function grunion_sort_objects( $a, $b ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_sort_objects' );
 
 	if ( isset( $a['order'] ) && isset( $b['order'] ) ) {
 		return $a['order'] <=> $b['order'];
@@ -634,10 +634,10 @@ function grunion_sort_objects( $a, $b ) {
  * Take an array of field types from the form builder, and construct a shortcode form.
  * returns both the shortcode form, and HTML markup representing a preview of the form
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode
  */
 function grunion_ajax_shortcode() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode' );
 
 	$field_shortcodes = array();
 	check_ajax_referer( 'grunion_shortcode' );
@@ -686,10 +686,10 @@ function grunion_ajax_shortcode() {
  * Takes a post_id, extracts the contact-form shortcode from that post (if there is one), parses it,
  * and constructs a json object representing its contents and attributes.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json
  */
 function grunion_ajax_shortcode_to_json() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_shortcode_to_json' );
 
 	global $post;
 
@@ -748,10 +748,10 @@ add_action( 'wp_ajax_grunion_ajax_spam', 'grunion_ajax_spam' );
 /**
  * Handle marking feedback as spam.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam
  */
 function grunion_ajax_spam() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_ajax_spam' );
 
 	global $wpdb;
 
@@ -927,10 +927,10 @@ function grunion_ajax_spam() {
 /**
  * Add the scripts that will add the "Check for Spam" button to the Feedbacks dashboard page.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck
  */
 function grunion_enable_spam_recheck() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_enable_spam_recheck' );
 
 	if ( ! defined( 'AKISMET_VERSION' ) ) {
 		return;
@@ -952,10 +952,10 @@ add_action( 'admin_enqueue_scripts', 'grunion_enable_spam_recheck' );
 /**
  * Add the JS and CSS necessary for the Feedback admin page to function.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts
  */
 function grunion_add_admin_scripts() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_add_admin_scripts' );
 
 	$screen = get_current_screen();
 
@@ -1008,11 +1008,11 @@ add_action( 'admin_enqueue_scripts', 'grunion_add_admin_scripts' );
 /**
  * Adds the 'Export' button to the feedback dashboard page.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button
  * @return void
  */
 function grunion_export_button() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_export_button' );
 
 	$current_screen = get_current_screen();
 	if ( ! in_array( $current_screen->id, array( 'edit-feedback', 'feedback_page_feedback-export' ), true ) ) {
@@ -1053,10 +1053,10 @@ function grunion_export_button() {
 /**
  * Add the "Check for Spam" button to the Feedbacks dashboard page.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button
  */
 function grunion_check_for_spam_button() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_check_for_spam_button' );
 
 	// Nonce name.
 	$nonce_name = 'jetpack_check_feedback_spam_' . (string) get_current_blog_id();
@@ -1087,10 +1087,10 @@ function grunion_check_for_spam_button() {
 /**
  * Recheck all approved feedbacks for spam.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue
  */
 function grunion_recheck_queue() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_recheck_queue' );
 
 	$blog_id = get_current_blog_id();
 
@@ -1171,10 +1171,10 @@ add_action( 'wp_ajax_grunion_recheck_queue', 'grunion_recheck_queue' );
 /**
  * Delete a number of spam feedbacks via an AJAX request.
  * 
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks
  */
 function grunion_delete_spam_feedbacks() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_delete_spam_feedbacks' );
 
 	if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'jetpack_delete_spam_feedbacks' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- core doesn't sanitize nonce checks either.
 		wp_send_json_error(
@@ -1242,10 +1242,10 @@ add_action( 'wp_ajax_jetpack_delete_spam_feedbacks', 'grunion_delete_spam_feedba
 /**
  * Show an admin notice if the "Empty Spam" or "Check Spam" process was unable to complete, probably due to a permissions error.
  * 
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice
  */
 function grunion_feedback_admin_notice() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->grunion_feedback_admin_notice' );
 
 	if ( isset( $_GET['jetpack_empty_feedback_spam_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		echo '<div class="notice notice-error"><p>' . esc_html( __( 'An error occurred while trying to empty the Feedback spam folder.', 'jetpack' ) ) . '</p></div>';
@@ -1260,7 +1260,7 @@ add_action( 'admin_notices', 'grunion_feedback_admin_notice' );
  *
  * Singleton for Grunion admin area support.
  * 
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin
  */
 class Grunion_Admin {
 	/**
@@ -1280,11 +1280,11 @@ class Grunion_Admin {
 	/**
 	 * Instantiates this singleton class
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin::init
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin::init
 	 * @return Grunion_Admin The Grunion Admin class instance.
 	 */
 	public static function init() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin::init' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin::init' );
 
 		static $instance = false;
 
@@ -1298,10 +1298,10 @@ class Grunion_Admin {
 	/**
 	 * Grunion_Admin constructor
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->__construct
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->__construct
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->__construct' );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'admin_footer-edit.php', array( $this, 'print_export_modal' ) );
@@ -1313,10 +1313,10 @@ class Grunion_Admin {
 	/**
 	 * Hook handler for admin_enqueue_scripts hook
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts
 	 */
 	public function admin_enqueue_scripts() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->admin_enqueue_scripts' );
 
 		$current_screen = get_current_screen();
 		if ( ! in_array( $current_screen->id, array( 'edit-feedback', 'feedback_page_feedback-export' ), true ) ) {
@@ -1333,10 +1333,10 @@ class Grunion_Admin {
 	/**
 	 * Prints the modal markup with export buttons/content.
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal
 	 */
 	public function print_export_modal() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->print_export_modal' );
 
 		if ( ! current_user_can( 'export' ) ) {
 			return;
@@ -1403,11 +1403,11 @@ class Grunion_Admin {
 	 * Ajax handler for wp_ajax_grunion_export_to_gdrive.
 	 * Exports data to Google Drive, based on POST data.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive
 	 * @see Grunion_Contact_Form_Plugin::get_feedback_entries_from_post
 	 */
 	public function export_to_gdrive() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->export_to_gdrive' );
 
 		$post_data = wp_unslash( $_POST );
 		if (
@@ -1473,10 +1473,10 @@ class Grunion_Admin {
 	/**
 	 * Return HTML markup for the CSV download button.
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section
 	 */
 	public function get_csv_export_section() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_csv_export_section' );
 
 		$button_csv_html = get_submit_button(
 			esc_html__( 'Download', 'jetpack' ),
@@ -1514,10 +1514,10 @@ class Grunion_Admin {
 	 * Render/output HTML markup for the export to gdrive section.
 	 * If the user doesn't hold a Google Drive connection a button to connect will render (See grunion-admin.js).
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section
 	 */
 	public function get_gdrive_export_section() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_section' );
 
 		$user_connected = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Connection_Manager( 'jetpack' ) )->is_user_connected( get_current_user_id() );
 		if ( ! $user_connected ) {
@@ -1584,10 +1584,10 @@ class Grunion_Admin {
 	 * Ajax handler. Sends a payload with connection status and html to replace
 	 * the Connect button with the Export button using get_gdrive_export_button
 	 * 
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection
 	 */
 	public function test_gdrive_connection() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->test_gdrive_connection' );
 
 		$post_data = wp_unslash( $_POST );
 		$user_id   = (int) get_current_user_id();
@@ -1626,11 +1626,11 @@ class Grunion_Admin {
 	/**
 	 * Markup helper so we DRY, returns the button markup for the export to GDrive feature.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup
 	 * @return string The HTML button markup
 	 */
 	public function get_gdrive_export_button_markup() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_gdrive_export_button_markup' );
 
 		return get_submit_button(
 			esc_html__( 'Export', 'jetpack' ),
@@ -1644,12 +1644,12 @@ class Grunion_Admin {
 	/**
 	 * Get a filename for export tasks
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename
 	 * @param string $source The filtered source for exported data.
 	 * @return string The filename without source nor date suffix.
 	 */
 	public function get_export_filename( $source = '' ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Admin->get_export_filename' );
 
 		return $source === ''
 			? sprintf(

--- a/projects/plugins/jetpack/modules/contact-form/class-grunion-contact-form-endpoint.php
+++ b/projects/plugins/jetpack/modules/contact-form/class-grunion-contact-form-endpoint.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Feedback CPT Permissions over-ride
  *
- * @deprecated $$next-version$$ Use automattic/jetpack-forms
+ * @deprecated 13.3 Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -14,18 +14,18 @@ if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
 	 * Class Grunion_Contact_Form_Endpoint
 	 * Used as 'rest_controller_class' parameter when 'feedback' post type is registered in modules/contact-form/grunion-contact-form.php.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint
 	 */
 	class Grunion_Contact_Form_Endpoint extends WP_REST_Posts_Controller {
 		/**
 		 * Check whether a given request has proper authorization to view feedback items.
 		 *
-		 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check
+		 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check
 		 * @param  WP_REST_Request $request Full details about the request.
 		 * @return WP_Error|boolean
 		 */
 		public function get_items_permissions_check( $request ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check' );
+			_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_items_permissions_check' );
 
 			return ( new Contact_Form_Endpoint( $this->post_type ) )->get_items_permissions_check( $request );
 		}
@@ -33,12 +33,12 @@ if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
 		/**
 		 * Check whether a given request has proper authorization to view feedback item.
 		 *
-		 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check
+		 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check
 		 * @param  WP_REST_Request $request Full details about the request.
 		 * @return WP_Error|boolean
 		 */
 		public function get_item_permissions_check( $request ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check' );
+			_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint->get_item_permissions_check' );
 
 			return ( new Contact_Form_Endpoint( $this->post_type ) )->get_item_permissions_check( $request );
 		}

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -4,7 +4,7 @@
  * Add a contact form to any post, page or text widget.
  * Emails will be sent to the post's author by default, or any email address you choose.
  *
- * @deprecated $$next-version$$ Use automattic/jetpack-forms
+ * @deprecated 13.3 Use automattic/jetpack-forms
  * @package automattic/jetpack
  */
 
@@ -26,10 +26,10 @@ add_action( 'rest_api_init', 'grunion_contact_form_require_endpoint' );
 /**
  * Require the Grunion endpoint.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  */
 function grunion_contact_form_require_endpoint() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3' );
 
 	require_once GRUNION_PLUGIN_DIR . 'class-grunion-contact-form-endpoint.php';
 }
@@ -43,11 +43,11 @@ function grunion_contact_form_require_endpoint() {
  *
  * This fixes Contact Form Blocks added to FSE _templates_ (e.g. Single or 404).
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute
  * @param string $template Template to be loaded.
  */
 function grunion_contact_form_set_block_template_attribute( $template ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute' );
 
 	global $_wp_current_template_content;
 	if ( 'template-canvas.php' === basename( $template ) ) {
@@ -69,11 +69,11 @@ add_filter( 'template_include', 'grunion_contact_form_set_block_template_attribu
  * This is part of the fix for Contact Form Blocks added to FSE _template parts_ (e.g footer).
  * The global is processed in Grunion_Contact_Form::parse().
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global
  * @param string $template_part_id ID for the currently rendered template part.
  */
 function grunion_contact_form_set_block_template_part_id_global( $template_part_id ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global' );
 
 	$GLOBALS['grunion_block_template_part_id'] = $template_part_id;
 }
@@ -87,13 +87,13 @@ add_action( 'gutenberg_render_block_core_template_part_none', 'grunion_contact_f
 /**
  * Unsets the global when block is done rendering.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global
  * @param string $content Rendered block content.
  * @param array  $block   The full block, including name and attributes.
  * @return string
  */
 function grunion_contact_form_unset_block_template_part_id_global( $content, $block ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global' );
 
 	if ( isset( $block['blockName'] )
 		&& 'core/template-part' === $block['blockName']
@@ -107,14 +107,14 @@ add_filter( 'render_block', 'grunion_contact_form_unset_block_template_part_id_g
 /**
  * Sets the 'widget' attribute on all instances of the contact form in the widget block.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content
  * @param string          $content  Existing widget block content.
  * @param array           $instance Array of settings for the current widget.
  * @param WP_Widget_Block $widget   Current Block widget instance.
  * @return string
  */
 function grunion_contact_form_filter_widget_block_content( $content, $instance, $widget ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content' );
 
 	Grunion_Contact_Form::style_on();
 	// Inject 'block_template' => <widget-id> into all instances of the contact form block.
@@ -130,13 +130,13 @@ add_filter( 'widget_block_content', 'grunion_contact_form_filter_widget_block_co
 /**
  * Adds a given attribute to all instances of the Contact Form block.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute
  * @param string $content  Existing content to process.
  * @param array  $new_attr New attributes to add.
  * @return string
  */
 function grunion_contact_form_apply_block_attribute( $content, $new_attr ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute' );
 
 	if ( false === stripos( $content, 'wp:jetpack/contact-form' ) ) {
 		return $content;
@@ -172,7 +172,7 @@ function grunion_contact_form_apply_block_attribute( $content, $new_attr ) {
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
  */
 class Grunion_Contact_Form_Plugin {
 
@@ -180,7 +180,7 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * The Widget ID of the widget currently being processed.  Used to build the unique contact-form ID for forms embedded in widgets.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @var string
 	 */
 	public $current_widget_id;
@@ -188,7 +188,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * If the contact form field is being used.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @var bool
 	 */
 	public static $using_contact_form_field = false;
@@ -214,10 +214,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Initializing function.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init
 	 */
 	public static function init() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init' );
 
 		static $instance = false;
 
@@ -234,10 +234,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Runs daily to clean up spam detection metadata after 15 days.  Keeps your DB squeaky clean.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup
 	 */
 	public function daily_akismet_meta_cleanup() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->daily_akismet_meta_cleanup' );
 
 		global $wpdb;
 
@@ -276,12 +276,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Strips HTML tags from input.  Output is NOT HTML safe.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags
 	 * @param mixed $data_with_tags - data we're stripping HTML tags from.
 	 * @return mixed
 	 */
 	public static function strip_tags( $data_with_tags ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::strip_tags' );
 
 		$data_without_tags = array();
 		if ( is_array( $data_with_tags ) ) {
@@ -438,12 +438,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prevent 'contact-form-styles' script from being concatenated.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm
 	 * @param array  $do_concat - the concatenation flag.
 	 * @param string $handle - script name.
 	 */
 	public static function disable_forms_style_script_concat( $do_concat, $handle ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3' );
 
 		if ( 'jetpack-block-contact-form' === $handle ) {
 			$do_concat = false;
@@ -552,14 +552,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the gutenblock form.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\ontact_Form_Block::gutenblock_render_form
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\ontact_Form_Block::gutenblock_render_form
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string
 	 */
 	public static function gutenblock_render_form( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::gutenblock_render_form' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::gutenblock_render_form' );
 
 		// Render fallback in other contexts than frontend (i.e. feed, emails, API, etc.), unless the form is being submitted.
 		if ( ! jetpack_is_frontend() && ! isset( $_POST['contact-form-id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
@@ -579,14 +579,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Turn block attribute to shortcode attributes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes
 	 * @param array  $atts - the block attributes.
 	 * @param string $type - the type.
 	 *
 	 * @return array
 	 */
 	public static function block_attributes_to_shortcode_attributes( $atts, $type ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes' );
 
 		$atts['type'] = $type;
 		if ( isset( $atts['className'] ) ) {
@@ -605,14 +605,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the text field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_text( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'text' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -621,14 +621,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the name field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_name( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_name' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'name' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -637,14 +637,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the email field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_email( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_email' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'email' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -653,14 +653,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the url field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_url( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_url' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'url' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -669,14 +669,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the date field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_date( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_date' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'date' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -685,14 +685,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the telephone field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_telephone( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_telephone' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'telephone' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -701,14 +701,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the text area field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_textarea( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_textarea' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'textarea' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -717,14 +717,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the checkbox field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_checkbox( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'checkbox' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -733,14 +733,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the multiple checkbox field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_checkbox_multiple( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'checkbox-multiple' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -749,14 +749,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the multiple choice field option.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_option( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_option' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'field-option' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -765,14 +765,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the radio button field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_radio( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'radio' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -781,14 +781,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the select field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
 	public static function gutenblock_render_field_select( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_select' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'select' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
@@ -797,12 +797,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Render the consent field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent
 	 * @param string $atts consent attributes.
 	 * @param string $content html content.
 	 */
 	public static function gutenblock_render_field_consent( $atts, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_consent' );
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'consent' );
 
@@ -820,10 +820,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu
 	 */
 	public function admin_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->admin_menu' );
 
 		$slug = 'feedback';
 
@@ -856,11 +856,11 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Add to REST API post type allowed list.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type
 	 * @param array $post_types - the post types.
 	 */
 	public function allow_feedback_rest_api_type( $post_types ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->allow_feedback_rest_api_type' );
 
 		$post_types[] = 'feedback';
 		return $post_types;
@@ -870,11 +870,11 @@ class Grunion_Contact_Form_Plugin {
 	 * Display the count of new feedback entries received. It's reset when user visits the Feedback screen.
 	 *
 	 * @since 4.1.0
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count
 	 * @param object $screen Information about the current screen.
 	 */
 	public function unread_count( $screen ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->unread_count' );
 
 		if ( isset( $screen->post_type ) && 'feedback' === $screen->post_type ) {
 			update_option( 'feedback_unread_count', 0 );
@@ -902,10 +902,10 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * Conditionally attached to `template_redirect`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission
 	 */
 	public function process_form_submission() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->process_form_submission' );
 
 		// Add a filter to replace tokens in the subject field with sanitized field values.
 		add_filter( 'contact_form_subject', array( $this, 'replace_tokens_with_input' ), 10, 2 );
@@ -1073,10 +1073,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Handle the ajax request.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request
 	 */
 	public function ajax_request() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->ajax_request' );
 
 		$submission_result = self::process_form_submission();
 
@@ -1108,14 +1108,14 @@ class Grunion_Contact_Form_Plugin {
 	 * Ensure the post author is always zero for contact-form feedbacks
 	 * Attached to `wp_insert_post_data`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter
 	 * @see Grunion_Contact_Form::process_submission()
 	 * @param array $data the data to insert.
 	 * @param array $postarr the data sent to wp_insert_post().
 	 * @return array The filtered $data to insert.
 	 */
 	public function insert_feedback_filter( $data, $postarr ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->insert_feedback_filter' );
 
 		if ( $data['post_type'] === 'feedback' && $postarr['post_type'] === 'feedback' ) {
 			$data['post_author'] = 0;
@@ -1128,10 +1128,10 @@ class Grunion_Contact_Form_Plugin {
 	 * Adds our contact-form shortcode
 	 * The "child" contact-field shortcode is enabled as needed by the contact-form shortcode handler
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode
 	 */
 	public function add_shortcode() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->add_shortcode' );
 
 		add_shortcode( 'contact-form', array( 'Grunion_Contact_Form', 'parse' ) );
 		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
@@ -1144,12 +1144,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Tokenize the label.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label
 	 * @param string $label - the label.
 	 * @return string
 	 */
 	public static function tokenize_label( $label ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->tokenize_label' );
 
 		return '{' . trim( preg_replace( '#^\d+_#', '', $label ) ) . '}';
 	}
@@ -1157,12 +1157,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Sanitize the value.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value
 	 * @param string $value - the value to sanitize.
 	 * @return string
 	 */
 	public static function sanitize_value( $value ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->sanitize_value' );
 
 		if ( null === $value ) {
 			return '';
@@ -1174,13 +1174,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Replaces tokens like {city} or {City} (case insensitive) with the value
 	 * of an input field of that name
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input
 	 * @param string $subject - the subject.
 	 * @param array  $field_values Array with field label => field value associations.
 	 * @return string The filtered $subject with the tokens replaced.
 	 */
 	public function replace_tokens_with_input( $subject, $field_values ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->replace_tokens_with_input' );
 
 		// Wrap labels into tokens (inside {})
 		$wrapped_labels = array_map( array( 'Grunion_Contact_Form_Plugin', 'tokenize_label' ), array_keys( $field_values ) );
@@ -1202,12 +1202,12 @@ class Grunion_Contact_Form_Plugin {
 	 * Tracks the widget currently being processed.
 	 * Attached to `dynamic_sidebar`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget
 	 * @see $current_widget_id - the current widget ID.
 	 * @param array $widget The widget data.
 	 */
 	public function track_current_widget( $widget ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->track_current_widget' );
 
 		$this->current_widget_id = $widget['id'];
 	}
@@ -1217,12 +1217,12 @@ class Grunion_Contact_Form_Plugin {
 	 * Used to tell the difference between post-embedded contact-forms and widget-embedded contact-forms
 	 * Attached to `widget_text`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts
 	 * @param string $text The widget text.
 	 * @return string The filtered widget text.
 	 */
 	public function widget_atts( $text ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_atts' );
 
 		Grunion_Contact_Form::style( true );
 
@@ -1233,12 +1233,12 @@ class Grunion_Contact_Form_Plugin {
 	 * For sites where text widgets are not processed for shortcodes, we add this hack to process just our shortcode
 	 * Attached to `widget_text`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack
 	 * @param string $text The widget text.
 	 * @return string The contact-form filtered widget text
 	 */
 	public function widget_shortcode_hack( $text ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->widget_shortcode_hack' );
 
 		if ( ! preg_match( '/\[contact-form([^a-zA-Z_-])/', $text ) ) {
 			return $text;
@@ -1264,13 +1264,13 @@ class Grunion_Contact_Form_Plugin {
 	 * removed from the public discussion.
 	 * Attached to `jetpack_contact_form_is_spam`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist
 	 * @param bool  $is_spam - if the submission is spam.
 	 * @param array $form - the form data.
 	 * @return bool TRUE => spam, FALSE => not spam
 	 */
 	public function is_spam_blocklist( $is_spam, $form = array() ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_blocklist' );
 
 		if ( $is_spam ) {
 			return $is_spam;
@@ -1283,13 +1283,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Check if a submission matches the comment disallowed list.
 	 * Attached to `jetpack_contact_form_in_comment_disallowed_list`.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list
 	 * @param boolean $in_disallowed_list Whether the feedback is in the disallowed list.
 	 * @param array   $form The form array.
 	 * @return bool Returns true if the form submission matches the disallowed list and false if it doesn't.
 	 */
 	public function is_in_disallowed_list( $in_disallowed_list, $form = array() ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_in_disallowed_list' );
 
 		if ( $in_disallowed_list ) {
 			return $in_disallowed_list;
@@ -1315,12 +1315,12 @@ class Grunion_Contact_Form_Plugin {
 	 * Populate an array with all values necessary to submit a NEW contact-form feedback to Akismet.
 	 * Note that this includes the current user_ip etc, so this should only be called when accepting a new item via $_POST
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet
 	 * @param array $form - contact form feedback array.
 	 * @return array feedback array with additional data ready for submission to Akismet.
 	 */
 	public function prepare_for_akismet( $form ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->prepare_for_akismet' );
 
 		$form['comment_type']     = 'contact_form';
 		$form['user_ip']          = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
@@ -1362,13 +1362,13 @@ class Grunion_Contact_Form_Plugin {
 	 * If you're accepting a new item via $_POST, run it Grunion_Contact_Form_Plugin::prepare_for_akismet() first
 	 * Attached to `jetpack_contact_form_is_spam`
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet
 	 * @param bool  $is_spam - if the submission is spam.
 	 * @param array $form - the form data.
 	 * @return bool|WP_Error TRUE => spam, FALSE => not spam, WP_Error => stop processing entirely
 	 */
 	public function is_spam_akismet( $is_spam, $form = array() ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->is_spam_akismet' );
 
 		global $akismet_api_host, $akismet_api_port;
 
@@ -1420,13 +1420,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Submit a feedback as either spam or ham
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit
 	 * @param string $as - Either 'spam' or 'ham'.
 	 * @param array  $form - the contact-form data.
 	 * @return bool|string
 	 */
 	public function akismet_submit( $as, $form ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->akismet_submit' );
 
 		global $akismet_api_host, $akismet_api_port;
 
@@ -1450,12 +1450,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prints a dropdown of posts with forms.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown
 	 * @param int $selected_id Currently selected post ID.
 	 * @return void
 	 */
 	public static function form_posts_dropdown( $selected_id ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::form_posts_dropdown' );
 
 		?>
 		<select name="jetpack_form_parent_id">
@@ -1468,14 +1468,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Fetch post content for a post and extract just the comment.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export
 	 * @param int $post_id The post id to fetch the content for.
 	 * @return string Trimmed post comment.
 	 *
 	 * @codeCoverageIgnore
 	 */
 	public function get_post_content_for_csv_export( $post_id ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_content_for_csv_export' );
 
 		$post_content = get_post_field( 'post_content', $post_id );
 		$content      = explode( '<!--more-->', $post_content );
@@ -1486,12 +1486,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get `_feedback_extra_fields` field from post meta data.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export
 	 * @param int $post_id Id of the post to fetch meta data for.
 	 * @return mixed
 	 */
 	public function get_post_meta_for_csv_export( $post_id ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_post_meta_for_csv_export' );
 
 		$md                     = (array) get_post_meta( $post_id, '_feedback_extra_fields', true );
 		$md['-3_response_date'] = get_the_date( 'Y-m-d H:i:s', $post_id );
@@ -1530,14 +1530,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get parsed feedback post fields.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post
 	 * @param int $post_id Id of the post to fetch parsed contents for.
 	 * @return array
 	 *
 	 * @codeCoverageIgnore - No need to be covered.
 	 */
 	public function get_parsed_field_contents_of_post( $post_id ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_parsed_field_contents_of_post' );
 
 		return self::parse_fields_from_content( $post_id );
 	}
@@ -1546,13 +1546,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Properly maps fields that are missing from the post meta data
 	 * to names, that are similar to those of the post meta.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names
 	 * @param array $parsed_post_content Parsed post content.
 	 * @see parse_fields_from_content for how the input data is generated.
 	 * @return array Mapped fields.
 	 */
 	public function map_parsed_field_contents_of_post_to_field_names( $parsed_post_content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->map_parsed_field_contents_of_post_to_field_names' );
 
 		$mapped_fields = array();
 
@@ -1581,13 +1581,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Registers the personal data exporter.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter
 	 * @since 6.1.1
 	 * @param  array $exporters An array of personal data exporters.
 	 * @return array $exporters An array of personal data exporters.
 	 */
 	public function register_personal_data_exporter( $exporters ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_exporter' );
 
 		$exporters['jetpack-feedback'] = array(
 			'exporter_friendly_name' => __( 'Feedback', 'jetpack' ),
@@ -1600,13 +1600,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Registers the personal data eraser.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser
 	 * @since 6.1.1
 	 * @param  array $erasers An array of personal data erasers.
 	 * @return array $erasers An array of personal data erasers.
 	 */
 	public function register_personal_data_eraser( $erasers ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->register_personal_data_eraser' );
 
 		$erasers['jetpack-feedback'] = array(
 			'eraser_friendly_name' => __( 'Feedback', 'jetpack' ),
@@ -1619,14 +1619,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Exports personal data.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter
 	 * @since 6.1.1
 	 * @param  string $email  Email address.
 	 * @param  int    $page   Page to export.
 	 * @return array  $return Associative array with keys expected by core.
 	 */
 	public function personal_data_exporter( $email, $page = 1 ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_exporter' );
 
 		return $this->internal_personal_data_exporter( $email, $page );
 	}
@@ -1637,7 +1637,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Allows us to have a different signature than core expects
 	 * while protecting against future core API changes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter
 	 * @internal
 	 * @since 6.5
 	 * @param  string $email    Email address.
@@ -1646,7 +1646,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array            Associative array with keys expected by core.
 	 */
 	public function internal_personal_data_exporter( $email, $page = 1, $per_page = 250 ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->internal_personal_data_exporter' );
 
 		$export_data = array();
 		$post_ids    = $this->personal_data_post_ids_by_email( $email, $per_page, $page );
@@ -1696,14 +1696,14 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Erases personal data.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser
 	 * @since 6.1.1
 	 * @param  string $email Email address.
 	 * @param  int    $page  Page to erase.
 	 * @return array         Associative array with keys expected by core.
 	 */
 	public function personal_data_eraser( $email, $page = 1 ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_eraser' );
 
 		return $this->_internal_personal_data_eraser( $email, $page );
 	}
@@ -1714,7 +1714,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Allows us to have a different signature than core expects
 	 * while protecting against future core API changes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser
 	 * @internal
 	 * @since 6.5
 	 * @param  string $email    Email address.
@@ -1723,7 +1723,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array            Associative array with keys expected by core.
 	 */
 	public function _internal_personal_data_eraser( $email, $page = 1, $per_page = 250 ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- this is called in other files.
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->_internal_personal_data_eraser' );
 
 		$post_id      = null;
 		$removed      = false;
@@ -1792,7 +1792,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Queries personal data by email address.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email
 	 * @since 6.1.1
 	 * @param  string $email        Email address.
 	 * @param  int    $per_page     Post IDs per page. Default is `250`.
@@ -1801,7 +1801,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array An array of post IDs.
 	 */
 	public function personal_data_post_ids_by_email( $email, $per_page = 250, $page = 1, $last_post_id = 0 ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_post_ids_by_email' );
 
 		add_filter( 'posts_search', array( $this, 'personal_data_search_filter' ) );
 
@@ -1835,13 +1835,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Filters searches by email address.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter
 	 * @since 6.1.1
 	 * @param  string $search SQL where clause.
 	 * @return array          Filtered SQL where clause.
 	 */
 	public function personal_data_search_filter( $search ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->personal_data_search_filter' );
 
 		global $wpdb;
 
@@ -1871,12 +1871,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Prepares feedback post data for CSV export.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts
 	 * @param array $post_ids Post IDs to fetch the data for. These need to be Feedback posts.
 	 * @return array
 	 */
 	public function get_export_data_for_posts( $post_ids ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_export_data_for_posts' );
 
 		$posts_data  = array();
 		$field_names = array();
@@ -2008,11 +2008,11 @@ class Grunion_Contact_Form_Plugin {
 	 * - Positive values render AFTER any form field/value column: 1, 30, 93...
 	 *   Mind using high numbering on these ones as the prefix is used on regular inputs: 1_Name, 2_Email, etc
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names
 	 * @return array
 	 */
 	public function get_well_known_column_names() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_well_known_column_names' );
 
 		return array(
 			'-9_title'         => __( 'Title', 'jetpack' ),
@@ -2026,10 +2026,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Extracts feedback entries based on POST data.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post
 	 */
 	public function get_feedback_entries_from_post() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_feedback_entries_from_post' );
 
 		if ( empty( $_POST['feedback_export_nonce_csv'] ) && empty( $_POST['feedback_export_nonce_gdrive'] ) ) {
 			return;
@@ -2101,10 +2101,10 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Download exported data as CSV
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv
 	 */
 	public function download_feedback_as_csv() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->download_feedback_as_csv' );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- verification is done on get_feedback_entries_from_post function
 		$post_data = wp_unslash( $_POST );
@@ -2181,13 +2181,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Send an event to Tracks
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event
 	 * @param string $event_name - the name of the event.
 	 * @param array  $event_props - event properties to send.
 	 * @return null|void
 	 */
 	public function record_tracks_event( $event_name, $event_props ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->record_tracks_event' );
 
 		/*
 		 * Event details.
@@ -2235,13 +2235,13 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * Additionally, Excel exposes the ability to launch arbitrary commands through the DDE protocol.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv
 	 * @see https://www.contextis.com/en/blog/comma-separated-vulnerabilities
 	 * @param string $field - the CSV field.
 	 * @return string
 	 */
 	public function esc_csv( $field ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->esc_csv' );
 
 		$active_content_triggers = array( '=', '+', '-', '@' );
 
@@ -2318,12 +2318,12 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Parse the contact form fields.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content
 	 * @param int $post_id - the post ID.
 	 * @return array Fields.
 	 */
 	public static function parse_fields_from_content( $post_id ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->parse_fields_from_content' );
 
 		static $post_fields;
 
@@ -2434,11 +2434,11 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Get the IP address.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address
 	 * @return string|null IP address.
 	 */
 	public static function get_ip_address() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->get_ip_address' );
 
 		return isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : null;
 	}
@@ -2446,13 +2446,13 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Disable Block Editor for feedbacks.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type
 	 * @param bool   $can_edit Whether the post type can be edited or not.
 	 * @param string $post_type The post type being checked.
 	 * @return bool
 	 */
 	public function use_block_editor_for_post_type( $can_edit, $post_type ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin->use_block_editor_for_post_type' );
 
 		return 'feedback' === $post_type ? false : $can_edit;
 	}
@@ -2464,14 +2464,14 @@ class Grunion_Contact_Form_Plugin {
 	 * - p1675781140892129-slack-C01CSBEN0QZ
 	 * - https://www.php.net/manual/en/function.print-r.php#93529
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print
 	 * @param string $print_r_output The array string to be reverted. Needs to being with 'Array'.
 	 * @param bool   $parse_html Whether to run html_entity_decode on each line.
 	 *                           As strings are stored right now, they are all escaped, so '=>' are '&gt;'.
 	 * @return array|string Array when succesfully reconstructed, string otherwise. Output will always be esc_html'd.
 	 */
 	public static function reverse_that_print( $print_r_output, $parse_html = false ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::reverse_that_print' );
 
 		$lines = explode( "\n", trim( $print_r_output ) );
 		if ( $parse_html ) {
@@ -2542,7 +2542,7 @@ class Grunion_Contact_Form_Plugin {
  *
  * Not very general - specific to Grunion.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
  *
  * // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
  */
@@ -2550,7 +2550,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The name of the shortcode: [$shortcode_name /].
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var string
 	 */
 	public $shortcode_name;
@@ -2558,7 +2558,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Key => value pairs for the shortcode's attributes: [$shortcode_name key="value" ... /]
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $attributes;
@@ -2566,7 +2566,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Key => value pair for attribute defaults.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $defaults = array();
@@ -2574,7 +2574,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The inner content of otherwise: [$shortcode_name]$content[/$shortcode_name]. Null for selfclosing shortcodes.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var null|string
 	 */
 	public $content;
@@ -2582,7 +2582,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Associative array of inner "child" shortcodes equivalent to the $content: [$shortcode_name][child 1/][child 2/][/$shortcode_name]
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var array
 	 */
 	public $fields;
@@ -2590,7 +2590,7 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * The HTML of the parsed inner "child" shortcodes".  Null for selfclosing shortcodes.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode
 	 * @var null|string
 	 */
 	public $body;
@@ -2598,12 +2598,12 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Constructor function.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct
 	 * @param array       $attributes An associative array of shortcode attributes.  @see shortcode_atts().
 	 * @param null|string $content Null for selfclosing shortcodes.  The inner content otherwise.
 	 */
 	public function __construct( $attributes, $content = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__construct' );
 
 		$this->attributes = $this->unesc_attr( $attributes );
 		if ( is_array( $content ) ) {
@@ -2623,11 +2623,11 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Processes the shortcode's inner content for "child" shortcodes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content
 	 * @param string $content The shortcode's inner content: [shortcode]$content[/shortcode].
 	 */
 	public function parse_content( $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->parse_content' );
 
 		if ( $content === null ) {
 			$this->body = null;
@@ -2639,12 +2639,12 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Returns the value of the requested attribute.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute
 	 * @param string $key The attribute to retrieve.
 	 * @return mixed
 	 */
 	public function get_attribute( $key ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->get_attribute' );
 
 		return isset( $this->attributes[ $key ] ) ? $this->attributes[ $key ] : null;
 	}
@@ -2652,12 +2652,12 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Escape attributes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr
 	 * @param array $value - the value we're escaping.
 	 * @return array
 	 */
 	public function esc_attr( $value ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->esc_attr' );
 
 		if ( is_array( $value ) ) {
 			return array_map( array( $this, 'esc_attr' ), $value );
@@ -2685,12 +2685,12 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Unescape attributes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr
 	 * @param array $value - the value we're escaping.
 	 * @return array
 	 */
 	public function unesc_attr( $value ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->unesc_attr' );
 
 		if ( is_array( $value ) ) {
 			return array_map( array( $this, 'unesc_attr' ), $value );
@@ -2715,10 +2715,10 @@ class Crunion_Contact_Form_Shortcode {
 	/**
 	 * Generates the shortcode
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString
 	 */
 	public function __toString() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Shortcode->__toString' );
 
 		$r = "[{$this->shortcode_name} ";
 
@@ -2777,14 +2777,14 @@ class Crunion_Contact_Form_Shortcode {
  * Parses shortcode to output the contact form as HTML
  * Sends email and stores the contact form response (a.k.a. "feedback")
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form
  */
 class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 	/**
 	 * The shortcode name.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var string
 	 */
 	public $shortcode_name = 'contact-form';
@@ -2793,7 +2793,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *
 	 * Stores form submission errors.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var WP_Error
 	 */
 	public $errors;
@@ -2801,7 +2801,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The SHA1 hash of the attributes that comprise the form.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var string
 	 */
 	public $hash;
@@ -2809,7 +2809,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The most recent (inclusive) contact-form shortcode processed.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var Grunion_Contact_Form
 	 */
 	public static $last;
@@ -2817,7 +2817,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Form we are currently looking at. If processed, will become $last
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var Whatever
 	 */
 	public static $current_form;
@@ -2825,7 +2825,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * All found forms, indexed by hash.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var array
 	 */
 	public static $forms = array();
@@ -2833,7 +2833,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Whether to print the grunion.css style when processing the contact-form shortcode
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var bool
 	 */
 	public static $style = false;
@@ -2841,7 +2841,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * When printing the submit button, what tags are allowed
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form
 	 * @var array
 	 */
 	public static $allowed_html_tags_for_submit_button = array( 'br' => array() );
@@ -2849,12 +2849,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Construction function.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct
 	 * @param array  $attributes - the attributes.
 	 * @param string $content - the content.
 	 */
 	public function __construct( $attributes, $content = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->__construct' );
 
 		global $post;
 
@@ -2956,13 +2956,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Store shortcode content for recall later
 	 *  - used to receate shortcode when user uses do_shortcode
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode
 	 * @param string $content - the content.
 	 * @param array  $attributes - the attributes.
 	 * @param string $hash - the hash.
 	 */
 	public static function store_shortcode( $content = null, $attributes = null, $hash = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::store_shortcode' );
 
 		if ( $content && isset( $attributes['id'] ) ) {
 
@@ -2984,12 +2984,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Toggle for printing the grunion.css stylesheet
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style
 	 * @param bool $style - the CSS style.
 	 * @return bool
 	 */
 	public static function style( $style ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::style' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::style' );
 
 		$previous_style = self::$style;
 		self::$style    = (bool) $style;
@@ -2999,13 +2999,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Turn on printing of grunion.css stylesheet
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on
 	 * @see ::style()
 	 * @internal
 	 * @return bool
 	 */
 	public static function style_on() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::style_on' );
 
 		return self::style( true );
 	}
@@ -3013,13 +3013,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The contact-form shortcode processor
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse
 	 * @param array       $attributes Key => Value pairs as parsed by shortcode_parse_atts().
 	 * @param string|null $content The shortcode's inner content: [contact-form]$content[/contact-form].
 	 * @return string HTML for the concat form.
 	 */
 	public static function parse( $attributes, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse' );
 
 		if ( Settings::is_syncing() ) {
 			return '';
@@ -3222,13 +3222,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Returns a success message to be returned if the form is sent via AJAX.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the contact form.
 	 * @return string $message
 	 */
 	public static function success_message( $feedback_id, $form ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::success_message' );
 
 		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
 			$message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
@@ -3277,13 +3277,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Returns a compiled form with labels and values in a form of  an array
 	 * of lines.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the form.
 	 * @return array $lines
 	 */
 	public static function get_compiled_form( $feedback_id, $form ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form' );
 
 		$feedback       = get_post( $feedback_id );
 		$field_ids      = $form->get_field_ids();
@@ -3372,13 +3372,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Returns a compiled form with labels and values formatted for the email response
 	 * in a form of an array of lines.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email
 	 * @param int                         $feedback_id - the feedback ID.
 	 * @param object Grunion_Contact_Form $form - the form.
 	 * @return array $lines
 	 */
 	public static function get_compiled_form_for_email( $feedback_id, $form ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_compiled_form_for_email' );
 
 		$feedback       = get_post( $feedback_id );
 		$field_ids      = $form->get_field_ids();
@@ -3489,12 +3489,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Escape and sanitize the field value.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value
 	 * @param string $value - the value we're escaping and sanitizing.
 	 * @return string
 	 */
 	public static function escape_and_sanitize_field_value( $value ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::escape_and_sanitize_field_value' );
 
 		$value = str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), $value );
 		return nl2br( wp_kses( $value, array() ) );
@@ -3503,12 +3503,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Only strip out empty string values and keep all the other values as they are.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty
 	 * @param string $single_value - the single value.
 	 * @return bool
 	 */
 	public static function remove_empty( $single_value ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::remove_empty' );
 
 		return ( $single_value !== '' );
 	}
@@ -3545,13 +3545,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * The contact-field shortcode processor.
 	 * We use an object method here instead of a static Grunion_Contact_Form_Field class method to parse contact-field shortcodes so that we can tie them to the contact-form object.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field
 	 * @param array       $attributes Key => Value pairs as parsed by shortcode_parse_atts().
 	 * @param string|null $content The shortcode's inner content: [contact-field]$content[/contact-field].
 	 * @return string HTML for the contact form field
 	 */
 	public static function parse_contact_field( $attributes, $content ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::parse_contact_field' );
 
 		// Don't try to parse contact form fields if not inside a contact form
 		if ( ! Grunion_Contact_Form_Plugin::$using_contact_form_field ) {
@@ -3641,12 +3641,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Get the default label from type.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type
 	 * @param string $type - the type of label.
 	 * @return string
 	 */
 	public static function get_default_label_from_type( $type ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_default_label_from_type' );
 
 		$str = null;
 		switch ( $type ) {
@@ -3730,11 +3730,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *  - admin.php / grunion_manage_post_columns - add the field to the render logic.
 	 *      Otherwise it will be missing from the admin Feedback view.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids
 	 * @return array
 	 */
 	public function get_field_ids() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->get_field_ids' );
 
 		$field_ids = array(
 			'all'   => array(), // array of all field_ids.
@@ -3797,10 +3797,10 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Process the contact form's POST submission
 	 * Stores feedback.  Sends email.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission
 	 */
 	public function process_submission() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->process_submission' );
 
 		global $post;
 
@@ -4398,7 +4398,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Wrapper for wp_mail() that enables HTML messages with text alternatives
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail
 	 * @param string|array $to          Array or comma-separated list of email addresses to send message.
 	 * @param string       $subject     Email subject.
 	 * @param string       $message     Message contents.
@@ -4407,7 +4407,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * @return bool Whether the email contents were sent successfully.
 	 */
 	public static function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail' );
 
 		add_filter( 'wp_mail_content_type', __CLASS__ . '::get_mail_content_type' );
 		add_action( 'phpmailer_init', __CLASS__ . '::add_plain_text_alternative' );
@@ -4426,12 +4426,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * SpamAssassin doesn't like addresses in HTML messages that are missing display names (e.g., `foo@bar.org`
 	 * instead of `Foo Bar <foo@bar.org>`.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address
 	 * @param string $address - the email address.
 	 * @return string
 	 */
 	public function add_name_to_address( $address ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form->add_name_to_address' );
 
 		// If it's just the address, without a display name
 		if ( is_email( $address ) ) {
@@ -4452,11 +4452,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Get the content type that should be assigned to outbound emails
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type
 	 * @return string
 	 */
 	public static function get_mail_content_type() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::get_mail_content_type' );
 
 		return 'text/html';
 	}
@@ -4466,14 +4466,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 *
 	 * This helps to ensure correct parsing by clients, and also helps avoid triggering spam filtering rules
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags
 	 * @param string $title - title of the email.
 	 * @param string $body - the message body.
 	 * @param string $footer - the footer containing meta information.
 	 * @return string
 	 */
 	public static function wrap_message_in_html_tags( $title, $body, $footer ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::wrap_message_in_html_tags' );
 
 		// Don't do anything if the message was already wrapped in HTML tags
 		// That could have be done by a plugin via filters
@@ -4516,11 +4516,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * This makes the message more accessible to mail clients that aren't HTML-aware, and decreases the likelihood
 	 * that the message will be flagged as spam.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative
 	 * @param PHPMailer $phpmailer - the phpmailer.
 	 */
 	public static function add_plain_text_alternative( $phpmailer ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form::add_plain_text_alternative' );
 
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
@@ -4544,12 +4544,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Add deepslashes.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep
 	 * @param array $value - the value.
 	 * @return array The value, with slashes added.
 	 */
 	public function addslashes_deep( $value ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block->addslashes_deep' );
 
 		if ( is_array( $value ) ) {
 			return array_map( array( $this, 'addslashes_deep' ), $value );
@@ -4569,12 +4569,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * Only allowin "wide" and "full" as "center", "left" and "right" don't
 	 * make much sense for the form.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class
 	 * @param array $attributes Block attributes.
 	 * @return string The CSS alignment class: alignfull | alignwide.
 	 */
 	public static function get_block_alignment_class( $attributes = array() ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Block::get_block_alignment_class' );
 
 		$align_to_class_map = array(
 			'wide' => 'alignwide',
@@ -4593,14 +4593,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
  * Parses shortcode to output the contact form field as HTML.
  * Validates input.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
  */
 class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 
 	/**
 	 * The shortcode name.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $shortcode_name = 'contact-field';
@@ -4608,7 +4608,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * The parent form.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var Grunion_Contact_Form
 	 */
 	public $form;
@@ -4616,7 +4616,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Default or POSTed value.
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $value;
@@ -4624,7 +4624,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Is the input valid?
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var bool
 	 */
 	public $error = false;
@@ -4632,7 +4632,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $block_styles = '';
@@ -4640,7 +4640,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $field_styles = '';
@@ -4648,7 +4648,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field option
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $option_styles = '';
@@ -4656,7 +4656,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Styles to be applied to the field
 	 *
-	 * @deprecated $$next-version$$ See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @deprecated 13.3 See Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 * @var string
 	 */
 	public $label_styles = '';
@@ -4664,13 +4664,13 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Constructor function.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct
 	 * @param array                $attributes An associative array of shortcode attributes.  @see shortcode_atts().
 	 * @param null|string          $content Null for selfclosing shortcodes.  The inner content otherwise.
 	 * @param Grunion_Contact_Form $form The parent form.
 	 */
 	public function __construct( $attributes, $content = null, $form = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->__construct' );
 
 		$attributes = shortcode_atts(
 			array(
@@ -4766,11 +4766,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * This field's input is invalid.  Flag as invalid and add an error to the parent form
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error
 	 * @param string $message The error message to display on the form.
 	 */
 	public function add_error( $message ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->add_error' );
 
 		$this->is_error = true;
 
@@ -4784,12 +4784,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Is the field input invalid?
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error
 	 * @see $error
 	 * @return bool
 	 */
 	public function is_error() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->is_error' );
 
 		return $this->error;
 	}
@@ -4797,10 +4797,10 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Validates the form input
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate
 	 */
 	public function validate() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->validate' );
 
 		// If it's not required, there's nothing to validate
 		if ( ! $this->get_attribute( 'required' ) ) {
@@ -4857,14 +4857,14 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Check the default value for options field
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value
 	 * @param string $value - the value we're checking.
 	 * @param int    $index - the index.
 	 * @param string $options - default field option.
 	 * @return string
 	 */
 	public function get_option_value( $value, $index, $options ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->get_option_value' );
 
 		if ( empty( $value[ $index ] ) ) {
 			return $options;
@@ -4875,11 +4875,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Outputs the HTML for this form field
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render
 	 * @return string HTML
 	 */
 	public function render() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render' );
 
 		global $current_user, $user_identity;
 
@@ -5012,7 +5012,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the label.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label
 	 * @param string $type - the field type.
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
@@ -5022,7 +5022,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_label( $type, $id, $label, $required, $required_field_text, $extra_attrs = array() ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_label' );
 
 		$form_style = $this->get_form_style();
 
@@ -5055,7 +5055,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the input field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field
 	 * @param string $type - the field type.
 	 * @param int    $id - the ID.
 	 * @param string $value - the value of the field.
@@ -5066,7 +5066,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_input_field( $type, $id, $value, $class, $placeholder, $required, $extra_attrs = array() ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_input_field' );
 
 		$extra_attrs_string = '';
 
@@ -5093,7 +5093,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5104,7 +5104,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_email_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_email_field' );
 
 		$field  = $this->render_label( 'email', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'email', $id, $value, $class, $placeholder, $required );
@@ -5114,7 +5114,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the telephone field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5125,7 +5125,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_telephone_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_telephone_field' );
 
 		$field  = $this->render_label( 'telephone', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'tel', $id, $value, $class, $placeholder, $required );
@@ -5135,7 +5135,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the URL field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5146,7 +5146,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_url_field' );
 
 		$custom_validation_message = __( 'Please enter a valid URL - https://www.example.com', 'jetpack' );
 		$validation_attrs          = array(
@@ -5165,7 +5165,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the text area field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5176,7 +5176,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_textarea_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_textarea_field' );
 
 		$field  = $this->render_label( 'textarea', 'contact-form-comment-' . $id, $label, $required, $required_field_text );
 		$field .= "<textarea
@@ -5195,7 +5195,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the radio field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5205,7 +5205,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_radio_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_radio_field' );
 
 		$field  = $this->render_label( '', $id, $label, $required, $required_field_text );
 		$field .= '<div class="grunion-radio-options">';
@@ -5234,7 +5234,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the checkbox field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5244,7 +5244,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_checkbox_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_field' );
 
 		$field  = "<label class='grunion-field-label checkbox" . ( $this->is_error() ? ' form-error' : '' ) . "' style='" . $this->label_styles . "'>";
 		$field .= "\t\t<input type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
@@ -5280,7 +5280,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the multiple checkbox field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5290,7 +5290,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_checkbox_multiple_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_checkbox_multiple_field' );
 
 		$field  = $this->render_label( '', $id, $label, $required, $required_field_text );
 		$field .= '<div class="grunion-checkbox-multiple-options">';
@@ -5313,7 +5313,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the select field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5323,7 +5323,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_select_field' );
 
 		$field  = $this->render_label( 'select', $id, $label, $required, $required_field_text );
 		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . ">\n";
@@ -5367,7 +5367,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5378,7 +5378,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_date_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_date_field' );
 
 		$field  = $this->render_label( 'date', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required );
@@ -5413,7 +5413,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the default field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param string $value - the value of the field.
@@ -5425,7 +5425,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_default_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder, $type ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_default_field' );
 
 		$field  = $this->render_label( $type, $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required );
@@ -5435,7 +5435,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the outlined label.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
@@ -5443,7 +5443,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_outline_label( $id, $label, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_outline_label' );
 
 		return '
 			<div class="notched-label">
@@ -5465,7 +5465,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the animated label.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
@@ -5473,7 +5473,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_animated_label( $id, $label, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_animated_label' );
 
 		return '
 			<label
@@ -5489,7 +5489,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the below label.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
@@ -5497,7 +5497,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_below_label( $id, $label, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_below_label' );
 
 		return '
 			<label
@@ -5512,7 +5512,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Return the HTML for the email field.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field
 	 * @param string $type - the type.
 	 * @param int    $id - the ID.
 	 * @param string $label - the label.
@@ -5524,7 +5524,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_field( $type, $id, $label, $value, $class, $placeholder, $required, $required_field_text ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field->render_field' );
 
 		$class .= ' grunion-field';
 
@@ -5679,10 +5679,10 @@ add_action( 'grunion_scheduled_delete', 'grunion_delete_old_spam' );
 /**
  * Deletes old spam feedbacks to keep the posts table size under control
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam'
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam'
  */
 function grunion_delete_old_spam() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );
 
 	global $wpdb;
 
@@ -5733,12 +5733,12 @@ function grunion_delete_old_spam() {
 /**
  * Send an event to Tracks on form submission.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent
  * @param int $post_id - the post_id for the CPT that is created.
  * @return null|void
  */
 function jetpack_tracks_record_grunion_pre_message_sent( $post_id ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent' );
 
 	$post = get_post( $post_id );
 	if ( $post ) {

--- a/projects/plugins/jetpack/modules/contact-form/grunion-editor-view.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-editor-view.php
@@ -12,18 +12,18 @@ use Automattic\Jetpack\Forms\ContactForm\Editor_View;
 /**
  * Grunion editor view class.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View
+ * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Editor_View
  */
 class Grunion_Editor_View {
 
 	/**
 	 * Add hooks according to screen.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks
 	 * @param WP_Screen $screen Data about current screen.
 	 */
 	public static function add_hooks( $screen ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
 
 		return Editor_View::add_hooks( $screen );
 	}
@@ -31,10 +31,10 @@ class Grunion_Editor_View {
 	/**
 	 * Admin header.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head
 	 */
 	public static function admin_head() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::admin_head' );
 
 		return Editor_View::admin_head();
 	}
@@ -42,10 +42,10 @@ class Grunion_Editor_View {
 	/**
 	 * Render the grunion media button.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button
 	 */
 	public static function grunion_media_button() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::grunion_media_button' );
 
 		return Editor_View::grunion_media_button();
 	}
@@ -53,12 +53,12 @@ class Grunion_Editor_View {
 	/**
 	 * Get external plugins.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins
 	 * @param array $plugin_array - the plugin array.
 	 * @return array
 	 */
 	public static function mce_external_plugins( $plugin_array ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_external_plugins' );
 
 		return Editor_View::mce_external_plugins( $plugin_array );
 	}
@@ -66,12 +66,12 @@ class Grunion_Editor_View {
 	/**
 	 * MCE buttons.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons
 	 * @param array $buttons - the buttons.
 	 * @return array
 	 */
 	public static function mce_buttons( $buttons ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::mce_buttons' );
 
 		return Editor_View::mce_buttons( $buttons );
 	}
@@ -79,10 +79,10 @@ class Grunion_Editor_View {
 	/**
 	 * WordPress Shortcode Editor View JS Code
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js
 	 */
 	public static function handle_editor_view_js() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::handle_editor_view_js' );
 
 		return Editor_View::handle_editor_view_js();
 	}
@@ -90,10 +90,10 @@ class Grunion_Editor_View {
 	/**
 	 * JS Templates.
 	 *
-	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates
+	 * @deprecated 13.3 Use Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates
 	 */
 	public static function editor_view_js_templates() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates' );
+		_deprecated_function( __METHOD__, 'jetpack-13.3', 'Automattic\Jetpack\Forms\ContactForm\Editor_View::editor_view_js_templates' );
 
 		return Editor_View::editor_view_js_templates();
 	}

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php
@@ -2,7 +2,7 @@
 /**
  * Jetpack_WooCommerce_Analytics_Checkout_Flow
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  *
  * @package automattic/jetpack
  * @author Automattic
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Jetpack_WooCommerce_Analytics_Checkout_Flow
  * Class that handles all page view events for the checkout flow (from product view to order confirmation view)
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  */
 class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 
@@ -28,7 +28,7 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 	/**
 	 * Jetpack_WooCommerce_Analytics_Checkout_Flow constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function __construct() {
 		$this->find_cart_checkout_content_sources();
@@ -51,7 +51,7 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 		/**
 		 * Track a product page view
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.3
 		 */
 	public function capture_product_view() {
 		global $product;
@@ -69,7 +69,7 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 	/**
 	 * Track the order confirmation page view
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function capture_order_confirmation_view() {
 		$order_id = absint( get_query_var( 'order-received' ) );
@@ -133,7 +133,7 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 	/**
 	 * Track the cart page view
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function capture_cart_view() {
 		if ( ! is_cart() ) {
@@ -152,7 +152,7 @@ class Jetpack_WooCommerce_Analytics_Checkout_Flow {
 	/**
 	 * Track the checkout page view
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function capture_checkout_view() {
 		global $post;

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
@@ -2,7 +2,7 @@
 /**
  * Jetpack_WooCommerce_Analytics_My_Account
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  *
  * @package automattic/jetpack
  * @author  Automattic
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Jetpack_WooCommerce_Analytics_My_Account
  * Filters and Actions added to My Account pages to perform analytics
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  */
 class Jetpack_WooCommerce_Analytics_My_Account {
 
@@ -28,7 +28,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Jetpack_WooCommerce_Analytics_My_Account constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function __construct() {
 
@@ -52,7 +52,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	 * We also track other events here, like order number clicks, order action clicks,
 	 * address clicks, payment method add and delete.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function track_tabs() {
 		global $wp;
@@ -145,7 +145,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Track address save events, this can only come from the my account page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param int    $customer_id The customer id.
 	 * @param string $load_address The address type (billing, shipping).
@@ -157,7 +157,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Track payment method add events, this can only come from the my account page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function track_add_payment_method() {
 		if ( isset( $_POST['woocommerce_add_payment_method'] ) && isset( $_POST['payment_method'] ) ) {
@@ -176,7 +176,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Track payment method delete events.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function track_delete_payment_method() {
 		global $wp;
@@ -189,7 +189,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Track order cancel events.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function track_order_cancel_event() {
 		if ( isset( $_GET['_wca_initiator'] ) && ( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'woocommerce-cancel_order' ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -200,7 +200,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Track order pay events.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function track_order_pay_event() {
 		if ( isset( $_GET['_wca_initiator'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.NonceVerification.Recommended
@@ -211,7 +211,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Track account details save events, this can only come from the my account page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function track_save_account_details() {
 		$this->queue_event( 'woocommerceanalytics_my_account_details_save' );
@@ -220,7 +220,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Track logout events.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function track_logouts() {
 		$common_props = $this->render_properties_as_js(
@@ -246,7 +246,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Add referrer prop to my account action links
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param array $actions My account action links.
 	 * @return array
@@ -275,7 +275,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	 * The get_view_order_url is used in a lot of places,
 	 * so we want to limit it just to my account page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function add_initiator_prop_to_order_urls() {
 		add_filter(
@@ -303,7 +303,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Add initiator to query vars
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param array $query_vars Query vars.
 	 * @return array
@@ -318,7 +318,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	 *
 	 * This is called on every page load, and will record all events that were queued up in session.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function trigger_queued_events() {
 		if ( is_object( WC()->session ) ) {
@@ -340,7 +340,7 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	/**
 	 * Queue an event in session to be recorded later on next page load.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param string $event_name The event name.
 	 * @param array  $event_props The event properties.

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -2,7 +2,7 @@
 /**
  * Jetpack_WooCommerce_Analytics_Trait
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  *
  * @package automattic/jetpack
  * @author  Automattic
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Jetpack_WooCommerce_Analytics_Trait
  * Common functionality for WooCommerce Analytics classes.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  */
 trait Jetpack_WooCommerce_Analytics_Trait {
 
@@ -61,7 +61,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	/**
 	 * Format Cart Items or Order Items to an array
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param array|WC_Order_Item[] $items Cart Items or Order Items.
 	 */
@@ -95,7 +95,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	/**
 	 * Get Cart/Checkout page view shared data
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	protected function get_cart_checkout_shared_data() {
 		$cart = WC()->cart;
@@ -141,7 +141,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	 * Gets the content of the cart/checkout page or where the cart/checkout page is ultimately derived from if using a template.
 	 * This method sets the class properties $checkout_content_source and $cart_content_source.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @return void Does not return, but sets class properties.
 	 */
@@ -270,7 +270,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	/**
 	 * Default event properties which should be included with all events.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @return array Array of standard event props.
 	 */
@@ -294,7 +294,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	/**
 	 * Render tracks event properties as string of JavaScript object props.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param  array $properties Array of key/value pairs.
 	 * @return string String of the form "key1: value1, key2: value2, " (etc).
@@ -314,7 +314,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		/**
 		 * Record an event with optional product and custom properties.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.3
 		 *
 		 * @param string  $event_name The name of the event to record.
 		 * @param array   $properties Optional array of (key => value) event properties.
@@ -330,7 +330,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		/**
 		 * Gather relevant product information
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.3
 		 *
 		 * @param \WC_Product $product product.
 		 * @return array
@@ -348,7 +348,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		/**
 		 * Gets product categories or varation attributes as a formatted concatenated string
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.3
 		 *
 		 * @param object $product WC_Product.
 		 * @return string
@@ -378,7 +378,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	/**
 	 * Compose event properties.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param string  $event_name The name of the event to record.
 	 * @param array   $properties Optional array of (key => value) event properties.
@@ -428,7 +428,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	/**
 	 * Get the current user id
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @return int
 	 */
@@ -444,7 +444,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	/**
 	 * Gets the IDs of additional blocks on the Cart/Checkout pages or templates.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param string $cart_or_checkout Whether to get blocks on the cart or checkout page.
 	 * @return array All inner blocks on the page.
@@ -517,7 +517,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	/**
 	 * Gets an array containing the block or shortcode use properties for the Cart page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @return array            An array containing the block or shortcode use properties for the Cart page.
 	 */
@@ -537,7 +537,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	/**
 	 * Gets an array containing the block or shortcode use properties for the Checkout page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @return array                An array containing the block or shortcode use properties for the Checkout page.
 	 */
@@ -562,7 +562,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 	 * Note: similar code is in a WooCommerce core PR:
 	 * https://github.com/woocommerce/woocommerce/pull/25932
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @return array
 	 */
@@ -580,7 +580,7 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		 * Note: similar code is in a WooCommerce core PR:
 		 * https://github.com/woocommerce/woocommerce/pull/25932
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.3
 		 *
 		 * @param integer $post_id The id of the post to search.
 		 * @param string  $text    The text to search for.

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -2,7 +2,7 @@
 /**
  * Jetpack_WooCommerce_Analytics_Universal
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  *
  * @package automattic/jetpack
  * @author Automattic
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Jetpack_WooCommerce_Analytics_Universal
  * Filters and Actions added to Store pages to perform analytics
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.3
  */
 class Jetpack_WooCommerce_Analytics_Universal {
 
@@ -31,7 +31,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * Jetpack_WooCommerce_Analytics_Universal constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function __construct() {
 		$this->find_cart_checkout_content_sources();
@@ -67,7 +67,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * On product lists or other non-product pages, add an event listener to "Add to Cart" button click
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function loop_session_events() {
 		// Check for previous events queued in session data.
@@ -92,7 +92,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * On the cart page, add an event listener for removal of product click
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function remove_from_cart() {
 		$common_props = $this->render_properties_as_js(
@@ -123,7 +123,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * Adds the product ID to the remove product link (for use by remove_from_cart above) if not present
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param string $url Full HTML a tag of the link to remove an item from the cart.
 	 * @param string $key Unique Key ID for a cart item.
@@ -151,7 +151,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 * Get the selected shipping option for a cart item. If the name cannot be found in the options table, the method's
 	 * ID will be used.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param string $cart_item_key the cart item key.
 	 *
@@ -196,7 +196,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * On the Checkout page, trigger an event for each product in the cart
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function checkout_process() {
 		global $post;
@@ -310,7 +310,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * After the checkout process, fire an event for each item in the order
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param string $order_id Order Id.
 	 */
@@ -400,7 +400,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 * Listen for clicks on the "Update Cart" button to know if an item has been removed by
 	 * updating its quantity to zero
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 */
 	public function remove_from_cart_via_quantity() {
 		$common_props = $this->render_properties_as_js(
@@ -429,7 +429,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * Gets the inner blocks of a block.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param array $inner_blocks The inner blocks.
 	 *
@@ -449,7 +449,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * Track adding items to the cart.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param string $cart_item_key Cart item key.
 	 * @param int    $product_id Product added to cart.
@@ -473,7 +473,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * Track in-session data.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param int    $product_id Product ID.
 	 * @param int    $quantity Quantity.
@@ -514,7 +514,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * Save createaccount post data to be used in $this->order_process.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param array $data post data from the checkout page.
 	 *
@@ -534,7 +534,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * Capture the create account event. Similar to save_checkout_post_data but works with Store API.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.3
 	 *
 	 * @param int   $customer_id Customer ID.
 	 * @param array $new_customer_data New customer data.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.3.0-a.1",
+	"version": "13.3.0-a.2",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.3.0-a.0",
+	"version": "13.3.0-a.1",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,9 +326,23 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.2.1 - 2024-03-12
-### Security
-- Subscriptions: improve security checks when displaying a Subscription form via a shortcode.
+### 13.3-a.1 - 2024-03-12
+#### Enhancements
+- Display Email settings on Newsletter settings page
+- Login block: Link to subscription management page with site URL as search query.
+- Member login block: link to individual subscription management page
+- Pass API parameter to indicate when deleting a memberships product should cancel subscriptions
+- Sharing: add a Threads sharing button and a Threads sharing button block.
+- Social Menu & Social Media Icons: Add support for an SMS button.
+- Uncheck users-new.php Invite user on load if WooCommerce plugin is activated
+
+#### Improved compatibility
+- Add metadata to the post to better diagnose need for Reader and Firehose
+
+#### Bug fixes
+- Sharing: avoid PHP warnings when using custom post types.
+- Sharing: fix the display of the sharing block in some classic themes.
+
 --------
 
 [See the previous changelogs here](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/CHANGELOG.md#changelog)

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.3 - 2024-03-12
+### Changed
+- Updated package dependencies. [#36309]
+
 ## 2.1.2 - 2024-03-11
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-connections-hosting-menu-item
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-connections-hosting-menu-item
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_3_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_3"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.3-alpha
+ * Version: 2.1.3
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.3-alpha",
+	"version": "2.1.3",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.3, jetpack 13.3-a.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.