### PR TITLE
Publicize: prevent panel from jumping after activation

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-social-panel-jump
+++ b/projects/plugins/jetpack/changelog/fix-social-panel-jump
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Publicize: prevent panel from jumping after activation

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -12,7 +12,7 @@ import { PostTypeSupportCheck } from '@wordpress/editor';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import { PublicizePlaceholder } from './components/placeholder';
 import PublicizeSkeletonLoader from './components/skeleton-loader';
-import { Settings } from './settings';
+import Settings from './settings';
 
 import './editor.scss';
 
@@ -22,31 +22,27 @@ const PublicizeSettings = () => {
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( name );
 
+	let children = null;
+
 	if ( isLoadingModules ) {
-		return (
-			<PostTypeSupportCheck supportKeys="publicize">
-				<JetpackPluginSidebar>
-					<PublicizeSkeletonLoader />
-				</JetpackPluginSidebar>
-			</PostTypeSupportCheck>
+		children = <PublicizeSkeletonLoader />;
+	} else if ( ! isModuleActive ) {
+		children = (
+			<PublicizePlaceholder
+				changeStatus={ changeStatus }
+				isModuleActive={ isModuleActive }
+				isLoading={ isChangingStatus }
+			/>
 		);
+	} else {
+		children = <Settings />;
 	}
 
-	if ( ! isModuleActive ) {
-		return (
-			<PostTypeSupportCheck supportKeys="publicize">
-				<JetpackPluginSidebar>
-					<PublicizePlaceholder
-						changeStatus={ changeStatus }
-						isModuleActive={ isModuleActive }
-						isLoading={ isChangingStatus }
-					/>
-				</JetpackPluginSidebar>
-			</PostTypeSupportCheck>
-		);
-	}
-
-	return <Settings />;
+	return (
+		<PostTypeSupportCheck supportKeys="publicize">
+			<JetpackPluginSidebar>{ children }</JetpackPluginSidebar>
+		</PostTypeSupportCheck>
+	);
 };
 
 export const settings = {

--- a/projects/plugins/jetpack/extensions/plugins/publicize/post-publish.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/post-publish.js
@@ -1,0 +1,15 @@
+import {
+	PostPublishManualSharing,
+	PostPublishReviewPrompt,
+} from '@automattic/jetpack-publicize-components';
+
+const PostPublishPanels = () => {
+	return (
+		<>
+			<PostPublishManualSharing />
+			<PostPublishReviewPrompt />
+		</>
+	);
+};
+
+export default PostPublishPanels;

--- a/projects/plugins/jetpack/extensions/plugins/publicize/pre-publish.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/pre-publish.js
@@ -1,0 +1,47 @@
+import {
+	PublicizePanel,
+	SocialImageGeneratorPanel,
+	useSyncPostDataToStore,
+	useSocialMediaConnections,
+} from '@automattic/jetpack-publicize-components';
+import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
+import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { __ } from '@wordpress/i18n';
+import UpsellNotice from './components/upsell';
+
+const PrePublishPanels = ( { isSocialImageGeneratorAvailable } ) => {
+	useSyncPostDataToStore();
+
+	const { hasEnabledConnections } = useSocialMediaConnections();
+
+	return (
+		<>
+			<PluginPrePublishPanel
+				initialOpen={ hasEnabledConnections }
+				id="publicize-title"
+				title={
+					<span id="publicize-defaults" key="publicize-title-span">
+						{ __( 'Share this post', 'jetpack' ) }
+					</span>
+				}
+				icon={ <JetpackEditorPanelLogo /> }
+			>
+				<PublicizePanel prePublish={ true }>
+					<UpsellNotice />
+				</PublicizePanel>
+			</PluginPrePublishPanel>
+
+			{ isSocialImageGeneratorAvailable && (
+				<PluginPrePublishPanel
+					initialOpen
+					title={ __( 'Social Image Generator', 'jetpack' ) }
+					icon={ <JetpackEditorPanelLogo /> }
+				>
+					<SocialImageGeneratorPanel prePublish={ true } />
+				</PluginPrePublishPanel>
+			) }
+		</>
+	);
+};
+
+export default PrePublishPanels;

--- a/projects/plugins/jetpack/extensions/plugins/publicize/settings.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/settings.js
@@ -1,60 +1,25 @@
 import {
-	PostPublishManualSharing,
-	PostPublishReviewPrompt,
 	PublicizePanel,
 	SocialImageGeneratorPanel,
-	useSyncPostDataToStore,
 	usePublicizeConfig,
-	useSocialMediaConnections,
 } from '@automattic/jetpack-publicize-components';
-import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
-import { PostTypeSupportCheck } from '@wordpress/editor';
-import { __ } from '@wordpress/i18n';
-import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import UpsellNotice from './components/upsell';
+import PostPublishPanels from './post-publish';
+import PrePublishPanels from './pre-publish';
 
-export const Settings = () => {
-	useSyncPostDataToStore();
-	const { hasEnabledConnections } = useSocialMediaConnections();
+const Settings = () => {
 	const { isSocialImageGeneratorAvailable } = usePublicizeConfig();
 
 	return (
-		<PostTypeSupportCheck supportKeys="publicize">
-			<JetpackPluginSidebar>
-				<PublicizePanel>
-					<UpsellNotice />
-				</PublicizePanel>
-				{ isSocialImageGeneratorAvailable && <SocialImageGeneratorPanel /> }
-			</JetpackPluginSidebar>
-
-			<PluginPrePublishPanel
-				initialOpen={ hasEnabledConnections }
-				id="publicize-title"
-				title={
-					<span id="publicize-defaults" key="publicize-title-span">
-						{ __( 'Share this post', 'jetpack' ) }
-					</span>
-				}
-				icon={ <JetpackEditorPanelLogo /> }
-			>
-				<PublicizePanel prePublish={ true }>
-					<UpsellNotice />
-				</PublicizePanel>
-			</PluginPrePublishPanel>
-
-			{ isSocialImageGeneratorAvailable && (
-				<PluginPrePublishPanel
-					initialOpen
-					title={ __( 'Social Image Generator', 'jetpack' ) }
-					icon={ <JetpackEditorPanelLogo /> }
-				>
-					<SocialImageGeneratorPanel prePublish={ true } />
-				</PluginPrePublishPanel>
-			) }
-
-			<PostPublishManualSharing />
-			<PostPublishReviewPrompt />
-		</PostTypeSupportCheck>
+		<>
+			<PublicizePanel>
+				<UpsellNotice />
+			</PublicizePanel>
+			{ isSocialImageGeneratorAvailable && <SocialImageGeneratorPanel /> }
+			<PrePublishPanels isSocialImageGeneratorAvailable={ isSocialImageGeneratorAvailable } />
+			<PostPublishPanels />
+		</>
 	);
 };
+
+export default Settings;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/33507

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR prevents the _Share this post_ panel from "jumping" to the bottom of the Jetpack sidebar after activating the Jetpack Social module.

The issue was most likely caused by rendering the `JetpackPluginSidebar` component.

https://github.com/Automattic/jetpack/assets/1620183/0f80455c-a625-455b-84d7-2f6cfae11380



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
- Spin up a test site with this branch
- Make sure to build the plugin if you're running it locally
- The site should have Jetpack Social deactivated
<img width="600" alt="Screenshot 2024-03-12 at 4 03 46 PM" src="https://github.com/Automattic/jetpack/assets/1620183/e34500e3-adbd-4c3b-aeff-fd0fbabbfaf0">

### Testing
- Create a new post
- Open the Jetpack sidebar
<img width="387" alt="Screenshot 2024-03-12 at 4 04 40 PM" src="https://github.com/Automattic/jetpack/assets/1620183/c3dd3e8a-5909-4dc8-b286-1107f208027b">

- Expand the _Share this post_ panel
- Activate Jetpack Social
- The panel should stay in the same position and still be expanded
- Click _Publish_. You should see the pre-publish panels.
<img width="283" alt="Screenshot 2024-03-12 at 4 16 54 PM" src="https://github.com/Automattic/jetpack/assets/1620183/3abf72f0-46f3-4db1-833c-408a0e4862fe">

- Verify that you see the _Share this post_ panel at the bottom of the sidebar
<img width="286" alt="Screenshot 2024-03-12 at 4 17 04 PM" src="https://github.com/Automattic/jetpack/assets/1620183/be9083ac-af81-460e-975c-67b3ac11127e">

- Confirm the publication
- Verify that you see the _Manual sharing_ panel at the bottom of the sidebar
<img width="280" alt="Screenshot 2024-03-12 at 4 17 16 PM" src="https://github.com/Automattic/jetpack/assets/1620183/2b64aa0d-dcd2-4e4a-8fb1-5898f270d71e">
